### PR TITLE
Exposing Environment() in config interface

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 // into some functions that need it
 type Config interface {
 	IsProduction() bool
+	Environment() string
 }
 
 // SetEnvironment loads in the ENV vars from a dotenv file

--- a/pkg/config/tripbot/helpers.go
+++ b/pkg/config/tripbot/helpers.go
@@ -4,20 +4,24 @@ import (
 	"strings"
 )
 
+func (c TripbotConfig) Environment() string {
+	return c.environment
+}
+
 func (c TripbotConfig) IsProduction() bool {
-	return c.Environment == "production"
+	return c.environment == "production"
 }
 
 func (c TripbotConfig) IsStaging() bool {
-	return c.Environment == "staging"
+	return c.environment == "staging"
 }
 
 func (c TripbotConfig) IsDevelopment() bool {
-	return c.Environment == "development"
+	return c.environment == "development"
 }
 
 func (c TripbotConfig) IsTesting() bool {
-	return c.Environment == "testing"
+	return c.environment == "testing"
 }
 
 // UserIsAdmin returns true if a given user runs the channel

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -1,7 +1,7 @@
 package config
 
 type TripbotConfig struct {
-	Environment string `required:"true" envconfig:"ENV"`
+	environment string `required:"true" envconfig:"ENV"`
 	ServerType  string `default:"tripbot"`
 
 	// ChannelName is the username of the stream

--- a/pkg/config/vlc-server/helpers.go
+++ b/pkg/config/vlc-server/helpers.go
@@ -1,17 +1,21 @@
 package config
 
+func (c VlcServerConfig) Environment() string {
+	return c.environment
+}
+
 func (c VlcServerConfig) IsProduction() bool {
-	return c.Environment == "production"
+	return c.environment == "production"
 }
 
 func (c VlcServerConfig) IsStaging() bool {
-	return c.Environment == "staging"
+	return c.environment == "staging"
 }
 
 func (c VlcServerConfig) IsDevelopment() bool {
-	return c.Environment == "development"
+	return c.environment == "development"
 }
 
 func (c VlcServerConfig) IsTesting() bool {
-	return c.Environment == "testing"
+	return c.environment == "testing"
 }

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -1,7 +1,7 @@
 package config
 
 type VlcServerConfig struct {
-	Environment string `required:"true" envconfig:"ENV"`
+	environment string `required:"true" envconfig:"ENV"`
 	ServerType  string `default:"vlc_server"`
 
 	// Verbose determines output verbosity

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -21,7 +21,7 @@ var dbConnection *sqlx.DB
 func init() {
 	var err error
 
-	err = godotenv.Load(".env." + c.Conf.Environment)
+	err = godotenv.Load(".env." + c.Conf.Environment())
 	if err != nil {
 		log.Println("Error loading .env file:", err)
 		log.Println("Continuing anyway...")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -17,6 +17,7 @@ func Initialize(c config.Config) {
 	sentry.Init(sentry.ClientOptions{
 		// enable tracing
 		TracesSampleRate: 0.2,
+		Environment:      c.Environment(),
 	})
 
 	conf = c

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -14,7 +14,10 @@ var conf config.Config
 // Initialize takes a Config interface and sets up a logger
 func Initialize(c config.Config) {
 	// sentry options are picked up through ENV vars
-	sentry.Init(sentry.ClientOptions{})
+	sentry.Init(sentry.ClientOptions{
+		// enable tracing
+		TracesSampleRate: 0.2,
+	})
 
 	conf = c
 }


### PR DESCRIPTION
I think this is unnecessary cause we have `SENTRY_ENVIRONMENT` set, but this work could be useful another time

---
<!-- markdownlint-disable -->
<details>
<summary>Commands and options</summary>
<br />

You can trigger actions by commenting on this PR:
- `/update` will merge `main` into this PR


</details>
