### PR TITLE
Bump VLC container to Ubuntu 24.04

### DIFF
--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \


### PR DESCRIPTION
## Summary
- Bump `infra/docker/vlc/Dockerfile` base from `ubuntu:22.04` to `ubuntu:24.04`, aligning with the OBS container shipped in #368.
- All apt packages (`vlc`, `vlc-plugin-base`, `libvlc-dev`, `xvfb`, `x11vnc`, `fluxbox`, etc.) are unchanged and present in Noble.
- No CI, compose, or Go changes — single-line FROM bump.

## Test plan
- [ ] `VLC Container` workflow passes (build → up → `/health/ready` → `/vlc/current`).
- [ ] `Docker` stack workflow stays green.
- [ ] Local: `docker compose -f infra/docker/docker-compose.yml up vlc` → VNC `localhost:5903` (password `123456`) shows the default dashcam clip looping cleanly. Watch for visual artifacts, color shifts, frame drops.

Follow-up B (Phase 2: VLC dashcam → OBS scene over RTSP) lands separately on top of this.