### PR TITLE
tripbot: rebuild on Ubuntu 24.04 + Go 1.21, revive Postgres 16

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -133,7 +133,7 @@ func connectToTwitch() {
 
 // gracefulShutdown catches CTRL-C and cleans up
 func gracefulShutdown() {
-	ctrlC := make(chan os.Signal)
+	ctrlC := make(chan os.Signal, 1)
 	signal.Notify(ctrlC, os.Interrupt, syscall.SIGTERM)
 
 	// wait for signal

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/adanalife/tripbot
 
-go 1.15
+go 1.21
+
+toolchain go1.21.13
 
 require (
 	cloud.google.com/go/logging v1.4.2
@@ -10,18 +12,14 @@ require (
 	github.com/dimiro1/banner v1.1.0
 	github.com/gempir/go-twitch-irc/v2 v2.8.1
 	github.com/getsentry/sentry-go v0.11.0
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/gorilla/mux v1.8.0
-	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/joho/godotenv v1.4.0
-	github.com/jonas-p/go-shp v0.1.1 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kelvins/geocoder v0.0.0-20200113010004-f579500e9e27
 	github.com/lib/pq v1.10.4
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/nathan-osman/go-sunrise v0.0.0-20201029015502-9a83cd1a5746
 	github.com/nicklaw5/helix v1.24.4
@@ -32,7 +30,46 @@ require (
 	github.com/slok/go-http-metrics v0.9.0
 	github.com/unrolled/secure v1.0.9
 	github.com/urfave/negroni v1.0.0
-	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect
-	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	googlemaps.github.io/maps v1.3.2
+)
+
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/common-nighthawk/go-figure v0.0.0-20200609044655-c4b36f998cf2 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/gorilla/schema v1.2.0 // indirect
+	github.com/jonas-p/go-shp v0.1.1 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
+	golang.org/x/mod v0.4.1 // indirect
+	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/tools v0.1.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.46.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a // indirect
+	google.golang.org/grpc v1.37.1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,7 +37,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
-cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 contrib.go.opencensus.io/exporter/prometheus v0.2.0/go.mod h1:TYmVAyE8Tn1lyPcltF5IYYfWp2KHu7lQGIZnj8iZMys=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -191,10 +190,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
-github.com/google/martian/v3 v3.1.0 h1:wCKgOCHuUEVfsaQLpPSJb7VdYCdTVZQAuOdYm1yc/60=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -276,10 +273,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJ
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/echo/v4 v4.1.17/go.mod h1:Tn2yRQL/UclUalpb5rPdXDevbkJ+lp/2svdyFBg6CHQ=
@@ -788,7 +783,6 @@ googlemaps.github.io/maps v1.3.2/go.mod h1:cCq0JKYAnnCRSdiaBi7Ex9CW15uxIAk7oPi8V
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/infra/docker/docker-compose.development.yml
+++ b/infra/docker/docker-compose.development.yml
@@ -42,7 +42,5 @@ services:
       - .bash_history.remote:/root/.bash_history
 
   db:
-    volumes:
-      - ./tmp/postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"

--- a/infra/docker/docker-compose.development.yml
+++ b/infra/docker/docker-compose.development.yml
@@ -42,5 +42,10 @@ services:
       - .bash_history.remote:/root/.bash_history
 
   db:
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+
+volumes:
+  postgres_data:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -81,8 +81,7 @@ services:
       POSTGRES_PASSWORD: "${DATABASE_PASS}"
       POSTGRES_USER: "${DATABASE_USER}"
       POSTGRES_DB: "${DATABASE_DB}"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
+    # data persistence is opt-in per environment (see docker-compose.development.yml)
 
   migrate:
     image: migrate/migrate
@@ -109,6 +108,3 @@ services:
     volumes:
       - .:/go/src/github.com/adanalife/tripbot
     restart: on-failure
-
-volumes:
-  postgres_data:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:13
+    image: postgres:16-alpine
     restart: always
     ports:
       - "5432"
@@ -81,9 +81,8 @@ services:
       POSTGRES_PASSWORD: "${DATABASE_PASS}"
       POSTGRES_USER: "${DATABASE_USER}"
       POSTGRES_DB: "${DATABASE_DB}"
-    # volumes:
-    #   - ./infra/docker/init.sql:/docker-entrypoint-initdb.d/init.sql
-    #   - ./tmp/data:/var/lib/postgresql/data
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   migrate:
     image: migrate/migrate
@@ -104,8 +103,12 @@ services:
       - infra/docker/env.docker
     depends_on:
       - migrate
+    working_dir: /go/src/github.com/adanalife/tripbot
     entrypoint: bash -c "infra/docker/bin/seed-db.sh"
     #TODO: this can be removed once the script is baked into the image
     volumes:
       - .:/go/src/github.com/adanalife/tripbot
     restart: on-failure
+
+volumes:
+  postgres_data:

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,7 +24,6 @@ COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -fsS http://localhost:8080/health/live || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD curl -fsS http://localhost:8080/health/live
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/tripbot"]

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -1,37 +1,30 @@
-# buster is the debian release, c.p. https://askubuntu.com/a/445496
-FROM golang:1.17.5-buster
+# Builder: produce a static-ish tripbot binary with Go 1.21
+FROM golang:1.21-bookworm AS builder
 
-WORKDIR /go/src/github.com/adanalife/tripbot
+WORKDIR /src
 
-# create app user
-# RUN adduser --system --group --disabled-password --no-create-home danalol
+COPY go.mod go.sum ./
+RUN go mod download
 
-# add Tini (simple init)
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-
-# copy over project
-#TODO: maybe just copy pkg, cmd, internal, etc?
 COPY . .
-# COPY --chown=danalol:danalol . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/tripbot ./cmd/tripbot
 
-# create symlink to /opt/tripbot and give user permissions on it
-RUN ln -s /go/src/github.com/adanalife/tripbot /opt/tripbot \
-  && mkdir /opt/data #\
-  # && chown danalol:danalol /opt/tripbot /opt/data
+# Runtime: minimal Ubuntu 24.04 matching the VLC/OBS containers
+FROM ubuntu:24.04
 
-# set home dir for app user
-# RUN usermod --home /opt/tripbot danalol
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    tini \
+    ca-certificates \
+    tzdata \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
 
-# switch to the app user
-# USER danalol
-
-# build the binary
-WORKDIR /opt/tripbot
-RUN go build -o bin/tripbot cmd/tripbot/tripbot.go
+COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
 EXPOSE 8080
 
-ENTRYPOINT ["/tini", "--"]
-CMD ["./bin/tripbot"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fsS http://localhost:8080/health/live || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/tripbot"]

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,6 +24,6 @@ COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD curl -fsS http://localhost:8080/health/live
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -fsS http://localhost:8080/health/live
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/tripbot"]


### PR DESCRIPTION
## Summary

Brings the tripbot Go service back to a buildable, runnable state by aligning it with the rest of the revived stack (VLC #366/#369, OBS #368/#371). This is **PR A** of the three-PR tripbot revival plan; it produces a buildable image and a working DB stack but does not yet wire tripbot into the running stream end-to-end (PR B does that).

### What changes

- **Dockerfile rewrite.** `golang:1.17.5-buster` is unbuildable now (Buster apt mirrors are gone). Replaced with a multistage build: `golang:1.21-bookworm` builder + `ubuntu:24.04` runtime, matching VLC/OBS. Tripbot has no X11/libvlc needs at runtime, so the runtime stage carries only `tini`, `ca-certificates`, `tzdata`, and `curl` (for the healthcheck). Binary built `CGO_ENABLED=0`. Adds a `HEALTHCHECK` against `/health/live`.
- **Go module bump.** `go.mod` directive moves from `go 1.15` → `go 1.21` (with `toolchain go1.21.13`). Per the revival plan this is the *minimum* bump to make Go 1.21 build the existing code — no proactive dependency modernization. `go mod tidy` reorganized direct/indirect requires into two blocks but didn't change any versions. One vet diagnostic surfaced and was fixed: `gracefulShutdown`'s `signal.Notify` channel is now buffered (size 1), the standard idiom.
- **Postgres revival.** `postgres:13` (EOL Nov 2025) → `postgres:16-alpine`. The previously commented-out data volume is replaced with a named `postgres_data` volume declared at the bottom of `docker-compose.yml`. The development.yml override that bind-mounted `./tmp/postgres_data` is dropped — the named volume works for both dev and prod. The `seed` service grows a `working_dir` so its relative-path entrypoint still resolves now that the tripbot image's runtime stage no longer chdirs.

### What this does NOT change

- Tripbot's compose service still runs `go run cmd/tripbot/tripbot.go` with the old source bind-mount — switching it to the baked binary is PR B.
- No vlc↔obs shared-volume wiring, no env.docker fixes, no Twilio stubs — all PR B.
- No `cmd/streamtest` TUI — PR C.
- Dependency audit deferred. `nicklaw5/helix v1.24.4`, `gempir/go-twitch-irc/v2 v2.8.1`, `cloud.google.com/go/logging v1.4.2`, `io/ioutil` usage — all left alone.

## Test plan

- [x] `go vet ./...` clean (excluding `pkg/vlc-server` and `cmd/vlc-server` which need libvlc-dev — no regressions vs. develop)
- [x] `go build ./cmd/tripbot` clean under Go 1.21
- [x] `docker build -f infra/docker/tripbot/Dockerfile .` succeeds, ~178MB image
- [x] `bin/devenv up -d db` brings up Postgres 16 cleanly
- [x] `bin/devenv run --rm migrate` applies all 9 migrations
- [x] `\dt` shows 8 user tables + `schema_migrations`
- [x] `bin/devenv run --rm seed` loads 4406 rows into `videos`
- [x] `tripbot --help` runs in the new image; bare invocation correctly exits with `You must set ENV`