### PR TITLE
compose: drop stale OBS dev override that crashloops on boot

### DIFF
--- a/infra/docker/docker-compose.development.yml
+++ b/infra/docker/docker-compose.development.yml
@@ -28,8 +28,6 @@ services:
     # set this to true to disable the OBS container
     #entrypoint: "true"
     restart: on-failure
-    entrypoint: bash
-    command: -c "cd /opt/tripbot && rm -f bin/vlc-server && script/container_startup.sh"
     volumes:
       - .bash_history.remote:/root/.bash_history
 


### PR DESCRIPTION
## Summary

The OBS service in `docker-compose.development.yml` had an `entrypoint`/`command` override left over from when OBS shipped as a combined OBS+vlc-server container with the tripbot source bind-mounted at `/opt/tripbot/`. After the OBS rebuild (#368) and the OBS/VLC decoupling (#370, #371), all of that override's preconditions disappeared:

- no source bind-mount → no `/opt/tripbot/`
- no `bin/vlc-server` to delete
- no `script/container_startup.sh` in the new image

The override exits 127 on every boot, and `restart: on-failure` puts the service in a crashloop. The image's own `ENTRYPOINT` (set in #368/#371) is the one we actually want — it runs the OBS entrypoint script that sets up Xvfb, x11vnc, loads the Tripbot scene collection, and starts OBS.

This is the cleanup item that was deferred during #371 and #373 ("don't touch in PR B, track separately"). Phase 5 of the revival made it the next blocker, so it's the right time.

## What changes

Drops two lines from `docker-compose.development.yml`:

```diff
-    entrypoint: bash
-    command: -c "cd /opt/tripbot && rm -f bin/vlc-server && script/container_startup.sh"
```

Keeps everything else: `restart: on-failure`, the `.bash_history.remote` mount, the `.env.development` env_file, the `DISABLE_OBS` interpolation, etc.

## Test plan

- [x] `bin/devenv up -d obs` brings the container up cleanly (Up, healthy, `restartCount=0`)
- [x] OBS logs show `Loaded scenes` for the Tripbot collection (`Background`, `Dashcam`, `Title`, the overlays)
- [x] Image `ENTRYPOINT` is `/usr/bin/tini -- /opt/obs/entrypoint.sh` per `docker inspect`
- [ ] VNC into `localhost:5902` shows the Main scene rendering (manual)
- [ ] `!middle hello` from a test account triggers a vlc-server write that OBS picks up and renders (manual)