### PR TITLE
obs: center the OBS window in the Xvfb display

### DIFF
--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -36,6 +36,13 @@ rm -f /tmp/.X11-unix/X0 /tmp/.X0-lock
 Xvfb "$DISPLAY" -screen 0 1920x1200x24 &
 sleep 1
 
+mkdir -p "$HOME/.fluxbox"
+cat > "$HOME/.fluxbox/apps" <<'EOF'
+[app] (class=obs)
+  [Position] (CENTER)	{0 0}
+[end]
+EOF
+
 fluxbox &
 sleep 1
 

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -36,6 +36,10 @@ rm -f /tmp/.X11-unix/X0 /tmp/.X0-lock
 Xvfb "$DISPLAY" -screen 0 1920x1200x24 &
 sleep 1
 
+# Pin the OBS main window to the center of the 1920x1200 Xvfb display via
+# fluxbox's apps file. Without this rule OBS opens at fluxbox's default
+# top-left corner, leaving most of the framebuffer empty in VNC. Match by
+# WM_CLASS=obs (stable across version/profile/scene title changes).
 mkdir -p "$HOME/.fluxbox"
 cat > "$HOME/.fluxbox/apps" <<'EOF'
 [app] (class=obs)


### PR DESCRIPTION
## Summary

OBS launches at fluxbox's default top-left position inside the 1920×1200 Xvfb framebuffer, leaving most of the VNC view empty. This adds a fluxbox `apps` rule (`[app] (class=obs) [Position] (CENTER) {0 0}`) written from `entrypoint.sh` before `fluxbox &`, so the OBS main window is centered on first paint.

OBS 32 reports `WM_CLASS = "obs", "obs"`, so matching by class is stable across version/profile/scene changes that show up in the window title. No new packages — fluxbox-native.

## Test plan

- [ ] `bin/devenv up --build obs`
- [ ] VNC into `127.0.0.1:5902` (password `123456`) and confirm OBS opens visually centered, not pinned to the upper-left
- [ ] (optional) `docker exec tripbot-obs-1 xprop -id <obs-window> WM_CLASS` returns `"obs", "obs"` and `xwininfo` reports the 1280×960 main window at (320, 118)