### PR TITLE
Mark OBS container unhealthy when the safe-mode crash dialog is up

### DIFF
--- a/infra/docker/obs/healthcheck.sh
+++ b/infra/docker/obs/healthcheck.sh
@@ -2,16 +2,14 @@
 # Healthy when:
 #   - the obs process is alive
 #   - the X server responds
-#   - no OBS modal dialog is wedging the UI
+#   - the OBS-32 safe-mode crash dialog is NOT up
 #
-# The modal check exists because OBS surfaces blocking, unrecoverable prompts
-# (OBS-32 safe-mode after a crashy restart, "Missing Files" when scene assets
-# vanish, etc.) that no automation in the container can dismiss. Without this
-# the container looks healthy while the app is actually inert. Detection: walk
-# _NET_CLIENT_LIST and fail if any window has WM_CLASS=obs and
-# _NET_WM_STATE_MODAL — that combination is unique to OBS's blocking dialogs;
-# normal OBS dock panes (Stats, Output Timer, etc.) are WM_CLASS=obs but not
-# modal.
+# Why specifically the safe-mode dialog: it appears on top of an empty
+# desktop instead of the OBS main window, blocking everything until a
+# human dismisses it. Other OBS modals ("Missing Files", etc.) leave
+# the main window functional and are tolerable. Detection: walk
+# _NET_CLIENT_LIST and fail when any window has WM_CLASS=obs,
+# _NET_WM_STATE_MODAL, and a WM_NAME containing "Crash Detected".
 set -u
 export DISPLAY=:0
 
@@ -21,9 +19,11 @@ xdpyinfo >/dev/null 2>&1 || exit 1
 for wid in $(xprop -root _NET_CLIENT_LIST 2>/dev/null | grep -oE '0x[0-9a-fA-F]+'); do
   cls=$(xprop -id "$wid" WM_CLASS 2>/dev/null)
   state=$(xprop -id "$wid" _NET_WM_STATE 2>/dev/null)
-  if [[ "$cls" == *'"obs"'* ]] && [[ "$state" == *_NET_WM_STATE_MODAL* ]]; then
-    name=$(xprop -id "$wid" WM_NAME 2>/dev/null | sed -n 's/^WM_NAME(STRING) = //p')
-    echo "OBS modal dialog blocking: $name ($wid)" >&2
+  name=$(xprop -id "$wid" WM_NAME 2>/dev/null)
+  if [[ "$cls"   == *'"obs"'* ]] && \
+     [[ "$state" == *_NET_WM_STATE_MODAL* ]] && \
+     [[ "$name"  == *"Crash Detected"* ]]; then
+    echo "OBS safe-mode dialog blocking the main window: $wid" >&2
     exit 1
   fi
 done

--- a/infra/docker/obs/healthcheck.sh
+++ b/infra/docker/obs/healthcheck.sh
@@ -1,2 +1,31 @@
 #!/usr/bin/env bash
-pgrep -x obs >/dev/null && DISPLAY=:0 xdpyinfo >/dev/null 2>&1
+# Healthy when:
+#   - the obs process is alive
+#   - the X server responds
+#   - no OBS modal dialog is wedging the UI
+#
+# The modal check exists because OBS surfaces blocking, unrecoverable prompts
+# (OBS-32 safe-mode after a crashy restart, "Missing Files" when scene assets
+# vanish, etc.) that no automation in the container can dismiss. Without this
+# the container looks healthy while the app is actually inert. Detection: walk
+# _NET_CLIENT_LIST and fail if any window has WM_CLASS=obs and
+# _NET_WM_STATE_MODAL — that combination is unique to OBS's blocking dialogs;
+# normal OBS dock panes (Stats, Output Timer, etc.) are WM_CLASS=obs but not
+# modal.
+set -u
+export DISPLAY=:0
+
+pgrep -x obs >/dev/null || exit 1
+xdpyinfo >/dev/null 2>&1 || exit 1
+
+for wid in $(xprop -root _NET_CLIENT_LIST 2>/dev/null | grep -oE '0x[0-9a-fA-F]+'); do
+  cls=$(xprop -id "$wid" WM_CLASS 2>/dev/null)
+  state=$(xprop -id "$wid" _NET_WM_STATE 2>/dev/null)
+  if [[ "$cls" == *'"obs"'* ]] && [[ "$state" == *_NET_WM_STATE_MODAL* ]]; then
+    name=$(xprop -id "$wid" WM_NAME 2>/dev/null | sed -n 's/^WM_NAME(STRING) = //p')
+    echo "OBS modal dialog blocking: $name ($wid)" >&2
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Extends `infra/docker/obs/healthcheck.sh` so the container reports unhealthy when OBS is wedged on the **safe-mode crash dialog** ("OBS Studio Crash Detected"). Today's check only verifies the obs process and X server are alive, so a wedged OBS still passes healthy and the orchestrator has no signal to recycle.

## Why only safe-mode

Other OBS modals like "Missing Files" leave the main window functional — the stream still runs, dock panes still respond, the overlay just nags about a missing asset. Recycling for that is overkill.

The safe-mode dialog is different: OBS opens it *instead of* the main window, so the entire UI is inaccessible until a human clicks through. That's the one worth bouncing on.

## Detection

Walk `_NET_CLIENT_LIST` via `xprop` and fail when any window has all three:
- `WM_CLASS=obs`
- `_NET_WM_STATE_MODAL`
- `WM_NAME` contains `Crash Detected`

The first two narrow to OBS's blocking dialogs (dock panes are `WM_CLASS=obs` but never modal). The third narrows to safe-mode specifically and excludes "Missing Files" and friends.

## Test plan

- [x] Running container wedged on the OBS-32 safe-mode crash prompt — old healthcheck reports healthy, new one reports unhealthy:
  ```
  OBS safe-mode dialog blocking the main window: 0x1000006
  exit=1
  ```
- [ ] Healthy container (no modal up) — exit 0
- [ ] Container with "Missing Files" modal up — exit 0 (functional, no false-positive)
- [ ] Container with dock panes (Stats etc.) opened — exit 0 (no false-positive)

## Caveat — out of scope

Docker compose's `restart: unless-stopped` does **not** recycle unhealthy containers, only crashed ones. This patch is the precondition for the orchestrator-side recycle (k3d/k8s liveness probe, or an autoheal sidecar under raw compose) to do anything useful. The orchestrator-side wiring is a separate piece of work.