### PR TITLE
Multi-arch tripbot + vlc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,17 @@ on:
       - v*
 
 jobs:
-  tripbot:
-    runs-on: ubuntu-latest
+  tripbot-build:
+    name: tripbot-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout (with LFS)
         uses: actions/checkout@v4
@@ -27,11 +36,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: adanalife/tripbot
+          flavor: |
+            latest=true
+            suffix=-${{ matrix.arch }},onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=raw,value=latest
 
       - name: Build & push
         uses: docker/build-push-action@v5
@@ -40,11 +51,52 @@ jobs:
           file: infra/docker/tripbot/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          cache-from: type=gha,scope=tripbot
-          cache-to: type=gha,mode=max,scope=tripbot
+          cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
-  vlc:
+  tripbot-manifest:
+    needs: tripbot-build
     runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: adanalife/tripbot
+          flavor: latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+
+      - name: Create multi-arch manifest lists
+        run: |
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "==> $tag = $tag-amd64 + $tag-arm64"
+            docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+  vlc-build:
+    name: vlc-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,11 +115,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: adanalife/vlc
+          flavor: |
+            latest=true
+            suffix=-${{ matrix.arch }},onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=raw,value=latest
 
       - name: Build & push
         uses: docker/build-push-action@v5
@@ -76,8 +130,40 @@ jobs:
           file: infra/docker/vlc/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          cache-from: type=gha,scope=vlc
-          cache-to: type=gha,mode=max,scope=vlc
+          cache-from: type=gha,scope=vlc-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
+
+  vlc-manifest:
+    needs: vlc-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: adanalife/vlc
+          flavor: latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+
+      - name: Create multi-arch manifest lists
+        run: |
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "==> $tag = $tag-amd64 + $tag-arm64"
+            docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
+          done <<< "${{ steps.meta.outputs.tags }}"
 
   obs-build:
     name: obs-build (${{ matrix.arch }})
@@ -168,7 +254,7 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   notify:
-    needs: [tripbot, vlc, obs-manifest]
+    needs: [tripbot-manifest, vlc-manifest, obs-manifest]
     runs-on: ubuntu-latest
     steps:
       - name: Discord notification


### PR DESCRIPTION
## Summary

Extends the OBS matrix pattern (#383) to tripbot and vlc. After v2.0.0 deployed cleanly to the local arm64 k3d cluster, tripbot and vlc \`ImagePullBackOff\`'d with \`no match for platform in manifest\` because they're still amd64-only on Docker Hub.

Both Dockerfiles are already arch-agnostic — tripbot is a \`CGO_ENABLED=0\` Go build that cross-compiles trivially, and vlc's Dockerfile already uses \`ARG TARGETARCH\` for the Go toolchain download, with all apt deps available on noble for both arches. No Dockerfile changes needed; release.yml gets the matrix + manifest-list pattern.

## Changes

- \`tripbot-build\`: matrix over \`{amd64, arm64}\` on \`{ubuntu-latest, ubuntu-24.04-arm}\` pushing per-arch tags (\`suffix=-<arch>\`).
- \`tripbot-manifest\`: combines per-arch tags into a multi-arch manifest list.
- \`vlc-build\` + \`vlc-manifest\`: same pattern.
- Per-arch GHA cache scopes (\`tripbot-amd64\`, \`tripbot-arm64\`, \`vlc-amd64\`, \`vlc-arm64\`).
- \`notify\` now needs all three manifest jobs.

OBS matrix is unchanged.

## Out of scope

- **CI parity:** \`tripbot.yml\` and \`vlc.yml\` still test amd64 only. Adding arm64 there would catch arch-specific issues earlier (before tagging) at the cost of doubled CI time per PR. Worth doing if release-time arch failures become a pattern; pragmatic to defer for now.

## Versioning

After merge to develop and promotion to master, suggest **\`#minor\` in the merge commit body** to cut **v2.1.0** — additive (new platform support), no breaking changes from v2.0.0.

## Test plan

- [ ] CI on this PR: \`tripbot.yml\` + \`vlc.yml\` + \`obs.yml\` all green
- [ ] After merge to develop, promote develop → master with \`#minor\` in merge body
- [ ] Auto-tag fires v2.1.0
- [ ] release.yml runs all 7 jobs to green (\`tripbot-build\` × 2, \`tripbot-manifest\`, \`vlc-build\` × 2, \`vlc-manifest\`, \`obs-build\` × 2, \`obs-manifest\`, \`notify\`)
- [ ] \`docker buildx imagetools inspect adanalife/tripbot:2.1.0\` shows linux/amd64 + linux/arm64
- [ ] \`docker buildx imagetools inspect adanalife/vlc:2.1.0\` shows linux/amd64 + linux/arm64
- [ ] Tear down + reapply stage-1 k3d; all four pods (tripbot, vlc-server, obs, postgres) reach Ready
- [ ] VNC into OBS and confirm Main scene with dashcam + browser_source onscreens rendering end-to-end