### PR TITLE
Release v2.0.1: develop → master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,17 @@ on:
       - v*
 
 jobs:
-  tripbot:
-    runs-on: ubuntu-latest
+  tripbot-build:
+    name: tripbot-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout (with LFS)
         uses: actions/checkout@v4
@@ -27,11 +36,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: adanalife/tripbot
+          flavor: |
+            latest=true
+            suffix=-${{ matrix.arch }},onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=raw,value=latest
 
       - name: Build & push
         uses: docker/build-push-action@v5
@@ -40,11 +51,52 @@ jobs:
           file: infra/docker/tripbot/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          cache-from: type=gha,scope=tripbot
-          cache-to: type=gha,mode=max,scope=tripbot
+          cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
-  vlc:
+  tripbot-manifest:
+    needs: tripbot-build
     runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: adanalife/tripbot
+          flavor: latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+
+      - name: Create multi-arch manifest lists
+        run: |
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "==> $tag = $tag-amd64 + $tag-arm64"
+            docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+  vlc-build:
+    name: vlc-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,11 +115,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: adanalife/vlc
+          flavor: |
+            latest=true
+            suffix=-${{ matrix.arch }},onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=raw,value=latest
 
       - name: Build & push
         uses: docker/build-push-action@v5
@@ -76,8 +130,40 @@ jobs:
           file: infra/docker/vlc/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          cache-from: type=gha,scope=vlc
-          cache-to: type=gha,mode=max,scope=vlc
+          cache-from: type=gha,scope=vlc-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
+
+  vlc-manifest:
+    needs: vlc-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: adanalife/vlc
+          flavor: latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+
+      - name: Create multi-arch manifest lists
+        run: |
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "==> $tag = $tag-amd64 + $tag-arm64"
+            docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
+          done <<< "${{ steps.meta.outputs.tags }}"
 
   obs-build:
     name: obs-build (${{ matrix.arch }})
@@ -168,7 +254,7 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   notify:
-    needs: [tripbot, vlc, obs-manifest]
+    needs: [tripbot-manifest, vlc-manifest, obs-manifest]
     runs-on: ubuntu-latest
     steps:
       - name: Discord notification


### PR DESCRIPTION
## Summary

Promote 1 commit from develop to master to cut **v2.0.1** — multi-arch tripbot + vlc.

### What's landing

- **#385** — release.yml: multi-arch tripbot + vlc, mirroring the OBS matrix pattern from #383

That's the only delta beyond v2.0.0.

### Why v2.0.1

Patch bump — completes v2.0.0's stage-1-arm64 story by adding arm64 manifests for tripbot and vlc. No new features, no breaking changes; just unblocks the platforms tripbot was already supposed to deploy on.

## Action at merge time

**No keyword needed in the merge commit body.** \`auto-tag.yml\` defaults to patch when no \`#major\` / \`#minor\` / \`#patch\` keyword is present, so v2.0.0 → v2.0.1 happens automatically.

Recommended merge type: **Create a merge commit** (consistent with v2.0.0).

## What happens after merge

1. \`auto-tag.yml\` fires → pushes \`v2.0.1\`
2. \`release.yml\` runs all 7 jobs:
   - \`tripbot-build\` × 2 (amd64 + arm64), \`tripbot-manifest\`
   - \`vlc-build\` × 2 (amd64 + arm64), \`vlc-manifest\`
   - \`obs-build\` × 2 (amd64 + arm64), \`obs-manifest\`
   - \`notify\`
3. Discord webhook fires
4. Redeploy stage-1 k3d: tripbot + vlc + obs all pull arm64 from Docker Hub, full stack reaches Ready
5. VNC into OBS and confirm dashcam RTSP + browser_source onscreens render end-to-end

## Test plan

- [ ] Merge (no keyword needed)
- [ ] Auto-tag pushes \`v2.0.1\`
- [ ] release.yml goes green for all 7 jobs
- [ ] \`docker buildx imagetools inspect adanalife/tripbot:2.0.1\` shows linux/amd64 + linux/arm64
- [ ] \`docker buildx imagetools inspect adanalife/vlc:2.0.1\` shows linux/amd64 + linux/arm64
- [ ] Stage-1 k3d: full stack Ready, VNC acceptance passes