### PR TITLE
obs: rename profile from Untitled to ADanaLife

### DIFF
--- a/infra/docker/obs/config/basic.ini
+++ b/infra/docker/obs/config/basic.ini
@@ -1,5 +1,5 @@
 [General]
-Name=Untitled
+Name=ADanaLife
 [Video]
 BaseCX=1920
 BaseCY=1080

--- a/infra/docker/obs/config/user.ini
+++ b/infra/docker/obs/config/user.ini
@@ -5,7 +5,7 @@ LastVersion=503316482
 PreviewEnabled=true
 WarnBeforeStoppingStream=false
 [Basic]
-Profile=Untitled
-ProfileDir=Untitled
+Profile=ADanaLife
+ProfileDir=ADanaLife
 SceneCollection=Tripbot
 SceneCollectionFile=Tripbot.json

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 OBS_HOME="${HOME:-/root}/.config/obs-studio"
-mkdir -p "$OBS_HOME/basic/profiles/Untitled" "$OBS_HOME/basic/scenes"
+mkdir -p "$OBS_HOME/basic/profiles/ADanaLife" "$OBS_HOME/basic/scenes"
 
 # OBS 32 split the legacy global.ini in two: app-level settings stayed in
 # global.ini (BrowserHWAccel etc.) and user-preference settings moved to
@@ -10,15 +10,15 @@ mkdir -p "$OBS_HOME/basic/profiles/Untitled" "$OBS_HOME/basic/scenes"
 # migration.
 cp /opt/obs/config/global.ini "$OBS_HOME/global.ini"
 cp /opt/obs/config/user.ini   "$OBS_HOME/user.ini"
-cp /opt/obs/config/basic.ini  "$OBS_HOME/basic/profiles/Untitled/basic.ini"
+cp /opt/obs/config/basic.ini  "$OBS_HOME/basic/profiles/ADanaLife/basic.ini"
 envsubst < /opt/obs/config/Tripbot.json.tmpl > "$OBS_HOME/basic/scenes/Tripbot.json"
 
-obs_args=(--disable-shutdown-check --collection 'Tripbot' --profile 'Untitled' --scene 'Main')
+obs_args=(--disable-shutdown-check --collection 'Tripbot' --profile 'ADanaLife' --scene 'Main')
 
 if [[ -n "${STREAM_KEY:-}" ]]; then
   echo "STREAM_KEY set; configuring Twitch and starting stream."
   envsubst < /opt/obs/config/service.json.tmpl \
-    > "$OBS_HOME/basic/profiles/Untitled/service.json"
+    > "$OBS_HOME/basic/profiles/ADanaLife/service.json"
   obs_args+=(--startstreaming)
 else
   echo "STREAM_KEY not set; OBS will start idle. VNC into :5902 to inspect."


### PR DESCRIPTION
## Summary

- Renames the seeded OBS profile from `Untitled` → `ADanaLife` so the profile dropdown shows the brand name instead of the placeholder.
- Updates `basic.ini` `Name`, `user.ini` `Profile` + `ProfileDir`, and the four `Untitled` references in `entrypoint.sh` (`mkdir`, `basic.ini` copy target, `--profile` arg, `service.json` write path).

## Test plan

- [ ] `bin/devenv down obs && bin/devenv up obs` brings the container up healthy.
- [ ] OBS UI shows `ADanaLife` in the profile dropdown (VNC :5902).
- [ ] With `STREAM_KEY` set, `service.json` lands at `$OBS_HOME/basic/profiles/ADanaLife/service.json` and stream starts.