### PR TITLE
ci: filter vlc.yml on PRs by VLC-impacting paths

### DIFF
--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -1,6 +1,14 @@
 name: VLC Container
 on:
   pull_request:
+    paths:
+      - 'pkg/vlc-server/**'
+      - 'pkg/vlc-client/**'
+      - 'infra/docker/vlc/**'
+      - 'infra/docker/docker-compose*.yml'
+      - '.github/workflows/vlc.yml'
+      - 'go.mod'
+      - 'go.sum'
   push:
     branches:
       - develop


### PR DESCRIPTION
## Summary

- Adds a `paths:` filter under `pull_request:` so the VLC workflow only fires on PRs that touch:
  - `pkg/vlc-server/**`, `pkg/vlc-client/**`
  - `infra/docker/vlc/**`, `infra/docker/docker-compose*.yml`
  - `.github/workflows/vlc.yml`
  - `go.mod`, `go.sum`
- Push events (develop branch + `v*` tags) intentionally keep firing unconditionally so release builds and post-merge develop are unaffected — mirrors the spirit of obs.yml, which always builds amd64 on push and only filters the slow leg on PRs.

## Test plan

- [ ] PR that only touches Go bot code (no VLC paths) does not trigger this workflow.
- [ ] PR that touches `pkg/vlc-server/` triggers it.
- [ ] Push to develop still triggers it (e.g. squash-merge of an unrelated PR).
- [ ] Tag push (`v*`) still triggers it.