### PR TITLE
server: fix /auth/twitch letting wrong non-empty secrets through

### DIFF
--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -99,7 +99,7 @@ func webhooksTwitchSubscriptionsEventsHandler(w http.ResponseWriter, r *http.Req
 // this endpoint returns private twitch access tokens
 func authTwitchHandler(w http.ResponseWriter, r *http.Request) {
 	secret, ok := r.URL.Query()["auth"]
-	if !ok || !isValidSecret(secret[0]) {
+	if !ok || isInvalidSecret(secret[0]) {
 		http.Error(w, "404 not found", http.StatusNotFound)
 		return
 	}

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -70,13 +70,7 @@ func TestWebhooksTwitchHandlerMissingChallengeReturns404(t *testing.T) {
 	}
 }
 
-// FIXME(security): authTwitchHandler currently lets *wrong* non-empty secrets
-// through with a 200. The check `!ok || !isValidSecret(secret[0])` is broken
-// because isValidSecret returns true when the secret is *invalid*, so the
-// double-negation passes invalid-but-non-empty secrets. This test pins the
-// current (broken) behavior so any fix flips it intentionally; do not treat
-// the 200 here as expected/correct.
-func TestAuthTwitchHandlerInvalidSecretFallsThroughBuggy(t *testing.T) {
+func TestAuthTwitchHandlerInvalidSecretReturns404(t *testing.T) {
 	saved := c.Conf.TripbotHttpAuth
 	defer func() { c.Conf.TripbotHttpAuth = saved }()
 	c.Conf.TripbotHttpAuth = "secret"
@@ -86,8 +80,8 @@ func TestAuthTwitchHandlerInvalidSecretFallsThroughBuggy(t *testing.T) {
 
 	authTwitchHandler(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected current (buggy) 200 fall-through, got %d — auth check may have been fixed; flip this assertion to 404", rec.Code)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,7 +97,8 @@ func Start() {
 	}
 }
 
-// isValidSecret returns true if the given secret matches the configured one
-func isValidSecret(secret string) bool {
+// isInvalidSecret returns true if the given secret is empty or doesn't match
+// the configured one.
+func isInvalidSecret(secret string) bool {
 	return len(secret) < 1 || secret != c.Conf.TripbotHttpAuth
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,28 +6,25 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 )
 
-// isValidSecret is misnamed: it returns TRUE when the secret is *invalid*
-// (empty or mismatched). These tests pin that existing inverted behavior so
-// future renames don't silently flip auth.
-func TestIsValidSecret(t *testing.T) {
+func TestIsInvalidSecret(t *testing.T) {
 	saved := c.Conf.TripbotHttpAuth
 	defer func() { c.Conf.TripbotHttpAuth = saved }()
 	c.Conf.TripbotHttpAuth = "secret-token"
 
 	tests := []struct {
-		name   string
-		input  string
+		name        string
+		input       string
 		wantInvalid bool
 	}{
-		{"empty string is treated as invalid", "", true},
+		{"empty string is invalid", "", true},
 		{"non-matching token is invalid", "wrong", true},
 		{"matching token is valid", "secret-token", false},
 		{"case mismatch is invalid", "Secret-Token", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isValidSecret(tt.input); got != tt.wantInvalid {
-				t.Fatalf("isValidSecret(%q) = %v, want %v", tt.input, got, tt.wantInvalid)
+			if got := isInvalidSecret(tt.input); got != tt.wantInvalid {
+				t.Fatalf("isInvalidSecret(%q) = %v, want %v", tt.input, got, tt.wantInvalid)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`isValidSecret` was misnamed and had inverted semantics — it returned `true` when the secret was *invalid*. The caller compounded the bug:

```go
if !ok || !isValidSecret(secret[0]) {  // !ok || !true == !ok  → false for wrong secret
    http.Error(w, "404 not found", http.StatusNotFound)
}
```

For any non-empty wrong secret, the guard fell through and `/auth/twitch` returned **200 with the JSON-encoded twitch tokens**. Empty / missing `auth=` was correctly 404'd, masking the bug.

## Fix

- Rename `isValidSecret` → `isInvalidSecret` to match what the body actually does (`return len(secret) < 1 || secret != configured`).
- Drop the `!` at the call site: `if !ok || isInvalidSecret(secret[0])`.
- Flip `TestAuthTwitchHandlerInvalidSecretFallsThroughBuggy` (which pinned the bug) → `TestAuthTwitchHandlerInvalidSecretReturns404` and assert 404. Drop the `FIXME(security)` block.
- Rename `TestIsValidSecret` → `TestIsInvalidSecret` and update the doc comment; the `wantInvalid` cases stay as-is since the semantics now match.

## Test plan

- [x] `task test` → `pkg/server` passes locally.
- [ ] CI runs the suite green.
- [ ] Manual: `curl -i 'http://localhost:8080/auth/twitch?auth=wrong'` returns 404 (was 200 + tokens).
- [ ] Manual: `curl -i 'http://localhost:8080/auth/twitch?auth=<correct>'` still returns 200 + tokens.
- [ ] Manual: `curl -i 'http://localhost:8080/auth/twitch'` (no param) still 404s.