### PR TITLE
helpers: lazy-init Twilio so vlc-server doesn't crash without creds

### DIFF
--- a/pkg/helpers/sms.go
+++ b/pkg/helpers/sms.go
@@ -3,15 +3,18 @@ package helpers
 import (
 	"log"
 	"os"
+	"sync"
 
 	"github.com/sfreiberg/gotwilio"
 )
 
-var twilioFromNum, twilioToNum string
-var twilioClient *gotwilio.Twilio
+var (
+	twilioFromNum, twilioToNum string
+	twilioClient               *gotwilio.Twilio
+	twilioOnce                 sync.Once
+)
 
-// set up Twilio (for text messages)
-func init() {
+func initTwilio() {
 	requiredVars := []string{
 		"TWILIO_ACCT_SID",
 		"TWILIO_AUTH_TOKEN",
@@ -19,20 +22,20 @@ func init() {
 		"TWILIO_TO_NUM",
 	}
 	for _, v := range requiredVars {
-		_, ok := os.LookupEnv(v)
-		if !ok {
+		if _, ok := os.LookupEnv(v); !ok {
 			log.Fatalf("You must set %s", v)
 		}
 	}
-	twilioAccountSid := os.Getenv("TWILIO_ACCT_SID")
-	twilioAuthToken := os.Getenv("TWILIO_AUTH_TOKEN")
 	twilioFromNum = os.Getenv("TWILIO_FROM_NUM")
 	twilioToNum = os.Getenv("TWILIO_TO_NUM")
-
-	twilioClient = gotwilio.NewTwilioClient(twilioAccountSid, twilioAuthToken)
+	twilioClient = gotwilio.NewTwilioClient(
+		os.Getenv("TWILIO_ACCT_SID"),
+		os.Getenv("TWILIO_AUTH_TOKEN"),
+	)
 }
 
 // sends an SMS (to myself)
 func SendSMS(message string) {
+	twilioOnce.Do(initTwilio)
 	twilioClient.SendSMS(twilioFromNum, twilioToNum, message, "", "")
 }


### PR DESCRIPTION
## Summary

`helpers/sms.go`'s `init()` calls `log.Fatal` when any `TWILIO_*` env var is missing. That kills any process that imports `pkg/helpers` — including the VLC server, which only uses non-SMS utilities like `FileExists`, `ProjectRoot`, `StateToStateAbbrev`, etc. and has no Twilio business.

## Fix

- Replace `init()` with a `sync.Once`-gated `initTwilio()` invoked at the top of `SendSMS`.
- Env-var validation moves with it; behavior at send time is unchanged (still `log.Fatal`s if creds are absent — the right place for that signal).
- The two existing `helpers.SendSMS(...)` call sites (`pkg/chatbot/commands.go:412`, `pkg/twitch/authentication.go:110`) are unaffected.

## Test plan

- [x] `task test` passes locally (smoke).
- [ ] CI green.
- [ ] Manual: vlc-server starts cleanly in an env without `TWILIO_*` set (this is the primary motivator).
- [ ] Manual: tripbot still sends SMS in a fully-configured env (regression check).