### PR TITLE
obs: install feh so fluxbox can set the (blank) wallpaper silently

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -21,6 +21,7 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
          xvfb \
          x11vnc \
          fluxbox \
+         feh \
          tini \
          gettext-base \
          procps \

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -90,7 +90,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
       | debconf-set-selections \
     && apt-get update && apt-get install -y --no-install-recommends \
-      xvfb x11vnc fluxbox tini gettext-base procps x11-utils \
+      xvfb x11vnc fluxbox feh tini gettext-base procps x11-utils \
       ca-certificates dbus-x11 libgl1-mesa-dri \
       fonts-dejavu-core ttf-mscorefonts-installer \
       # OBS runtime deps (mirrors the build deps with -dev stripped) \


### PR DESCRIPTION
## Summary

Kills the `fbsetbg: I can't find an app to set the wallpaper with...` warning that the OBS container logs on every boot. fluxbox's `fbsetbg` shells out to one of `Esetroot` / `feh` / `hsetroot` / etc.; with none installed it spams the help message and gives up.

We don't render a wallpaper (OBS owns the framebuffer), this is purely log noise. `feh` is the smallest fix that satisfies fbsetbg's lookup, applied to both the amd64 PPA-based image and the arm64 from-source image.

## Test plan

- [ ] CI green on both OBS legs.
- [ ] `bin/devenv up obs` no longer logs the `fbsetbg`/`Esetroot` warning.
- [ ] OBS still comes up healthy and renders to Xvfb.