### PR TITLE
obs: switch the Test scene background to Twitch chat dark

### DIFF
--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -270,7 +270,7 @@
       "push-to-talk": false,
       "push-to-talk-delay": 0,
       "settings": {
-        "color": 4278190080,
+        "color": 4279965720,
         "width": 1920,
         "height": 1080
       },

--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -270,7 +270,7 @@
       "push-to-talk": false,
       "push-to-talk-delay": 0,
       "settings": {
-        "color": 4280163886,
+        "color": 4278190080,
         "width": 1920,
         "height": 1080
       },


### PR DESCRIPTION
## Summary

The shared `Background` color_source was `4280163886` (ABGR `0xFF1E1E2E`, RGB `#2E1E1E` — a muddy reddish-brown). Swap to `4279965720` (ABGR `0xFF1B1818`, RGB `#18181B` — Twitch chat's background dark).

Initial draft of this PR (commit `d542e3e`) used pure black `#000000`; in review we picked Twitch chat dark instead — slightly off-black, on-platform aesthetically, and reads warmer in preview without losing the dashcam-fades-in property on Main.

The `Background` source is referenced by both Main and Test scenes, but in Main it sits beneath the dashcam stream + overlays and isn't visible. The visible change is the Test fallback scene.

## Test plan

- [ ] CI green.
- [ ] `bin/devenv up obs` and switch to the `Test` scene over VNC :5902 — background renders as Twitch-chat dark.
- [ ] Main scene unchanged (overlays/dashcam still cover the canvas).