### PR TITLE
ci: bump actions/checkout from v2 to v4 across remaining workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,7 +12,7 @@ jobs:
     name: golint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golint
         uses: reviewdog/action-golangci-lint@v2.0.3
         with:
@@ -24,7 +24,7 @@ jobs:
     name: errcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v2.0.3
         with:
@@ -35,7 +35,7 @@ jobs:
     name: misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: run-linters
         uses: github/super-linter@v4.5.1
         env:

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

`actions/checkout@v2` is unsupported (it ran on Node 12, which GitHub deprecated). Bumps to `@v4` (current major) in the four workflows still pinned to v2:

- `.github/workflows/codeql-analysis.yml` (1)
- `.github/workflows/linting.yml` (3)
- `.github/workflows/super-linter.yml` (1)
- `.github/workflows/update-pr.yml` (1)

The other six workflows (`release`, `tripbot`, `obs`, `vlc`, `testing`, `auto-tag`) are already on `@v4` from the recent CI sweeps (#381, #382).

## Why this is safe

All six call sites use bare `uses: actions/checkout@v2` (or `update-pr.yml`'s `with: fetch-depth: 0` + `token:` — both unchanged across the major bump). No inputs we use changed semantics between v2, v3, and v4.

## Out of scope

Filed in the same TODO entry but not bumped here (each is its own atomic PR per the action-version-hygiene plan):

- `github/codeql-action/{init,autobuild,analyze}@v1` → `@v3` in `codeql-analysis.yml` (codeql v1 is past-EOL; needs verification that the analyze step still works)
- `reviewdog/action-golangci-lint@v2.0.3` and `github/super-linter@v4.5.1` are also dated but not in the original TODO scope.

The TODO's mention of `bump-and-release.yml` is stale — that file was removed in a prior CI sweep.

## Test plan

- [ ] CI runs the touched workflows green on this PR.