### PR TITLE
ci: bump github/codeql-action from v1 to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -59,4 +59,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

CodeQL Action v1 is past end-of-life (Node 12 runtime, no longer maintained by GitHub). Bumps the three call sites in `.github/workflows/codeql-analysis.yml` to `@v3` (current major):

- `github/codeql-action/init@v1` → `@v3`
- `github/codeql-action/autobuild@v1` → `@v3`
- `github/codeql-action/analyze@v1` → `@v3`

## Why this is safe

The only input we pass is `languages: ${{ matrix.language }}` on `init`; `autobuild` and `analyze` take no inputs in this workflow. None of those have changed across v1→v2→v3. Authentication / permissions / output format are also stable.

## Out of scope (next batches)

Other dated actions found in the audit, deferred per the action-version-hygiene plan (each its own PR):

- `github/super-linter@v4.5.1` → v6/v7 (major bump; v5 and v6 had behavioral changes — needs careful review)
- `reviewdog/action-golangci-lint@v2.0.3` → latest v2.x (patch bump within current major; will conflict with #395's `linting.yml` edits, so wait until that lands)
- `actions/setup-go@v2.1.5` mentioned in the original TODO — confirmed gone, prior CI sweeps already removed it.

## Test plan

- [ ] CI green on this PR.
- [ ] Next CodeQL scheduled run (`cron: 34 22 * * 4`) lands without error after merge.