### PR TITLE
ci: trivially-bumpable action versions across .github/workflows/

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -20,7 +20,7 @@ jobs:
       # downstream workflows, so release.yml wouldn't trigger on the
       # auto-created tag. The PAT inherits the token owner's perms.
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.71.0
+        uses: anothrNick/github-tag-action@1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}
           DEFAULT_BUMP: patch

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golint
-        uses: reviewdog/action-golangci-lint@v2.0.3
+        uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint"
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: errcheck
-        uses: reviewdog/action-golangci-lint@v2.0.3
+        uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@v2.0.3
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint"
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: errcheck
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@v2.0.3
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck"

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -63,11 +63,11 @@ jobs:
     # ubuntu-24.04-arm runners.
     - name: Set up Docker Buildx (amd64)
       if: matrix.arch == 'amd64'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build OBS container (amd64, cached)
       if: matrix.arch == 'amd64'
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: infra/docker/obs/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord notification
-        uses: Ilshidur/action-discord@0.3.2
+        uses: Ilshidur/action-discord@0.4.0
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           VERSION_TAG: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,17 +23,17 @@ jobs:
           lfs: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: adanalife/tripbot
           flavor: |
@@ -45,7 +45,7 @@ jobs:
             type=semver,pattern=v{{major}}
 
       - name: Build & push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: infra/docker/tripbot/Dockerfile
@@ -59,17 +59,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: adanalife/tripbot
           flavor: latest=true
@@ -102,17 +102,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: adanalife/vlc
           flavor: |
@@ -124,7 +124,7 @@ jobs:
             type=semver,pattern=v{{major}}
 
       - name: Build & push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: infra/docker/vlc/Dockerfile
@@ -138,17 +138,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: adanalife/vlc
           flavor: latest=true
@@ -184,10 +184,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -198,7 +198,7 @@ jobs:
       # gets the suffix on per-arch images.
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: adanalife/obs
           flavor: |
@@ -210,7 +210,7 @@ jobs:
             type=semver,pattern=v{{major}}
 
       - name: Build & push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -224,10 +224,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -236,7 +236,7 @@ jobs:
       # T-amd64 + T-arm64 pair into a multi-arch manifest list at T.
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: adanalife/obs
           flavor: latest=true

--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Fetch videos from cache
         id: restore-videos
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: assets/video
           key: ${{ runner.os }}-video-${{ hashFiles('assets/video/manifest.txt') }}
@@ -33,10 +33,10 @@ jobs:
           lfs: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build tripbot image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: infra/docker/tripbot/Dockerfile

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -19,10 +19,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build VLC container 🤖
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: infra/docker/vlc/Dockerfile


### PR DESCRIPTION
## Summary

Sweep of all GitHub Actions still pinned to outdated versions, limited to bumps that are genuinely **trivial** for our usage. Three commits, grouped by reason:

### 1. Infra actions → Node 24 runtimes

Each upstream major bump in this group is just a Node 20 → Node 24 runtime upgrade per the maintainers' release notes. Our inputs/outputs all stay on the stable subset; no behavioral change for our usage. GitHub-hosted runners (`ubuntu-latest`, `ubuntu-24.04*`) are already well past the required Actions Runner v2.327.1.

| Action | From | To | Notes |
|---|---|---|---|
| `actions/cache` | v4 | v5 | Node 24 only |
| `docker/build-push-action` | v5 | v7 | v6 added build-summary (we don't read it); v7 = Node 24 + removed deprecated env vars we don't use |
| `docker/login-action` | v3 | v4 | Node 24 only |
| `docker/metadata-action` | v5 | v6 | Node 24 + minor `#`-in-list-values parsing tweak (we use simple values) |
| `docker/setup-buildx-action` | v3 | v4 | Node 24 + removed deprecated inputs we don't use |
| `dorny/paths-filter` | v3 | v4 | Node 24 only |

### 2. Third-party actions → current

| Action | From | To | Notes |
|---|---|---|---|
| `Ilshidur/action-discord` | 0.3.2 | 0.4.0 | Pre-1.0 minor; we just pass `args:` body text |
| `anothrNick/github-tag-action` | 1.71.0 | 1 | Latest is 1.75.0; switch to floating major tag |

### 3. Reverted: `reviewdog/action-golangci-lint`

Initially bumped `v2.0.3 → v2`, but CI exposed a latent issue: the action's `golangci_lint_version: latest` default now resolves to **golangci-lint v2.12.1**, which renamed `--disable-all` to `--default=none` and removed the deprecated `golint` linter entirely. The old `@v2.0.3` was effectively pinning a v1.x golangci-lint via the action's older defaults, so it kept passing.

Reverting just the reviewdog bump in this PR keeps it surgical. The lint config itself needs a real rewrite (golint → revive, flag syntax update); filed as a follow-up TODO.

## Out of scope

Deferred from this batch — each warrants its own PR:

- **`github/super-linter@v4.5.1` → v7** — three majors behind, with documented behavioral changes (env var renames, default rule changes between v4→v5→v6, and the action moved orgs to `super-linter/super-linter` along the way). Not trivial.
- **`actions/checkout@v2` → @v4** — covered by #395.
- **`github/codeql-action/*@v1` → @v3** — covered by #396.
- **`ankitvgupta/pr-updater@v1.4.0`** — already at latest (last release 2020 — likely abandoned upstream; worth replacing rather than bumping).

## Test plan

- [x] CI green (after the reviewdog revert).
- [ ] Tag-driven `release.yml` exercised on next `v*` tag (this PR doesn't tag, so the docker login/metadata/build-push v6/v7/v4 paths in the release flow remain untested until then).