### PR TITLE
ci: rewrite linting.yml for golangci-lint v2

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,16 +8,23 @@ on:
       - v*
 jobs:
 
-  golint:
-    name: golint
+  revive:
+    name: revive
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: golint
-        uses: reviewdog/action-golangci-lint@v2.0.3
+      - name: revive
+        uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--disable-all -E golint"
+          # Pin golangci_lint_version explicitly: the action's default of
+          # `latest` floats and broke us once already (PR #397) when v2
+          # renamed flags + removed deprecated linters.
+          golangci_lint_version: v2.12.1
+          # golangci-lint v2 dropped golint (deprecated upstream); revive
+          # is its successor. Flag syntax: --disable-all → --default=none,
+          # -E NAME → --enable=NAME.
+          golangci_lint_flags: "--default=none --enable=revive"
           level: warning # GitHub Status Check won't become failure with this level.
 
   errcheck:
@@ -26,10 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: errcheck
-        uses: reviewdog/action-golangci-lint@v2.0.3
+        uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--disable-all -E errcheck"
+          golangci_lint_version: v2.12.1
+          golangci_lint_flags: "--default=none --enable=errcheck"
 
   misspell:
     name: misspell


### PR DESCRIPTION
## Summary

Completes the lint-config rewrite filed as a follow-up TODO from PR #397's reviewdog revert. golangci-lint v2 dropped the deprecated `golint` linter and renamed the `--disable-all` / `-E` flags; this PR migrates `linting.yml` to v2's flag syntax and the documented `revive` successor.

## Changes

| Before | After | Why |
|---|---|---|
| `golint` job → `--disable-all -E golint` | `revive` job → `--default=none --enable=revive` | golint deprecated upstream + removed in golangci-lint v2; revive is the successor |
| `errcheck` job → `--disable-all -E errcheck` | `errcheck` job → `--default=none --enable=errcheck` | flag syntax update only; errcheck still ships in v2 |
| `reviewdog/action-golangci-lint@v2.0.3` | `@v2` | floating major matches convention elsewhere in `.github/workflows/` |
| (no `golangci_lint_version` pin) | `golangci_lint_version: v2.12.1` | the action's default of `latest` was the root cause of #397's break; explicit pin prevents the same time bomb on the next golangci-lint major |

`misspell` is unchanged (different action, no v2 migration needed).

## Job rename

The `golint` job is now called `revive`. If branch protection on `develop` requires the `golint` check to pass, the rule needs updating to require `revive` instead — flagging here so it's not a surprise.

## Test plan

- [ ] CI green — both `revive` and `errcheck` jobs run and surface annotations (or no annotations) instead of erroring on flag parsing.
- [ ] Spot-check one annotation on a PR with a real lint issue (revive should match what the old golint would've flagged for exported-without-comment, etc.).