### PR TITLE
ci: bump super-linter from v4.5.1 to v8.6.0

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -36,3 +36,22 @@ jobs:
           # disabled until we go through and fix the issues
           VALIDATE_JSCPD: false
           VALIDATE_ENV: false
+          # Linters newly enabled by default in super-linter v5+ that
+          # surfaced pre-existing issues. Turning them off here preserves
+          # v4 behavior parity so the version bump is surgical; the
+          # "audit super-linter config" TODO covers actually enabling
+          # the ones we want.
+          VALIDATE_BIOME_FORMAT: false           # JS formatter; we have no JS
+          VALIDATE_CHECKOV: false                # IaC security scanner
+          VALIDATE_GITHUB_ACTIONS: false         # actionlint — real issues to fix later
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false  # action-security scanner
+          VALIDATE_GO_MODULES: false             # paired with VALIDATE_GO
+          VALIDATE_GO_RELEASER: false            # we don't use goreleaser
+          VALIDATE_JSON_PRETTIER: false          # opinionated JSON formatting
+          VALIDATE_MARKDOWN_PRETTIER: false      # opinionated MD formatting
+          VALIDATE_NATURAL_LANGUAGE: false       # textlint prose checker
+          VALIDATE_SHELL_SHFMT: false            # shfmt formatting
+          VALIDATE_SPELL_CODESPELL: false        # spell-check; revisit in audit
+          VALIDATE_SQLFLUFF: false               # SQL formatter
+          VALIDATE_TRIVY: false                  # vuln scanner; needs separate triage
+          VALIDATE_YAML_PRETTIER: false          # opinionated YAML formatting

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: run-linters
-        # Pinned explicitly per the #397 lesson — the action also
-        # moved orgs from github/super-linter in v7.
         uses: super-linter/super-linter@v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,16 +29,13 @@ jobs:
           # audited against hadolint yet.
           VALIDATE_DOCKERFILE_HADOLINT: false
           # disabled cause they dont support CRDs rn
-          # (kubeval was renamed to kubeconform in v5)
           VALIDATE_KUBERNETES_KUBECONFORM: false
           # disabled until we go through and fix the issues
           VALIDATE_JSCPD: false
           VALIDATE_ENV: false
           # Linters newly enabled by default in super-linter v5+ that
           # surfaced pre-existing issues. Turning them off here preserves
-          # v4 behavior parity so the version bump is surgical; the
-          # "audit super-linter config" TODO covers actually enabling
-          # the ones we want.
+          # v4 behavior parity so the version bump is surgical.
           VALIDATE_BIOME_FORMAT: false           # JS formatter; we have no JS
           VALIDATE_CHECKOV: false                # IaC security scanner
           VALIDATE_GITHUB_ACTIONS: false         # actionlint — real issues to fix later

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,16 +15,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: run-linters
-        uses: github/super-linter@v4.5.1
+        # Pinned explicitly per the #397 lesson — the action also
+        # moved orgs from github/super-linter in v7.
+        uses: super-linter/super-linter@v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # disabled because it's not working with C libs
           VALIDATE_GO: false
-          # disabled cause there are lots to change in Dockerfile.nvidia
+          # disabled — none of the in-tree Dockerfiles have been
+          # audited against hadolint yet.
           VALIDATE_DOCKERFILE_HADOLINT: false
           # disabled cause they dont support CRDs rn
-          VALIDATE_KUBERNETES_KUBEVAL: false
+          # (kubeval was renamed to kubeconform in v5)
+          VALIDATE_KUBERNETES_KUBECONFORM: false
           # disabled until we go through and fix the issues
           VALIDATE_JSCPD: false
           VALIDATE_ENV: false
-          VALIDATE_SQL: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,20 +33,18 @@ jobs:
           # disabled until we go through and fix the issues
           VALIDATE_JSCPD: false
           VALIDATE_ENV: false
-          # Linters newly enabled by default in super-linter v5+ that
-          # surfaced pre-existing issues. Turning them off here preserves
-          # v4 behavior parity so the version bump is surgical.
-          VALIDATE_BIOME_FORMAT: false           # JS formatter; we have no JS
-          VALIDATE_CHECKOV: false                # IaC security scanner
-          VALIDATE_GITHUB_ACTIONS: false         # actionlint — real issues to fix later
-          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false  # action-security scanner
-          VALIDATE_GO_MODULES: false             # paired with VALIDATE_GO
-          VALIDATE_GO_RELEASER: false            # we don't use goreleaser
-          VALIDATE_JSON_PRETTIER: false          # opinionated JSON formatting
-          VALIDATE_MARKDOWN_PRETTIER: false      # opinionated MD formatting
-          VALIDATE_NATURAL_LANGUAGE: false       # textlint prose checker
-          VALIDATE_SHELL_SHFMT: false            # shfmt formatting
-          VALIDATE_SPELL_CODESPELL: false        # spell-check; revisit in audit
-          VALIDATE_SQLFLUFF: false               # SQL formatter
-          VALIDATE_TRIVY: false                  # vuln scanner; needs separate triage
-          VALIDATE_YAML_PRETTIER: false          # opinionated YAML formatting
+          # disabled until we can resolve their issues
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_CHECKOV: false
+          VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_GO_MODULES: false
+          VALIDATE_GO_RELEASER: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SHELL_SHFMT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_SQLFLUFF: false
+          VALIDATE_TRIVY: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # fetch-depth: 0 is required by super-linter v6+: it diffs against
+      # the default branch (develop) to figure out which files changed,
+      # which means develop has to be present in the local checkout.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: run-linters
         # Pinned explicitly per the #397 lesson — the action also
         # moved orgs from github/super-linter in v7.


### PR DESCRIPTION
## Summary

Migrates `super-linter.yml` from `github/super-linter@v4.5.1` (2022) to `super-linter/super-linter@v8.6.0` (2026-03).

## Migration mapping

| Before | After | Why |
|---|---|---|
| `github/super-linter@v4.5.1` | `super-linter/super-linter@v8.6.0` | Org rename happened in v7 |
| `VALIDATE_KUBERNETES_KUBEVAL: false` | `VALIDATE_KUBERNETES_KUBECONFORM: false` | kubeval was replaced with kubeconform in v5 |
| `VALIDATE_SQL: false` | _(removed)_ | sql-lint was deleted from the bundle in v7 |
| Dockerfile-Hadolint comment referenced `Dockerfile.nvidia` (deleted) | Reworded to "no Dockerfile has been audited against hadolint yet" | Comment hygiene |

`VALIDATE_GO`, `VALIDATE_DOCKERFILE_HADOLINT`, `VALIDATE_JSCPD`, `VALIDATE_ENV` carry over unchanged.

## v5+ default-enabled linters disabled for behavior parity

v5 through v8 added a wave of new default-enabled linters that surfaced pre-existing issues across the codebase. Disabled here to keep this PR surgical (just the version migration); deciding which to re-enable is a separate audit task.

`BIOME_FORMAT`, `CHECKOV`, `GITHUB_ACTIONS` (actionlint), `GITHUB_ACTIONS_ZIZMOR`, `GO_MODULES`, `GO_RELEASER`, `JSON_PRETTIER`, `MARKDOWN_PRETTIER`, `NATURAL_LANGUAGE`, `SHELL_SHFMT`, `SPELL_CODESPELL`, `SQLFLUFF`, `TRIVY`, `YAML_PRETTIER`.

## Behavioral notes

- **v6 runs linters in parallel** — straight speedup, no config impact.
- **v6 lints the whole workspace on push** instead of changed-files-only. This workflow's `push:` trigger is `branches: [main]`, which we never push to (default is `develop`), so the change is dormant. If/when this triggers on push to develop, expect a fuller lint run.
- **v6 needs `fetch-depth: 0` on `actions/checkout`** to diff against the default branch. Added.
- **v8 added vue support + removed some unmaintained linters.** None we were using.

## Out of scope

- Auditing the disabled-by-default-now linters (e.g. enable actionlint, codespell, hadolint, etc.) — separate follow-up.
- The `branches: [main]` push trigger oddity (super-linter never fires on the actual default branch `develop`). Likely worth either changing to `[develop, main]` or dropping the push trigger entirely.

## Test plan

- [ ] CI green — super-linter starts and finishes without env-var-recognition errors.
- [ ] Spot-check: kubeconform doesn't fail on the k8s manifests (since we explicitly disabled it; if it still complains, the env var name might be wrong).