### PR TITLE
release: Taskfile targets for stage-1 deploy + smoke verification

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,6 +23,9 @@ jobs:
         uses: super-linter/super-linter@v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # don't post a "Super-linter summary" comment on every PR run
+          # (the Actions step summary tab still gets the same content)
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           # disabled because it's not working with C libs
           VALIDATE_GO: false
           # disabled — none of the in-tree Dockerfiles have been

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,3 +36,47 @@ tasks:
     interactive: true
     cmds:
       - ENV=testing bin/devenv run --rm test bash
+
+  # Release smoke flow — see vault/tripbot/release-checklist.md.
+  # Targets the local k3d cluster running the stage-1 overlay
+  # (cloudflared tunnel + apps).
+
+  release:verify-images:
+    desc: Verify multi-arch manifests for a release version (VERSION=v2.0.2 or 2.0.2)
+    requires:
+      vars: [VERSION]
+    vars:
+      # docker/metadata-action strips the leading "v" — Docker tags are
+      # bare semver. Accept either VERSION=v2.0.2 or VERSION=2.0.2.
+      TAG: '{{trimPrefix "v" .VERSION}}'
+    cmds:
+      - docker buildx imagetools inspect adanalife/tripbot:{{.TAG}}
+      - docker buildx imagetools inspect adanalife/vlc:{{.TAG}}
+      - docker buildx imagetools inspect adanalife/obs:{{.TAG}}
+
+  release:smoke:whalecore:
+    desc: Smoke-check tripbot.whalecore.com (requires allowlisted IP). Blocks on failure.
+    cmds:
+      - curl -sfS --max-time 10 https://tripbot.whalecore.com/health/live > /dev/null
+      - 'echo "✓ tripbot.whalecore.com/health/live"'
+
+  release:smoke:local:
+    desc: Smoke-check in-cluster tripbot+vlc-server health via kubectl port-forward.
+    cmds:
+      - bin/release-smoke-local
+
+  release:smoke:stage-1:
+    desc: Deploy stage-1 to local k3d, wait for rollouts, smoke-test public+local.
+    cmds:
+      - task -d {{.HOME}}/adanalife/infra k8s-apply-stage-1
+      - kubectl rollout status deploy/tripbot     --timeout=120s
+      - kubectl rollout status deploy/vlc-server  --timeout=120s
+      - kubectl rollout status deploy/obs         --timeout=120s
+      - kubectl rollout status deploy/cloudflared --timeout=60s
+      - task: release:smoke:local
+      - task: release:smoke:whalecore
+
+  release:smoke:
+    desc: Alias for release:smoke:stage-1
+    cmds:
+      - task: release:smoke:stage-1

--- a/bin/release-smoke-local
+++ b/bin/release-smoke-local
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Smoke-check tripbot + vlc-server health endpoints via kubectl
+# port-forward against the currently-active kube context. Used by
+# `task release:smoke:local`. See vault/tripbot/release-checklist.md.
+set -euo pipefail
+
+TRIPBOT_PORT=18080
+VLC_PORT=18081
+
+kubectl port-forward svc/tripbot     "${TRIPBOT_PORT}:8080" >/dev/null 2>&1 &
+TRIPBOT_PF=$!
+kubectl port-forward svc/vlc-server  "${VLC_PORT}:8080"     >/dev/null 2>&1 &
+VLC_PF=$!
+
+cleanup() {
+  kill "${TRIPBOT_PF}" "${VLC_PF}" 2>/dev/null || true
+  wait "${TRIPBOT_PF}" "${VLC_PF}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# port-forward needs a moment to bind
+for _ in 1 2 3 4 5; do
+  if curl -sfS --max-time 1 "http://localhost:${TRIPBOT_PORT}/health/live" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+curl -sfS --max-time 5 "http://localhost:${TRIPBOT_PORT}/health/live"  >/dev/null
+echo "✓ tripbot/health/live"
+curl -sfS --max-time 5 "http://localhost:${TRIPBOT_PORT}/health/ready" >/dev/null
+echo "✓ tripbot/health/ready"
+curl -sfS --max-time 5 "http://localhost:${VLC_PORT}/health/live"      >/dev/null
+echo "✓ vlc-server/health/live"


### PR DESCRIPTION
## Summary

Adds a `release:*` namespace in `Taskfile.yml` plus a small bash helper
(`bin/release-smoke-local`) so cutting a release can be exercised end to
end with a single command instead of cobbling together kubectl
port-forwards, curls, and remembering hostnames.

## What's in here

- `release:verify-images` — multi-arch manifest checks for tripbot/vlc/obs.
  Accepts `VERSION=v2.0.2` or `VERSION=2.0.2` (Docker tags strip the
  leading `v` that git tags carry; the task uses `trimPrefix` to normalize).
- `release:smoke:whalecore` — public health check via the Cloudflare
  tunnel. Blocks on failure so a tunnel/Access regression fails the smoke.
- `release:smoke:local` — port-forwards `tripbot` + `vlc-server` services
  and hits `/health/{live,ready}`. Bash helper traps `EXIT` to clean up
  port-forwards rather than leak background `kubectl` procs.
- `release:smoke:stage-1` — shells out to `~/adanalife/infra` to run
  `task k8s-apply-stage-1` (single source of truth for the deploy),
  waits for the four rollouts (tripbot, vlc-server, obs, cloudflared),
  then runs both local and whalecore smokes.
- `release:smoke` — alias for `release:smoke:stage-1`.

## Notes

- No prod variant — there's no prod infrastructure yet. When prod stands
  up, mirror `release:smoke:stage-1` for it.
- Manifests in `~/adanalife/infra` pin to `:latest` with
  `imagePullPolicy: IfNotPresent`. Smoke is meaningful on a fresh k3d
  cluster; long-running clusters with cached `:latest` will silently
  test old images. Either bring up a fresh cluster (`task k8s-up`) or
  delete the pods so they re-pull.

## Test plan

- [x] Walked through the full flow against v2.0.2 (PR #401):
  - [x] `task release:verify-images VERSION=v2.0.2` — all three multi-arch manifests resolve
  - [x] `task release:smoke:stage-1` — 4/4 rollouts ready, local + whalecore health both green