### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,7 +8,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,7 +12,7 @@ jobs:
     name: golint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: golint
         uses: reviewdog/action-golangci-lint@v2.0.3
         with:
@@ -24,7 +24,7 @@ jobs:
     name: errcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v2.0.3
         with:
@@ -35,7 +35,7 @@ jobs:
     name: misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Cached buildx path for amd64. arm64 keeps `docker compose build` —
     # the CEF compile dominates wall time and isn't helped meaningfully

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout (with LFS)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
@@ -99,7 +99,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -181,7 +181,7 @@ jobs:
             dockerfile: infra/docker/obs/Dockerfile.arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
       # fetch-depth: 0 is required by super-linter v6+: it diffs against
       # the default branch (develop) to figure out which files changed,
       # which means develop has to be present in the local checkout.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: run-linters

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: arduino/setup-task@v2
       with:
         version: 3.x

--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout (without LFS)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch videos from cache
         id: restore-videos
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-video-
 
       - name: Checkout (with LFS)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: steps.restore-videos.outputs.cache-hit != 'true'
         continue-on-error: true
         with:

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Bumps `actions/checkout` from v4 to v6 across all 10 workflows. v6 is the Node 24 major (no API surface changes vs v4 — release notes verified).

Dependabot stopped tracking this for tripbot some time ago — the open #355 was for v2 → v4, which already landed. This PR brings us up to current latest.

## What's not in here

After auditing every action used in tripbot workflows against its latest GitHub release, `actions/checkout` is the only one behind:

- `actions/cache@v5`, `anothrNick/github-tag-action@1`, `arduino/setup-task@v2`, `docker/build-push-action@v7`, `docker/login-action@v4`, `docker/metadata-action@v6`, `docker/setup-buildx-action@v4`, `dorny/paths-filter@v4`, `github/codeql-action/*@v3`, `reviewdog/action-misspell@v1` — all on floating major tags that auto-cover their latest release.
- `Ilshidur/action-discord@0.4.0`, `super-linter/super-linter@v8.6.0`, `ankitvgupta/pr-updater@v1.4.0` — all already pinned at latest.
- `reviewdog/action-golangci-lint@v2.0.3` — being addressed by #398 (floats to `@v2`).

The other tripbot Dependabot GHA PRs (#352, #355, #356, #357, #364) were closed earlier as already-superseded.

## Files touched

`.github/workflows/auto-tag.yml`, `codeql-analysis.yml`, `linting.yml`, `obs.yml`, `release.yml`, `super-linter.yml`, `testing.yml`, `tripbot.yml`, `update-pr.yml`, `vlc.yml`

## Merge plan

Squash-merge into `develop`.