### PR TITLE
Expose build version on tripbot, vlc-server, and OBS containers

### DIFF
--- a/.github/scripts/verify-stamped-image.sh
+++ b/.github/scripts/verify-stamped-image.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify that a just-pushed release image has the expected version + SHA
+# stamped into /etc/tripbot/{version,sha}. Pulls the image, runs `cat` via
+# --entrypoint (overriding the image's tini/entrypoint.sh), and compares
+# the contents against expected values.
+#
+# Usage: verify-stamped-image.sh <image> <expected-version> <expected-sha>
+#
+# Fails (exit 1) if:
+#   - either file is missing or empty
+#   - either file's contents disagree with the expected values
+#   - the version reads as the literal string "dev" (build-arg not propagated)
+set -euo pipefail
+
+IMAGE="${1:?missing image arg}"
+EXPECTED_VERSION="${2:?missing version arg}"
+EXPECTED_SHA="${3:?missing sha arg}"
+
+GOT_VERSION=$(docker run --rm --entrypoint cat "$IMAGE" /etc/tripbot/version)
+GOT_SHA=$(docker run --rm --entrypoint cat "$IMAGE" /etc/tripbot/sha)
+
+echo "image:    $IMAGE"
+echo "expected: version=$EXPECTED_VERSION sha=$EXPECTED_SHA"
+echo "got:      version=$GOT_VERSION sha=$GOT_SHA"
+
+fail=0
+if [[ "$GOT_VERSION" == "dev" ]]; then
+  echo "::error::release built with VERSION=dev — build-arg not propagated"
+  fail=1
+fi
+if [[ "$GOT_VERSION" != "$EXPECTED_VERSION" ]]; then
+  echo "::error::version mismatch in $IMAGE (got '$GOT_VERSION', want '$EXPECTED_VERSION')"
+  fail=1
+fi
+if [[ "$GOT_SHA" != "$EXPECTED_SHA" ]]; then
+  echo "::error::sha mismatch in $IMAGE (got '$GOT_SHA', want '$EXPECTED_SHA')"
+  fail=1
+fi
+
+if (( fail )); then
+  exit 1
+fi
+
+echo "OK"

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -147,6 +147,20 @@ jobs:
         echo "OBS failed to become healthy" >&2
         exit 1
 
+    - name: Verify version files baked into image
+      run: |
+        cid=$(docker compose \
+          --project-directory . \
+          -f infra/docker/docker-compose.yml \
+          ${{ matrix.arch_compose }} \
+          -f infra/docker/docker-compose.testing.yml \
+          -f infra/docker/docker-compose.github.yml \
+          ps -q obs)
+        docker exec "$cid" test -s /etc/tripbot/version
+        docker exec "$cid" test -s /etc/tripbot/sha
+        echo "version: $(docker exec "$cid" cat /etc/tripbot/version)"
+        echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
+
     - name: Check VLC container logs
       if: always()
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
           file: infra/docker/tripbot/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
@@ -130,6 +132,8 @@ jobs:
           file: infra/docker/vlc/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha,scope=vlc-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
 
@@ -216,6 +220,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha,scope=obs-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=obs-${{ matrix.arch }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,12 @@ jobs:
           cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
+      - name: Verify version stamping
+        run: |
+          IMAGE="adanalife/tripbot:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          .github/scripts/verify-stamped-image.sh "$IMAGE" \
+            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+
   tripbot-manifest:
     needs: tripbot-build
     runs-on: ubuntu-latest
@@ -138,6 +144,12 @@ jobs:
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=vlc-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
+
+      - name: Verify version stamping
+        run: |
+          IMAGE="adanalife/vlc:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          .github/scripts/verify-stamped-image.sh "$IMAGE" \
+            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
 
   vlc-manifest:
     needs: vlc-build
@@ -227,6 +239,12 @@ jobs:
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=obs-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=obs-${{ matrix.arch }}
+
+      - name: Verify version stamping
+        run: |
+          IMAGE="adanalife/obs:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          .github/scripts/verify-stamped-image.sh "$IMAGE" \
+            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
 
   obs-manifest:
     needs: obs-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
+            SHA=${{ github.sha }}
           cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
@@ -134,6 +135,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
+            SHA=${{ github.sha }}
           cache-from: type=gha,scope=vlc-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
 
@@ -222,6 +224,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
+            SHA=${{ github.sha }}
           cache-from: type=gha,scope=obs-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=obs-${{ matrix.arch }}
 

--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -73,6 +73,17 @@ jobs:
       - name: Check running containers
         run: docker ps -a
 
+      - name: Verify version files baked into image
+        run: |
+          docker exec tripbot-tripbot-1 test -s /etc/tripbot/version
+          docker exec tripbot-tripbot-1 test -s /etc/tripbot/sha
+          echo "version: $(docker exec tripbot-tripbot-1 cat /etc/tripbot/version)"
+          echo "sha:     $(docker exec tripbot-tripbot-1 cat /etc/tripbot/sha)"
+
+      - name: Verify /version HTTP endpoint
+        run: |
+          docker exec tripbot-tripbot-1 curl -fsS http://localhost:8080/version
+
       - name: Stop containers
         if: always()
         continue-on-error: true

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -76,6 +76,22 @@ jobs:
     - name: Check VLC current video
       run: curl -v http://localhost:$VLC_PORT/vlc/current
 
+    - name: Verify version files baked into image
+      run: |
+        cid=$(docker compose \
+          --project-directory . \
+          -f infra/docker/docker-compose.yml \
+          -f infra/docker/docker-compose.testing.yml \
+          -f infra/docker/docker-compose.github.yml \
+          ps -q vlc)
+        docker exec "$cid" test -s /etc/tripbot/version
+        docker exec "$cid" test -s /etc/tripbot/sha
+        echo "version: $(docker exec "$cid" cat /etc/tripbot/version)"
+        echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
+
+    - name: Verify /version HTTP endpoint
+      run: curl -fsS http://localhost:$VLC_PORT/version
+
     - name: Check container logs
       run: |
         docker compose \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ devenv down
 ```
 
 
+### Finding the deployed build version
+
+Each release stamps its tag and commit SHA into the published images so you can confirm what's running in stage / prod / locally. Three surfaces, in order of preference:
+
+1. **HTTP `/version`** (tripbot bot, vlc-server) — returns JSON `{tag, sha, built_at, dirty}`.
+   ```bash
+   curl http://<host>:8080/version
+   ```
+2. **`/etc/tripbot/version` and `/etc/tripbot/sha`** (all three containers) — plain-text files baked in at build time. Useful when HTTP isn't reachable, or for the OBS container which has no HTTP server.
+   ```bash
+   docker exec <container> cat /etc/tripbot/version
+   docker exec <container> cat /etc/tripbot/sha
+   ```
+3. **Container startup logs** — each container logs its version on the first line of output (`docker logs <container> | head -1`).
+
+The Go binaries also expose `service.version` via OpenTelemetry, so the same value is queryable in Grafana on any traced span / metric / log.
+
+Manual `docker build` invocations default `VERSION=dev` and `SHA=unknown`; only release-tag builds via `.github/workflows/release.yml` populate the real values.
+
 ### Other Useful Docs
 
 #### Infra

--- a/README.md
+++ b/README.md
@@ -50,25 +50,6 @@ devenv down
 ```
 
 
-### Finding the deployed build version
-
-Each release stamps its tag and commit SHA into the published images so you can confirm what's running in stage / prod / locally. Three surfaces, in order of preference:
-
-1. **HTTP `/version`** (tripbot bot, vlc-server) — returns JSON `{tag, sha, built_at, dirty}`.
-   ```bash
-   curl http://<host>:8080/version
-   ```
-2. **`/etc/tripbot/version` and `/etc/tripbot/sha`** (all three containers) — plain-text files baked in at build time. Useful when HTTP isn't reachable, or for the OBS container which has no HTTP server.
-   ```bash
-   docker exec <container> cat /etc/tripbot/version
-   docker exec <container> cat /etc/tripbot/sha
-   ```
-3. **Container startup logs** — each container logs its version on the first line of output (`docker logs <container> | head -1`).
-
-The Go binaries also expose `service.version` via OpenTelemetry, so the same value is queryable in Grafana on any traced span / metric / log.
-
-Manual `docker build` invocations default `VERSION=dev` and `SHA=unknown`; only release-tag builds via `.github/workflows/release.yml` populate the real values.
-
 ### Other Useful Docs
 
 #### Infra

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -37,10 +37,12 @@ var telemetryShutdown telemetry.ShutdownFunc
 
 // main performs the various steps to get the bot running
 func main() {
+	log.Println(aurora.Cyan(fmt.Sprintf("tripbot version %s", version)))
 	createRandomSeed()
 	listenForShutdown()
 	initializeTelemetry()
 	initializeErrorLogger()
+	server.SetVersion(version)
 	startHttpServer()
 	findInitialVideo()
 	users.InitLeaderboard()

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -27,6 +27,8 @@ var version = "dev"
 var telemetryShutdown telemetry.ShutdownFunc
 
 func main() {
+	log.Println(aurora.Cyan(fmt.Sprintf("vlc-server version %s", version)))
+
 	// we don't yet support libvlc on darwin
 	if helpers.RunningOnDarwin() {
 		log.Fatal("This doesn't yet work on darwin")
@@ -55,6 +57,7 @@ func main() {
 	vlcServer.PlayRandom() // play a random video
 
 	// start the webserver
+	vlcServer.SetVersion(version)
 	vlcServer.Start()
 
 	// listen for termination signals and gracefully shutdown

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -39,6 +39,9 @@ RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh
 
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 
+ARG VERSION=dev
+RUN echo "${VERSION}" > /etc/tripbot-version
+
 EXPOSE 5900
 
 ENV VNC_PASSWD=123456

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -40,7 +40,10 @@ RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 
 ARG VERSION=dev
-RUN echo "${VERSION}" > /etc/tripbot-version
+ARG SHA=unknown
+RUN mkdir -p /etc/tripbot \
+  && echo "${VERSION}" > /etc/tripbot/version \
+  && echo "${SHA}" > /etc/tripbot/sha
 
 EXPOSE 5900
 

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -136,7 +136,10 @@ RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 
 ARG VERSION=dev
-RUN echo "${VERSION}" > /etc/tripbot-version
+ARG SHA=unknown
+RUN mkdir -p /etc/tripbot \
+  && echo "${VERSION}" > /etc/tripbot/version \
+  && echo "${SHA}" > /etc/tripbot/sha
 
 EXPOSE 5900
 

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -135,6 +135,9 @@ RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh
 
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 
+ARG VERSION=dev
+RUN echo "${VERSION}" > /etc/tripbot-version
+
 EXPOSE 5900
 
 ENV VNC_PASSWD=123456

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "OBS container, tripbot version $(cat /etc/tripbot-version 2>/dev/null || echo dev)"
+echo "OBS container, tripbot version $(cat /etc/tripbot/version 2>/dev/null || echo dev) (sha: $(cat /etc/tripbot/sha 2>/dev/null || echo unknown))"
 
 OBS_HOME="${HOME:-/root}/.config/obs-studio"
 mkdir -p "$OBS_HOME/basic/profiles/ADanaLife" "$OBS_HOME/basic/scenes"

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "OBS container, tripbot version $(cat /etc/tripbot-version 2>/dev/null || echo dev)"
+
 OBS_HOME="${HOME:-/root}/.config/obs-studio"
 mkdir -p "$OBS_HOME/basic/profiles/ADanaLife" "$OBS_HOME/basic/scenes"
 

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
+ARG VERSION=dev
+
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/tripbot ./cmd/tripbot
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot
 
 # Runtime: minimal Ubuntu 24.04 matching the VLC/OBS containers
 FROM ubuntu:24.04

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,6 +24,12 @@ RUN apt-get update \
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
+ARG VERSION=dev
+ARG SHA=unknown
+RUN mkdir -p /etc/tripbot \
+  && echo "${VERSION}" > /etc/tripbot/version \
+  && echo "${SHA}" > /etc/tripbot/sha
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -fsS http://localhost:8080/health/live

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -44,8 +44,13 @@ RUN ln -s /go/src/github.com/adanalife/tripbot /opt/tripbot \
   && mkdir -p /opt/data
 
 ARG VERSION=dev
+ARG SHA=unknown
 
 WORKDIR /opt/tripbot
 RUN go build -ldflags="-X main.version=${VERSION}" -o bin/vlc-server cmd/vlc-server/vlc-server.go
+
+RUN mkdir -p /etc/tripbot \
+  && echo "${VERSION}" > /etc/tripbot/version \
+  && echo "${SHA}" > /etc/tripbot/sha
 
 ENTRYPOINT ["/opt/tripbot/script/container_startup.sh"]

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -43,7 +43,9 @@ COPY . .
 RUN ln -s /go/src/github.com/adanalife/tripbot /opt/tripbot \
   && mkdir -p /opt/data
 
+ARG VERSION=dev
+
 WORKDIR /opt/tripbot
-RUN go build -o bin/vlc-server cmd/vlc-server/vlc-server.go
+RUN go build -ldflags="-X main.version=${VERSION}" -o bin/vlc-server cmd/vlc-server/vlc-server.go
 
 ENTRYPOINT ["/opt/tripbot/script/container_startup.sh"]

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/adanalife/tripbot/pkg/chatbot"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -14,10 +16,52 @@ import (
 	"github.com/logrusorgru/aurora"
 )
 
+// versionTag is set by main via SetVersion; overridden at build time
+// through `-ldflags "-X main.version=..."`.
+var versionTag = "dev"
+
+// SetVersion lets cmd/tripbot inject its build-time version string
+// before the HTTP server starts.
+func SetVersion(v string) {
+	if v != "" {
+		versionTag = v
+	}
+}
+
 //TODO: write real healthchecks for ready vs live
 // healthcheck URL, for tools to verify the bot is alive
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "OK")
+}
+
+// versionHandler returns build metadata as JSON. The tag comes from the
+// build-time ldflag; sha + built_at are read from the binary's embedded
+// VCS info (Go's automatic -buildvcs).
+func versionHandler(w http.ResponseWriter, r *http.Request) {
+	resp := struct {
+		Tag      string `json:"tag"`
+		Sha      string `json:"sha"`
+		BuiltAt  string `json:"built_at"`
+		Dirty    bool   `json:"dirty"`
+	}{Tag: versionTag}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				resp.Sha = s.Value
+			case "vcs.time":
+				resp.BuiltAt = s.Value
+			case "vcs.modified":
+				resp.Dirty = s.Value == "true"
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		terrors.Log(err, "couldn't encode version response")
+	}
 }
 
 // twitch issues a request here when creating a new webhook subscription

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,6 +20,37 @@ func TestHealthHandler(t *testing.T) {
 	}
 	if rec.Body.String() != "OK" {
 		t.Fatalf("got body %q, want %q", rec.Body.String(), "OK")
+	}
+}
+
+func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
+	saved := versionTag
+	defer func() { versionTag = saved }()
+	SetVersion("v9.9.9-test")
+
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	rec := httptest.NewRecorder()
+
+	versionHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("got Content-Type %q, want %q", got, "application/json")
+	}
+
+	var body struct {
+		Tag     string `json:"tag"`
+		Sha     string `json:"sha"`
+		BuiltAt string `json:"built_at"`
+		Dirty   bool   `json:"dirty"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("couldn't decode response: %v", err)
+	}
+	if body.Tag != "v9.9.9-test" {
+		t.Fatalf("got tag %q, want %q", body.Tag, "v9.9.9-test")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,6 +33,9 @@ func Start() {
 	hp.HandleFunc("/live", healthHandler)
 	hp.HandleFunc("/ready", healthHandler)
 
+	// version endpoint — returns build metadata as JSON
+	r.HandleFunc("/version", versionHandler).Methods("GET", "HEAD")
+
 	// webhooks endpoints
 	// note that these can be both GET and POST requests
 	wh := r.PathPrefix("/webhooks").Subrouter()

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -1,9 +1,11 @@
 package vlcServer
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -13,9 +15,51 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// versionTag is set by main via SetVersion; overridden at build time
+// through `-ldflags "-X main.version=..."`.
+var versionTag = "dev"
+
+// SetVersion lets cmd/vlc-server inject its build-time version string
+// before the HTTP server starts.
+func SetVersion(v string) {
+	if v != "" {
+		versionTag = v
+	}
+}
+
 // healthcheck URL, for tools to verify the stream is alive
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "OK")
+}
+
+// versionHandler returns build metadata as JSON. The tag comes from the
+// build-time ldflag; sha + built_at are read from the binary's embedded
+// VCS info (Go's automatic -buildvcs).
+func versionHandler(w http.ResponseWriter, r *http.Request) {
+	resp := struct {
+		Tag     string `json:"tag"`
+		Sha     string `json:"sha"`
+		BuiltAt string `json:"built_at"`
+		Dirty   bool   `json:"dirty"`
+	}{Tag: versionTag}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				resp.Sha = s.Value
+			case "vcs.time":
+				resp.BuiltAt = s.Value
+			case "vcs.modified":
+				resp.Dirty = s.Value == "true"
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		terrors.Log(err, "couldn't encode version response")
+	}
 }
 
 func vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/vlc-server/handlers_test.go
+++ b/pkg/vlc-server/handlers_test.go
@@ -1,12 +1,44 @@
 package vlcServer
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gorilla/mux"
 )
+
+func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
+	saved := versionTag
+	defer func() { versionTag = saved }()
+	SetVersion("v9.9.9-test")
+
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	rec := httptest.NewRecorder()
+
+	versionHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("got Content-Type %q, want %q", got, "application/json")
+	}
+
+	var body struct {
+		Tag     string `json:"tag"`
+		Sha     string `json:"sha"`
+		BuiltAt string `json:"built_at"`
+		Dirty   bool   `json:"dirty"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("couldn't decode response: %v", err)
+	}
+	if body.Tag != "v9.9.9-test" {
+		t.Fatalf("got tag %q, want %q", body.Tag, "v9.9.9-test")
+	}
+}
 
 // These tests exercise *parse-error* paths only — the handlers reject bad
 // input before reaching libvlc, so we never touch the real player.

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -34,6 +34,9 @@ func Start() {
 	hp.HandleFunc("/live", healthHandler)
 	hp.HandleFunc("/ready", healthHandler)
 
+	// version endpoint — returns build metadata as JSON
+	r.HandleFunc("/version", versionHandler).Methods("GET", "HEAD")
+
 	// vlc endpoints
 	vlc := r.PathPrefix("/vlc").Methods("GET").Subrouter()
 	vlc.HandleFunc("/current", vlcCurrentHandler)


### PR DESCRIPTION
## Summary

Exposes the deployed build version on all three project containers (tripbot, vlc-server, OBS) and gates releases on the version actually being stamped.

### Surfaces

- **HTTP `GET/HEAD /version`** on tripbot bot and vlc-server, returning JSON `{tag, sha, built_at, dirty}`. Tag comes from a build-time ldflag; sha/built_at/dirty come from `runtime/debug.ReadBuildInfo()` (Go's automatic `-buildvcs`).
- **`/etc/tripbot/version`** and **`/etc/tripbot/sha`** baked into all three images at build time. Same path on every container, so HTTP-less containers (OBS) and HTTP-having containers stay symmetric.
- **Startup log lines** in all three containers — `tripbot version <tag>`, `vlc-server version <tag>`, and OBS's entrypoint echoes the version + SHA.

### Plumbing

- **`Dockerfile` ARGs** plumbed: `ARG VERSION=dev` + `ARG SHA=unknown` on tripbot, vlc, obs (amd64), obs.arm64. Manual `docker build` invocations get `dev`/`unknown`.
- **`release.yml`** passes `VERSION=${{ steps.meta.outputs.version }}` + `SHA=${{ github.sha }}` to all three build-push-action steps.

### CI gates

- **Release**: a new `.github/scripts/verify-stamped-image.sh` runs after each per-arch build/push in `release.yml`. It pulls the just-pushed image, cats `/etc/tripbot/{version,sha}`, and fails the workflow if either file is empty, says `dev`, or disagrees with the expected tag/SHA. The manifest jobs only assemble multi-arch lists if all three per-arch verify steps pass — so a regression that loses the build-args can't ship a tagged release with a `dev` version.
- **PR**: `tripbot.yml` / `vlc.yml` / `obs.yml` each assert `/etc/tripbot/{version,sha}` are non-empty after bring-up, and the Go containers also curl `/version` to confirm the HTTP endpoint is reachable. PR builds use `VERSION=dev` so we can't pin exact values — these checks catch Dockerfile-level regressions (typo'd RUN, missing ARG redeclare in stage, etc.) at PR time.

`/health/{live,ready}` stay bare-`OK` so the existing Docker `HEALTHCHECK` directives and any future k8s probes don't have to parse JSON.

## Test plan

- [x] `go test ./pkg/server/...` — new `TestVersionHandlerReturnsInjectedTag` passes
- [x] `go test ./pkg/vlc-server/...` — new `TestVersionHandlerReturnsInjectedTag` passes
- [ ] CI green on this PR (tripbot.yml, vlc.yml, obs.yml all run their new verify steps against `dev` builds)
- [ ] After merge to develop and a release PR to master cuts a tag, verify the next release publishes images that report the right tag at:
  - `curl http://<tripbot>:8080/version` → `{"tag":"X.Y.Z","sha":"...","built_at":"...","dirty":false}`
  - `curl http://<vlc-server>:8080/version` → same shape
  - `docker exec <container> cat /etc/tripbot/version` (all three) → `X.Y.Z`
  - `docker exec <container> cat /etc/tripbot/sha` (all three) → 40-char SHA
  - `docker logs <container> | head -1` → version-bearing startup line
  - `release.yml`'s "Verify version stamping" step shows `OK` for each of tripbot/vlc/obs
- [ ] Confirm `service.version` in OTel emissions stops being `dev` post-release (Grafana Cloud)