### PR TITLE
release: use bare semver for VERSION build-arg + verify image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           lfs: true
 
+      - name: Resolve bare version
+        id: ver
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -52,16 +56,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
       - name: Verify version stamping
         run: |
-          IMAGE="adanalife/tripbot:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          IMAGE="adanalife/tripbot:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"
           .github/scripts/verify-stamped-image.sh "$IMAGE" \
-            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
 
   tripbot-manifest:
     needs: tripbot-build
@@ -110,6 +114,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve bare version
+        id: ver
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -140,16 +148,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=vlc-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
 
       - name: Verify version stamping
         run: |
-          IMAGE="adanalife/vlc:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          IMAGE="adanalife/vlc:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"
           .github/scripts/verify-stamped-image.sh "$IMAGE" \
-            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
 
   vlc-manifest:
     needs: vlc-build
@@ -201,6 +209,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve bare version
+        id: ver
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -235,16 +247,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=obs-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=obs-${{ matrix.arch }}
 
       - name: Verify version stamping
         run: |
-          IMAGE="adanalife/obs:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          IMAGE="adanalife/obs:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"
           .github/scripts/verify-stamped-image.sh "$IMAGE" \
-            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
 
   obs-manifest:
     needs: obs-build


### PR DESCRIPTION
## Problem

v2.2.0's release run failed all five build legs (every per-arch leg of tripbot/vlc/obs) at the new `Verify version stamping` step from [#419](https://github.com/adanalife/tripbot/pull/419) — and revealed a deeper, sneakier bug.

[`docker/metadata-action`'s](https://github.com/docker/metadata-action) `outputs.version` reflects whatever `flavor:` modifiers were applied. Since each per-arch matrix leg sets `flavor: suffix=-${{ matrix.arch }}`, `outputs.version` is `2.2.0-amd64` / `2.2.0-arm64`, **not** `2.2.0`.

In #419 I used `${{ steps.meta.outputs.version }}` for both the `VERSION=` build-arg and the verify step's image-name construction. Two consequences:

1. **Per-arch images for v2.2.0 shipped with broken version stamping** — `/etc/tripbot/version` reads `2.2.0-amd64` / `2.2.0-arm64`, and the Go binaries' `service.version` ldflag carries the same. Multi-arch manifests were correctly skipped (the verify gate failed first), so `:latest` and `:2.2.0` were not published; the only consumers of the broken images would be anyone explicitly pulling `:2.2.0-amd64` / `:2.2.0-arm64`.
2. **Verify step itself failed at exit 125** — it appended `-${{ matrix.arch }}` to the already-suffixed `outputs.version`, asking docker to pull `adanalife/tripbot:2.2.0-amd64-amd64` (note the doubled suffix), which doesn't exist.

The first consequence is what makes this a real bug — the second is what made it visible.

## Fix

Add a `Resolve bare version` step to each of the three build jobs that exposes `steps.ver.outputs.value = ${GITHUB_REF_NAME#v}` (e.g., `2.2.0` from tag `v2.2.0`). Use that bare value in:

- `build-args: VERSION=...` — so the stamped `service.version` and `/etc/tripbot/version` are clean semver
- `IMAGE="adanalife/...:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"` — so the verify pulls the actual published per-arch tag
- the third arg to `verify-stamped-image.sh` — so the expected version comparison uses the bare semver

The matrix `arch` only goes onto the published per-arch tag, never into the binary's version string.

## Aftermath

- v2.2.0 git tag exists but never produced a usable multi-arch manifest. Once this lands, cut **v2.2.1** (default patch bump) and the next `release.yml` run will publish correct images and update `:latest`.
- The broken `:2.2.0-amd64` / `:2.2.0-arm64` per-arch tags on Docker Hub have no consumers (since `:latest` and `:2.2.0` weren't moved to them) and can be deleted at your convenience.
- The v2.2.0 git tag itself can be left alone or deleted; nothing pins to it.

## Test plan

- [ ] CI green (super-linter, etc. — release.yml itself only fires on `v*` tags)
- [ ] After merging, a v2.2.1 release run hits the `Verify version stamping` step with the corrected logic and passes — the images get the bare semver baked in, manifests assemble, `:latest` moves
- [ ] After deploy, `kubectl exec deploy/tripbot -- cat /etc/tripbot/version` reads `2.2.1` (no arch suffix)
- [ ] In Grafana, `service.version=2.2.1` shows up on tripbot/vlc-server emissions