### PR TITLE
Release v2.2.1: develop → master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           lfs: true
 
+      - name: Resolve bare version
+        id: ver
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -52,16 +56,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
 
       - name: Verify version stamping
         run: |
-          IMAGE="adanalife/tripbot:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          IMAGE="adanalife/tripbot:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"
           .github/scripts/verify-stamped-image.sh "$IMAGE" \
-            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
 
   tripbot-manifest:
     needs: tripbot-build
@@ -110,6 +114,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve bare version
+        id: ver
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -140,16 +148,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=vlc-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
 
       - name: Verify version stamping
         run: |
-          IMAGE="adanalife/vlc:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          IMAGE="adanalife/vlc:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"
           .github/scripts/verify-stamped-image.sh "$IMAGE" \
-            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
 
   vlc-manifest:
     needs: vlc-build
@@ -201,6 +209,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve bare version
+        id: ver
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -235,16 +247,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
           cache-from: type=gha,scope=obs-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=obs-${{ matrix.arch }}
 
       - name: Verify version stamping
         run: |
-          IMAGE="adanalife/obs:${{ steps.meta.outputs.version }}-${{ matrix.arch }}"
+          IMAGE="adanalife/obs:${{ steps.ver.outputs.value }}-${{ matrix.arch }}"
           .github/scripts/verify-stamped-image.sh "$IMAGE" \
-            "${{ steps.meta.outputs.version }}" "${{ github.sha }}"
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
 
   obs-manifest:
     needs: obs-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.2.1] — 2026-05-08
+
+Re-ship of v2.2.0 with corrected version stamping. v2.2.0's `release.yml` run failed at the new `Verify version stamping` gate on every per-arch build leg, so the multi-arch `:2.2.0` and `:latest` manifests were never assembled — only broken per-arch tags reached Docker Hub. v2.2.1 publishes those manifests correctly.
+
+### CI
+
+- **Use bare semver for the `VERSION` build-arg and the verify step's image name.** `docker/metadata-action`'s `outputs.version` reflects the per-arch `flavor: suffix=-${arch}`, so it carried the arch suffix already. Plumbing it as the `VERSION` build-arg stamped binaries with `service.version=2.2.0-amd64` (defeating the v2.2.0 release's clean version-stamping); the verify step then double-applied the arch suffix and tried to pull `:2.2.0-amd64-amd64`, which doesn't exist. New `Resolve bare version` step per build job exposes `${GITHUB_REF_NAME#v}` (e.g., `2.2.0`) for both consumers; the matrix arch only goes onto the published per-arch tag. ([#421])
+
 ## [v2.2.0] — 2026-05-08
 
 Ships first-class build-version exposure across all three containers (HTTP `/version`, `/etc/tripbot/{version,sha}`, startup log lines) and the Go-side of OpenTelemetry instrumentation — `service.version` now reads as the real release tag in Grafana instead of `dev`. Pairs with the infra-side Grafana Cloud OTLP wiring landing separately. Plus a Go toolchain bump.
@@ -178,3 +186,4 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#411]: https://github.com/adanalife/tripbot/pull/411
 [#417]: https://github.com/adanalife/tripbot/pull/417
 [#419]: https://github.com/adanalife/tripbot/pull/419
+[#421]: https://github.com/adanalife/tripbot/pull/421


### PR DESCRIPTION
Re-ship of v2.2.0 with corrected version stamping.

v2.2.0's [release.yml run](https://github.com/adanalife/tripbot/actions/runs/25574729429) failed at the new `Verify version stamping` gate on every per-arch build leg — the verify step tried to pull `adanalife/<image>:2.2.0-${arch}-${arch}` (doubled arch suffix) and got `manifest unknown`. Multi-arch `:2.2.0` and `:latest` were never assembled; only broken per-arch tags (`:2.2.0-amd64`, `:2.2.0-arm64`) reached Docker Hub, and those carried `service.version=2.2.0-amd64` / `-arm64` baked into the binary — the exact opposite of what the v2.2.0 release was supposed to introduce.

`#421` fixes both ends of the bug (build-arg + verify step) by reading the bare semver from `${GITHUB_REF_NAME#v}` instead of `metadata-action`'s arch-suffixed `outputs.version`. v2.2.1 re-runs the build with that fix.

### What's landing

**CI**

- [#421](https://github.com/adanalife/tripbot/pull/421) — `release`: use bare semver for `VERSION` build-arg + verify image name. Each build leg gets a `Resolve bare version` step exposing `${GITHUB_REF_NAME#v}`; both consumers switch to it. Matrix arch is only appended to the published per-arch tag, never into the binary's version string.

Plus the CHANGELOG entry documenting the re-ship.

### Substantive content (unchanged from v2.2.0)

For consumers who never saw v2.2.0's manifests publish, v2.2.1 is effectively the v2.2.0 release. The features promised in v2.2.0's CHANGELOG entry — OpenTelemetry instrumentation ([#411](https://github.com/adanalife/tripbot/pull/411)), build-version surfaces ([#419](https://github.com/adanalife/tripbot/pull/419)), Go 1.26.3 bump ([#417](https://github.com/adanalife/tripbot/pull/417)) — only actually deploy with this release.

### Why patch (v2.2.1, not v2.3.0)

This is a build-pipeline fix re-shipping the same feature content. No new features, no breaking changes. Default patch bump fits.

### Pre-flight

- [x] CHANGELOG.md updated for v2.2.1
- [x] CI on this PR will be green (only release.yml exercises the fix; that fires on tag push, not on this PR)
- [x] Infra-side OTLP wiring already deployed on stage-1 (verified earlier today)

### Release plumbing

- Merging this PR (no `#minor`, default patch) → `auto-tag.yml` bumps to `v2.2.1` → `release.yml` builds + pushes multi-arch images for tripbot, vlc, obs to Docker Hub → `verify-stamped-image.sh` from #419 (now fixed via #421) gates each build leg before manifest assembly.
- Stage-1 redeploy via `kubectl rollout restart deploy/tripbot deploy/vlc-server` to pull the new `:latest`.

### Stale artifacts to clean up post-merge (optional)

- Docker Hub: `adanalife/{tripbot,vlc,obs}:2.2.0-amd64` / `:2.2.0-arm64` — broken per-arch tags from v2.2.0's failed run. No consumers (manifests never updated `:latest` or `:2.2.0` to point at them).
- Git tag `v2.2.0` — exists but never produced a usable image. Could delete; nothing pins to it.