### PR TITLE
docker+version: build vlc-server from package path; drop perpetually-true dirty field

### DIFF
--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -47,7 +47,7 @@ ARG VERSION=dev
 ARG SHA=unknown
 
 WORKDIR /opt/tripbot
-RUN go build -ldflags="-X main.version=${VERSION}" -o bin/vlc-server cmd/vlc-server/vlc-server.go
+RUN go build -ldflags="-X main.version=${VERSION}" -o bin/vlc-server ./cmd/vlc-server
 
 RUN mkdir -p /etc/tripbot \
   && echo "${VERSION}" > /etc/tripbot/version \

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -39,10 +39,9 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 // VCS info (Go's automatic -buildvcs).
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag      string `json:"tag"`
-		Sha      string `json:"sha"`
-		BuiltAt  string `json:"built_at"`
-		Dirty    bool   `json:"dirty"`
+		Tag     string `json:"tag"`
+		Sha     string `json:"sha"`
+		BuiltAt string `json:"built_at"`
 	}{Tag: versionTag}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
@@ -52,8 +51,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 				resp.Sha = s.Value
 			case "vcs.time":
 				resp.BuiltAt = s.Value
-			case "vcs.modified":
-				resp.Dirty = s.Value == "true"
 			}
 		}
 	}

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -44,7 +44,6 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-		Dirty   bool   `json:"dirty"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("couldn't decode response: %v", err)

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -40,7 +40,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-		Dirty   bool   `json:"dirty"`
 	}{Tag: versionTag}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
@@ -50,8 +49,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 				resp.Sha = s.Value
 			case "vcs.time":
 				resp.BuiltAt = s.Value
-			case "vcs.modified":
-				resp.Dirty = s.Value == "true"
 			}
 		}
 	}

--- a/pkg/vlc-server/handlers_test.go
+++ b/pkg/vlc-server/handlers_test.go
@@ -30,7 +30,6 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-		Dirty   bool   `json:"dirty"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("couldn't decode response: %v", err)


### PR DESCRIPTION
Two cosmetic-but-correctness-bearing follow-ups from the v2.2.1 stage-1 verification:

## 1. Build vlc-server from the package path so `-buildvcs` embeds VCS info

The vlc Dockerfile's `go build` invocation pointed at a single file (`cmd/vlc-server/vlc-server.go`). Go's automatic `-buildvcs` only embeds VCS info (`vcs.revision`, `vcs.time`, `vcs.modified`) when the main package is built via its **directory** path, not via a single-file path. So `runtime/debug.ReadBuildInfo()` returned no VCS settings, and vlc-server's `/version` JSON shipped with empty `sha` and `built_at`:

```bash
$ kubectl exec deploy/vlc-server -- curl -s http://localhost:8080/version
{"tag":"2.2.1","sha":"","built_at":"","dirty":false}
```

Tripbot's binary builds via `./cmd/tripbot` and returned the expected values. One-line fix changes `cmd/vlc-server/vlc-server.go` → `./cmd/vlc-server`.

`/etc/tripbot/sha` was unaffected because that's plumbed via the `SHA` build-arg, not BuildInfo.

## 2. Drop the `dirty` field from `/version`

`runtime/debug.ReadBuildInfo()`'s `vcs.modified` read `true` even on a build of the clean tagged v2.2.1 commit. v2.2.1's tag points at a clean master commit, so the field shouldn't have been `true` — but tripbot's `/version` shipped to stage with `"dirty": true`.

Most likely cause is `actions/checkout@v6` with `lfs: true` materializing tracked files differently from what HEAD references (LFS pointers vs. actual content), but I want to root-cause that before claiming to know. Until then a perpetually-`true` `dirty` field is worse than no field at all — readers learn to distrust it.

Drop the field from both handlers + the matching test expectation structs. Tracked as a follow-up to investigate the root cause and restore.

## Test plan

- [x] `go test -run Version ./pkg/server/... ./pkg/vlc-server/...` passes
- [ ] CI green
- [ ] After next release deploys, `kubectl exec deploy/vlc-server -- curl -s http://localhost:8080/version` returns populated `sha` and `built_at`
- [ ] No `dirty` key in either Go service's response