### PR TITLE
Release v2.2.2: develop → master

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -15,6 +15,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}
       - name: Automatic Update
-        uses: ankitvgupta/pr-updater@v1.4.0
+        uses: ankitvgupta/pr-updater@v1.4.1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.2.2] — 2026-05-08
+
+Stage-1 verification of v2.2.1 surfaced two cosmetic-but-correctness-bearing follow-ups; this release picks them up.
+
+### Observability
+
+- **`vlc-server`'s `/version` now populates `sha` and `built_at`.** The vlc Dockerfile was building from a single-file path (`cmd/vlc-server/vlc-server.go`), which bypasses Go's automatic `-buildvcs` VCS metadata embedding. Switched to the package path (`./cmd/vlc-server`) — same form `tripbot` was already using. `/etc/tripbot/sha` is unaffected (that's plumbed via the `SHA` build-arg). ([#423])
+- **`/version` no longer returns a `dirty` field.** `runtime/debug.ReadBuildInfo()`'s `vcs.modified` read `true` even on a build of the clean tagged v2.2.1 commit (likely an `actions/checkout@v6` LFS-materialization artifact). Until the root cause is understood, a perpetually-true `dirty` field is misleading; remove from the JSON shape on both Go services. Restoring is tracked as a follow-up. ([#423])
+
+### CI
+
+- **`ankitvgupta/pr-updater` bumped 1.4.0 → 1.4.1.** Dependabot. ([#415])
+
 ## [v2.2.1] — 2026-05-08
 
 Re-ship of v2.2.0 with corrected version stamping. v2.2.0's `release.yml` run failed at the new `Verify version stamping` gate on every per-arch build leg, so the multi-arch `:2.2.0` and `:latest` manifests were never assembled — only broken per-arch tags reached Docker Hub. v2.2.1 publishes those manifests correctly.
@@ -187,3 +200,5 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#417]: https://github.com/adanalife/tripbot/pull/417
 [#419]: https://github.com/adanalife/tripbot/pull/419
 [#421]: https://github.com/adanalife/tripbot/pull/421
+[#415]: https://github.com/adanalife/tripbot/pull/415
+[#423]: https://github.com/adanalife/tripbot/pull/423

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -47,7 +47,7 @@ ARG VERSION=dev
 ARG SHA=unknown
 
 WORKDIR /opt/tripbot
-RUN go build -ldflags="-X main.version=${VERSION}" -o bin/vlc-server cmd/vlc-server/vlc-server.go
+RUN go build -ldflags="-X main.version=${VERSION}" -o bin/vlc-server ./cmd/vlc-server
 
 RUN mkdir -p /etc/tripbot \
   && echo "${VERSION}" > /etc/tripbot/version \

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -39,10 +39,9 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 // VCS info (Go's automatic -buildvcs).
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag      string `json:"tag"`
-		Sha      string `json:"sha"`
-		BuiltAt  string `json:"built_at"`
-		Dirty    bool   `json:"dirty"`
+		Tag     string `json:"tag"`
+		Sha     string `json:"sha"`
+		BuiltAt string `json:"built_at"`
 	}{Tag: versionTag}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
@@ -52,8 +51,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 				resp.Sha = s.Value
 			case "vcs.time":
 				resp.BuiltAt = s.Value
-			case "vcs.modified":
-				resp.Dirty = s.Value == "true"
 			}
 		}
 	}

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -44,7 +44,6 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-		Dirty   bool   `json:"dirty"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("couldn't decode response: %v", err)

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -40,7 +40,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-		Dirty   bool   `json:"dirty"`
 	}{Tag: versionTag}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
@@ -50,8 +49,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 				resp.Sha = s.Value
 			case "vcs.time":
 				resp.BuiltAt = s.Value
-			case "vcs.modified":
-				resp.Dirty = s.Value == "true"
 			}
 		}
 	}

--- a/pkg/vlc-server/handlers_test.go
+++ b/pkg/vlc-server/handlers_test.go
@@ -30,7 +30,6 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-		Dirty   bool   `json:"dirty"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("couldn't decode response: %v", err)


### PR DESCRIPTION
Patch release. Two cosmetic-but-correctness-bearing cleanups from v2.2.1's stage-1 verification, plus one dependabot bump.

### What's landing

**Observability**

- [#423](https://github.com/adanalife/tripbot/pull/423) — `docker+version`: build vlc-server from the package path so `runtime/debug.ReadBuildInfo()` populates `vcs.revision` / `vcs.time`; drop the perpetually-true `dirty` field from the `/version` JSON shape pending root-cause of the LFS-checkout interaction. After this lands, `vlc-server`'s `/version` will report `sha` and `built_at` like `tripbot` already does.

**CI**

- [#415](https://github.com/adanalife/tripbot/pull/415) — `build(deps)`: bump `ankitvgupta/pr-updater` 1.4.0 → 1.4.1.

### Why patch (v2.2.2)

No functional change for operators. Default patch bump fits — no `#minor` needed.

### Pre-flight

- [x] CHANGELOG.md updated for v2.2.2 (committed direct to develop, in this PR's diff)
- [x] Infra-side companion ([adanalife/infra#411](https://github.com/adanalife/infra/pull/411), `imagePullPolicy: Always`) merged. Apply via `task k8s-apply-stage-1` before the post-release rollout restart, so the next pull from the registry is guaranteed instead of cached.

### Release plumbing

- Merging this PR (no `#minor`, default patch) → `auto-tag.yml` → `v2.2.2` → `release.yml` builds + pushes multi-arch images for tripbot, vlc, obs to Docker Hub → `verify-stamped-image.sh` gates each build leg.
- After build green: `task k8s-apply-stage-1` (so Always takes effect on the deployment spec), then `kubectl rollout restart deploy/tripbot deploy/vlc-server` to pull the new `:latest`. With Always, no manual cache eviction required.

### Stale artifacts (still optional)

- Docker Hub broken per-arch tags from v2.2.0: `:2.2.0-amd64`, `:2.2.0-arm64` for tripbot/vlc/obs. No consumers.
- Git tag `v2.2.0`. Never produced a usable image.