### PR TITLE
telemetry: emit Go runtime metrics through OTLP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/prometheus/procfs v0.20.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,8 @@ go.opentelemetry.io/contrib/bridges/otelslog v0.18.0 h1:hhPGP3zvvy1xWT9RTy970wln
 go.opentelemetry.io/contrib/bridges/otelslog v0.18.0/go.mod h1:twJF7inoMza6kxMcF8JOdL3mPmtOZu7GEr34CUNE6Dg=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8VOmDefoh0+ztfGaymYbhdB/tT3zs79QaZTNGY=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0/go.mod h1:BuhAPThV8PBHBvg8ZzZ/Ok3idOdhWIodywz2xEcRbJo=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 h1:jhVIQEprwUTV+KfzzliLidclhoTOoHTgdz96kAyR8mU=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0/go.mod h1:4HsdbLUbernaTnA8CNaNE+1g026SciXb3juRYe3l8EY=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 h1:HIBTQ3VO5aupLKjC90JgMqpezVXwFuq6Ryjn0/izoag=

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -17,8 +17,10 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
+	otelruntime "go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -86,6 +88,10 @@ func Init(ctx context.Context, serviceName, serviceVersion string) (ShutdownFunc
 		sdkmetric.WithResource(res),
 	)
 	otel.SetMeterProvider(mp)
+
+	if err := otelruntime.Start(otelruntime.WithMinimumReadMemStatsInterval(15 * time.Second)); err != nil {
+		return noopShutdown, fmt.Errorf("runtime instrumentation: %w", err)
+	}
 
 	logExp, err := otlploghttp.New(ctx)
 	if err != nil {
@@ -161,6 +167,9 @@ func initPromOnlyMeter(ctx context.Context, name, version string) error {
 		sdkmetric.WithResource(res),
 	)
 	otel.SetMeterProvider(mp)
+	if err := otelruntime.Start(otelruntime.WithMinimumReadMemStatsInterval(15 * time.Second)); err != nil {
+		return fmt.Errorf("runtime instrumentation: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Wire `go.opentelemetry.io/contrib/instrumentation/runtime` into both `pkg/telemetry/Init` paths so Go runtime stats (`process.runtime.go.goroutines`, `process.runtime.go.gc.*`, `process.runtime.go.mem.heap.*`, etc.) flow through the OTel meter to Grafana Cloud.
- Previously the Go runtime collectors lived in Prometheus's default registry — served on `/metrics` for scrape but never reaching OTLP — so the Go-runtime dashboard shipped in [infra#414](https://github.com/adanalife/infra/pull/414) was a placeholder.

## Why

After [#411](https://github.com/adanalife/tripbot/pull/411) wired OTLP, the Grafana Cloud dashboards started populating but Go runtime panels stayed empty. Adding `runtime.Start()` after the global `MeterProvider` is set registers an OTel-meter-backed runtime instrumentation that emits the standard `process.runtime.go.*` series via OTLP. Includes the prom-only branch too, so local dev's `/metrics` also exposes them.

## Follow-up

After this lands and metrics are visible in Grafana Cloud Explore, replace the placeholder dashboard at `infra/terraform/stage-1/grafana-dashboards/go-runtime.json` with a real one built against the new metric names — separate infra-side PR.

## Test plan

- [ ] `mise exec -- go test ./pkg/telemetry/...` passes locally
- [ ] After deploy, `process.runtime.go.goroutines` queryable in Grafana Cloud Explore against the Mimir datasource
- [ ] `/metrics` endpoint on local dev still serves; new `process_runtime_*` (or equivalent) families appear there too