### PR TITLE
telemetry: set http.route attribute per registered route

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,8 @@ import (
 	"github.com/unrolled/secure"
 	"github.com/urfave/negroni"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var server *http.Server
@@ -30,32 +32,32 @@ func Start() {
 
 	// healthcheck endpoints
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.HandleFunc("/live", healthHandler)
-	hp.HandleFunc("/ready", healthHandler)
+	hp.Handle("/live", tagged("/health/live", healthHandler))
+	hp.Handle("/ready", tagged("/health/ready", healthHandler))
 
 	// version endpoint — returns build metadata as JSON
-	r.HandleFunc("/version", versionHandler).Methods("GET", "HEAD")
+	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")
 
 	// webhooks endpoints
 	// note that these can be both GET and POST requests
 	wh := r.PathPrefix("/webhooks").Subrouter()
-	wh.HandleFunc("/twitch", webhooksTwitchHandler).Methods("GET")
-	wh.HandleFunc("/twitch/users/follows", webhooksTwitchUsersFollowsHandler).Methods("POST")
-	wh.HandleFunc("/twitch/subscriptions/events", webhooksTwitchSubscriptionsEventsHandler).Methods("POST")
+	wh.Handle("/twitch", tagged("/webhooks/twitch", webhooksTwitchHandler)).Methods("GET")
+	wh.Handle("/twitch/users/follows", tagged("/webhooks/twitch/users/follows", webhooksTwitchUsersFollowsHandler)).Methods("POST")
+	wh.Handle("/twitch/subscriptions/events", tagged("/webhooks/twitch/subscriptions/events", webhooksTwitchSubscriptionsEventsHandler)).Methods("POST")
 
 	// auth endpoints
 	auth := r.PathPrefix("/auth").Methods("GET").Subrouter()
-	auth.HandleFunc("/twitch", authTwitchHandler)
-	auth.HandleFunc("/callback", authCallbackHandler)
+	auth.Handle("/twitch", tagged("/auth/twitch", authTwitchHandler))
+	auth.Handle("/callback", tagged("/auth/callback", authCallbackHandler))
 
 	// static assets
-	r.HandleFunc("/favicon.ico", faviconHandler).Methods("GET")
+	r.Handle("/favicon.ico", tagged("/favicon.ico", faviconHandler)).Methods("GET")
 
 	// prometheus metrics endpoint
-	r.Path("/metrics").Handler(promhttp.Handler())
+	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
 	// catch everything else
-	r.HandleFunc("/", catchAllHandler)
+	r.Handle("/", tagged("/", catchAllHandler))
 
 	if c.Conf.Verbose {
 		helpers.PrintAllRoutes(r)
@@ -105,4 +107,20 @@ func Start() {
 // the configured one.
 func isInvalidSecret(secret string) bool {
 	return len(secret) < 1 || secret != c.Conf.TripbotHttpAuth
+}
+
+// tagged wraps a HandlerFunc so the http.route attribute is set on metrics
+// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
+// surface the underlying mux route template to the otelhttp middleware, so
+// each registration declares it.
+func tagged(route string, h http.HandlerFunc) http.Handler {
+	attr := semconv.HTTPRoute(route)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
+			labeler.Add(attr)
+		}
+		trace.SpanFromContext(ctx).SetAttributes(attr)
+		h(w, req)
+	})
 }

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -19,6 +19,8 @@ import (
 	"github.com/unrolled/secure"
 	"github.com/urfave/negroni"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Start starts the web server
@@ -30,46 +32,46 @@ func Start() {
 	// healthcheck endpoints
 	//TODO: handle HEAD requests here too
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.HandleFunc("/", healthHandler)
-	hp.HandleFunc("/live", healthHandler)
-	hp.HandleFunc("/ready", healthHandler)
+	hp.Handle("/", tagged("/health/", healthHandler))
+	hp.Handle("/live", tagged("/health/live", healthHandler))
+	hp.Handle("/ready", tagged("/health/ready", healthHandler))
 
 	// version endpoint — returns build metadata as JSON
-	r.HandleFunc("/version", versionHandler).Methods("GET", "HEAD")
+	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")
 
 	// vlc endpoints
 	vlc := r.PathPrefix("/vlc").Methods("GET").Subrouter()
-	vlc.HandleFunc("/current", vlcCurrentHandler)
-	vlc.HandleFunc("/play/{video}", vlcPlayHandler)
-	vlc.HandleFunc("/random", vlcRandomHandler)
-	vlc.HandleFunc("/back", vlcBackHandler)
-	vlc.HandleFunc("/back/{n}", vlcBackHandler)
-	vlc.HandleFunc("/skip", vlcSkipHandler)
-	vlc.HandleFunc("/skip/{n}", vlcSkipHandler)
+	vlc.Handle("/current", tagged("/vlc/current", vlcCurrentHandler))
+	vlc.Handle("/play/{video}", tagged("/vlc/play/{video}", vlcPlayHandler))
+	vlc.Handle("/random", tagged("/vlc/random", vlcRandomHandler))
+	vlc.Handle("/back", tagged("/vlc/back", vlcBackHandler))
+	vlc.Handle("/back/{n}", tagged("/vlc/back/{n}", vlcBackHandler))
+	vlc.Handle("/skip", tagged("/vlc/skip", vlcSkipHandler))
+	vlc.Handle("/skip/{n}", tagged("/vlc/skip/{n}", vlcSkipHandler))
 
 	// onscreen endpoints
 	osc := r.PathPrefix("/onscreens").Methods("GET").Subrouter()
 	//TODO: add state variable
-	osc.HandleFunc("/flag/{action}", onscreensFlagHandler)
-	osc.HandleFunc("/gps/{action}", onscreensGpsHandler)
-	osc.HandleFunc("/leaderboard/{action}", onscreensLeaderboardHandler)
-	osc.HandleFunc("/middle/{action}", onscreensMiddleHandler)
-	osc.HandleFunc("/timewarp/{action}", onscreensTimewarpHandler)
+	osc.Handle("/flag/{action}", tagged("/onscreens/flag/{action}", onscreensFlagHandler))
+	osc.Handle("/gps/{action}", tagged("/onscreens/gps/{action}", onscreensGpsHandler))
+	osc.Handle("/leaderboard/{action}", tagged("/onscreens/leaderboard/{action}", onscreensLeaderboardHandler))
+	osc.Handle("/middle/{action}", tagged("/onscreens/middle/{action}", onscreensMiddleHandler))
+	osc.Handle("/timewarp/{action}", tagged("/onscreens/timewarp/{action}", onscreensTimewarpHandler))
 	// browser-source feeds: state JSON, per-onscreen HTML pages, and image assets.
 	// These back the OBS browser_source entries in Tripbot.json.tmpl after the
 	// vlc<->obs file-share decoupling.
-	osc.HandleFunc("/state.json", onscreensStateHandler)
-	osc.HandleFunc("/render/{name}", onscreensRenderHandler)
-	osc.HandleFunc("/asset/{name}", onscreensAssetHandler)
+	osc.Handle("/state.json", tagged("/onscreens/state.json", onscreensStateHandler))
+	osc.Handle("/render/{name}", tagged("/onscreens/render/{name}", onscreensRenderHandler))
+	osc.Handle("/asset/{name}", tagged("/onscreens/asset/{name}", onscreensAssetHandler))
 
 	// prometheus metrics endpoint
-	r.Path("/metrics").Handler(promhttp.Handler())
+	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
 	// static assets
-	r.HandleFunc("/favicon.ico", faviconHandler).Methods("GET")
+	r.Handle("/favicon.ico", tagged("/favicon.ico", faviconHandler)).Methods("GET")
 
 	// catch everything else
-	r.HandleFunc("/", catchAllHandler)
+	r.Handle("/", tagged("/", catchAllHandler))
 
 	if c.Conf.Verbose {
 		helpers.PrintAllRoutes(r)
@@ -117,4 +119,20 @@ func Start() {
 	if err := srv.ListenAndServe(); err != nil {
 		terrors.Fatal(err, "couldn't start server")
 	}
+}
+
+// tagged wraps a HandlerFunc so the http.route attribute is set on metrics
+// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
+// surface the underlying mux route template to the otelhttp middleware, so
+// each registration declares it.
+func tagged(route string, h http.HandlerFunc) http.Handler {
+	attr := semconv.HTTPRoute(route)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
+			labeler.Add(attr)
+		}
+		trace.SpanFromContext(ctx).SetAttributes(attr)
+		h(w, req)
+	})
 }


### PR DESCRIPTION
## Summary

- Set `http.route` on metrics (via `otelhttp.Labeler`) and traces (via the active span) for every route in `pkg/server` and `pkg/vlc-server`.
- Adds a small `tagged(route, h)` helper per server that handles both registrations.
- Path templates use mux's `{var}` syntax (e.g. `/vlc/play/{video}`) so cardinality stays bounded.

## Why

`otelhttp.NewHandler` wraps the whole negroni stack, but negroni doesn't surface the underlying mux route template to the middleware — so `http_route` was empty on every metric/trace and route-level breakdowns in Grafana collapsed to one row. After this lands, the HTTP Routes Explorer dashboard shipped in [infra#414](https://github.com/adanalife/infra/pull/414) can switch its grouping back from `http_request_method` to `http_route` for proper per-endpoint breakdowns.

## Note on `WithRouteTag`

The previous TODO referenced `otelhttp.WithRouteTag`, but that function is no longer exported in the current `otelhttp` (v0.68.0). The modern replacement is the `Labeler`/span-attribute pattern this PR uses — same `http.route` semantic convention, just set inside the handler chain rather than via a wrapper.

## Test plan

- [x] `mise exec -- go build ./pkg/server/... ./pkg/vlc-server/...` passes
- [x] `mise exec -- go vet ./pkg/server/...` clean
- [ ] After deploy, query `http_server_request_duration_seconds_count` in Grafana Cloud Explore — `http_route` label should be non-empty and show distinct values per endpoint
- [ ] HTTP Routes Explorer dashboard groups by `http_route` shows multiple rows