### PR TITLE
telemetry: span per inbound chat message + per cron tick

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -26,7 +26,25 @@ import (
 	"github.com/gempir/go-twitch-irc/v2"
 	"github.com/getsentry/sentry-go"
 	"github.com/logrusorgru/aurora"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
+
+var cronTracer = otel.Tracer("github.com/adanalife/tripbot/cmd/tripbot/cron")
+
+// tracedJob wraps a cron callback in a span so each tick shows up as its
+// own trace. Slow or failing jobs become visible in Grafana traces without
+// having to thread context through the underlying functions (the cron
+// library only accepts func()).
+func tracedJob(name string, fn func()) func() {
+	return func() {
+		_, span := cronTracer.Start(context.Background(), "cron."+name,
+			trace.WithAttributes(attribute.String("cron.job", name)))
+		defer span.End()
+		fn()
+	}
+}
 
 // version is overridable at build time via -ldflags "-X main.version=...".
 var version = "dev"
@@ -190,17 +208,17 @@ func scheduleBackgroundJobs() {
 	var err error
 
 	// schedule these functions
-	err = background.Cron.AddFunc("@every 60s", video.GetCurrentlyPlaying)
-	err = background.Cron.AddFunc("@every 61s", users.UpdateSession)
-	err = background.Cron.AddFunc("@every 62s", users.UpdateLeaderboard)
-	err = background.Cron.AddFunc("@every 5m", onscreensClient.ShowGuessLeaderboard)
-	err = background.Cron.AddFunc("@every 5m", users.PrintCurrentSession)
-	err = background.Cron.AddFunc("@every 5m", mytwitch.GetSubscribers)
-	err = background.Cron.AddFunc("@every 1h", mytwitch.RefreshUserAccessToken)
-	err = background.Cron.AddFunc("@every 2h57m30s", chatbot.Chatter)
-	err = background.Cron.AddFunc("@every 12h", mytwitch.UpdateWebhookSubscriptions)
+	err = background.Cron.AddFunc("@every 60s", tracedJob("video.GetCurrentlyPlaying", video.GetCurrentlyPlaying))
+	err = background.Cron.AddFunc("@every 61s", tracedJob("users.UpdateSession", users.UpdateSession))
+	err = background.Cron.AddFunc("@every 62s", tracedJob("users.UpdateLeaderboard", users.UpdateLeaderboard))
+	err = background.Cron.AddFunc("@every 5m", tracedJob("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
+	err = background.Cron.AddFunc("@every 5m", tracedJob("users.PrintCurrentSession", users.PrintCurrentSession))
+	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetSubscribers", mytwitch.GetSubscribers))
+	err = background.Cron.AddFunc("@every 1h", tracedJob("twitch.RefreshUserAccessToken", mytwitch.RefreshUserAccessToken))
+	err = background.Cron.AddFunc("@every 2h57m30s", tracedJob("chatbot.Chatter", chatbot.Chatter))
+	err = background.Cron.AddFunc("@every 12h", tracedJob("twitch.UpdateWebhookSubscriptions", mytwitch.UpdateWebhookSubscriptions))
 	if !helpers.RunningOnWindows() {
-		err = background.Cron.AddFunc("@every 12h", mytwitch.SetStreamTags)
+		err = background.Cron.AddFunc("@every 12h", tracedJob("twitch.SetStreamTags", mytwitch.SetStreamTags))
 	}
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/urfave/negroni v1.0.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
@@ -41,6 +42,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	googlemaps.github.io/maps v1.3.2
 )
 
@@ -73,9 +75,7 @@ require (
 	github.com/prometheus/procfs v0.20.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -11,13 +12,18 @@ import (
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/gempir/go-twitch-irc/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
+
+var tracer = otel.Tracer("github.com/adanalife/tripbot/pkg/chatbot")
 
 func incChatCommandCounter(command string) {
 	instrumentation.ChatCommands.Inc(command)
 }
 
-func runCommand(user *users.User, message string) {
+func runCommand(ctx context.Context, user *users.User, message string) {
 	var err error
 	var params []string
 
@@ -43,6 +49,13 @@ func runCommand(user *users.User, message string) {
 		command = command + params[0]
 		// remove the first element from the params
 		params = params[1:]
+	}
+
+	// Tag the active span with the parsed command. Bare-word triggers
+	// (e.g. "hello") aren't included to keep the attribute's cardinality
+	// bounded to the bot's actual command surface (and typos thereof).
+	if strings.HasPrefix(command, "!") {
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String("twitch.command", command))
 	}
 
 	switch command {
@@ -205,6 +218,10 @@ func runCommand(user *users.User, message string) {
 func PrivateMessage(msg twitch.PrivateMessage) {
 	username := msg.User.Name
 
+	ctx, span := tracer.Start(context.Background(), "chatbot.handle_message",
+		trace.WithAttributes(attribute.String("twitch.user", username)))
+	defer span.End()
+
 	// increment the Prometheus counter
 	instrumentation.ChatMessages.Inc()
 
@@ -219,7 +236,7 @@ func PrivateMessage(msg twitch.PrivateMessage) {
 	// log in the user
 	user := users.LoginIfNecessary(username)
 
-	runCommand(user, message)
+	runCommand(ctx, user, message)
 }
 
 // this event fires when a user joins the channel


### PR DESCRIPTION
## Summary

Two more high-payoff additions toward "Expand OTel trace coverage" — items #1 (Twitch IRC) and #2 (cron jobs) from the ranked list.

- **`pkg/chatbot/handlers.go`** — `PrivateMessage` now starts a `chatbot.handle_message` span around the full handler (login + dispatch). `twitch.user` is set on span start; `twitch.command` is set inside `runCommand` only when the message is `!`-prefixed, so the attribute's cardinality stays bounded to the bot's actual command surface (and typos thereof). Bare-word triggers like `hello`/`hi` aren't tagged — rare and lower debugging value than keeping cardinality tight.
- **`cmd/tripbot/tripbot.go`** — each `scheduleBackgroundJobs` callback is wrapped in a new `tracedJob(name, fn)` helper that opens a `cron.<name>` span around the callback. Slow or failing jobs become visible in Grafana traces.

## Why now

The Twitch IRC path is the heart of the bot today and was completely invisible to tracing before this. Cron ticks are the next-most-visible scheduled surface — wrapping them at the registration site is cheap and self-contained.

## Caveat

The `robfig/cron` callback signature is bare `func()` — no `context.Context`. The wrapper opens a cron span but discards the ctx, so any child spans created *inside* the job (e.g., DB queries via otelsql, HTTP via otelhttp client) won't auto-link to the cron parent. To get full propagation we'd need to thread ctx into each cron-scheduled function. Out of scope here; the timing/error visibility on the cron span itself is the primary value.

## Test plan

- [x] `mise exec -- go build ./pkg/chatbot/... ./cmd/tripbot/...` clean
- [x] `mise exec -- go vet ./pkg/chatbot/... ./cmd/tripbot/...` clean
- [x] `go.mod` promotes `go.opentelemetry.io/otel/trace` and `.../contrib/instrumentation/runtime` from indirect → direct (already present transitively)
- [ ] After deploy, query `chatbot.handle_message` spans in Grafana Cloud Explore — `twitch.user` always present, `twitch.command` present on `!`-prefixed messages
- [ ] `cron.video.GetCurrentlyPlaying` and the other `cron.*` spans appear at their expected cadences

## Follow-up

Items #3–#6 from `vault/tripbot/tripbot/TODO.md:15` (Helix client transport, EventSub sub-spans, onscreens lifecycle, libvlc-go) remain open as separate work.