### PR TITLE
docker: bump vlc image Go to 1.26.3

### DIFF
--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -24,7 +24,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-RUN curl -fsSL https://go.dev/dl/go1.21.13.linux-${TARGETARCH}.tar.gz \
+RUN curl -fsSL https://go.dev/dl/go1.26.3.linux-${TARGETARCH}.tar.gz \
   | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:/go/bin:${PATH}"
 ENV GOPATH="/go"


### PR DESCRIPTION
## Summary

- `infra/docker/vlc/Dockerfile`: curl-installed Go bumped from `1.21.13` to `1.26.3`, matching the toolchain used by `go.mod`, `.tool-versions`, and the test/tripbot Dockerfiles since [#417](https://github.com/adanalife/tripbot/pull/417).

The vlc image uses an Ubuntu 24.04 base (needs system `libvlc-dev`), so it can't ride the `golang:1.26-bookworm` image like the others — Go gets curled in separately, and that URL was the last stale `1.21` reference in the repo.

Verified both `https://go.dev/dl/go1.26.3.linux-amd64.tar.gz` and `…-arm64.tar.gz` return 200 (~64 MB each) before pushing, so the multi-arch release build should resolve cleanly on both legs.

## Test plan

- [ ] `release.yml` vlc-build matrix succeeds on both `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64) legs
- [ ] vlc-manifest job assembles the multi-arch list cleanly
- [ ] Resulting image runs in stage-1 k3d (vlc-server pod Running 1/1, RTSP serving)