### PR TITLE
chatbot/log: skip Stackdriver chat logging on staging too

### DIFF
--- a/pkg/chatbot/log/log.go
+++ b/pkg/chatbot/log/log.go
@@ -15,7 +15,7 @@ func init() {
 	var err error
 
 	// don't bother with this if we're in a test environment
-	if c.Conf.IsTesting() || c.Conf.IsDevelopment() {
+	if c.Conf.IsTesting() || c.Conf.IsDevelopment() || c.Conf.IsStaging() {
 		return
 	}
 
@@ -37,7 +37,7 @@ func init() {
 }
 
 func ChatMsg(username, msg string) {
-	if c.Conf.IsTesting() || c.Conf.IsDevelopment() {
+	if c.Conf.IsTesting() || c.Conf.IsDevelopment() || c.Conf.IsStaging() {
 		return
 	}
 	chatLogger.Printf("%s: %s", username, msg)


### PR DESCRIPTION
## Summary

Mirror the dev-skip rule in `pkg/chatbot/log/log.go` for staging. Both gates (init at `:18`, ChatMsg at `:40`) now early-return on `IsTesting() || IsDevelopment() || IsStaging()`.

## Why

Pairs with v2.2.4's [#433](https://github.com/adanalife/tripbot/pull/433/changes) Sentry gate broaden + the [adanalife/infra#424](https://github.com/adanalife/infra/pull/424) ESO wiring. Next step in the launch-plan Phase 1 was flipping `ENV=development` → `ENV=staging` on the local overlay so Sentry actually fires in the soak. But that flip would also activate Stackdriver's `logging.NewClient(ctx, projectID)` call — and the cluster has both `GOOGLE_APPLICATION_CREDENTIALS=` and `GOOGLE_APPS_PROJECT_ID=` empty. NewClient would error on missing ADC, hit `log.Fatalf` at line 30, and pods would CrashLoopBackoff.

The launch plan's framing is "make staging count for what we explicitly opt in." We opted in for Sentry; we have not opted in for Stackdriver chat logging in staging. Adding `IsStaging()` to the skip list keeps the existing semantics: dev/test/staging skip Stackdriver, only production runs it.

## Test plan

- [x] `mise exec -- go build ./pkg/chatbot/log/` clean
- [x] `mise exec -- go vet ./pkg/chatbot/log/` clean
- [ ] After v2.2.5 ships and the infra ENV flip lands: pods come up clean (no CrashLoopBackoff)
- [ ] Production behavior unchanged — Stackdriver still logs there

## Follow-up

After this lands, the infra-side ENV flip in `apps/{tripbot,vlc-server}/overlays/local/kustomization.yaml` is safe to merge.