### PR TITLE
ci: action-version hygiene sweep

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: golint
-        uses: reviewdog/action-golangci-lint@v2.0.3
+        uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
           # Pin golangci_lint_version explicitly: the action's default of

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: run-linters
-        uses: super-linter/super-linter@v8.6.0
+        uses: super-linter/super-linter@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # don't post a "Super-linter summary" comment on every PR run


### PR DESCRIPTION
## Summary
- Float `reviewdog/action-golangci-lint` `v2.0.3` → `v2` in `linting.yml` (revive job). The errcheck job in the same file already used the floating major; this just brings the revive job in line so future v2.x releases flow in automatically.
- Float `super-linter/super-linter` `v8.6.0` → `v8` in `super-linter.yml`. Same floating-major convention used elsewhere in the workflow set.

Two atomic commits, one per action. All other workflow pins were checked against latest stable and are already current — no further bumps needed in this pass.

Notes:
- `reviewdog/action-golangci-lint@v2`: latest is v2.10.0; existing `golangci_lint_version: v2.12.1` pin is preserved, so the action upgrade itself shouldn't change linter behavior.
- `super-linter@v8`: latest is v8.6.0, so this is a no-op move today; the value is in not having to bump the pin again on v8.7.0.

## Test plan
- [ ] Workflows trigger on this PR — confirm green CI before merge.
- [ ] Spot-check the `Linting / revive` and `Super Linter / Run Linters` job runs in this PR for any input-shape regressions (neither v2 nor v8 majors should change inputs from where the pins were previously, but worth eyeballing).