### PR TITLE
helpers/sms: lazy-init the Twilio client

### DIFF
--- a/pkg/helpers/sms.go
+++ b/pkg/helpers/sms.go
@@ -3,36 +3,47 @@ package helpers
 import (
 	"log"
 	"os"
+	"sync"
 
 	"github.com/sfreiberg/gotwilio"
 )
 
-var twilioFromNum, twilioToNum string
-var twilioClient *gotwilio.Twilio
+var (
+	twilioOnce    sync.Once
+	twilioClient  *gotwilio.Twilio
+	twilioFromNum string
+	twilioToNum   string
+)
 
-// set up Twilio (for text messages)
-func init() {
-	requiredVars := []string{
-		"TWILIO_ACCT_SID",
-		"TWILIO_AUTH_TOKEN",
-		"TWILIO_FROM_NUM",
-		"TWILIO_TO_NUM",
-	}
-	for _, v := range requiredVars {
-		_, ok := os.LookupEnv(v)
-		if !ok {
-			log.Fatalf("You must set %s", v)
+// twilio constructs (on first call) and returns the Twilio client.
+// It log.Fatals if the required env vars are missing — but only when
+// SMS is actually being sent, so importing this package no longer
+// fails at startup for binaries that never send SMS.
+func twilio() *gotwilio.Twilio {
+	twilioOnce.Do(func() {
+		requiredVars := []string{
+			"TWILIO_ACCT_SID",
+			"TWILIO_AUTH_TOKEN",
+			"TWILIO_FROM_NUM",
+			"TWILIO_TO_NUM",
 		}
-	}
-	twilioAccountSid := os.Getenv("TWILIO_ACCT_SID")
-	twilioAuthToken := os.Getenv("TWILIO_AUTH_TOKEN")
-	twilioFromNum = os.Getenv("TWILIO_FROM_NUM")
-	twilioToNum = os.Getenv("TWILIO_TO_NUM")
+		for _, v := range requiredVars {
+			_, ok := os.LookupEnv(v)
+			if !ok {
+				log.Fatalf("You must set %s", v)
+			}
+		}
+		twilioAccountSid := os.Getenv("TWILIO_ACCT_SID")
+		twilioAuthToken := os.Getenv("TWILIO_AUTH_TOKEN")
+		twilioFromNum = os.Getenv("TWILIO_FROM_NUM")
+		twilioToNum = os.Getenv("TWILIO_TO_NUM")
 
-	twilioClient = gotwilio.NewTwilioClient(twilioAccountSid, twilioAuthToken)
+		twilioClient = gotwilio.NewTwilioClient(twilioAccountSid, twilioAuthToken)
+	})
+	return twilioClient
 }
 
 // sends an SMS (to myself)
 func SendSMS(message string) {
-	twilioClient.SendSMS(twilioFromNum, twilioToNum, message, "", "")
+	twilio().SendSMS(twilioFromNum, twilioToNum, message, "", "")
 }


### PR DESCRIPTION
## Summary
- Move Twilio client construction from `init()` into a `sync.Once`-gated getter so importing `pkg/helpers` no longer requires Twilio env vars.
- Fixes vlc-server's startup, which imports `pkg/helpers` for non-SMS utilities and previously died on missing creds.
- `SendSMS` still log.Fatals cleanly if creds are missing on the first call, preserving the fail-fast behavior for SMS-using callers.

## Test plan
- [x] `go test ./pkg/helpers/...` passes (now runs without TWILIO env vars set — previously would have died at init time)
- [x] `go vet ./pkg/helpers/... ./pkg/chatbot/... ./pkg/twitch/...` clean
- [ ] Run vlc-server with no Twilio env vars and confirm it starts cleanly
- [ ] Run tripbot with broken Twilio creds and confirm it still log.Fatals on first SMS attempt

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>