### PR TITLE
ci: race detector + coveralls.io coverage publishing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,3 +24,14 @@ jobs:
       run: |
         echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
         tail -1 coverage.txt >> "$GITHUB_STEP_SUMMARY"
+    # Convert Go's coverage.out to lcov so coveralls.io can ingest it.
+    - name: Convert coverage to lcov
+      uses: jandelgado/gcov2lcov-action@v1.2.0
+      with:
+        infile: coverage.out
+        outfile: coverage.lcov
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@v2.3.6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage.lcov

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,9 +16,9 @@ tasks:
       - ENV=testing bin/devenv run --rm test go test ./...
 
   test:cover:
-    desc: Run tests with coverage; prints per-function and total coverage
+    desc: Run tests with coverage + race detector; prints per-function and total coverage
     cmds:
-      - ENV=testing bin/devenv run --rm test bash -c 'go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out'
+      - ENV=testing bin/devenv run --rm test bash -c 'go test -v -race -covermode=atomic -coverprofile=coverage.out ./... && go tool cover -func=coverage.out'
 
   test:cover:html:
     desc: Generate HTML coverage report at coverage.html


### PR DESCRIPTION
## Summary
- Add `-race` to CI test runs to catch data races (with `-covermode=atomic` since `-race` requires atomic counting). Originally TODO suggested `-covermode=count`, but `atomic` is what `-race` needs — the rest of the pattern is otherwise as suggested.
- Generate a coverage profile at every test run; upload to coveralls.io via gcov2lcov + coveralls-action so coverage % is visible on the PR and tracked over time.
- Salvaged from closed PR [#126](https://github.com/adanalife/tripbot/pull/126) (2020) but rebuilt with current action versions (`jandelgado/gcov2lcov-action@v1.2.0`, `coverallsapp/github-action@v2.3.6`, both latest stable as of opening).

The `-v -race -covermode=atomic` flags went into `task test:cover` itself rather than only on the CI invocation, so local `task test:cover` runs match what CI does. (Day-to-day fast iteration still has `task test` without race.)

## Heads-up
- **First run may surface real data races.** That's the point — but it would block this PR from going green. If `-race` flags something, please don't try to bandaid it in this PR; let's open a follow-up TODO and triage separately.
- **Coveralls.io GitHub App may not be installed on the `adanalife` org yet.** If the upload step fails, that's a one-time install action — visit https://github.com/apps/coveralls and install on `adanalife/tripbot` (or org-wide). The PR is otherwise mergeable; the upload step will start working as soon as the App is installed.

## Test plan
- [x] YAML structurally valid (single-step edits, no structural changes)
- [ ] CI run on this PR completes; race detector finds nothing (or surfaces real issues to file separately)
- [ ] Coveralls.io receives the upload and posts a coverage comment
- [ ] Coverage % is visible on the PR