### PR TITLE
users: auto-mark ignore-list users as bots in login()

### DIFF
--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -1,7 +1,6 @@
 package users
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -91,9 +90,13 @@ func login(username string) *User {
 	user.lastLocation = now.AddDate(0, 0, -1)
 	user.save()
 
-	// raise an error if a user is supposed to be a bot
+	// auto-flag known bots: if a user is on the ignore-list but not yet
+	// marked IsBot, set the flag and persist so we don't keep flagging them
+	// on every login
 	if c.UserIsIgnored(username) && !user.IsBot {
-		log.Println(aurora.Red(username), errors.New("user should be bot"))
+		log.Println(aurora.Yellow(username), "is on the ignore-list; auto-flagging as bot")
+		user.IsBot = true
+		user.save()
 	}
 
 	// just a silly message to confirm subscriber feature is working

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -81,7 +81,7 @@ func (u User) save() {
 	if c.Conf.Verbose {
 		log.Println("saving user", u)
 	}
-	query := `UPDATE users SET last_seen=:last_seen, num_visits=:num_visits, miles=:miles WHERE id = :id`
+	query := `UPDATE users SET last_seen=:last_seen, num_visits=:num_visits, miles=:miles, is_bot=:is_bot WHERE id = :id`
 	_, err := database.Connection().NamedExec(query, u)
 	if err != nil {
 		terrors.Log(err, "error saving user")


### PR DESCRIPTION
## Summary
- Fix log-and-ignore bug in `pkg/users/session.go` `login()` — when a user is in the ignore-list but `IsBot=false`, set `IsBot=true` and persist instead of just logging "user should be bot".
- Updates `save()` to include `is_bot` in its UPDATE so the flag actually reaches the database (the existing query only persisted `last_seen`, `num_visits`, `miles`).
- Salvaged from closed PR [#199](https://github.com/adanalife/tripbot/pull/199) (2021); the original PR's hardcoded `username != "mathgaming"` exception is intentionally NOT carried forward (it's 5 years stale).

## Test plan
- [x] `go vet ./pkg/users/...` passes
- [ ] Tail tripbot logs over a real session; confirm any auto-corrected bots get flagged once and don't re-trigger the log on subsequent logins