### PR TITLE
users/session: log monthly miles and guess score on logout

### DIFF
--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -122,7 +122,9 @@ func (u User) logout() {
 		prettyDur := durafmt.ParseShort(loggedInDur)
 		dur := fmt.Sprintf("(%s)", aurora.Green(prettyDur))
 		miles := fmt.Sprintf("(%1.2fmi)", aurora.Yellow(sessionMiles))
-		log.Println("logging out", u, dur, miles)
+		monthlyMiles := fmt.Sprintf("(%1.2fmi this month)", aurora.Yellow(u.CurrentMonthlyMiles()))
+		guessScore := fmt.Sprintf("(%1.0f guesses)", aurora.Cyan(u.GetScore(scoreboards.CurrentGuessScoreboard())))
+		log.Println("logging out", u, dur, miles, monthlyMiles, guessScore)
 	}
 
 	// update miles


### PR DESCRIPTION
## Summary
- Extend `User.logout()` log line to include monthly miles and guess score, matching the format of the existing duration + session-miles bits.
- Helps post-session debugging without needing DB access.
- Salvages the TODO comments from closed PR [#196](https://github.com/adanalife/tripbot/pull/196).

Both helpers are already in use elsewhere — `CurrentMonthlyMiles()` (used by `!miles`) and `GetScore(CurrentGuessScoreboard())` (used by `!guessleaderboard`) — so this is two extra reads on a per-session-logout path. Cost is acceptable given how rarely `logout()` fires.

## Test plan
- [x] `go build ./...` and `go test ./pkg/users/...` pass (CI; local sandbox blocked the toolchain run)
- [ ] Tail tripbot logs across a real logout; confirm monthly miles + guess score render in the log line