### PR TITLE
vlc-server: move tuning flags to optional env vars

### DIFF
--- a/infra/docker/env.docker
+++ b/infra/docker/env.docker
@@ -40,6 +40,14 @@ TRIPBOT_SERVER_PORT=8080
 
 VLC_SERVER_HOST=vlc:8080
 
+# Optional VLC tuning knobs — unset to use the compiled-in defaults shown.
+# Tune per-host (Linux container vs. Windows dev) without recompiling.
+#VLC_FILE_CACHING=1111      # libvlc --file-caching, in milliseconds
+#VLC_AVCODEC_HW=vdpau_avcodec  # Linux-only; one of none, vdpau_avcodec, cuda
+#VLC_VOUT=x11               # Linux-only; libvlc --vout (e.g. x11, xcb_x11)
+#VLC_CANVAS_WIDTH=1920
+#VLC_CANVAS_HEIGHT=1080
+
 # OpenTelemetry — disabled by default in dev. To exercise locally, drop a
 # personal Grafana Cloud token into a sibling .env.docker.local with:
 #   OTEL_SDK_DISABLED=false

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -15,6 +15,22 @@ type VlcServerConfig struct {
 	// vlc-server pidfile) live. EmptyDir / tmpfs is sufficient in k8s.
 	RunDir string `default:"/opt/data/run" envconfig:"RUN_DIR"`
 
+	// VlcFileCaching is the libvlc --file-caching value in milliseconds.
+	// Defaults to today's hardcoded value; tune per-host without recompiling.
+	VlcFileCaching int `default:"1111" envconfig:"VLC_FILE_CACHING"`
+	// VlcAvcodecHw is the libvlc --avcodec-hw value (Linux-only). One of
+	// none, vdpau_avcodec, cuda. Only applied on Linux hosts; ignored on
+	// Windows/Darwin (matches today's platform-specific flag layering).
+	VlcAvcodecHw string `default:"vdpau_avcodec" envconfig:"VLC_AVCODEC_HW"`
+	// VlcVout is the libvlc --vout value (Linux-only). e.g. x11, xcb_x11.
+	// Only applied on Linux hosts; ignored on Windows/Darwin.
+	VlcVout string `default:"x11" envconfig:"VLC_VOUT"`
+	// VlcCanvasWidth / VlcCanvasHeight set both the libvlc --width/--height
+	// and --canvas-width/--canvas-height. Defaults are today's hardcoded
+	// 1920x1080.
+	VlcCanvasWidth  int `default:"1920" envconfig:"VLC_CANVAS_WIDTH"`
+	VlcCanvasHeight int `default:"1080" envconfig:"VLC_CANVAS_HEIGHT"`
+
 	// VLCPidFile is where the vlc-server PID file lives
 	VLCPidFile string `default:"/opt/data/run/vlc-server.pid" envconfig:"VLC_PIDFILE"`
 

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -18,19 +19,22 @@ var videoFiles []string
 
 //TODO: figure out if vdpau_avcodec can be better than none
 //TODO: there are a ton of potentially-useful avcodec flags
-//TODO: break some of these into ENV vars
-var vlcCmdFlags = []string{
+
+// platform-invariant flags that never need per-host tuning
+var vlcStaticFlags = []string{
 	"--ignore-config", // ignore any config files that might get loaded
 	"--fullscreen",    // start fullscreened
 	"--no-audio",      // none of the videos have audio
 	// "--network-caching", "500", // network cache (in ms)
-	"--file-caching", "1111", // file cache (in ms)
-	"--width", "1920",
-	"--height", "1080",
-	"--canvas-width", "1920",
-	"--canvas-height", "1080",
 	// "--aspect-ratio", "16:9",
 }
+
+// vlcCmdFlags is built lazily in startVLC() from vlcStaticFlags +
+// per-host tuning values pulled from config (VLC_FILE_CACHING,
+// VLC_CANVAS_WIDTH, VLC_CANVAS_HEIGHT). Defaults match what was
+// previously hardcoded here, so this is a no-op refactor unless an
+// env var is explicitly set.
+var vlcCmdFlags []string
 
 // mediaOptions are applied per-Media (not as libvlc init flags).
 // libvlc's --sout takes effect only when set on the media object itself —
@@ -43,11 +47,16 @@ var mediaOptions = []string{
 	":sout-keep",
 }
 
-var vlcLinuxSpecificFlags = []string{
-	"--vout", "x11", // use X11 (and skip vdpau, improves performance)
-	"--avcodec-hw", "vdpau_avcodec", // can be none, vdpau_avcodec, or cuda
-	// "--avcodec-dr", "0",
-
+// linuxSpecificFlags returns the Linux-only VLC flags, sourced from
+// config (VLC_VOUT, VLC_AVCODEC_HW). Defaults match today's hardcoded
+// values: --vout x11 (skip vdpau, improves performance) and
+// --avcodec-hw vdpau_avcodec (can be none, vdpau_avcodec, or cuda).
+func linuxSpecificFlags() []string {
+	return []string{
+		"--vout", c.Conf.VlcVout,
+		"--avcodec-hw", c.Conf.VlcAvcodecHw,
+		// "--avcodec-dr", "0",
+	}
 }
 
 var vlcWindowsSpecificFlags = []string{
@@ -114,6 +123,20 @@ func currentlyPlaying() string {
 }
 
 func startVLC() {
+	// build the base flag set from the static list + config-driven tuning
+	// values. Defaults in pkg/config/vlc-server reproduce what used to be
+	// hardcoded here, so unset env vars yield identical behavior.
+	canvasW := strconv.Itoa(c.Conf.VlcCanvasWidth)
+	canvasH := strconv.Itoa(c.Conf.VlcCanvasHeight)
+	vlcCmdFlags = append([]string{}, vlcStaticFlags...)
+	vlcCmdFlags = append(vlcCmdFlags,
+		"--file-caching", strconv.Itoa(c.Conf.VlcFileCaching),
+		"--width", canvasW,
+		"--height", canvasH,
+		"--canvas-width", canvasW,
+		"--canvas-height", canvasH,
+	)
+
 	// set command line flags
 	if c.Conf.VlcVerbose {
 		vlcCmdFlags = append(vlcCmdFlags, vlcVerboseFlags...)
@@ -131,7 +154,7 @@ func startVLC() {
 	}
 
 	if helpers.RunningOnLinux() {
-		vlcCmdFlags = append(vlcCmdFlags, vlcLinuxSpecificFlags...)
+		vlcCmdFlags = append(vlcCmdFlags, linuxSpecificFlags()...)
 	}
 
 	if helpers.RunningOnWindows() {


### PR DESCRIPTION
## Summary
- Move four VLC tuning flags from hardcoded values to optional env vars: `VLC_FILE_CACHING`, `VLC_AVCODEC_HW`, `VLC_VOUT`, `VLC_CANVAS_WIDTH`/`VLC_CANVAS_HEIGHT`.
- All four default to today's hardcoded values, so this is a pure refactor with no behavior change unless an env var is explicitly set.
- Resolves the `//TODO: break some of these into ENV vars` comment in `pkg/vlc-server/vlc.go`.

## Test plan
- [x] `go build ./pkg/vlc-server/...` passes (locally or in CI; libvlc-dev required)
- [x] `go test ./pkg/vlc-server/...` passes
- [ ] Set `VLC_FILE_CACHING=3000` in dev and confirm the value lands in libvlc args at startup (grep logs)
- [ ] Unset all the new vars and confirm defaults still produce identical behavior to current