### PR TITLE
chatbot: !skip and !back UX improvements

### DIFF
--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -140,6 +140,22 @@ func parseSkipParams(params []string, defaultN int) (int, bool) {
 	return n, true
 }
 
+// formatSkipReply renders the chat reply for !skip / !back. forward is
+// the direction the playhead actually moved (after any negative-input
+// rewriting); count is the magnitude. Both !skip 3 and !back -3 result
+// in (count=3, forward=true) and read identically in chat.
+func formatSkipReply(count int, forward bool) string {
+	noun := "videos"
+	if count == 1 {
+		noun = "video"
+	}
+	direction := "back"
+	if forward {
+		direction = "forward"
+	}
+	return fmt.Sprintf("Skipped %d %s %s!", count, noun, direction)
+}
+
 func skipCmd(user *users.User, params []string) {
 	var err error
 	log.Println(user.Username, "ran !skip")
@@ -166,10 +182,18 @@ func skipCmd(user *users.User, params []string) {
 
 	// negative skip is equivalent to going back; route through Back
 	// so the underlying client serializes the offset correctly
-	if n < 0 {
-		err = vlcClient.Back(-n)
+	forward := n >= 0
+	count := n
+	if count < 0 {
+		count = -count
+	}
+	if count == 0 {
+		count = 1
+	}
+	if forward {
+		err = vlcClient.Skip(count)
 	} else {
-		err = vlcClient.Skip(n)
+		err = vlcClient.Back(count)
 	}
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
@@ -178,6 +202,8 @@ func skipCmd(user *users.User, params []string) {
 	video.GetCurrentlyPlaying()
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
+	// confirm what just happened in chat
+	Say(formatSkipReply(count, forward))
 }
 
 func backCmd(user *users.User, params []string) {
@@ -206,10 +232,18 @@ func backCmd(user *users.User, params []string) {
 
 	// negative back is equivalent to skipping forward; route through Skip
 	// so the underlying client serializes the offset correctly
-	if n < 0 {
-		err = vlcClient.Skip(-n)
+	forward := n < 0
+	count := n
+	if count < 0 {
+		count = -count
+	}
+	if count == 0 {
+		count = 1
+	}
+	if forward {
+		err = vlcClient.Skip(count)
 	} else {
-		err = vlcClient.Back(n)
+		err = vlcClient.Back(count)
 	}
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
@@ -218,4 +252,6 @@ func backCmd(user *users.User, params []string) {
 	video.GetCurrentlyPlaying()
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
+	// confirm what just happened in chat
+	Say(formatSkipReply(count, forward))
 }

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -122,9 +122,26 @@ func jumpCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
+// parseSkipParams extracts the integer offset from chat-command params.
+// Returns (n, ok). If ok is false, the caller should bail with a usage
+// message — params were malformed (non-numeric, too many args, or empty
+// string). An empty params list is valid and yields the supplied default.
+func parseSkipParams(params []string, defaultN int) (int, bool) {
+	if len(params) == 0 {
+		return defaultN, true
+	}
+	if len(params) > 1 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(params[0])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 func skipCmd(user *users.User, params []string) {
 	var err error
-	var n int
 	log.Println(user.Username, "ran !skip")
 
 	// exit early if we're on OS X
@@ -141,23 +158,19 @@ func skipCmd(user *users.User, params []string) {
 		}
 	}
 
-	// first we count the given params
-	if len(params) == 0 {
-		// just skip once if no params
-		n = 1
-	} else {
-		// we were given args
-		// try and convert their input to a number
-		n, err = strconv.Atoi(params[0])
-		// if conversion fails or they give too many args
-		if err != nil || len(params) > 1 {
-			Say("Usage: !skip [num]")
-			return
-		}
+	n, ok := parseSkipParams(params, 1)
+	if !ok {
+		Say("Usage: !skip [num]")
+		return
 	}
 
-	// skip to a new video
-	err = vlcClient.Skip(n)
+	// negative skip is equivalent to going back; route through Back
+	// so the underlying client serializes the offset correctly
+	if n < 0 {
+		err = vlcClient.Back(-n)
+	} else {
+		err = vlcClient.Skip(n)
+	}
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}
@@ -169,7 +182,6 @@ func skipCmd(user *users.User, params []string) {
 
 func backCmd(user *users.User, params []string) {
 	var err error
-	var n int
 	log.Println(user.Username, "ran !back")
 
 	// exit early if we're on OS X
@@ -186,23 +198,19 @@ func backCmd(user *users.User, params []string) {
 		}
 	}
 
-	// first we count the given params
-	if len(params) == 0 {
-		// just back once if no params
-		n = 1
-	} else {
-		// we were given args
-		// try and convert their input to a number
-		n, err = strconv.Atoi(params[0])
-		// if conversion fails or they give too many args
-		if err != nil || len(params) > 1 {
-			Say("Usage: !back [num]")
-			return
-		}
+	n, ok := parseSkipParams(params, 1)
+	if !ok {
+		Say("Usage: !back [num]")
+		return
 	}
 
-	// back to an old video
-	err = vlcClient.Back(n)
+	// negative back is equivalent to skipping forward; route through Skip
+	// so the underlying client serializes the offset correctly
+	if n < 0 {
+		err = vlcClient.Skip(-n)
+	} else {
+		err = vlcClient.Back(n)
+	}
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -1,6 +1,9 @@
 package chatbot
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseSkipParams(t *testing.T) {
 	tests := []struct {
@@ -27,6 +30,35 @@ func TestParseSkipParams(t *testing.T) {
 			}
 			if ok && n != tc.wantN {
 				t.Errorf("parseSkipParams(%v, %d) n = %d, want %d", tc.params, tc.defaultN, n, tc.wantN)
+			}
+		})
+	}
+}
+
+func TestFormatSkipReply(t *testing.T) {
+	tests := []struct {
+		name    string
+		count   int
+		forward bool
+		want    string
+	}{
+		{"single forward", 1, true, "Skipped 1 video forward!"},
+		{"single back", 1, false, "Skipped 1 video back!"},
+		{"plural forward", 5, true, "Skipped 5 videos forward!"},
+		{"plural back", 3, false, "Skipped 3 videos back!"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatSkipReply(tc.count, tc.forward)
+			if got != tc.want {
+				t.Errorf("formatSkipReply(%d, %v) = %q, want %q", tc.count, tc.forward, got, tc.want)
+			}
+			// concise enough for Twitch's 500-char limit (with headroom)
+			if len(got) > 100 {
+				t.Errorf("reply too long for chat: %d chars", len(got))
+			}
+			if !strings.HasPrefix(got, "Skipped ") {
+				t.Errorf("reply does not start with 'Skipped ': %q", got)
 			}
 		})
 	}

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -1,0 +1,33 @@
+package chatbot
+
+import "testing"
+
+func TestParseSkipParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     []string
+		defaultN   int
+		wantN      int
+		wantOK     bool
+	}{
+		{"empty uses default", []string{}, 1, 1, true},
+		{"empty uses default 5", []string{}, 5, 5, true},
+		{"positive number", []string{"3"}, 1, 3, true},
+		{"negative number", []string{"-30"}, 1, -30, true},
+		{"zero", []string{"0"}, 1, 0, true},
+		{"non-numeric rejected", []string{"abc"}, 1, 0, false},
+		{"too many args rejected", []string{"1", "2"}, 1, 0, false},
+		{"empty string rejected", []string{""}, 1, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n, ok := parseSkipParams(tc.params, tc.defaultN)
+			if ok != tc.wantOK {
+				t.Errorf("parseSkipParams(%v, %d) ok = %v, want %v", tc.params, tc.defaultN, ok, tc.wantOK)
+			}
+			if ok && n != tc.wantN {
+				t.Errorf("parseSkipParams(%v, %d) n = %d, want %d", tc.params, tc.defaultN, n, tc.wantN)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `!skip` and `!back` now accept negative numbers — `!skip -30` is equivalent to `!back 30`, and `!back -3` is equivalent to `!skip 3`.
- Both commands now reply in chat with a one-line confirmation naming the magnitude (videos, singular/plural-aware) and direction the playhead moved.
- Two atomic commits, per the project's commit-style convention. The shared param parser was lifted into a small testable helper (`parseSkipParams`), seeding `pkg/chatbot/`'s previously-empty test set.

A couple of notes on the unit chosen for the reply:
- `!skip N` / `!back N` operate on **videos** (N entries forward/back in the playlist), not seconds — the reply uses "videos" as the unit accordingly. The TODO copy said "amount of time skipped", but no per-video duration is stored in the project, so summing real durations would have meant new infra (a video-length helper or constant) and pulled the change out of "easy". Happy to re-scope to durations in a follow-up if you want; lmk.
- `n=0` is normalised to 1 (matching today's silent behaviour: the underlying client drops 0 and the server defaults to 1) so the reply is never \"Skipped 0 videos\".

## Test plan
- [x] `go build ./pkg/chatbot/...` and `go vet ./pkg/chatbot/...` pass
- [x] `task test` passes (full repo suite, run via `bin/devenv`)
- [ ] Send `!skip 3` in chat and confirm bot replies "Skipped 3 videos forward!"
- [ ] Send `!skip -3` and confirm same effect as `!back 3` (reply: "Skipped 3 videos back!")
- [ ] Send `!back -2` and confirm same effect as `!skip 2` (reply: "Skipped 2 videos forward!")
- [ ] Send `!skip 1` and confirm singular form ("1 video forward")