### PR TITLE
ci: filter vlc.yml on push by VLC-impacting paths

### DIFF
--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -6,7 +6,9 @@ on:
       - 'pkg/vlc-client/**'
       - 'infra/docker/vlc/**'
       - 'infra/docker/docker-compose*.yml'
+      - 'infra/docker/env.docker'
       - '.github/workflows/vlc.yml'
+      - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
   push:
@@ -19,7 +21,9 @@ on:
       - 'pkg/vlc-client/**'
       - 'infra/docker/vlc/**'
       - 'infra/docker/docker-compose*.yml'
+      - 'infra/docker/env.docker'
       - '.github/workflows/vlc.yml'
+      - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
 

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -14,6 +14,14 @@ on:
       - develop
     tags:
       - v*
+    paths:
+      - 'pkg/vlc-server/**'
+      - 'pkg/vlc-client/**'
+      - 'infra/docker/vlc/**'
+      - 'infra/docker/docker-compose*.yml'
+      - '.github/workflows/vlc.yml'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Extend the `paths:` filter on `vlc.yml` to the `push` trigger as well as `pull_request`. PR #390 already added it to PR triggers; this brings the develop-push and release-tag pushes in line.
- Filter list: `pkg/vlc-server/**`, `pkg/vlc-client/**`, `infra/docker/vlc/**`, `infra/docker/docker-compose*.yml`, `infra/docker/env.docker`, `.github/workflows/vlc.yml` itself, `.dockerignore`, `go.mod`, `go.sum`.
- Cuts wasted CI runs on develop merges and release tags that don't touch VLC inputs. `release.yml` continues to own the actual multi-arch release builds; this workflow is purely a smoke test, so skipping it on unrelated pushes is consistent with its purpose.

`env.docker` is in the list because the smoke test runs `docker compose ... --env-file infra/docker/env.docker up -d vlc` — changes affect what env vars VLC boots with. `.dockerignore` is in the list because the VLC Dockerfile does `COPY . .`, so changes to the ignore set silently change the build context.

A follow-up TODO covers `obs.yml` separately (it has different relevant paths and already uses `dorny/paths-filter` job-internally for the slow arm64 leg, so the shape of that fix is different).

## Test plan
- [x] `vlc.yml` parses as valid YAML
- [ ] On a future docs-only PR / develop merge, confirm `vlc.yml` does NOT trigger
- [ ] On a future `pkg/vlc-server/` PR, confirm `vlc.yml` DOES trigger
- [ ] On a future `.dockerignore` or `env.docker` PR, confirm `vlc.yml` DOES trigger