### PR TITLE
ci: filter obs.yml on pull_request by OBS-impacting paths

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -1,6 +1,10 @@
 name: OBS Container
 on:
   pull_request:
+    paths:
+      - 'infra/docker/obs/**'
+      - 'infra/docker/docker-compose*.yml'
+      - '.github/workflows/obs.yml'
   push:
     branches:
       - develop


### PR DESCRIPTION
## Summary
- Limit `obs.yml`'s `pull_request` trigger to changes under `infra/docker/obs/`, the docker-compose files, and `obs.yml` itself. Cuts wasted CI runs on PRs that don't touch OBS image inputs (saves the amd64 smoke-test runner-minutes on doc-only / unrelated PRs).
- Companion to #447 which did the same for `vlc.yml`.
- The `push` trigger (develop merges + `v*` tags) is left unfiltered intentionally: `release.yml` owns the actual multi-arch release builds, and the develop-push smoke test stays useful as a build-soundness check on the integration branch. The combined `branches`/`tags` push block also means a `paths:` filter there would apply to release tags too — better to leave it alone.
- The existing `dorny/paths-filter` job inside the workflow (gating the slow ~30 min arm64 from-source CEF leg) is unchanged — that's a job-internal gate, distinct from the workflow-level trigger filter being added here.

## Test plan
- [x] `obs.yml` parses as valid YAML
- [ ] On a future docs-only PR, confirm `obs.yml` does NOT trigger
- [ ] On a future `infra/docker/obs/` PR, confirm `obs.yml` DOES trigger