### PR TITLE
ci(super-linter): re-enable GITHUB_ACTIONS + GO_MODULES; report on the rest

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -40,6 +40,7 @@ jobs:
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_CHECKOV: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_GO_MODULES: false
           VALIDATE_GO_RELEASER: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -39,7 +39,6 @@ jobs:
           # disabled until we can resolve their issues
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_CHECKOV: false
-          VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_GO_MODULES: false
           VALIDATE_GO_RELEASER: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -40,7 +40,6 @@ jobs:
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_CHECKOV: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
-          VALIDATE_GO_MODULES: false
           VALIDATE_GO_RELEASER: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -57,12 +57,12 @@ jobs:
           -f infra/docker/docker-compose.testing.yml \
           -f infra/docker/docker-compose.github.yml \
           port vlc 8080 | cut -d: -f2)
-        echo "VLC_PORT=$PORT" >> $GITHUB_ENV
+        echo "VLC_PORT=$PORT" >> "$GITHUB_ENV"
 
     - name: Wait for healthcheck
       run: |
         for i in $(seq 1 30); do
-          if curl -sf http://localhost:$VLC_PORT/health/ready; then
+          if curl -sf "http://localhost:$VLC_PORT/health/ready"; then
             echo ""
             echo "VLC server is ready!"
             exit 0
@@ -74,7 +74,7 @@ jobs:
         exit 1
 
     - name: Check VLC current video
-      run: curl -v http://localhost:$VLC_PORT/vlc/current
+      run: curl -v "http://localhost:$VLC_PORT/vlc/current"
 
     - name: Verify version files baked into image
       run: |
@@ -90,7 +90,7 @@ jobs:
         echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
 
     - name: Verify /version HTTP endpoint
-      run: curl -fsS http://localhost:$VLC_PORT/version
+      run: curl -fsS "http://localhost:$VLC_PORT/version"
 
     - name: Check container logs
       run: |


### PR DESCRIPTION
## Summary

Re-enabled 1 super-linter validator in `super-linter.yml` and fixed the issues `actionlint` surfaced. Each change is its own commit to keep `git revert` granular.

The PR body's hard-ones report does the real triage work — most of the remaining disables would touch many files or need a config decision before they can land. One attempted re-enable (`VALIDATE_GO_MODULES`) had to be reverted after CI surfaced a blocker that the local check missed; details below.

### Re-enabled (this PR)
- **`VALIDATE_GITHUB_ACTIONS`** (actionlint) — 4 findings in 1 file (`.github/workflows/vlc.yml`), all SC2086 quoting nits on `$VLC_PORT` and `$GITHUB_ENV`. Fixed in a separate prep commit.

### Attempted, reverted

- **`VALIDATE_GO_MODULES`** — looked clean locally (`go mod tidy` produces no diff), but super-linter's `GO_MODULES` validator runs `golangci-lint` with the `gomoddirectives` analyzer, which compiles the module and blows up on `vlc/vlc.h: No such file or directory`. This is the same root cause as `VALIDATE_GO` being disabled ("not working with C libs"). Reverted; should stay disabled until the C-deps story is sorted (likely the same fix that re-enables `VALIDATE_GO`).

### Hard ones — left disabled, with rationale

- **`VALIDATE_GITHUB_ACTIONS_ZIZMOR`** — 171 findings (53 suppressed, 23 fixable): 9 informational, 16 low, 35 medium, 58 high. Dominated by `unpinned-uses` (every `uses:` would need pinning to a SHA per the blanket policy) and `excessive-permissions` (every job needs an explicit `permissions:` block). Project-wide policy decision; should be its own dedicated PR or sequence.
- **`VALIDATE_SPELL_CODESPELL`** — 32 findings across ~17 files, but most are false positives that need an `--ignore-words-list` config to suppress: `ND` (North Dakota in `pkg/helpers/states.go`), `caf` (test fixture for stripping `é` from `café`), `ABitrate` (OBS config field), `delimeter` (Go identifier with callers across the codebase), and dozens of intentional Twitch-command misspellings in `pkg/chatbot/handlers.go` (e.g. `!loacation`, `!quess`, `!gusss` are deliberate user-fallback aliases). Genuine fixes (`volumn` -> `volume` in two k8s manifest comments) are buried in the noise. Needs a `.codespellrc` or super-linter `CODESPELL_CONFIG_FILE` setup before re-enabling.
- **`VALIDATE_NATURAL_LANGUAGE`** (write-good) — 100s of findings across `CHANGELOG.md`, `README.md`, `infra/README.md`, etc. Flags passive voice, "weasel words" (only, just, completely), wordiness — all stylistic preferences that don't suit technical changelogs and runbooks. Would need a dedicated prose pass, plus likely some excludes.
- **`VALIDATE_GO_RELEASER`** — `cmd/tripbot/.goreleaser.yml` is config version 0; goreleaser requires version 2 now. The file appears unreferenced (no goreleaser invocation in workflows, Taskfile, bin/, or script/). Three options before re-enabling: bump to v2 syntax, delete the file, or wire it into the release pipeline. Out of scope here.
- **`VALIDATE_JSON_PRETTIER`** / **`VALIDATE_BIOME_FORMAT`** — both flag the same 4 OBS config files (`configs/obs-studio/Dashcam_Scenes.{darwin,linux,windows}.json`, `service.json`). These are managed by OBS itself; reformatting them risks divergence from what OBS writes back. Skipped per TODO body (formatters not worth enabling without a dedicated formatting pass).
- **`VALIDATE_MARKDOWN_PRETTIER`** — 5 files (`README.md`, `CHANGELOG.md`, `infra/README.md`, `db/README.md`, `.github/pull_request_template.md`). Skipped per TODO body.
- **`VALIDATE_YAML_PRETTIER`** — 25 files (every workflow, every k8s manifest, every docker-compose, the Taskfile). Skipped per TODO body.
- **`VALIDATE_SHELL_SHFMT`** — 11 shell scripts across `bin/`, `script/`, `infra/docker/obs/`, `.github/scripts/`. Skipped per TODO body.
- **`VALIDATE_SQLFLUFF`** — every migration in `db/migrate/` flags layout findings (column-alignment whitespace, line length, indent depth). Migrations are immutable history; reformatting them rewrites file content for the sake of style. Skipped — would need a dialect-specific config tuned to the existing alignment style, plus a decision on whether migrations should be exempt.
- **`VALIDATE_TRIVY`**, **`VALIDATE_CHECKOV`** — vuln/IaC scanners. Per TODO body, both need separate triage and exclusion config; out of scope for this audit pass.

### How findings were measured

Each candidate validator was run locally (Docker images for `actionlint`, `zizmor`, `prettier`, `biome`, `codespell`, `write-good`, `shfmt`, `sqlfluff`, `goreleaser`) against the worktree at `develop` HEAD, with one validator at a time. Counts above are the un-tweaked output of each tool with its defaults. The `GO_MODULES` revert is a reminder that local-tool checks don't always exercise the same compilation path as super-linter's bundled `golangci-lint` — for Go-side validators, CI is the authoritative oracle.

## Test plan
- [x] `actionlint` clean locally on develop HEAD after the vlc.yml fix
- [ ] CI super-linter run on the PR is green