### PR TITLE
Release v2.2.5: develop → master

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,3 +24,14 @@ jobs:
       run: |
         echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
         tail -1 coverage.txt >> "$GITHUB_STEP_SUMMARY"
+    # Convert Go's coverage.out to lcov so coveralls.io can ingest it.
+    - name: Convert coverage to lcov
+      uses: jandelgado/gcov2lcov-action@v1.2.0
+      with:
+        infile: coverage.out
+        outfile: coverage.lcov
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@v2.3.6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage.lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.2.5] — 2026-05-10
+
+Patch release. One observability gate broaden completing the staging-Sentry pipeline started in v2.2.4, plus a CI improvement and a vlc-server config refactor.
+
+### Observability
+
+- **`pkg/chatbot/log` skips Stackdriver chat logging on staging too.** Both gates (`init()` at `:18` and `ChatMsg()` at `:40`) now early-return on `IsTesting() || IsDevelopment() || IsStaging()`. Pairs with the [adanalife/infra#427](https://github.com/adanalife/infra/pull/427) overlay flip — without this, `ENV=staging` would activate `logging.NewClient` against an empty `GOOGLE_APPLICATION_CREDENTIALS` and `log.Fatalf` at init. Mirrors v2.2.4's launch-plan framing: staging counts for what we explicitly opt in (Sentry), dev-like for everything else. ([#435])
+
+### CI
+
+- **Race detector + coveralls.io coverage publishing.** `testing.yml` now runs `go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` and publishes via `jandelgado/gcov2lcov-action` + `coverallsapp/github-action`. Salvaged from closed PR [#126](https://github.com/adanalife/tripbot/pull/126); pairs with the in-progress unit-testing improvements tracked in `vault/tripbot/TODO.md`. ([#438])
+
+### Cleanup
+
+- **vlc-server tuning flags now optional env vars.** `VLC_FILE_CACHING`, `VLC_AVCODEC_HW`, `VLC_VOUT`, `VLC_CANVAS_WIDTH`, `VLC_CANVAS_HEIGHT` move from hardcoded values to env-var overrides; all default to today's values, so this is a pure refactor. Resolves the `//TODO: break some of these into ENV vars` comment in `pkg/vlc-server/vlc.go`. ([#445])
+
 ## [v2.2.4] — 2026-05-09
 
 Patch release. Sentry SDK gets a long-overdue bump and the error-reporting gate broadens to fire from staging too — pairs with infra-side ESO wiring that delivers per-app DSNs into stage-1. Plus one Dockerfile cleanup.
@@ -237,3 +253,6 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#431]: https://github.com/adanalife/tripbot/pull/431
 [#432]: https://github.com/adanalife/tripbot/pull/432
 [#433]: https://github.com/adanalife/tripbot/pull/433
+[#435]: https://github.com/adanalife/tripbot/pull/435
+[#438]: https://github.com/adanalife/tripbot/pull/438
+[#445]: https://github.com/adanalife/tripbot/pull/445

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,9 +16,9 @@ tasks:
       - ENV=testing bin/devenv run --rm test go test ./...
 
   test:cover:
-    desc: Run tests with coverage; prints per-function and total coverage
+    desc: Run tests with coverage + race detector; prints per-function and total coverage
     cmds:
-      - ENV=testing bin/devenv run --rm test bash -c 'go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out'
+      - ENV=testing bin/devenv run --rm test bash -c 'go test -v -race -covermode=atomic -coverprofile=coverage.out ./... && go tool cover -func=coverage.out'
 
   test:cover:html:
     desc: Generate HTML coverage report at coverage.html

--- a/infra/docker/env.docker
+++ b/infra/docker/env.docker
@@ -40,6 +40,14 @@ TRIPBOT_SERVER_PORT=8080
 
 VLC_SERVER_HOST=vlc:8080
 
+# Optional VLC tuning knobs — unset to use the compiled-in defaults shown.
+# Tune per-host (Linux container vs. Windows dev) without recompiling.
+#VLC_FILE_CACHING=1111      # libvlc --file-caching, in milliseconds
+#VLC_AVCODEC_HW=vdpau_avcodec  # Linux-only; one of none, vdpau_avcodec, cuda
+#VLC_VOUT=x11               # Linux-only; libvlc --vout (e.g. x11, xcb_x11)
+#VLC_CANVAS_WIDTH=1920
+#VLC_CANVAS_HEIGHT=1080
+
 # OpenTelemetry — disabled by default in dev. To exercise locally, drop a
 # personal Grafana Cloud token into a sibling .env.docker.local with:
 #   OTEL_SDK_DISABLED=false

--- a/pkg/chatbot/log/log.go
+++ b/pkg/chatbot/log/log.go
@@ -15,7 +15,7 @@ func init() {
 	var err error
 
 	// don't bother with this if we're in a test environment
-	if c.Conf.IsTesting() || c.Conf.IsDevelopment() {
+	if c.Conf.IsTesting() || c.Conf.IsDevelopment() || c.Conf.IsStaging() {
 		return
 	}
 
@@ -37,7 +37,7 @@ func init() {
 }
 
 func ChatMsg(username, msg string) {
-	if c.Conf.IsTesting() || c.Conf.IsDevelopment() {
+	if c.Conf.IsTesting() || c.Conf.IsDevelopment() || c.Conf.IsStaging() {
 		return
 	}
 	chatLogger.Printf("%s: %s", username, msg)

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -15,6 +15,22 @@ type VlcServerConfig struct {
 	// vlc-server pidfile) live. EmptyDir / tmpfs is sufficient in k8s.
 	RunDir string `default:"/opt/data/run" envconfig:"RUN_DIR"`
 
+	// VlcFileCaching is the libvlc --file-caching value in milliseconds.
+	// Defaults to today's hardcoded value; tune per-host without recompiling.
+	VlcFileCaching int `default:"1111" envconfig:"VLC_FILE_CACHING"`
+	// VlcAvcodecHw is the libvlc --avcodec-hw value (Linux-only). One of
+	// none, vdpau_avcodec, cuda. Only applied on Linux hosts; ignored on
+	// Windows/Darwin (matches today's platform-specific flag layering).
+	VlcAvcodecHw string `default:"vdpau_avcodec" envconfig:"VLC_AVCODEC_HW"`
+	// VlcVout is the libvlc --vout value (Linux-only). e.g. x11, xcb_x11.
+	// Only applied on Linux hosts; ignored on Windows/Darwin.
+	VlcVout string `default:"x11" envconfig:"VLC_VOUT"`
+	// VlcCanvasWidth / VlcCanvasHeight set both the libvlc --width/--height
+	// and --canvas-width/--canvas-height. Defaults are today's hardcoded
+	// 1920x1080.
+	VlcCanvasWidth  int `default:"1920" envconfig:"VLC_CANVAS_WIDTH"`
+	VlcCanvasHeight int `default:"1080" envconfig:"VLC_CANVAS_HEIGHT"`
+
 	// VLCPidFile is where the vlc-server PID file lives
 	VLCPidFile string `default:"/opt/data/run/vlc-server.pid" envconfig:"VLC_PIDFILE"`
 

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -18,19 +19,22 @@ var videoFiles []string
 
 //TODO: figure out if vdpau_avcodec can be better than none
 //TODO: there are a ton of potentially-useful avcodec flags
-//TODO: break some of these into ENV vars
-var vlcCmdFlags = []string{
+
+// platform-invariant flags that never need per-host tuning
+var vlcStaticFlags = []string{
 	"--ignore-config", // ignore any config files that might get loaded
 	"--fullscreen",    // start fullscreened
 	"--no-audio",      // none of the videos have audio
 	// "--network-caching", "500", // network cache (in ms)
-	"--file-caching", "1111", // file cache (in ms)
-	"--width", "1920",
-	"--height", "1080",
-	"--canvas-width", "1920",
-	"--canvas-height", "1080",
 	// "--aspect-ratio", "16:9",
 }
+
+// vlcCmdFlags is built lazily in startVLC() from vlcStaticFlags +
+// per-host tuning values pulled from config (VLC_FILE_CACHING,
+// VLC_CANVAS_WIDTH, VLC_CANVAS_HEIGHT). Defaults match what was
+// previously hardcoded here, so this is a no-op refactor unless an
+// env var is explicitly set.
+var vlcCmdFlags []string
 
 // mediaOptions are applied per-Media (not as libvlc init flags).
 // libvlc's --sout takes effect only when set on the media object itself —
@@ -43,11 +47,16 @@ var mediaOptions = []string{
 	":sout-keep",
 }
 
-var vlcLinuxSpecificFlags = []string{
-	"--vout", "x11", // use X11 (and skip vdpau, improves performance)
-	"--avcodec-hw", "vdpau_avcodec", // can be none, vdpau_avcodec, or cuda
-	// "--avcodec-dr", "0",
-
+// linuxSpecificFlags returns the Linux-only VLC flags, sourced from
+// config (VLC_VOUT, VLC_AVCODEC_HW). Defaults match today's hardcoded
+// values: --vout x11 (skip vdpau, improves performance) and
+// --avcodec-hw vdpau_avcodec (can be none, vdpau_avcodec, or cuda).
+func linuxSpecificFlags() []string {
+	return []string{
+		"--vout", c.Conf.VlcVout,
+		"--avcodec-hw", c.Conf.VlcAvcodecHw,
+		// "--avcodec-dr", "0",
+	}
 }
 
 var vlcWindowsSpecificFlags = []string{
@@ -114,6 +123,20 @@ func currentlyPlaying() string {
 }
 
 func startVLC() {
+	// build the base flag set from the static list + config-driven tuning
+	// values. Defaults in pkg/config/vlc-server reproduce what used to be
+	// hardcoded here, so unset env vars yield identical behavior.
+	canvasW := strconv.Itoa(c.Conf.VlcCanvasWidth)
+	canvasH := strconv.Itoa(c.Conf.VlcCanvasHeight)
+	vlcCmdFlags = append([]string{}, vlcStaticFlags...)
+	vlcCmdFlags = append(vlcCmdFlags,
+		"--file-caching", strconv.Itoa(c.Conf.VlcFileCaching),
+		"--width", canvasW,
+		"--height", canvasH,
+		"--canvas-width", canvasW,
+		"--canvas-height", canvasH,
+	)
+
 	// set command line flags
 	if c.Conf.VlcVerbose {
 		vlcCmdFlags = append(vlcCmdFlags, vlcVerboseFlags...)
@@ -131,7 +154,7 @@ func startVLC() {
 	}
 
 	if helpers.RunningOnLinux() {
-		vlcCmdFlags = append(vlcCmdFlags, vlcLinuxSpecificFlags...)
+		vlcCmdFlags = append(vlcCmdFlags, linuxSpecificFlags()...)
 	}
 
 	if helpers.RunningOnWindows() {


### PR DESCRIPTION
Patch release. Completes the staging-Sentry pipeline started in v2.2.4 (Stackdriver gate broaden so the `ENV=staging` overlay flip won't crash pods), plus a CI improvement and a vlc-server config refactor.

### What's landing

**Observability**

- [#435](https://github.com/adanalife/tripbot/pull/435/changes) — `chatbot/log`: skip Stackdriver chat logging on staging too. Both gates (`init()` at `:18`, `ChatMsg()` at `:40`) now early-return on `IsTesting() || IsDevelopment() || IsStaging()`. Mirrors the launch-plan framing: staging counts for what we explicitly opt in (Sentry, via v2.2.4), dev-like for everything else. Required before [adanalife/infra#427](https://github.com/adanalife/infra/pull/427/changes) (the `ENV=development` → `ENV=staging` flip) can merge — without this, that flip would activate `logging.NewClient` against an empty `GOOGLE_APPLICATION_CREDENTIALS` and `log.Fatalf` at init.

**CI**

- [#438](https://github.com/adanalife/tripbot/pull/438/changes) — `ci`: race detector + coveralls.io coverage publishing. `testing.yml` now runs `go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` and publishes via `jandelgado/gcov2lcov-action` + `coverallsapp/github-action`. Salvaged from closed PR [#126](https://github.com/adanalife/tripbot/pull/126).

**Cleanup**

- [#445](https://github.com/adanalife/tripbot/pull/445/changes) — `vlc-server`: move tuning flags to optional env vars. `VLC_FILE_CACHING`, `VLC_AVCODEC_HW`, `VLC_VOUT`, `VLC_CANVAS_{WIDTH,HEIGHT}` move from hardcoded values to env-var overrides; all default to today's values. Pure refactor, no behavior change unless an operator sets one. Resolves the `//TODO: break some of these into ENV vars` comment in `pkg/vlc-server/vlc.go`.

### Why patch (v2.2.5)

No new user-facing capability, no breaking change — observability gate broaden, CI improvement, and pure config refactor. Default patch fits.

### Pre-flight

- [x] CHANGELOG.md updated for v2.2.5 (committed direct to develop, in this PR's diff)

### Release plumbing

- Merge with a **merge commit** (not squash) per `merge-strategy-by-target-branch` — preserves develop's commits as ancestors of master so future develop→master merges stay clean.
- Merging this PR (no `#minor`, default patch) → `auto-tag.yml` → `v2.2.5` → `release.yml` builds + pushes multi-arch images for tripbot, vlc, obs to Docker Hub → `verify-stamped-image.sh` gates each build leg.
- After build green: `kubectl rollout restart deploy/tripbot deploy/vlc-server`; verify pod SHA matches the v2.2.5 commit before doing anything else.
- **Then** mark [adanalife/infra#427](https://github.com/adanalife/infra/pull/427/changes) ready and merge — that flips the overlay `ENV=staging`, which makes Sentry start firing from the cluster.