### PR TITLE
db: add oauth_tokens table (010)

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -29,6 +29,10 @@ Migrations are run using [go-migrate](https://github.com/golang-migrate/migrate)
 
 `migrate create -ext sql -seq -digits 3 -dir db/migrate <migration_name>`
 
+## Migrations of note
+
+- `010_create_oauth_tokens` — stores Twitch OAuth refresh + access tokens for the bot account. Populate via `task tripbot:auth:bootstrap` (one-time, local). The bot reads the row at boot and refreshes hourly.
+
 ## To take a backup
 
 `pg_dump <postgres://url> > db_dump.$(date "+%Y%m%d").sql`

--- a/db/README.md
+++ b/db/README.md
@@ -21,9 +21,23 @@ You might need to add `?sslmode=disable` for local development servers.
 
 ## To run a migration
 
-Migrations are run using [go-migrate](https://github.com/golang-migrate/migrate).
+Migrations are run using [golang-migrate](https://github.com/golang-migrate/migrate). Install with `brew install golang-migrate` on macOS.
+
+Apply all pending migrations:
+
+`migrate -database <postgres://url> -source file://./db/migrate up`
+
+Apply a specific number of pending migrations:
 
 `migrate -database <postgres://url> -source file://./db/migrate up <migration_number>`
+
+Roll back the most recent migration:
+
+`migrate -database <postgres://url> -source file://./db/migrate down 1`
+
+Show the current schema version:
+
+`migrate -database <postgres://url> -source file://./db/migrate version`
 
 ## To create a new migration
 

--- a/db/migrate/010_create_oauth_tokens.down.sql
+++ b/db/migrate/010_create_oauth_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_tokens;

--- a/db/migrate/010_create_oauth_tokens.up.sql
+++ b/db/migrate/010_create_oauth_tokens.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE oauth_tokens (
+  id                  SERIAL PRIMARY KEY,
+  provider            TEXT NOT NULL DEFAULT 'twitch',
+  username            TEXT NOT NULL,
+  twitch_user_id      TEXT,
+  access_token        TEXT NOT NULL,
+  refresh_token       TEXT NOT NULL,
+  expires_at          TIMESTAMP WITH TIME ZONE NOT NULL,
+  scopes              TEXT NOT NULL,
+  refresh_fail_count  INTEGER NOT NULL DEFAULT 0,
+  last_refresh_at     TIMESTAMP WITH TIME ZONE,
+  date_created        TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  date_updated        TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (provider, username)
+);


### PR DESCRIPTION
## Summary

Adds migration `010_create_oauth_tokens` for a Postgres table that will store Twitch OAuth refresh + access tokens, keyed by `(provider, username)` with a unique constraint. The table is the source of truth for the bot's IRC credential and will be populated via a one-time bootstrap CLI in a follow-up PR.

Also expands `db/README.md` with the previously-undocumented `down 1` rollback and `version` status commands, plus a `brew install golang-migrate` hint and a "Migrations of note" section that points future-readers at this table.

## Why

[infra#431](https://github.com/adanalife/infra/pull/431) moved the static `TWITCH_AUTH_TOKEN` into AWS Secrets Manager via ESO — that fixed *delivery* but not *acquisition*. The token is still minted by `twitchtokengenerator.com` (a third-party site that issues tokens against its own Twitch app, so we lose access the moment they touch their config).

This PR is Phase 0 of replacing that with the Twitch OAuth2 Authorization Code flow against our own `tripbot-development` app, with refresh-token rotation persisted to this new table. Subsequent PRs add a `pkg/oauth_tokens` storage package, the `cmd/auth-bootstrap` CLI, and rewire `pkg/twitch/authentication.go` to read from the table at boot and refresh hourly.

## Why Postgres for the refresh token

Twitch rotates refresh tokens on every use, so the store has to be writable by the running pod. Postgres is already in cluster, tripbot already has read/write access, no new IAM grants. DynamoDB would be the canonical AWS-native answer here (purpose-built for app-mutable state, conditional writes for race-safety) — that's a candidate for a future migration if there's an AWS-coupling case to justify pulling the SDK into tripbot.

## Commits

- `db: add oauth_tokens table (010)` — the migration files + the "Migrations of note" entry naming this table.
- `db: expand golang-migrate runbook in README` — standalone runbook improvements (brew install, down/version commands, separating "up all pending" from "up N"). Touches the same file but is independent of this migration; split per atomic-commits.

## Test plan

- [ ] CI brings up the stack and `tripbot-migrate-1` logs show `010_create_oauth_tokens` applied without error
- [ ] After merging, locally: `migrate -database "\$DATABASE_URL" -source file://./db/migrate up`, then `\d oauth_tokens` in psql shows the expected columns + unique constraint
- [ ] `migrate -database "\$DATABASE_URL" -source file://./db/migrate down 1` rolls back cleanly to schema version 9
- [ ] Re-applying `migrate ... up` is idempotent