### PR TITLE
chatbot: accept ¡ as an alternate command prefix

### DIFF
--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -23,11 +23,22 @@ func incChatCommandCounter(command string) {
 	instrumentation.ChatCommands.Inc(command)
 }
 
+// normalizeCommandPrefix rewrites a leading Spanish inverted exclamation mark
+// `¡` (U+00A1, two bytes in UTF-8: 0xC2 0xA1) to a regular `!` so that
+// Spanish-keyboard users (who type `¡` where US keyboards type `!`) can run
+// commands without switching layouts. e.g. `¡miles` -> `!miles`.
+func normalizeCommandPrefix(msg string) string {
+	if strings.HasPrefix(msg, "¡") {
+		return "!" + strings.TrimPrefix(msg, "¡")
+	}
+	return msg
+}
+
 func runCommand(ctx context.Context, user *users.User, message string) {
 	var err error
 	var params []string
 
-	msg := strings.TrimSpace(message)
+	msg := normalizeCommandPrefix(strings.TrimSpace(message))
 	split := strings.Split(msg, " ")
 
 	// the command is the first part

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -1,0 +1,70 @@
+package chatbot
+
+import "testing"
+
+func TestNormalizeCommandPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "leading inverted bang is rewritten to !",
+			in:   "¡miles",
+			want: "!miles",
+		},
+		{
+			name: "inverted bang with params is rewritten to !",
+			in:   "¡goto 42",
+			want: "!goto 42",
+		},
+		{
+			name: "regular ! prefix is untouched",
+			in:   "!miles",
+			want: "!miles",
+		},
+		{
+			name: "bare-word (no prefix) is untouched",
+			in:   "hello",
+			want: "hello",
+		},
+		{
+			name: "inverted bang not at the start is untouched",
+			in:   "say ¡hola",
+			want: "say ¡hola",
+		},
+		{
+			name: "empty string is untouched",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeCommandPrefix(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeCommandPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeCommandPrefix_DispatchEquivalence asserts the same downstream
+// "command" token (i.e. the first whitespace-separated word of the normalized
+// message) is produced for `¡foo` and `!foo`. This is the property the
+// dispatcher in runCommand() relies on for both prefixes to route to the same
+// switch case.
+func TestNormalizeCommandPrefix_DispatchEquivalence(t *testing.T) {
+	cases := []string{"miles", "location", "leaderboard", "goto 42"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			gotBang := normalizeCommandPrefix("!" + c)
+			gotInverted := normalizeCommandPrefix("¡" + c)
+			if gotBang != gotInverted {
+				t.Errorf("dispatch divergence: !%s -> %q vs ¡%s -> %q",
+					c, gotBang, c, gotInverted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Accept `¡` (U+00A1) as an alternate command prefix alongside `!`, so Spanish-keyboard users can run commands like `¡miles` or `¡location` without switching layouts.
- Implementation: normalize a leading `¡` to `!` at the entrance of `runCommand` (single touchpoint, additive — existing `!` path is untouched). The new `normalizeCommandPrefix` helper is rune-aware (uses `strings.HasPrefix` / `strings.TrimPrefix`) because `¡` is two bytes in UTF-8 (0xC2 0xA1) and byte-indexing would mangle it.

## Test plan
- [x] `task test` passes locally (`pkg/chatbot 0.014s ok`).
- [x] New `handlers_test.go` covers `normalizeCommandPrefix` directly: leading `¡` is rewritten, regular `!` is untouched, bare-word messages are untouched, non-leading `¡` is untouched, empty string is untouched. A second test asserts dispatch-equivalence for `!foo` vs `¡foo` across a handful of representative commands.
- [ ] Try `¡miles` (or any command) in the live chat from a Spanish-keyboard input.