### PR TITLE
oauthtokens: add DB-backed token store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	cloud.google.com/go/logging v1.4.2
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/XSAM/otelsql v0.42.0
 	github.com/adrg/libvlc-go/v3 v3.1.5
 	github.com/bradfitz/latlong v0.0.0-20170410180902-f3db6d0dff40

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.2.0/go.mod h1:TYmVAyE8Tn1lyPcltF
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/XSAM/otelsql v0.42.0 h1:Li0xF4eJUxG2e0x3D4rvRlys1f27yJKvjTh7ljkUP5o=
 github.com/XSAM/otelsql v0.42.0/go.mod h1:4mOrEv+cS1KmKzrvTktvJnstr5GtKSAK+QHvFR9OcpI=
 github.com/adrg/libvlc-go/v3 v3.1.5 h1:TGO0dvubmLCSE4ocOtJYMBlPYALm8aGMkCuDZ6cXnM0=
@@ -236,6 +238,7 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kelvins/geocoder v0.0.0-20200113010004-f579500e9e27 h1:ekI686mLb7Nxb8fgczSM1iV235ypZpOZwL/ANcGZ9Lg=
 github.com/kelvins/geocoder v0.0.0-20200113010004-f579500e9e27/go.mod h1:JaVDVP24FJxa8OtNO5T1A2WKgstNreJGyK1PvBRzPW0=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/oauthtokens/oauthtokens.go
+++ b/pkg/oauthtokens/oauthtokens.go
@@ -1,0 +1,173 @@
+// Package oauthtokens is the storage layer for OAuth refresh + access tokens
+// rotated by the bot itself. The on-disk source of truth lives in the
+// `oauth_tokens` table (migration 010); this package wraps it with sqlx queries
+// matching the rest of tripbot's DB access pattern.
+package oauthtokens
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrNoToken is returned by Get when no row matches (provider, username).
+// Callers handle this as the cold-start signal — typically log.Fatal pointing
+// at the bootstrap CLI.
+var ErrNoToken = errors.New("oauthtokens: no row for (provider, username); run task tripbot:auth:bootstrap")
+
+// Token mirrors the oauth_tokens row.
+type Token struct {
+	ID               int          `db:"id"`
+	Provider         string       `db:"provider"`
+	Username         string       `db:"username"`
+	TwitchUserID     string       `db:"twitch_user_id"`
+	AccessToken      string       `db:"access_token"`
+	RefreshToken     string       `db:"refresh_token"`
+	ExpiresAt        time.Time    `db:"expires_at"`
+	Scopes           string       `db:"scopes"` // space-joined
+	RefreshFailCount int          `db:"refresh_fail_count"`
+	LastRefreshAt    sql.NullTime `db:"last_refresh_at"`
+	DateCreated      time.Time    `db:"date_created"`
+	DateUpdated      time.Time    `db:"date_updated"`
+}
+
+// Get returns the row for (provider, username) or ErrNoToken if missing.
+func Get(provider, username string) (Token, error) {
+	return getFromDB(database.Connection(), provider, username)
+}
+
+func getFromDB(db *sqlx.DB, provider, username string) (Token, error) {
+	var t Token
+	query := `SELECT * FROM oauth_tokens WHERE provider=$1 AND username=$2`
+	err := db.Get(&t, query, provider, username)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Token{}, ErrNoToken
+	}
+	if err != nil {
+		return Token{}, fmt.Errorf("oauthtokens.Get: %w", err)
+	}
+	return t, nil
+}
+
+// Upsert inserts the row or updates the existing one matching (provider, username).
+// On UPDATE, refresh_fail_count is reset to 0 (Upsert implies a successful refresh
+// or a fresh bootstrap), last_refresh_at + date_updated are stamped to now(),
+// and date_created is preserved.
+func Upsert(t Token) error {
+	return upsertOnDB(database.Connection(), t)
+}
+
+func upsertOnDB(db *sqlx.DB, t Token) error {
+	tx, err := db.Beginx()
+	if err != nil {
+		return fmt.Errorf("oauthtokens.Upsert begin: %w", err)
+	}
+	query := `
+		INSERT INTO oauth_tokens
+			(provider, username, twitch_user_id, access_token, refresh_token,
+			 expires_at, scopes, refresh_fail_count, last_refresh_at)
+		VALUES
+			(:provider, :username, :twitch_user_id, :access_token, :refresh_token,
+			 :expires_at, :scopes, 0, NOW())
+		ON CONFLICT (provider, username) DO UPDATE SET
+			twitch_user_id     = EXCLUDED.twitch_user_id,
+			access_token       = EXCLUDED.access_token,
+			refresh_token      = EXCLUDED.refresh_token,
+			expires_at         = EXCLUDED.expires_at,
+			scopes             = EXCLUDED.scopes,
+			refresh_fail_count = 0,
+			last_refresh_at    = NOW(),
+			date_updated       = NOW()
+	`
+	if _, err := tx.NamedExec(query, t); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("oauthtokens.Upsert exec: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("oauthtokens.Upsert commit: %w", err)
+	}
+	return nil
+}
+
+// IncrementFailCount bumps refresh_fail_count by 1 and stamps last_refresh_at.
+// Called by the refresh loop on Twitch-side errors (5xx, network blip, revoked
+// token) so persistent failures surface in monitoring.
+func IncrementFailCount(provider, username string) error {
+	return incrementOnDB(database.Connection(), provider, username)
+}
+
+func incrementOnDB(db *sqlx.DB, provider, username string) error {
+	query := `
+		UPDATE oauth_tokens
+		SET refresh_fail_count = refresh_fail_count + 1,
+		    last_refresh_at    = NOW(),
+		    date_updated       = NOW()
+		WHERE provider=$1 AND username=$2
+	`
+	res, err := db.Exec(query, provider, username)
+	if err != nil {
+		return fmt.Errorf("oauthtokens.IncrementFailCount: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("oauthtokens.IncrementFailCount rows: %w", err)
+	}
+	if n == 0 {
+		return ErrNoToken
+	}
+	return nil
+}
+
+// TryRefreshLock attempts to acquire a Postgres session-scoped advisory lock
+// keyed on (provider, username). The lock prevents concurrent refresh between
+// a local-dev tripbot and a cluster pod sharing the same Twitch account: only
+// one can rotate the refresh token at a time.
+//
+// On success, acquired=true and the caller MUST invoke release() when done.
+// On contention, acquired=false; the caller should re-Get the row (the winner
+// has rotated it) and proceed without calling release().
+//
+// The lock is held against a single pooled connection; release() unlocks and
+// returns the connection to the pool.
+func TryRefreshLock(provider, username string) (bool, func(), error) {
+	return tryRefreshLockOnDB(database.Connection(), provider, username)
+}
+
+func tryRefreshLockOnDB(db *sqlx.DB, provider, username string) (bool, func(), error) {
+	ctx := context.Background()
+	conn, err := db.Connx(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("oauthtokens.TryRefreshLock conn: %w", err)
+	}
+	key := lockKey(provider, username)
+	var acquired bool
+	if err := conn.GetContext(ctx, &acquired, "SELECT pg_try_advisory_lock($1)", key); err != nil {
+		_ = conn.Close()
+		return false, nil, fmt.Errorf("oauthtokens.TryRefreshLock acquire: %w", err)
+	}
+	if !acquired {
+		_ = conn.Close()
+		return false, nil, nil
+	}
+	release := func() {
+		// Best-effort unlock; closing the conn releases it regardless.
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key)
+		_ = conn.Close()
+	}
+	return acquired, release, nil
+}
+
+// lockKey hashes the lock identifier into a stable int64 suitable for
+// pg_try_advisory_lock(bigint). The hashtext() approach used elsewhere is
+// 32-bit; we use SHA-256 → first 8 bytes as int64 for a wider key space.
+func lockKey(provider, username string) int64 {
+	h := sha256.Sum256([]byte("oauth_refresh:" + provider + ":" + username))
+	return int64(binary.BigEndian.Uint64(h[:8]))
+}

--- a/pkg/oauthtokens/oauthtokens_test.go
+++ b/pkg/oauthtokens/oauthtokens_test.go
@@ -1,0 +1,215 @@
+package oauthtokens
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+)
+
+func newMockDB(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	// Default matcher is QueryMatcherRegexp; the expected strings below are
+	// substrings/patterns of the real queries.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlx.NewDb(db, "postgres"), mock
+}
+
+func sampleToken() Token {
+	return Token{
+		Provider:     "twitch",
+		Username:     "tripbot4000",
+		TwitchUserID: "12345",
+		AccessToken:  "access-abc",
+		RefreshToken: "refresh-xyz",
+		ExpiresAt:    time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		Scopes:       "chat:read chat:edit channel:read:subscriptions user:edit:broadcast",
+	}
+}
+
+func TestGet_Hit(t *testing.T) {
+	db, mock := newMockDB(t)
+	rows := sqlmock.NewRows([]string{
+		"id", "provider", "username", "twitch_user_id", "access_token", "refresh_token",
+		"expires_at", "scopes", "refresh_fail_count", "last_refresh_at",
+		"date_created", "date_updated",
+	}).AddRow(
+		1, "twitch", "tripbot4000", "12345", "access-abc", "refresh-xyz",
+		time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		"chat:read chat:edit",
+		0, nil,
+		time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+	)
+	mock.ExpectQuery(`SELECT .* FROM oauth_tokens WHERE provider=`).
+		WithArgs("twitch", "tripbot4000").
+		WillReturnRows(rows)
+
+	got, err := getFromDB(db, "twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("getFromDB: %v", err)
+	}
+	if got.Username != "tripbot4000" || got.AccessToken != "access-abc" || got.RefreshToken != "refresh-xyz" {
+		t.Errorf("unexpected token: %+v", got)
+	}
+	if got.RefreshFailCount != 0 {
+		t.Errorf("expected RefreshFailCount=0, got %d", got.RefreshFailCount)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGet_Miss(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery(`SELECT .* FROM oauth_tokens WHERE provider=`).
+		WithArgs("twitch", "ghost").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := getFromDB(db, "twitch", "ghost")
+	if !errors.Is(err, ErrNoToken) {
+		t.Errorf("expected ErrNoToken, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpsert_RunsExpectedQuery(t *testing.T) {
+	db, mock := newMockDB(t)
+	tok := sampleToken()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO oauth_tokens`).
+		WithArgs(
+			tok.Provider, tok.Username, tok.TwitchUserID,
+			tok.AccessToken, tok.RefreshToken, tok.ExpiresAt, tok.Scopes,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := upsertOnDB(db, tok); err != nil {
+		t.Fatalf("upsertOnDB: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpsert_RollsBackOnExecError(t *testing.T) {
+	db, mock := newMockDB(t)
+	tok := sampleToken()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO oauth_tokens`).
+		WillReturnError(errors.New("boom"))
+	mock.ExpectRollback()
+
+	err := upsertOnDB(db, tok)
+	if err == nil {
+		t.Fatal("expected error from upsertOnDB, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIncrementFailCount_UpdatesRow(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec(`UPDATE oauth_tokens`).
+		WithArgs("twitch", "tripbot4000").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := incrementOnDB(db, "twitch", "tripbot4000"); err != nil {
+		t.Fatalf("incrementOnDB: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIncrementFailCount_NoRowReturnsErrNoToken(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec(`UPDATE oauth_tokens`).
+		WithArgs("twitch", "ghost").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := incrementOnDB(db, "twitch", "ghost")
+	if !errors.Is(err, ErrNoToken) {
+		t.Errorf("expected ErrNoToken, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTryRefreshLock_Acquired(t *testing.T) {
+	db, mock := newMockDB(t)
+	key := lockKey("twitch", "tripbot4000")
+
+	mock.ExpectQuery(`pg_try_advisory_lock`).
+		WithArgs(key).
+		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(true))
+	mock.ExpectExec(`pg_advisory_unlock`).
+		WithArgs(key).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	acquired, release, err := tryRefreshLockOnDB(db, "twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("tryRefreshLockOnDB: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected acquired=true")
+	}
+	if release == nil {
+		t.Fatal("expected non-nil release fn")
+	}
+	release()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTryRefreshLock_Contended(t *testing.T) {
+	db, mock := newMockDB(t)
+	key := lockKey("twitch", "tripbot4000")
+
+	mock.ExpectQuery(`pg_try_advisory_lock`).
+		WithArgs(key).
+		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(false))
+
+	acquired, release, err := tryRefreshLockOnDB(db, "twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("tryRefreshLockOnDB: %v", err)
+	}
+	if acquired {
+		t.Fatal("expected acquired=false")
+	}
+	if release != nil {
+		t.Fatal("expected nil release fn on contention")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestLockKey_StableAndDistinct(t *testing.T) {
+	a := lockKey("twitch", "tripbot4000")
+	b := lockKey("twitch", "tripbot4000")
+	if a != b {
+		t.Errorf("lockKey not stable: %d vs %d", a, b)
+	}
+	if lockKey("twitch", "tripbot4000") == lockKey("twitch", "adanalife") {
+		t.Error("lockKey collision between distinct usernames")
+	}
+	if lockKey("twitch", "tripbot4000") == lockKey("github", "tripbot4000") {
+		t.Error("lockKey collision between distinct providers")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pkg/oauthtokens`, the storage layer for the new `oauth_tokens` table from [tripbot#452](https://github.com/adanalife/tripbot/pull/452). Pure storage — no helix dep, no consumers yet. Auth-flow rewire ships in a follow-up PR.

The package exposes four functions:

- `Get(provider, username) (Token, error)` — SELECT one row; returns sentinel `ErrNoToken` on miss so callers can detect cold-start.
- `Upsert(Token) error` — single-tx INSERT ... ON CONFLICT DO UPDATE. Resets `refresh_fail_count = 0` and stamps `last_refresh_at` / `date_updated` to NOW() on every Upsert (success implies the token is fresh again).
- `IncrementFailCount(provider, username) error` — bumps `refresh_fail_count` and `last_refresh_at`. Returns `ErrNoToken` if no row matches.
- `TryRefreshLock(provider, username) (acquired bool, release func(), err error)` — Postgres session-scoped advisory lock keyed on `(provider, username)`. Prevents simultaneous rotation between a local-dev tripbot and a cluster pod sharing the same Twitch account; loser of the lock simply re-Gets the rotated row.

## Why a separate package over extending pkg/twitch

`pkg/twitch` already mixes helix client + auth globals + API calls. Keeping storage isolated lets it stay helix-free, matches the per-table package shape used elsewhere (`pkg/users`, `pkg/video`, `pkg/scoreboards`), and makes the package unit-testable with sqlmock without dragging in helix.

## Advisory-lock key

`lockKey(provider, username)` hashes the identifier via SHA-256 and takes the first 8 bytes as an int64 — wider key space than the `hashtext()` approach used in some Postgres patterns (which is 32-bit). Stability + collision-freedom between adjacent identifiers is verified in `TestLockKey_StableAndDistinct`.

## Why this can ship before #452 merges

Tests use [go-sqlmock](https://github.com/DATA-DOG/go-sqlmock) (`v1.5.2`, latest stable) and don't touch a real Postgres. The package compiles and tests cleanly without the migration applied. Runtime use lands in the follow-up auth rewire and depends on #452.

## Test plan

- [x] `go test ./pkg/oauthtokens/... -v` passes locally — 9/9 green
- [x] `go vet ./pkg/oauthtokens/...` clean
- [x] `go build ./pkg/oauthtokens/...` clean
- [x] `go mod tidy` leaves sqlmock as a direct dep, not indirect
- [ ] CI on this PR runs the full `task test` suite green