### PR TITLE
twitch: DB-backed OAuth + state validation + auth-bootstrap CLI

### DIFF
--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -46,7 +46,7 @@ jobs:
           cache-from: type=gha,scope=tripbot
           cache-to: type=gha,mode=max,scope=tripbot
 
-      - name: Bring up the stack (db + migrate + tripbot)
+      - name: Bring up db + migrate
         env:
           CHANNEL_NAME: ${{ secrets.CHANNEL_NAME }}
           BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
@@ -60,12 +60,54 @@ jobs:
             -f infra/docker/docker-compose.yml \
             -f infra/docker/docker-compose.testing.yml \
             -f infra/docker/docker-compose.github.yml \
-            up -d db migrate tripbot
+            up -d db migrate
 
-      - run: sleep 10
+      - run: sleep 5
 
       - name: Check logs (migrate)
         run: docker logs tripbot-migrate-1
+
+      # tripbot's LoadFromDB at boot refuses to start without an oauth_tokens
+      # row (cluster contract: bootstrap-or-fatal). CI has no real Twitch
+      # creds to bootstrap with, so seed a syntactically-valid placeholder row
+      # so cmd/tripbot can boot far enough to verify version files + /version.
+      - name: Seed placeholder oauth_tokens row for build-stack tripbot
+        env:
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+        run: |
+          docker exec -i tripbot-db-1 \
+            psql -U tripbot_docker -d tripbot_docker \
+              -v ON_ERROR_STOP=1 \
+              -v BOT_USERNAME="$BOT_USERNAME" <<'SQL'
+          INSERT INTO oauth_tokens
+            (provider, username, access_token, refresh_token, expires_at, scopes)
+          VALUES
+            ('twitch', :'BOT_USERNAME', 'ci-placeholder-access',
+             'ci-placeholder-refresh', NOW() + INTERVAL '1 hour',
+             'chat:read chat:edit')
+          ON CONFLICT (provider, username) DO UPDATE
+            SET access_token = EXCLUDED.access_token,
+                refresh_token = EXCLUDED.refresh_token,
+                expires_at    = EXCLUDED.expires_at;
+          SQL
+
+      - name: Bring up tripbot
+        env:
+          CHANNEL_NAME: ${{ secrets.CHANNEL_NAME }}
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+          TWITCH_AUTH_TOKEN: ${{ secrets.TWITCH_AUTH_TOKEN }}
+          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+        run: |
+          docker compose \
+            --project-directory . \
+            --env-file infra/docker/env.docker \
+            -f infra/docker/docker-compose.yml \
+            -f infra/docker/docker-compose.testing.yml \
+            -f infra/docker/docker-compose.github.yml \
+            up -d tripbot
+
+      - run: sleep 10
 
       - name: Check logs (tripbot)
         run: docker logs tripbot-tripbot-1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,18 @@ tasks:
     cmds:
       - ENV=testing bin/devenv run --rm test bash
 
+  auth:bootstrap:
+    desc: One-time Twitch OAuth bootstrap; writes refresh token to oauth_tokens. Run on host (needs a browser); bring up Postgres first (`bin/devenv up -d db migrate` locally, or `task tripbot:db:up` in infra for cluster DB).
+    env:
+      # Local-bootstrap defaults. Override at the shell to point elsewhere.
+      ENV: '{{.ENV | default "development"}}'
+      DATABASE_HOST: '{{.DATABASE_HOST | default "localhost"}}'
+      EXTERNAL_URL: '{{.EXTERNAL_URL | default "http://localhost:8080"}}'
+    cmds:
+      # `mise exec --` activates the pinned Go toolchain in task's
+      # non-interactive subshell (where ~/.zshrc isn't sourced).
+      - mise exec -- go run ./cmd/auth-bootstrap
+
   # Release smoke flow — see vault/tripbot/release-checklist.md.
   # Targets the local k3d cluster running the stage-1 overlay
   # (cloudflared tunnel + apps).

--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -1,0 +1,114 @@
+// cmd/auth-bootstrap is the one-time interactive Twitch OAuth bootstrap.
+// Runs locally (on Dana's laptop) against the cluster Postgres via port-forward
+// to populate the oauth_tokens row that the cluster tripbot pod consumes at
+// boot.
+//
+// Flow:
+//   1. Verify DB reachable.
+//   2. Generate CSRF state, build authorize URL with mytwitch.Scopes.
+//   3. Spin up a tiny localhost:8080 HTTP listener for the OAuth callback.
+//   4. Open the browser to the authorize URL. Dana signs in as tripbot4000.
+//   5. Twitch redirects to localhost:8080/auth/callback. The handler validates
+//      state, exchanges the code via mytwitch.GenerateUserAccessToken (which
+//      Upserts the row), and signals completion.
+//   6. Exit cleanly.
+//
+// The Twitch app's registered redirect URI is http://localhost:8080/auth/callback;
+// this CLI relies on that registration matching what helix.Client sends.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	_ "github.com/adanalife/tripbot/pkg/config/tripbot" // env loader via package init
+	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+	"github.com/logrusorgru/aurora"
+	"github.com/nicklaw5/helix"
+)
+
+const (
+	listenAddr     = "localhost:8080"
+	callbackPath   = "/auth/callback"
+	flowTimeout    = 5 * time.Minute
+	shutdownGrace  = 5 * time.Second
+	successHTML    = `<!doctype html><html><head><meta charset="utf-8"><title>tripbot — bootstrap success</title><style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style></head><body><div><h1>Success</h1><p>Refresh token persisted. You may close this tab.</p></div></body></html>`
+)
+
+func main() {
+	// Verify the DB is reachable before any user-facing work; if the
+	// port-forward isn't up this is where it surfaces.
+	if database.Connection() == nil {
+		log.Fatal("could not connect to database; ensure DATABASE_HOST/USER/PASS/DB are set and a port-forward to the cluster Postgres is up (task tripbot:db:up)")
+	}
+
+	client, err := mytwitch.Client()
+	if err != nil {
+		log.Fatalf("could not build Twitch client: %v", err)
+	}
+
+	state := oauthstate.New()
+	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
+		Scopes:       mytwitch.Scopes,
+		ResponseType: "code",
+		State:        state,
+	})
+
+	done := make(chan error, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+		if !oauthstate.Validate(r.URL.Query().Get("state")) {
+			http.Error(w, "invalid or expired state", http.StatusBadRequest)
+			done <- errors.New("state validation failed")
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "no code in response from twitch", http.StatusBadRequest)
+			done <- errors.New("no code")
+			return
+		}
+		if err := mytwitch.GenerateUserAccessToken(code); err != nil {
+			http.Error(w, "code exchange failed: "+err.Error(), http.StatusInternalServerError)
+			done <- err
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, successHTML)
+		done <- nil
+	})
+
+	srv := &http.Server{Addr: listenAddr, Handler: mux}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			done <- fmt.Errorf("listener: %w", err)
+		}
+	}()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	log.Println(aurora.Cyan("Opening browser for Twitch sign-in..."))
+	log.Println("If your browser doesn't open automatically, visit:")
+	log.Println(aurora.Blue(authURL).Underline())
+	helpers.OpenInBrowser(authURL)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Fatalf("bootstrap failed: %v", err)
+		}
+		log.Println(aurora.Green("bootstrap successful — refresh token persisted to oauth_tokens"))
+	case <-time.After(flowTimeout):
+		log.Fatalf("timed out after %s waiting for Twitch callback", flowTimeout)
+	}
+}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -65,6 +66,7 @@ func main() {
 	findInitialVideo()
 	users.InitLeaderboard()
 	startCron()
+	loadTwitchToken()   // must precede chatbot.Initialize — provides the IRC token
 	setUpTwitchClient() // required for the below
 	updateSubscribers()
 	getCurrentUsers()
@@ -125,6 +127,18 @@ func startCron() {
 	// start cron and attach cronjobs
 	background.StartCron()
 	scheduleBackgroundJobs()
+}
+
+// loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
+// Refuses to start if the row is missing — pointing at the bootstrap CLI
+// is louder than running IRC-less.
+func loadTwitchToken() {
+	if err := mytwitch.LoadFromDB(); err != nil {
+		if errors.Is(err, mytwitch.ErrNoToken) {
+			log.Fatalf("no oauth_tokens row for %q — run `task tripbot:auth:bootstrap` against the cluster DB (port-forward via `task tripbot:db:up` in infra)", c.Conf.BotUsername)
+		}
+		terrors.Fatal(err, "failed to load Twitch token from DB")
+	}
 }
 
 // setUpTwitchClient sets up the Twitch client,

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -9,13 +9,11 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
-	"github.com/adanalife/tripbot/pkg/helpers"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gempir/go-twitch-irc/v2"
 	"github.com/kelvins/geocoder"
-	"github.com/logrusorgru/aurora"
 	"github.com/nicklaw5/helix"
 )
 
@@ -39,25 +37,14 @@ func Initialize() *twitch.Client {
 	geocoder.ApiKey = c.Conf.GoogleMapsAPIKey
 
 	// initialize the twitch API client
-	myClient, err := mytwitch.Client()
+	_, err = mytwitch.Client()
 	if err != nil {
 		terrors.Fatal(err, "unable to create twitch API client")
 	}
 
-	if !c.Conf.DisableTwitchWebhooks {
-		//TODO: actually use the security features provided here
-		authURL := myClient.GetAuthorizationURL(&helix.AuthorizationURLParams{
-			//TODO: move to configs lib
-			//TODO: revisit that we need all of these
-			Scopes:       []string{"openid", "user:edit:broadcast", "channel:read:subscriptions"},
-			ResponseType: "code",
-		})
-		log.Println("if your browser doesn't open automatically:")
-		log.Println(aurora.Blue(authURL).Underline())
-		helpers.OpenInBrowser(authURL)
-	}
-
-	client = twitch.NewClient(c.Conf.BotUsername, mytwitch.AuthToken)
+	// The IRC token comes from the DB-backed oauth_tokens row populated by
+	// cmd/auth-bootstrap; cmd/tripbot calls mytwitch.LoadFromDB before this.
+	client = twitch.NewClient(c.Conf.BotUsername, mytwitch.IRCAuthToken())
 
 	// attach handlers
 	client.OnUserJoinMessage(UserJoin)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,4 +45,12 @@ func SetEnvironment() {
 		log.Println("Error loading .env file:", err)
 		log.Println("Continuing anyway...")
 	}
+
+	// Also load the docker env file as a base layer; docker-compose layers
+	// this in via `--env-file infra/docker/env.docker`, but host-side runs
+	// (e.g. cmd/auth-bootstrap) don't go through compose. godotenv.Load
+	// doesn't overwrite existing values, so shell-env and .env.<env> stay
+	// authoritative. Silent no-op in containers without this file present
+	// (e.g. the cluster pod).
+	_ = godotenv.Load("infra/docker/env.docker")
 }

--- a/pkg/oauthtokens/oauthtokens.go
+++ b/pkg/oauthtokens/oauthtokens.go
@@ -22,20 +22,23 @@ import (
 // at the bootstrap CLI.
 var ErrNoToken = errors.New("oauthtokens: no row for (provider, username); run task tripbot:auth:bootstrap")
 
-// Token mirrors the oauth_tokens row.
+// Token mirrors the oauth_tokens row. TwitchUserID + LastRefreshAt are
+// nullable in the schema; the bootstrap CLI populates twitch_user_id from
+// helix.GetUsers, but any out-of-band INSERT (CI seed, ad-hoc psql) may
+// leave it unset, so sqlx scans must handle NULL.
 type Token struct {
-	ID               int          `db:"id"`
-	Provider         string       `db:"provider"`
-	Username         string       `db:"username"`
-	TwitchUserID     string       `db:"twitch_user_id"`
-	AccessToken      string       `db:"access_token"`
-	RefreshToken     string       `db:"refresh_token"`
-	ExpiresAt        time.Time    `db:"expires_at"`
-	Scopes           string       `db:"scopes"` // space-joined
-	RefreshFailCount int          `db:"refresh_fail_count"`
-	LastRefreshAt    sql.NullTime `db:"last_refresh_at"`
-	DateCreated      time.Time    `db:"date_created"`
-	DateUpdated      time.Time    `db:"date_updated"`
+	ID               int            `db:"id"`
+	Provider         string         `db:"provider"`
+	Username         string         `db:"username"`
+	TwitchUserID     sql.NullString `db:"twitch_user_id"`
+	AccessToken      string         `db:"access_token"`
+	RefreshToken     string         `db:"refresh_token"`
+	ExpiresAt        time.Time      `db:"expires_at"`
+	Scopes           string         `db:"scopes"` // space-joined
+	RefreshFailCount int            `db:"refresh_fail_count"`
+	LastRefreshAt    sql.NullTime   `db:"last_refresh_at"`
+	DateCreated      time.Time      `db:"date_created"`
+	DateUpdated      time.Time      `db:"date_updated"`
 }
 
 // Get returns the row for (provider, username) or ErrNoToken if missing.

--- a/pkg/oauthtokens/oauthtokens_test.go
+++ b/pkg/oauthtokens/oauthtokens_test.go
@@ -26,7 +26,7 @@ func sampleToken() Token {
 	return Token{
 		Provider:     "twitch",
 		Username:     "tripbot4000",
-		TwitchUserID: "12345",
+		TwitchUserID: sql.NullString{String: "12345", Valid: true},
 		AccessToken:  "access-abc",
 		RefreshToken: "refresh-xyz",
 		ExpiresAt:    time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -11,10 +11,21 @@ import (
 	"github.com/adanalife/tripbot/pkg/chatbot"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/logrusorgru/aurora"
+	"github.com/nicklaw5/helix"
 )
+
+// generateUserAccessToken is overridable in tests so the /auth/callback
+// happy path can be exercised without round-tripping to Twitch.
+var generateUserAccessToken = mytwitch.GenerateUserAccessToken
+
+// helixClient is overridable in tests so /auth/init's URL-construction can be
+// exercised without triggering mytwitch.Client()'s lazy network init (which
+// would request a real App Access Token from Twitch).
+var helixClient = mytwitch.Client
 
 // versionTag is set by main via SetVersion; overridden at build time
 // through `-ldflags "-X main.version=..."`.
@@ -149,27 +160,66 @@ func authTwitchHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, twitchAuthJSON())
 }
 
-// oauth callback URL, requests come from Twitch and have a special code
-// we then use that code to generate a User Access Token
+// authCallbackHandler completes the OAuth Authorization Code flow. Validates
+// the CSRF state, exchanges the code for an access+refresh token via helix,
+// and persists the row (mytwitch.GenerateUserAccessToken handles the helix
+// call + Upsert).
 func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
-	codes, ok := r.URL.Query()["code"]
-
-	if !ok || len(codes[0]) < 1 {
-		msg := "no code in response from twitch"
-		terrors.Log(errors.New("code missing"), msg)
-		//TODO: better error than StatusNotFound (404)
-		http.Error(w, msg, http.StatusNotFound)
+	state := r.URL.Query().Get("state")
+	if !oauthstate.Validate(state) {
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
 		return
 	}
-	code := string(codes[0])
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		terrors.Log(errors.New("code missing"), "no code in response from twitch")
+		http.Error(w, "no code in response from twitch", http.StatusBadRequest)
+		return
+	}
+
+	if err := generateUserAccessToken(code); err != nil {
+		terrors.Log(err, "GenerateUserAccessToken failed")
+		http.Error(w, "failed to exchange code: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	log.Println(aurora.Cyan("successfully received token from twitch!"))
-	// use the code to generate an access token
-	mytwitch.GenerateUserAccessToken(code)
-
-	//TODO: return a pretty HTML page here (black background, logo, etc)
-	fmt.Fprintf(w, "Success!")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, authSuccessHTML)
 }
+
+// authInitHandler kicks off an OAuth Authorization Code flow from a browser.
+// Generates a state, redirects (302) to Twitch's authorize URL with the
+// configured Scopes. The cluster pod serves this for emergency re-bootstrap
+// when Dana isn't near a laptop; locally cmd/auth-bootstrap does its own
+// equivalent without going through the public Ingress.
+func authInitHandler(w http.ResponseWriter, r *http.Request) {
+	client, err := helixClient()
+	if err != nil {
+		terrors.Log(err, "helix client unavailable for /auth/init")
+		http.Error(w, "auth unavailable", http.StatusInternalServerError)
+		return
+	}
+	state := oauthstate.New()
+	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
+		Scopes:       mytwitch.Scopes,
+		ResponseType: "code",
+		State:        state,
+	})
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// authSuccessHTML is the body returned after a successful code exchange.
+// Inline so the handler doesn't depend on a template file; if this needs
+// styling beyond a few lines, move to an embed.FS template.
+const authSuccessHTML = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>tripbot — auth success</title>
+<style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>
+</head>
+<body><div><h1>Success</h1><p>You may close this tab.</p></div></body>
+</html>`
 
 // return a favicon if anyone asks for one
 func faviconHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -2,11 +2,14 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 )
 
 func TestHealthHandler(t *testing.T) {
@@ -124,6 +127,123 @@ func TestAuthTwitchHandlerMissingSecretReturns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// withStubGenerateUserAccessToken swaps the package-level generator so the
+// /auth/callback handler can be tested without round-tripping to Twitch.
+func withStubGenerateUserAccessToken(t *testing.T, stub func(string) error) {
+	t.Helper()
+	saved := generateUserAccessToken
+	generateUserAccessToken = stub
+	t.Cleanup(func() { generateUserAccessToken = saved })
+}
+
+func TestAuthCallbackHandler_NoStateReturns400(t *testing.T) {
+	withStubGenerateUserAccessToken(t, func(string) error {
+		t.Fatal("generator should not be called when state is missing")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=anything", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthCallbackHandler_BadStateReturns400(t *testing.T) {
+	withStubGenerateUserAccessToken(t, func(string) error {
+		t.Fatal("generator should not be called when state is invalid")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state=not-real&code=anything", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthCallbackHandler_NoCodeReturns400(t *testing.T) {
+	state := oauthstate.New()
+	withStubGenerateUserAccessToken(t, func(string) error {
+		t.Fatal("generator should not be called when code is missing")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state, nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthCallbackHandler_HappyPath(t *testing.T) {
+	state := oauthstate.New()
+	var gotCode string
+	withStubGenerateUserAccessToken(t, func(code string) error {
+		gotCode = code
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=the-code", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotCode != "the-code" {
+		t.Errorf("generator got code %q, want %q", gotCode, "the-code")
+	}
+	if !strings.Contains(rec.Header().Get("Content-Type"), "text/html") {
+		t.Errorf("Content-Type %q is not html", rec.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(rec.Body.String(), "Success") {
+		t.Errorf("body should contain 'Success'; got %q", rec.Body.String())
+	}
+}
+
+func TestAuthCallbackHandler_GeneratorErrorReturns500(t *testing.T) {
+	state := oauthstate.New()
+	withStubGenerateUserAccessToken(t, func(string) error {
+		return errors.New("twitch broke")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=anything", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAuthCallbackHandler_StateIsSingleUse(t *testing.T) {
+	state := oauthstate.New()
+	withStubGenerateUserAccessToken(t, func(string) error { return nil })
+
+	// First call consumes the state and succeeds.
+	req1 := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=x", nil)
+	rec1 := httptest.NewRecorder()
+	authCallbackHandler(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first call: got status %d, want %d", rec1.Code, http.StatusOK)
+	}
+
+	// Second call with the same state should 400.
+	req2 := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=x", nil)
+	rec2 := httptest.NewRecorder()
+	authCallbackHandler(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("second call: got status %d, want %d (state should be single-use)", rec2.Code, http.StatusBadRequest)
 	}
 }
 

--- a/pkg/server/oauthstate/oauthstate.go
+++ b/pkg/server/oauthstate/oauthstate.go
@@ -1,0 +1,67 @@
+// Package oauthstate generates and validates the `state` query parameter for
+// the OAuth Authorization Code flow. Generators stash a random token before
+// redirecting to the IdP; validators consume it on the callback.
+//
+// State entries auto-expire after a short TTL and are single-use (deleted on
+// successful Validate). The in-memory store is process-local — fine for the
+// callback flow where the same process serves /auth/init and /auth/callback,
+// not designed for distribution.
+package oauthstate
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// TTL is how long a state token remains valid after New.
+const TTL = 5 * time.Minute
+
+var (
+	mu    sync.Mutex
+	store = map[string]time.Time{} // state -> expiry
+	now   = time.Now              // overridable in tests
+)
+
+// New mints a fresh state token, stores it with TTL, and returns it.
+func New() string {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// crypto/rand failure is a process-wide problem; panic is acceptable.
+		panic("oauthstate: crypto/rand: " + err.Error())
+	}
+	state := hex.EncodeToString(buf[:])
+	mu.Lock()
+	store[state] = now().Add(TTL)
+	mu.Unlock()
+	return state
+}
+
+// Validate consumes the state token. Returns true exactly once per New().
+// Subsequent calls (or expired/unknown states) return false.
+func Validate(state string) bool {
+	if state == "" {
+		return false
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	sweepLocked()
+	exp, ok := store[state]
+	if !ok {
+		return false
+	}
+	delete(store, state)
+	return now().Before(exp)
+}
+
+// sweepLocked drops expired entries. Called from Validate so we never grow
+// the store unboundedly when state tokens go unused.
+func sweepLocked() {
+	t := now()
+	for k, exp := range store {
+		if !t.Before(exp) {
+			delete(store, k)
+		}
+	}
+}

--- a/pkg/server/oauthstate/oauthstate_test.go
+++ b/pkg/server/oauthstate/oauthstate_test.go
@@ -1,0 +1,105 @@
+package oauthstate
+
+import (
+	"testing"
+	"time"
+)
+
+func resetStore(t *testing.T) {
+	t.Helper()
+	savedNow := now
+	t.Cleanup(func() {
+		mu.Lock()
+		store = map[string]time.Time{}
+		mu.Unlock()
+		now = savedNow
+	})
+	mu.Lock()
+	store = map[string]time.Time{}
+	mu.Unlock()
+}
+
+func TestNew_GeneratesUniqueStates(t *testing.T) {
+	resetStore(t)
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		s := New()
+		if s == "" {
+			t.Fatal("New returned empty state")
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate state generated: %q", s)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+func TestValidate_Hit(t *testing.T) {
+	resetStore(t)
+	s := New()
+	if !Validate(s) {
+		t.Fatal("expected Validate(New()) to return true")
+	}
+}
+
+func TestValidate_DoubleUseRejected(t *testing.T) {
+	resetStore(t)
+	s := New()
+	if !Validate(s) {
+		t.Fatal("first Validate should succeed")
+	}
+	if Validate(s) {
+		t.Fatal("second Validate of same state should fail (single-use)")
+	}
+}
+
+func TestValidate_ExpiredRejected(t *testing.T) {
+	resetStore(t)
+	t0 := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return t0 }
+	s := New()
+	// advance past TTL
+	now = func() time.Time { return t0.Add(TTL + time.Second) }
+	if Validate(s) {
+		t.Fatal("expired state should not validate")
+	}
+}
+
+func TestValidate_UnknownRejected(t *testing.T) {
+	resetStore(t)
+	if Validate("not-a-real-state") {
+		t.Fatal("unknown state should not validate")
+	}
+}
+
+func TestValidate_EmptyStringRejected(t *testing.T) {
+	resetStore(t)
+	if Validate("") {
+		t.Fatal("empty state should not validate")
+	}
+}
+
+func TestSweepClearsExpiredEntries(t *testing.T) {
+	resetStore(t)
+	t0 := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return t0 }
+	// generate several states that will expire
+	for i := 0; i < 5; i++ {
+		New()
+	}
+	mu.Lock()
+	beforeSweep := len(store)
+	mu.Unlock()
+	if beforeSweep != 5 {
+		t.Fatalf("expected 5 entries before sweep, got %d", beforeSweep)
+	}
+	// jump past TTL, then Validate (which triggers sweep)
+	now = func() time.Time { return t0.Add(TTL + time.Second) }
+	Validate("anything") // miss, but triggers sweep
+	mu.Lock()
+	afterSweep := len(store)
+	mu.Unlock()
+	if afterSweep != 0 {
+		t.Fatalf("expected sweep to clear expired entries, %d remain", afterSweep)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,6 +48,7 @@ func Start() {
 	// auth endpoints
 	auth := r.PathPrefix("/auth").Methods("GET").Subrouter()
 	auth.Handle("/twitch", tagged("/auth/twitch", authTwitchHandler))
+	auth.Handle("/init", tagged("/auth/init", authInitHandler))
 	auth.Handle("/callback", tagged("/auth/callback", authCallbackHandler))
 
 	// static assets

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,9 +1,14 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/nicklaw5/helix"
 )
 
 func TestIsInvalidSecret(t *testing.T) {
@@ -27,5 +32,55 @@ func TestIsInvalidSecret(t *testing.T) {
 				t.Fatalf("isInvalidSecret(%q) = %v, want %v", tt.input, got, tt.wantInvalid)
 			}
 		})
+	}
+}
+
+func TestAuthInit_RedirectsToTwitch(t *testing.T) {
+	// Build a real *helix.Client with non-empty options. GetAuthorizationURL
+	// is pure URL construction (no network), so this works without app tokens.
+	stub, err := helix.NewClient(&helix.Options{
+		ClientID:    "test-client-id",
+		RedirectURI: "http://localhost:8080/auth/callback",
+	})
+	if err != nil {
+		t.Fatalf("helix.NewClient: %v", err)
+	}
+	saved := helixClient
+	helixClient = func() (*helix.Client, error) { return stub, nil }
+	t.Cleanup(func() { helixClient = saved })
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/init", nil)
+	rec := httptest.NewRecorder()
+	authInitHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("got status %d, want %d (302 redirect)", rec.Code, http.StatusFound)
+	}
+	loc := rec.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("Location header empty")
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("Location is not a valid URL: %v", err)
+	}
+	if !strings.Contains(u.Host, "id.twitch.tv") {
+		t.Errorf("redirect host %q does not contain id.twitch.tv", u.Host)
+	}
+	if !strings.HasSuffix(u.Path, "/oauth2/authorize") {
+		t.Errorf("redirect path %q does not end with /oauth2/authorize", u.Path)
+	}
+	q := u.Query()
+	if q.Get("state") == "" {
+		t.Error("redirect URL missing state param")
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q, want %q", q.Get("response_type"), "code")
+	}
+	scopes := q.Get("scope")
+	for _, required := range []string{"chat:read", "chat:edit"} {
+		if !strings.Contains(scopes, required) {
+			t.Errorf("scope param %q missing required scope %q", scopes, required)
+		}
 	}
 }

--- a/pkg/server/twitch.go
+++ b/pkg/server/twitch.go
@@ -28,7 +28,7 @@ func twitchAuthJSON() string {
 	var jsonData []byte
 	auth := TwitchAuthentication{
 		ChannelID:       mytwitch.ChannelID,
-		UserAccessToken: mytwitch.UserAccessToken,
+		UserAccessToken: mytwitch.CurrentUserAccessToken(),
 		ClientID:        mytwitch.ClientID,
 		AppAccessToken:  mytwitch.AppAccessToken,
 	}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -1,127 +1,284 @@
 package twitch
 
 import (
+	"errors"
 	"log"
 	"os"
+	"strings"
+	"sync"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
 	"github.com/logrusorgru/aurora"
 	"github.com/nicklaw5/helix"
 )
 
-// currentTwitchClient is the standard twitch client
+// Scopes is the OAuth scope set requested for the bot account. Single source
+// of truth — referenced by Client() (App Access Token request),
+// GenerateUserAccessToken (initial user-token exchange), and any code that
+// builds an authorize URL (cmd/auth-bootstrap, /auth/init).
+//
+// chat:read + chat:edit are required for IRC. The remaining scopes preserve
+// the broadcast + subscription Helix calls the bot already made.
+var Scopes = []string{
+	"chat:read",
+	"chat:edit",
+	"channel:read:subscriptions",
+	"user:edit:broadcast",
+}
+
+// ErrNoToken signals "no oauth_tokens row for the bot account; run the
+// bootstrap CLI." Re-exported from oauthtokens for caller convenience.
+var ErrNoToken = oauthtokens.ErrNoToken
+
+// currentTwitchClient is the lazy-initialized helix client.
 var currentTwitchClient *helix.Client
 
-// these are used to authenticate to twitch
-var ClientID string
-var ClientSecret string
-var AuthToken string
-var AppAccessToken string
+// ClientID, ClientSecret are set from env at init.
+// AppAccessToken is set in Client() (Client Credentials grant).
+var (
+	ClientID       string
+	ClientSecret   string
+	AppAccessToken string
+)
 
-// these are used to authenticate requests that require user permissions
-var UserAccessToken string
-var UserRefreshToken string
+// tokenMu guards currentUserToken. RWMutex because reads (IRCAuthToken,
+// CurrentUserAccessToken) outnumber writes (LoadFromDB, refresh).
+var (
+	tokenMu          sync.RWMutex
+	currentUserToken oauthtokens.Token
+)
 
-// init makes sure we have all of the require ENV vars
+// init requires the static credentials needed to build a helix client.
+// TWITCH_AUTH_TOKEN is intentionally NOT required — the IRC token now lives
+// in the oauth_tokens table and is loaded via LoadFromDB at boot.
 func init() {
 	requiredVars := []string{
-		"TWITCH_AUTH_TOKEN",
 		"TWITCH_CLIENT_ID",
 		"TWITCH_CLIENT_SECRET",
 	}
 	for _, v := range requiredVars {
-		_, ok := os.LookupEnv(v)
-		if !ok {
+		if _, ok := os.LookupEnv(v); !ok {
 			log.Fatalf("You must set %s", v)
 		}
 	}
-	AuthToken = os.Getenv("TWITCH_AUTH_TOKEN")
 	ClientID = os.Getenv("TWITCH_CLIENT_ID")
 	ClientSecret = os.Getenv("TWITCH_CLIENT_SECRET")
 }
 
-// Client creates a twitch client, or returns the existing one
+// Client returns the shared helix client, lazy-initializing on first call.
+// First-call side effect: requests an App Access Token (Client Credentials).
 func Client() (*helix.Client, error) {
-	// use the existing client if we have one
 	if currentTwitchClient != nil {
 		return currentTwitchClient, nil
 	}
 	client, err := helix.NewClient(&helix.Options{
 		ClientID:     ClientID,
 		ClientSecret: ClientSecret,
-		// this is set at https://dev.twitch.tv/console/apps
+		// Registered at https://dev.twitch.tv/console/apps; matched by
+		// cmd/auth-bootstrap's local HTTP listener.
 		RedirectURI: c.Conf.ExternalURL + "/auth/callback",
 	})
 	if err != nil {
 		terrors.Log(err, "error creating client")
 	}
 
-	//TODO: move to configs lib
-	//TODO: revisit that we need all of these
-	scopes := []string{"openid", "user:edit:broadcast", "channel:read:subscriptions"}
-	// set the AppAccessToken
-	resp, err := client.RequestAppAccessToken(scopes)
+	resp, err := client.RequestAppAccessToken(Scopes)
 	if err != nil {
 		terrors.Log(err, "error getting app access token from twitch")
 	}
 	AppAccessToken = resp.Data.AccessToken
 	client.SetAppAccessToken(AppAccessToken)
 
-	// use this as the shared client
 	currentTwitchClient = client
-
 	return client, err
 }
 
-// GenerateUserAccessToken sends a code to Twitch to generate a
-// user access token. This is called by the web server after
-// going through the OAuth flow
-func GenerateUserAccessToken(code string) {
-	resp, err := currentTwitchClient.RequestUserAccessToken(code)
+// LoadFromDB pulls the row for the configured bot account into in-memory
+// state. cmd/tripbot calls this once at boot before chatbot.Initialize; the
+// returned error is checked for ErrNoToken so the cold-start message points
+// at the bootstrap CLI.
+func LoadFromDB() error {
+	t, err := oauthtokens.Get("twitch", c.Conf.BotUsername)
 	if err != nil {
-		terrors.Log(err, "error getting user access token from twitch")
-		return
+		return err
 	}
+	tokenMu.Lock()
+	currentUserToken = t
+	tokenMu.Unlock()
 
-	UserAccessToken = resp.Data.AccessToken
-	UserRefreshToken = resp.Data.RefreshToken
-
-	// update the current client with the access token
-	currentTwitchClient.SetUserAccessToken(UserAccessToken)
+	// If the helix client is already built, prime its user-access-token so
+	// follow-up Helix calls that need user-scoped permissions work.
+	if currentTwitchClient != nil {
+		currentTwitchClient.SetUserAccessToken(t.AccessToken)
+	}
+	return nil
 }
 
-// RefreshUserAccessToken makes a call to Twitch to generate a
-// fresh user access token. It requires a UserRefreshToken to be
-// set already.
-func RefreshUserAccessToken() {
-	// check to see if we have the required tokens to work with
-	if UserRefreshToken == "" || UserAccessToken == "" {
-		log.Println("no user access token was present, did you log in with OAuth?")
-		authURL := currentTwitchClient.GetAuthorizationURL(&helix.AuthorizationURLParams{
-			//TODO: move to configs lib
-			Scopes:       []string{"openid", "user:edit:broadcast", "channel:read:subscriptions"},
-			ResponseType: "code",
-		})
-		log.Println(aurora.Blue(authURL).Underline())
-		// send a text message cause some features won't work
-		// without a user access token
-		helpers.SendSMS("refreshing user access token failed!")
-		return
+// IRCAuthToken returns the bot's IRC oauth: token, ready for
+// twitch.NewClient. Returns "" if no token has been loaded.
+func IRCAuthToken() string {
+	tokenMu.RLock()
+	defer tokenMu.RUnlock()
+	if currentUserToken.AccessToken == "" {
+		return ""
 	}
+	return "oauth:" + currentUserToken.AccessToken
+}
 
-	resp, err := currentTwitchClient.RefreshUserAccessToken(UserRefreshToken)
+// CurrentUserAccessToken returns the raw access token (no oauth: prefix).
+// Used by pkg/server/twitch.go's /auth/twitch JSON endpoint until that
+// endpoint is deleted in a separate PR.
+func CurrentUserAccessToken() string {
+	tokenMu.RLock()
+	defer tokenMu.RUnlock()
+	return currentUserToken.AccessToken
+}
+
+// GenerateUserAccessToken exchanges a code for an access+refresh token,
+// derives the authenticated username via helix.GetUsers (so bootstrap is
+// account-agnostic — the row is keyed by whoever signed in at consent),
+// and Upserts. If the resulting row matches BOT_USERNAME, also primes the
+// in-memory state so the running bot picks up the rotated token.
+//
+// Returns error (no longer swallows). Callers: /auth/callback handler,
+// cmd/auth-bootstrap.
+func GenerateUserAccessToken(code string) error {
+	client, err := Client()
 	if err != nil {
-		terrors.Log(err, "error refreshing user access token")
+		return err
+	}
+
+	resp, err := client.RequestUserAccessToken(code)
+	if err != nil {
+		return err
+	}
+	if resp == nil || resp.Data.AccessToken == "" {
+		return errors.New("twitch: empty access token in code-exchange response")
+	}
+
+	// Set the access token so GetUsers identifies the caller from the
+	// Authorization header (helix.UsersParams without IDs/Logins returns
+	// the authenticated user).
+	client.SetUserAccessToken(resp.Data.AccessToken)
+	usersResp, err := client.GetUsers(&helix.UsersParams{})
+	if err != nil {
+		return err
+	}
+	if usersResp == nil || len(usersResp.Data.Users) == 0 {
+		return errors.New("twitch: GetUsers returned no users")
+	}
+	u := usersResp.Data.Users[0]
+
+	tok := oauthtokens.Token{
+		Provider:     "twitch",
+		Username:     u.Login,
+		TwitchUserID: u.ID,
+		AccessToken:  resp.Data.AccessToken,
+		RefreshToken: resp.Data.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second),
+		Scopes:       strings.Join(resp.Data.Scopes, " "),
+	}
+	if err := oauthtokens.Upsert(tok); err != nil {
+		return err
+	}
+
+	// Bootstrapping a non-bot account (e.g. the broadcaster) writes the row
+	// but doesn't change the running bot's IRC session.
+	if u.Login == c.Conf.BotUsername {
+		tokenMu.Lock()
+		currentUserToken = tok
+		tokenMu.Unlock()
+	}
+	return nil
+}
+
+// RefreshUserAccessToken is the hourly cron entry point. Reads the bot's row,
+// refreshes if within 30 minutes of expiry, and writes the rotated tokens
+// back. A Postgres advisory lock fences concurrent rotation between local
+// dev and a cluster pod sharing the same Twitch account.
+//
+// TODO: helix client surface should move behind an interface so this
+// function can be unit-tested without a real Twitch round-trip.
+func RefreshUserAccessToken() {
+	botUser := c.Conf.BotUsername
+
+	acquired, release, err := oauthtokens.TryRefreshLock("twitch", botUser)
+	if err != nil {
+		terrors.Log(err, "oauth refresh lock acquisition failed")
+		return
+	}
+	if !acquired {
+		// Another process is rotating. Wait briefly, re-read the rotated
+		// row, sync in-memory.
+		time.Sleep(2 * time.Second)
+		t, gerr := oauthtokens.Get("twitch", botUser)
+		if gerr != nil {
+			terrors.Log(gerr, "post-contention re-read failed")
+			return
+		}
+		tokenMu.Lock()
+		currentUserToken = t
+		tokenMu.Unlock()
+		return
+	}
+	defer release()
+
+	t, err := oauthtokens.Get("twitch", botUser)
+	if err != nil {
+		terrors.Log(err, "no oauth_tokens row to refresh")
 		return
 	}
 
-	UserAccessToken = resp.Data.AccessToken
-	UserRefreshToken = resp.Data.RefreshToken
+	if time.Until(t.ExpiresAt) > 30*time.Minute {
+		return
+	}
 
-	// update the current client with the new access token
-	currentTwitchClient.SetUserAccessToken(UserAccessToken)
+	client, err := Client()
+	if err != nil {
+		terrors.Log(err, "helix client unavailable for refresh")
+		return
+	}
+	resp, err := client.RefreshUserAccessToken(t.RefreshToken)
+	if err != nil {
+		_ = oauthtokens.IncrementFailCount("twitch", botUser)
+		terrors.Log(err, "twitch refresh API failed")
+		return
+	}
+	if resp == nil || resp.Data.AccessToken == "" {
+		// Empty body typically means invalid_grant (refresh token revoked).
+		// Treat as terminal — blank in-memory so IRC reconnect fails loudly,
+		// SMS so Dana sees it on his phone.
+		_ = oauthtokens.IncrementFailCount("twitch", botUser)
+		tokenMu.Lock()
+		currentUserToken.AccessToken = ""
+		tokenMu.Unlock()
+		helpers.SendSMS(botUser + " oauth refresh failed; run task tripbot:auth:bootstrap")
+		terrors.Log(errors.New("empty access token in refresh response"), "oauth refresh failed; need re-bootstrap")
+		return
+	}
 
-	log.Println(aurora.Cyan("successfully updated user access token"))
+	rotated := oauthtokens.Token{
+		Provider:     t.Provider,
+		Username:     t.Username,
+		TwitchUserID: t.TwitchUserID,
+		AccessToken:  resp.Data.AccessToken,
+		RefreshToken: resp.Data.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second),
+		Scopes:       strings.Join(resp.Data.Scopes, " "),
+	}
+	if err := oauthtokens.Upsert(rotated); err != nil {
+		terrors.Log(err, "post-refresh Upsert failed")
+		return
+	}
+
+	tokenMu.Lock()
+	currentUserToken = rotated
+	tokenMu.Unlock()
+	client.SetUserAccessToken(rotated.AccessToken)
+
+	log.Println(aurora.Cyan("successfully refreshed user access token"))
 }

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -1,6 +1,7 @@
 package twitch
 
 import (
+	"database/sql"
 	"errors"
 	"log"
 	"os"
@@ -176,7 +177,7 @@ func GenerateUserAccessToken(code string) error {
 	tok := oauthtokens.Token{
 		Provider:     "twitch",
 		Username:     u.Login,
-		TwitchUserID: u.ID,
+		TwitchUserID: sql.NullString{String: u.ID, Valid: u.ID != ""},
 		AccessToken:  resp.Data.AccessToken,
 		RefreshToken: resp.Data.RefreshToken,
 		ExpiresAt:    time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second),

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -1,0 +1,119 @@
+package twitch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
+)
+
+// resetToken restores currentUserToken after a test mutation.
+func resetToken(t *testing.T) {
+	t.Helper()
+	saved := currentUserToken
+	t.Cleanup(func() {
+		tokenMu.Lock()
+		currentUserToken = saved
+		tokenMu.Unlock()
+	})
+}
+
+func TestIRCAuthToken_PrefixesOauth(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{AccessToken: "abc123"}
+	tokenMu.Unlock()
+
+	got := IRCAuthToken()
+	if got != "oauth:abc123" {
+		t.Errorf("IRCAuthToken() = %q, want %q", got, "oauth:abc123")
+	}
+}
+
+func TestIRCAuthToken_EmptyWhenUnloaded(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{}
+	tokenMu.Unlock()
+
+	if got := IRCAuthToken(); got != "" {
+		t.Errorf("IRCAuthToken() with empty token = %q, want \"\"", got)
+	}
+}
+
+func TestCurrentUserAccessToken_ReturnsRaw(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{AccessToken: "raw-no-prefix"}
+	tokenMu.Unlock()
+
+	if got := CurrentUserAccessToken(); got != "raw-no-prefix" {
+		t.Errorf("CurrentUserAccessToken() = %q, want %q", got, "raw-no-prefix")
+	}
+}
+
+func TestScopes_IncludesIRCScopes(t *testing.T) {
+	required := []string{"chat:read", "chat:edit"}
+	have := map[string]bool{}
+	for _, s := range Scopes {
+		have[s] = true
+	}
+	for _, r := range required {
+		if !have[r] {
+			t.Errorf("Scopes missing required IRC scope %q (have %v)", r, Scopes)
+		}
+	}
+}
+
+func TestScopes_NoDuplicates(t *testing.T) {
+	seen := map[string]bool{}
+	for _, s := range Scopes {
+		if seen[s] {
+			t.Errorf("duplicate scope %q in Scopes", s)
+		}
+		seen[s] = true
+	}
+}
+
+func TestScopes_DropsOpenID(t *testing.T) {
+	// openid was in the previous scope set but the bot doesn't read ID
+	// claims; dropping it shrinks the consent screen and reduces surface.
+	for _, s := range Scopes {
+		if s == "openid" {
+			t.Errorf("Scopes still includes openid; expected drop")
+		}
+	}
+}
+
+func TestErrNoToken_AliasesOAuthTokens(t *testing.T) {
+	if ErrNoToken != oauthtokens.ErrNoToken {
+		t.Errorf("ErrNoToken does not match oauthtokens.ErrNoToken; sentinel comparisons will fail")
+	}
+}
+
+// TestIRCAuthToken_ConcurrentReads is a smoke check that the RWMutex doesn't
+// deadlock under parallel reads while a writer takes the lock.
+func TestIRCAuthToken_ConcurrentReads(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{AccessToken: "race-check"}
+	tokenMu.Unlock()
+
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = IRCAuthToken()
+			}
+			done <- struct{}{}
+		}()
+	}
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < 8; i++ {
+		select {
+		case <-done:
+		case <-deadline:
+			t.Fatal("concurrent IRCAuthToken readers timed out (deadlock?)")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the durable Twitch chat-token acquisition work. Replaces the env-var `TWITCH_AUTH_TOKEN` (sourced from twitchtokengenerator.com — a third-party site that mints tokens against its own Twitch app) with a self-owned OAuth Authorization Code flow against our `tripbot-development` app. Refresh tokens rotate hourly and persist to the `oauth_tokens` table from [#452](https://github.com/adanalife/tripbot/pull/452/changes); storage layer from [#454](https://github.com/adanalife/tripbot/pull/454/changes) (both merged).

After a one-time interactive bootstrap, the bot self-refreshes forever. Pods restart, cluster rebuilds — no human in the loop.

## Verified end-to-end locally

The bootstrap flow was exercised against a local `bin/devenv up -d db migrate` Postgres before opening this PR:

```
SELECT id, provider, username, twitch_user_id, expires_at, scopes, refresh_fail_count
FROM oauth_tokens;
 id | provider |  username   | twitch_user_id |          expires_at           |                               scopes                               | refresh_fail_count
----+----------+-------------+----------------+-------------------------------+--------------------------------------------------------------------+--------------------
  1 | twitch   | tripbot4000 | 433548792      | 2026-05-11 03:28:45.844767+00 | channel:read:subscriptions chat:edit chat:read user:edit:broadcast |                  0
```

- Browser opens, Twitch consent screen renders the four expected scopes.
- Callback validates state, exchanges code, derives username from `helix.GetUsers`, Upserts.
- `expires_at` ~4h ahead of now matches Twitch's user-token TTL.

## Commits

1. `oauthstate: state validation primitive for OAuth Authorization Code flow` — new `pkg/server/oauthstate` package, 5-min TTL, single-use crypto/rand states. Tests cover happy/double-use/expired/empty/sweep.
2. `twitch: replace static AuthToken with DB-backed OAuth flow` — `pkg/twitch/authentication.go` full rewrite. `LoadFromDB` / `IRCAuthToken` / `CurrentUserAccessToken` / new `Scopes` package var (drops `openid`, adds `chat:read` + `chat:edit`). `GenerateUserAccessToken` now returns error and derives username from `helix.GetUsers` (so bootstrap is account-agnostic). `RefreshUserAccessToken` uses `pg_try_advisory_lock` for refresh-race fencing and runs on the existing hourly cron slot. Drops the pre-existing browser-opening block in `chatbot.go` — `cmd/auth-bootstrap` owns that flow now.
3. `server: state-validate /auth/callback, add /auth/init` — hardens the OAuth callback with CSRF state validation (closes the lowpri state TODO from the http-endpoints audit), serves a small inline HTML success page, and adds `/auth/init` so cloud-based emergency re-bootstrap is possible. Function-var indirection (`generateUserAccessToken`, `helixClient`) lets handlers be unit-tested without Twitch round-trips.
4. `config: layer infra/docker/env.docker after .env.<env> for host-side runs` — `docker-compose` layers `env.docker` via `--env-file`, but host-side binaries (cmd/auth-bootstrap, host-side cmd/tripbot) only saw `.env.<env>` and failed envconfig for vars that only live in `env.docker` (e.g. `TRIPBOT_HTTP_AUTH`). Added a second `godotenv.Load` after `.env.<env>`; precedence is shell env > `.env.<env>` > `env.docker`. Silent no-op in containers without the file.
5. `cmd: auth-bootstrap CLI + boot-time LoadFromDB + Taskfile entry` — new `cmd/auth-bootstrap`, ~115 LOC. `cmd/tripbot` now `log.Fatal`s on `ErrNoToken` with a clear hint pointing at `task tripbot:auth:bootstrap`. Pods crashloop until the row exists. Taskfile entry uses `mise exec --` so task's non-interactive subshell picks up the pinned Go toolchain; sets sensible local-bootstrap defaults for `ENV` / `DATABASE_HOST` / `EXTERNAL_URL`.
6. `ci: seed oauth_tokens placeholder so build-stack tripbot can boot` — the build job brings up `db + migrate + tripbot` to verify the image; with the cold-start contract above, tripbot can't boot far enough to `docker exec` against without an `oauth_tokens` row. Split the bring-up into `db + migrate` → seed a placeholder row via `psql` → `tripbot`. Placeholder values are obviously fake (`ci-placeholder-access`); the build job only checks version files + `/version`, doesn't make Twitch calls.

## Test coverage (new)

- `pkg/server/oauthstate` — 7 tests: New uniqueness, Validate hit/double-use/expired/unknown/empty, sweep.
- `pkg/twitch` — 7 new tests: `IRCAuthToken` prefix + empty + concurrent reads, `CurrentUserAccessToken` raw, `Scopes` IRC presence + no duplicates + openid dropped, `ErrNoToken` aliasing.
- `pkg/server` — 7 new tests: `/auth/callback` no-state / bad-state / no-code / happy path / generator error / state single-use; `/auth/init` 302 to id.twitch.tv with state + scopes.

Helix-call paths (`GenerateUserAccessToken` and `RefreshUserAccessToken` end-to-end) are not unit-tested in this PR — they got integration coverage via the bootstrap CLI run above. A TODO in `pkg/twitch/authentication.go` flags moving helix behind an interface for cleaner future testing.

## Post-merge — Dana drives

Pairs with [adanalife/infra#434](https://github.com/adanalife/infra/pull/434/changes) which adds the `tripbot:db:up`/`down` Taskfile entries this flow references.

```bash
# In ~/adanalife/infra
task tripbot:db:up

# In ~/adanalife/tripbot — Taskfile sets sensible local defaults
task auth:bootstrap
# → browser opens
# → sign in as tripbot4000 (or other)
# → "Success" page

# Verify the row exists
psql "postgres://<user>:<pass>@localhost:5432/<db>" \
  -c "SELECT username, scopes, expires_at, refresh_fail_count FROM oauth_tokens;"

# Restart the cluster tripbot pod and tail logs
kubectl rollout restart deploy/tripbot -n tripbot
kubectl logs -l app=tripbot -n tripbot --tail=50
# → expect "successfully refreshed user access token" or chatbot IRC connect

task tripbot:db:down
```

After the cluster pod is healthy on the new code, a follow-up infra PR drops `TWITCH_AUTH_TOKEN` from the `twitch-external-secret.yaml` mapping (Phase 3b of the broader rollout).

## Test plan

- [x] `go test ./pkg/twitch/... ./pkg/server/... ./pkg/oauthtokens/...` green locally (28 new tests)
- [x] `go vet` clean across changed packages
- [x] `go build ./cmd/tripbot/... ./cmd/auth-bootstrap/...` clean
- [x] **Bootstrap exercised end-to-end locally** — row appears in `oauth_tokens` with correct username (from helix.GetUsers), scopes, expires_at
- [ ] CI green on this PR (build job split + oauth_tokens seed lands with this push)
- [ ] Manual: empty `oauth_tokens` + boot `cmd/tripbot` locally → fatal with bootstrap hint (not a regression — desired behavior)
- [ ] Manual: full bootstrap against cluster DB → row appears → cluster pod connects to IRC successfully