### PR TITLE
Release v2.2.6: develop → master

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -39,7 +39,6 @@ jobs:
           # disabled until we can resolve their issues
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_CHECKOV: false
-          VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_GO_MODULES: false
           VALIDATE_GO_RELEASER: false

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -57,12 +57,12 @@ jobs:
           -f infra/docker/docker-compose.testing.yml \
           -f infra/docker/docker-compose.github.yml \
           port vlc 8080 | cut -d: -f2)
-        echo "VLC_PORT=$PORT" >> $GITHUB_ENV
+        echo "VLC_PORT=$PORT" >> "$GITHUB_ENV"
 
     - name: Wait for healthcheck
       run: |
         for i in $(seq 1 30); do
-          if curl -sf http://localhost:$VLC_PORT/health/ready; then
+          if curl -sf "http://localhost:$VLC_PORT/health/ready"; then
             echo ""
             echo "VLC server is ready!"
             exit 0
@@ -74,7 +74,7 @@ jobs:
         exit 1
 
     - name: Check VLC current video
-      run: curl -v http://localhost:$VLC_PORT/vlc/current
+      run: curl -v "http://localhost:$VLC_PORT/vlc/current"
 
     - name: Verify version files baked into image
       run: |
@@ -90,7 +90,7 @@ jobs:
         echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
 
     - name: Verify /version HTTP endpoint
-      run: curl -fsS http://localhost:$VLC_PORT/version
+      run: curl -fsS "http://localhost:$VLC_PORT/version"
 
     - name: Check container logs
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.2.6] — 2026-05-10
+
+Patch release. One small UX addition and one CI hygiene step.
+
+### Chatbot
+
+- **Accept `¡` (U+00A1) as an alternate command prefix.** Spanish-keyboard users can run commands like `¡miles` or `¡location` without switching layouts. A new `normalizeCommandPrefix` helper rewrites a leading `¡` to `!` at the entrance of `runCommand`; the existing `!` path is untouched. Rune-aware (`strings.HasPrefix`/`TrimPrefix`) because `¡` is two bytes in UTF-8 and byte-indexing would mangle it. ([#453])
+
+### CI
+
+- **Super-linter: re-enable `VALIDATE_GITHUB_ACTIONS` (actionlint).** Fixes 4 SC2086 quoting nits in `.github/workflows/vlc.yml` (`$VLC_PORT`, `$GITHUB_ENV`) in a separate prep commit. `VALIDATE_GO_MODULES` was also attempted but reverted — the underlying `golangci-lint` analyzer compiles the module and trips on `vlc/vlc.h: No such file or directory` (same root cause as `VALIDATE_GO` being disabled). The PR body documents the remaining disabled validators with rationale for each, so future re-enables have a starting point. ([#449])
+
 ## [v2.2.5] — 2026-05-10
 
 Patch release. One observability gate broaden completing the staging-Sentry pipeline started in v2.2.4, plus a CI improvement and a vlc-server config refactor.
@@ -256,3 +268,5 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#435]: https://github.com/adanalife/tripbot/pull/435
 [#438]: https://github.com/adanalife/tripbot/pull/438
 [#445]: https://github.com/adanalife/tripbot/pull/445
+[#449]: https://github.com/adanalife/tripbot/pull/449
+[#453]: https://github.com/adanalife/tripbot/pull/453

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -23,11 +23,22 @@ func incChatCommandCounter(command string) {
 	instrumentation.ChatCommands.Inc(command)
 }
 
+// normalizeCommandPrefix rewrites a leading Spanish inverted exclamation mark
+// `¡` (U+00A1, two bytes in UTF-8: 0xC2 0xA1) to a regular `!` so that
+// Spanish-keyboard users (who type `¡` where US keyboards type `!`) can run
+// commands without switching layouts. e.g. `¡miles` -> `!miles`.
+func normalizeCommandPrefix(msg string) string {
+	if strings.HasPrefix(msg, "¡") {
+		return "!" + strings.TrimPrefix(msg, "¡")
+	}
+	return msg
+}
+
 func runCommand(ctx context.Context, user *users.User, message string) {
 	var err error
 	var params []string
 
-	msg := strings.TrimSpace(message)
+	msg := normalizeCommandPrefix(strings.TrimSpace(message))
 	split := strings.Split(msg, " ")
 
 	// the command is the first part

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -1,0 +1,70 @@
+package chatbot
+
+import "testing"
+
+func TestNormalizeCommandPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "leading inverted bang is rewritten to !",
+			in:   "¡miles",
+			want: "!miles",
+		},
+		{
+			name: "inverted bang with params is rewritten to !",
+			in:   "¡goto 42",
+			want: "!goto 42",
+		},
+		{
+			name: "regular ! prefix is untouched",
+			in:   "!miles",
+			want: "!miles",
+		},
+		{
+			name: "bare-word (no prefix) is untouched",
+			in:   "hello",
+			want: "hello",
+		},
+		{
+			name: "inverted bang not at the start is untouched",
+			in:   "say ¡hola",
+			want: "say ¡hola",
+		},
+		{
+			name: "empty string is untouched",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeCommandPrefix(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeCommandPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeCommandPrefix_DispatchEquivalence asserts the same downstream
+// "command" token (i.e. the first whitespace-separated word of the normalized
+// message) is produced for `¡foo` and `!foo`. This is the property the
+// dispatcher in runCommand() relies on for both prefixes to route to the same
+// switch case.
+func TestNormalizeCommandPrefix_DispatchEquivalence(t *testing.T) {
+	cases := []string{"miles", "location", "leaderboard", "goto 42"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			gotBang := normalizeCommandPrefix("!" + c)
+			gotInverted := normalizeCommandPrefix("¡" + c)
+			if gotBang != gotInverted {
+				t.Errorf("dispatch divergence: !%s -> %q vs ¡%s -> %q",
+					c, gotBang, c, gotInverted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Patch release. One UX addition (Spanish-keyboard command prefix) and one CI hygiene step (super-linter validator re-enable).

### What's landing

**Chatbot**

- [#453](https://github.com/adanalife/tripbot/pull/453/changes) — `chatbot`: accept `¡` (U+00A1) as an alternate command prefix. Spanish-keyboard users can run `¡miles` / `¡location` etc. without switching layouts. Single touchpoint at the entrance of `runCommand`; existing `!` path untouched.

**CI**

- [#449](https://github.com/adanalife/tripbot/pull/449/changes) — `ci(super-linter)`: re-enable `VALIDATE_GITHUB_ACTIONS` (actionlint), fix 4 SC2086 quoting nits it surfaced in `.github/workflows/vlc.yml`. `VALIDATE_GO_MODULES` was attempted but reverted — same C-deps blocker as `VALIDATE_GO`. PR body documents the remaining disabled validators with rationale.

### Why patch (v2.2.6)

Additive UX feature + a CI hygiene step. No breaking change, no user-visible regression. Default patch fits.

### Pre-flight

- [x] CHANGELOG.md updated for v2.2.6 (committed direct to develop, in this PR's diff)

### Release plumbing

- Merge with a **merge commit** (not squash) per `merge-strategy-by-target-branch` — preserves develop's commits as ancestors of master so future develop→master merges stay clean.
- Merging this PR (no `#minor`, default patch) → `auto-tag.yml` → `v2.2.6` → `release.yml` builds + pushes multi-arch images for tripbot, vlc, obs to Docker Hub → `verify-stamped-image.sh` gates each build leg.
- After build green: `kubectl rollout restart deploy/tripbot deploy/vlc-server`; verify pod SHA matches the v2.2.6 commit before doing anything else.