### PR TITLE
Release v2.3.0: develop → master #minor

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -1,6 +1,10 @@
 name: OBS Container
 on:
   pull_request:
+    paths:
+      - 'infra/docker/obs/**'
+      - 'infra/docker/docker-compose*.yml'
+      - '.github/workflows/obs.yml'
   push:
     branches:
       - develop

--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -46,7 +46,7 @@ jobs:
           cache-from: type=gha,scope=tripbot
           cache-to: type=gha,mode=max,scope=tripbot
 
-      - name: Bring up the stack (db + migrate + tripbot)
+      - name: Bring up db + migrate
         env:
           CHANNEL_NAME: ${{ secrets.CHANNEL_NAME }}
           BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
@@ -60,12 +60,54 @@ jobs:
             -f infra/docker/docker-compose.yml \
             -f infra/docker/docker-compose.testing.yml \
             -f infra/docker/docker-compose.github.yml \
-            up -d db migrate tripbot
+            up -d db migrate
 
-      - run: sleep 10
+      - run: sleep 5
 
       - name: Check logs (migrate)
         run: docker logs tripbot-migrate-1
+
+      # tripbot's LoadFromDB at boot refuses to start without an oauth_tokens
+      # row (cluster contract: bootstrap-or-fatal). CI has no real Twitch
+      # creds to bootstrap with, so seed a syntactically-valid placeholder row
+      # so cmd/tripbot can boot far enough to verify version files + /version.
+      - name: Seed placeholder oauth_tokens row for build-stack tripbot
+        env:
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+        run: |
+          docker exec -i tripbot-db-1 \
+            psql -U tripbot_docker -d tripbot_docker \
+              -v ON_ERROR_STOP=1 \
+              -v BOT_USERNAME="$BOT_USERNAME" <<'SQL'
+          INSERT INTO oauth_tokens
+            (provider, username, access_token, refresh_token, expires_at, scopes)
+          VALUES
+            ('twitch', :'BOT_USERNAME', 'ci-placeholder-access',
+             'ci-placeholder-refresh', NOW() + INTERVAL '1 hour',
+             'chat:read chat:edit')
+          ON CONFLICT (provider, username) DO UPDATE
+            SET access_token = EXCLUDED.access_token,
+                refresh_token = EXCLUDED.refresh_token,
+                expires_at    = EXCLUDED.expires_at;
+          SQL
+
+      - name: Bring up tripbot
+        env:
+          CHANNEL_NAME: ${{ secrets.CHANNEL_NAME }}
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+          TWITCH_AUTH_TOKEN: ${{ secrets.TWITCH_AUTH_TOKEN }}
+          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+        run: |
+          docker compose \
+            --project-directory . \
+            --env-file infra/docker/env.docker \
+            -f infra/docker/docker-compose.yml \
+            -f infra/docker/docker-compose.testing.yml \
+            -f infra/docker/docker-compose.github.yml \
+            up -d tripbot
+
+      - run: sleep 10
 
       - name: Check logs (tripbot)
         run: docker logs tripbot-tripbot-1

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -6,7 +6,9 @@ on:
       - 'pkg/vlc-client/**'
       - 'infra/docker/vlc/**'
       - 'infra/docker/docker-compose*.yml'
+      - 'infra/docker/env.docker'
       - '.github/workflows/vlc.yml'
+      - '.dockerignore'
       - 'go.mod'
       - 'go.sum'
   push:
@@ -14,6 +16,16 @@ on:
       - develop
     tags:
       - v*
+    paths:
+      - 'pkg/vlc-server/**'
+      - 'pkg/vlc-client/**'
+      - 'infra/docker/vlc/**'
+      - 'infra/docker/docker-compose*.yml'
+      - 'infra/docker/env.docker'
+      - '.github/workflows/vlc.yml'
+      - '.dockerignore'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.3.0] — 2026-05-10
+
+Minor release. Replaces the static `TWITCH_AUTH_TOKEN` env var (sourced from a third-party token generator) with a self-owned OAuth Authorization Code flow against tripbot's own Twitch dev app. The bot's IRC refresh token now lives in Postgres and rotates hourly via a `pg_try_advisory_lock`-fenced cron job; one-time bootstrap via a new `cmd/auth-bootstrap` CLI. Plus two CI trigger-path filters.
+
+### Authentication
+
+- **`oauth_tokens` table + `pkg/oauthtokens` storage package.** Migration `010_create_oauth_tokens` introduces the table (keyed by `(provider, username)`, stores refresh + access tokens, scopes, expiry, fail counter). The Go-side package wraps it with sqlx queries plus `pg_try_advisory_lock`-backed `TryRefreshLock` so a local-dev tripbot and a cluster pod sharing the same Twitch account can't both rotate the refresh token simultaneously. The lock-id is SHA-256-hashed for a wider key space than `hashtext()`'s 32 bits. ([#452], [#454])
+- **`pkg/twitch/authentication.go` rewired off the static env-var token.** `TWITCH_AUTH_TOKEN` env var is no longer required. New `LoadFromDB()` reads the bot's row at boot; missing row → `log.Fatal` with hint pointing at the bootstrap CLI. `IRCAuthToken()` accessor replaces the dropped `AuthToken` global. `RefreshUserAccessToken` uses helix to mint a rotated pair and writes both back to the table; on terminal failure (revoked refresh token) it blanks in-memory state + sends SMS so the bot crashes loudly. Scopes consolidated to a `Scopes` package var (drops `openid`, adds `chat:read` + `chat:edit`). The pre-existing browser-opening block in `chatbot.go` is deleted — `cmd/auth-bootstrap` owns that flow now. ([#455])
+- **`/auth/callback` hardened with CSRF state validation + HTML success page.** New `pkg/server/oauthstate` (5-minute TTL, single-use, crypto/rand) generates state at the redirect-initiating side and the callback handler validates it. New `/auth/init` route generates state + 302s to Twitch — provides a cloud-based emergency re-bootstrap path when no laptop is handy. ([#455])
+- **New `cmd/auth-bootstrap` CLI + `task auth:bootstrap`.** One-time interactive bootstrap; signs in to Twitch on Dana's laptop, exchanges the code for tokens, derives the username from `helix.GetUsers` (so the row is account-agnostic — bootstrapping the broadcaster account later works identically without an env-var dance), Upserts to the cluster DB via port-forward. After this, all pod restarts and cluster rebuilds are headless. ([#455])
+- **`pkg/config` layers `infra/docker/env.docker` after `.env.<env>` for host-side runs.** `docker-compose` does this via `--env-file` inside containers, but host-side binaries (the new bootstrap CLI, host-side cmd/tripbot) previously missed it and failed envconfig for vars that only live in the docker env file (e.g. `TRIPBOT_HTTP_AUTH`). Silent no-op in cluster pods (file not in the image). ([#455])
+
+### CI
+
+- **`obs.yml` PR trigger filtered to OBS-impacting paths.** Skips wasted runs on docs-only / unrelated PRs. The push trigger (develop / `v*` tags) stays unfiltered intentionally — `release.yml` owns the actual release builds and the develop-push smoke test stays useful as a build-soundness check. ([#448])
+- **`vlc.yml` push trigger filtered to VLC-impacting paths.** Pairs with [#390](https://github.com/adanalife/tripbot/pull/390)'s PR-side filter; brings develop-push + release-tag pushes in line. ([#447])
+
 ## [v2.2.6] — 2026-05-10
 
 Patch release. One small UX addition and one CI hygiene step.
@@ -270,3 +287,8 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#445]: https://github.com/adanalife/tripbot/pull/445
 [#449]: https://github.com/adanalife/tripbot/pull/449
 [#453]: https://github.com/adanalife/tripbot/pull/453
+[#447]: https://github.com/adanalife/tripbot/pull/447
+[#448]: https://github.com/adanalife/tripbot/pull/448
+[#452]: https://github.com/adanalife/tripbot/pull/452
+[#454]: https://github.com/adanalife/tripbot/pull/454
+[#455]: https://github.com/adanalife/tripbot/pull/455

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,18 @@ tasks:
     cmds:
       - ENV=testing bin/devenv run --rm test bash
 
+  auth:bootstrap:
+    desc: One-time Twitch OAuth bootstrap; writes refresh token to oauth_tokens. Run on host (needs a browser); bring up Postgres first (`bin/devenv up -d db migrate` locally, or `task tripbot:db:up` in infra for cluster DB).
+    env:
+      # Local-bootstrap defaults. Override at the shell to point elsewhere.
+      ENV: '{{.ENV | default "development"}}'
+      DATABASE_HOST: '{{.DATABASE_HOST | default "localhost"}}'
+      EXTERNAL_URL: '{{.EXTERNAL_URL | default "http://localhost:8080"}}'
+    cmds:
+      # `mise exec --` activates the pinned Go toolchain in task's
+      # non-interactive subshell (where ~/.zshrc isn't sourced).
+      - mise exec -- go run ./cmd/auth-bootstrap
+
   # Release smoke flow — see vault/tripbot/release-checklist.md.
   # Targets the local k3d cluster running the stage-1 overlay
   # (cloudflared tunnel + apps).

--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -1,0 +1,114 @@
+// cmd/auth-bootstrap is the one-time interactive Twitch OAuth bootstrap.
+// Runs locally (on Dana's laptop) against the cluster Postgres via port-forward
+// to populate the oauth_tokens row that the cluster tripbot pod consumes at
+// boot.
+//
+// Flow:
+//   1. Verify DB reachable.
+//   2. Generate CSRF state, build authorize URL with mytwitch.Scopes.
+//   3. Spin up a tiny localhost:8080 HTTP listener for the OAuth callback.
+//   4. Open the browser to the authorize URL. Dana signs in as tripbot4000.
+//   5. Twitch redirects to localhost:8080/auth/callback. The handler validates
+//      state, exchanges the code via mytwitch.GenerateUserAccessToken (which
+//      Upserts the row), and signals completion.
+//   6. Exit cleanly.
+//
+// The Twitch app's registered redirect URI is http://localhost:8080/auth/callback;
+// this CLI relies on that registration matching what helix.Client sends.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	_ "github.com/adanalife/tripbot/pkg/config/tripbot" // env loader via package init
+	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+	"github.com/logrusorgru/aurora"
+	"github.com/nicklaw5/helix"
+)
+
+const (
+	listenAddr     = "localhost:8080"
+	callbackPath   = "/auth/callback"
+	flowTimeout    = 5 * time.Minute
+	shutdownGrace  = 5 * time.Second
+	successHTML    = `<!doctype html><html><head><meta charset="utf-8"><title>tripbot — bootstrap success</title><style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style></head><body><div><h1>Success</h1><p>Refresh token persisted. You may close this tab.</p></div></body></html>`
+)
+
+func main() {
+	// Verify the DB is reachable before any user-facing work; if the
+	// port-forward isn't up this is where it surfaces.
+	if database.Connection() == nil {
+		log.Fatal("could not connect to database; ensure DATABASE_HOST/USER/PASS/DB are set and a port-forward to the cluster Postgres is up (task tripbot:db:up)")
+	}
+
+	client, err := mytwitch.Client()
+	if err != nil {
+		log.Fatalf("could not build Twitch client: %v", err)
+	}
+
+	state := oauthstate.New()
+	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
+		Scopes:       mytwitch.Scopes,
+		ResponseType: "code",
+		State:        state,
+	})
+
+	done := make(chan error, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+		if !oauthstate.Validate(r.URL.Query().Get("state")) {
+			http.Error(w, "invalid or expired state", http.StatusBadRequest)
+			done <- errors.New("state validation failed")
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "no code in response from twitch", http.StatusBadRequest)
+			done <- errors.New("no code")
+			return
+		}
+		if err := mytwitch.GenerateUserAccessToken(code); err != nil {
+			http.Error(w, "code exchange failed: "+err.Error(), http.StatusInternalServerError)
+			done <- err
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, successHTML)
+		done <- nil
+	})
+
+	srv := &http.Server{Addr: listenAddr, Handler: mux}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			done <- fmt.Errorf("listener: %w", err)
+		}
+	}()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	log.Println(aurora.Cyan("Opening browser for Twitch sign-in..."))
+	log.Println("If your browser doesn't open automatically, visit:")
+	log.Println(aurora.Blue(authURL).Underline())
+	helpers.OpenInBrowser(authURL)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Fatalf("bootstrap failed: %v", err)
+		}
+		log.Println(aurora.Green("bootstrap successful — refresh token persisted to oauth_tokens"))
+	case <-time.After(flowTimeout):
+		log.Fatalf("timed out after %s waiting for Twitch callback", flowTimeout)
+	}
+}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -65,6 +66,7 @@ func main() {
 	findInitialVideo()
 	users.InitLeaderboard()
 	startCron()
+	loadTwitchToken()   // must precede chatbot.Initialize — provides the IRC token
 	setUpTwitchClient() // required for the below
 	updateSubscribers()
 	getCurrentUsers()
@@ -125,6 +127,18 @@ func startCron() {
 	// start cron and attach cronjobs
 	background.StartCron()
 	scheduleBackgroundJobs()
+}
+
+// loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
+// Refuses to start if the row is missing — pointing at the bootstrap CLI
+// is louder than running IRC-less.
+func loadTwitchToken() {
+	if err := mytwitch.LoadFromDB(); err != nil {
+		if errors.Is(err, mytwitch.ErrNoToken) {
+			log.Fatalf("no oauth_tokens row for %q — run `task tripbot:auth:bootstrap` against the cluster DB (port-forward via `task tripbot:db:up` in infra)", c.Conf.BotUsername)
+		}
+		terrors.Fatal(err, "failed to load Twitch token from DB")
+	}
 }
 
 // setUpTwitchClient sets up the Twitch client,

--- a/db/README.md
+++ b/db/README.md
@@ -21,13 +21,31 @@ You might need to add `?sslmode=disable` for local development servers.
 
 ## To run a migration
 
-Migrations are run using [go-migrate](https://github.com/golang-migrate/migrate).
+Migrations are run using [golang-migrate](https://github.com/golang-migrate/migrate). Install with `brew install golang-migrate` on macOS.
+
+Apply all pending migrations:
+
+`migrate -database <postgres://url> -source file://./db/migrate up`
+
+Apply a specific number of pending migrations:
 
 `migrate -database <postgres://url> -source file://./db/migrate up <migration_number>`
+
+Roll back the most recent migration:
+
+`migrate -database <postgres://url> -source file://./db/migrate down 1`
+
+Show the current schema version:
+
+`migrate -database <postgres://url> -source file://./db/migrate version`
 
 ## To create a new migration
 
 `migrate create -ext sql -seq -digits 3 -dir db/migrate <migration_name>`
+
+## Migrations of note
+
+- `010_create_oauth_tokens` — stores Twitch OAuth refresh + access tokens for the bot account. Populate via `task tripbot:auth:bootstrap` (one-time, local). The bot reads the row at boot and refreshes hourly.
 
 ## To take a backup
 

--- a/db/migrate/010_create_oauth_tokens.down.sql
+++ b/db/migrate/010_create_oauth_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_tokens;

--- a/db/migrate/010_create_oauth_tokens.up.sql
+++ b/db/migrate/010_create_oauth_tokens.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE oauth_tokens (
+  id                  SERIAL PRIMARY KEY,
+  provider            TEXT NOT NULL DEFAULT 'twitch',
+  username            TEXT NOT NULL,
+  twitch_user_id      TEXT,
+  access_token        TEXT NOT NULL,
+  refresh_token       TEXT NOT NULL,
+  expires_at          TIMESTAMP WITH TIME ZONE NOT NULL,
+  scopes              TEXT NOT NULL,
+  refresh_fail_count  INTEGER NOT NULL DEFAULT 0,
+  last_refresh_at     TIMESTAMP WITH TIME ZONE,
+  date_created        TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  date_updated        TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (provider, username)
+);

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	cloud.google.com/go/logging v1.4.2
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/XSAM/otelsql v0.42.0
 	github.com/adrg/libvlc-go/v3 v3.1.5
 	github.com/bradfitz/latlong v0.0.0-20170410180902-f3db6d0dff40

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.2.0/go.mod h1:TYmVAyE8Tn1lyPcltF
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/XSAM/otelsql v0.42.0 h1:Li0xF4eJUxG2e0x3D4rvRlys1f27yJKvjTh7ljkUP5o=
 github.com/XSAM/otelsql v0.42.0/go.mod h1:4mOrEv+cS1KmKzrvTktvJnstr5GtKSAK+QHvFR9OcpI=
 github.com/adrg/libvlc-go/v3 v3.1.5 h1:TGO0dvubmLCSE4ocOtJYMBlPYALm8aGMkCuDZ6cXnM0=
@@ -236,6 +238,7 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kelvins/geocoder v0.0.0-20200113010004-f579500e9e27 h1:ekI686mLb7Nxb8fgczSM1iV235ypZpOZwL/ANcGZ9Lg=
 github.com/kelvins/geocoder v0.0.0-20200113010004-f579500e9e27/go.mod h1:JaVDVP24FJxa8OtNO5T1A2WKgstNreJGyK1PvBRzPW0=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -9,13 +9,11 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
-	"github.com/adanalife/tripbot/pkg/helpers"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gempir/go-twitch-irc/v2"
 	"github.com/kelvins/geocoder"
-	"github.com/logrusorgru/aurora"
 	"github.com/nicklaw5/helix"
 )
 
@@ -39,25 +37,14 @@ func Initialize() *twitch.Client {
 	geocoder.ApiKey = c.Conf.GoogleMapsAPIKey
 
 	// initialize the twitch API client
-	myClient, err := mytwitch.Client()
+	_, err = mytwitch.Client()
 	if err != nil {
 		terrors.Fatal(err, "unable to create twitch API client")
 	}
 
-	if !c.Conf.DisableTwitchWebhooks {
-		//TODO: actually use the security features provided here
-		authURL := myClient.GetAuthorizationURL(&helix.AuthorizationURLParams{
-			//TODO: move to configs lib
-			//TODO: revisit that we need all of these
-			Scopes:       []string{"openid", "user:edit:broadcast", "channel:read:subscriptions"},
-			ResponseType: "code",
-		})
-		log.Println("if your browser doesn't open automatically:")
-		log.Println(aurora.Blue(authURL).Underline())
-		helpers.OpenInBrowser(authURL)
-	}
-
-	client = twitch.NewClient(c.Conf.BotUsername, mytwitch.AuthToken)
+	// The IRC token comes from the DB-backed oauth_tokens row populated by
+	// cmd/auth-bootstrap; cmd/tripbot calls mytwitch.LoadFromDB before this.
+	client = twitch.NewClient(c.Conf.BotUsername, mytwitch.IRCAuthToken())
 
 	// attach handlers
 	client.OnUserJoinMessage(UserJoin)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,4 +45,12 @@ func SetEnvironment() {
 		log.Println("Error loading .env file:", err)
 		log.Println("Continuing anyway...")
 	}
+
+	// Also load the docker env file as a base layer; docker-compose layers
+	// this in via `--env-file infra/docker/env.docker`, but host-side runs
+	// (e.g. cmd/auth-bootstrap) don't go through compose. godotenv.Load
+	// doesn't overwrite existing values, so shell-env and .env.<env> stay
+	// authoritative. Silent no-op in containers without this file present
+	// (e.g. the cluster pod).
+	_ = godotenv.Load("infra/docker/env.docker")
 }

--- a/pkg/oauthtokens/oauthtokens.go
+++ b/pkg/oauthtokens/oauthtokens.go
@@ -22,20 +22,23 @@ import (
 // at the bootstrap CLI.
 var ErrNoToken = errors.New("oauthtokens: no row for (provider, username); run task tripbot:auth:bootstrap")
 
-// Token mirrors the oauth_tokens row.
+// Token mirrors the oauth_tokens row. TwitchUserID + LastRefreshAt are
+// nullable in the schema; the bootstrap CLI populates twitch_user_id from
+// helix.GetUsers, but any out-of-band INSERT (CI seed, ad-hoc psql) may
+// leave it unset, so sqlx scans must handle NULL.
 type Token struct {
-	ID               int          `db:"id"`
-	Provider         string       `db:"provider"`
-	Username         string       `db:"username"`
-	TwitchUserID     string       `db:"twitch_user_id"`
-	AccessToken      string       `db:"access_token"`
-	RefreshToken     string       `db:"refresh_token"`
-	ExpiresAt        time.Time    `db:"expires_at"`
-	Scopes           string       `db:"scopes"` // space-joined
-	RefreshFailCount int          `db:"refresh_fail_count"`
-	LastRefreshAt    sql.NullTime `db:"last_refresh_at"`
-	DateCreated      time.Time    `db:"date_created"`
-	DateUpdated      time.Time    `db:"date_updated"`
+	ID               int            `db:"id"`
+	Provider         string         `db:"provider"`
+	Username         string         `db:"username"`
+	TwitchUserID     sql.NullString `db:"twitch_user_id"`
+	AccessToken      string         `db:"access_token"`
+	RefreshToken     string         `db:"refresh_token"`
+	ExpiresAt        time.Time      `db:"expires_at"`
+	Scopes           string         `db:"scopes"` // space-joined
+	RefreshFailCount int            `db:"refresh_fail_count"`
+	LastRefreshAt    sql.NullTime   `db:"last_refresh_at"`
+	DateCreated      time.Time      `db:"date_created"`
+	DateUpdated      time.Time      `db:"date_updated"`
 }
 
 // Get returns the row for (provider, username) or ErrNoToken if missing.

--- a/pkg/oauthtokens/oauthtokens.go
+++ b/pkg/oauthtokens/oauthtokens.go
@@ -1,0 +1,173 @@
+// Package oauthtokens is the storage layer for OAuth refresh + access tokens
+// rotated by the bot itself. The on-disk source of truth lives in the
+// `oauth_tokens` table (migration 010); this package wraps it with sqlx queries
+// matching the rest of tripbot's DB access pattern.
+package oauthtokens
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrNoToken is returned by Get when no row matches (provider, username).
+// Callers handle this as the cold-start signal — typically log.Fatal pointing
+// at the bootstrap CLI.
+var ErrNoToken = errors.New("oauthtokens: no row for (provider, username); run task tripbot:auth:bootstrap")
+
+// Token mirrors the oauth_tokens row.
+type Token struct {
+	ID               int          `db:"id"`
+	Provider         string       `db:"provider"`
+	Username         string       `db:"username"`
+	TwitchUserID     string       `db:"twitch_user_id"`
+	AccessToken      string       `db:"access_token"`
+	RefreshToken     string       `db:"refresh_token"`
+	ExpiresAt        time.Time    `db:"expires_at"`
+	Scopes           string       `db:"scopes"` // space-joined
+	RefreshFailCount int          `db:"refresh_fail_count"`
+	LastRefreshAt    sql.NullTime `db:"last_refresh_at"`
+	DateCreated      time.Time    `db:"date_created"`
+	DateUpdated      time.Time    `db:"date_updated"`
+}
+
+// Get returns the row for (provider, username) or ErrNoToken if missing.
+func Get(provider, username string) (Token, error) {
+	return getFromDB(database.Connection(), provider, username)
+}
+
+func getFromDB(db *sqlx.DB, provider, username string) (Token, error) {
+	var t Token
+	query := `SELECT * FROM oauth_tokens WHERE provider=$1 AND username=$2`
+	err := db.Get(&t, query, provider, username)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Token{}, ErrNoToken
+	}
+	if err != nil {
+		return Token{}, fmt.Errorf("oauthtokens.Get: %w", err)
+	}
+	return t, nil
+}
+
+// Upsert inserts the row or updates the existing one matching (provider, username).
+// On UPDATE, refresh_fail_count is reset to 0 (Upsert implies a successful refresh
+// or a fresh bootstrap), last_refresh_at + date_updated are stamped to now(),
+// and date_created is preserved.
+func Upsert(t Token) error {
+	return upsertOnDB(database.Connection(), t)
+}
+
+func upsertOnDB(db *sqlx.DB, t Token) error {
+	tx, err := db.Beginx()
+	if err != nil {
+		return fmt.Errorf("oauthtokens.Upsert begin: %w", err)
+	}
+	query := `
+		INSERT INTO oauth_tokens
+			(provider, username, twitch_user_id, access_token, refresh_token,
+			 expires_at, scopes, refresh_fail_count, last_refresh_at)
+		VALUES
+			(:provider, :username, :twitch_user_id, :access_token, :refresh_token,
+			 :expires_at, :scopes, 0, NOW())
+		ON CONFLICT (provider, username) DO UPDATE SET
+			twitch_user_id     = EXCLUDED.twitch_user_id,
+			access_token       = EXCLUDED.access_token,
+			refresh_token      = EXCLUDED.refresh_token,
+			expires_at         = EXCLUDED.expires_at,
+			scopes             = EXCLUDED.scopes,
+			refresh_fail_count = 0,
+			last_refresh_at    = NOW(),
+			date_updated       = NOW()
+	`
+	if _, err := tx.NamedExec(query, t); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("oauthtokens.Upsert exec: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("oauthtokens.Upsert commit: %w", err)
+	}
+	return nil
+}
+
+// IncrementFailCount bumps refresh_fail_count by 1 and stamps last_refresh_at.
+// Called by the refresh loop on Twitch-side errors (5xx, network blip, revoked
+// token) so persistent failures surface in monitoring.
+func IncrementFailCount(provider, username string) error {
+	return incrementOnDB(database.Connection(), provider, username)
+}
+
+func incrementOnDB(db *sqlx.DB, provider, username string) error {
+	query := `
+		UPDATE oauth_tokens
+		SET refresh_fail_count = refresh_fail_count + 1,
+		    last_refresh_at    = NOW(),
+		    date_updated       = NOW()
+		WHERE provider=$1 AND username=$2
+	`
+	res, err := db.Exec(query, provider, username)
+	if err != nil {
+		return fmt.Errorf("oauthtokens.IncrementFailCount: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("oauthtokens.IncrementFailCount rows: %w", err)
+	}
+	if n == 0 {
+		return ErrNoToken
+	}
+	return nil
+}
+
+// TryRefreshLock attempts to acquire a Postgres session-scoped advisory lock
+// keyed on (provider, username). The lock prevents concurrent refresh between
+// a local-dev tripbot and a cluster pod sharing the same Twitch account: only
+// one can rotate the refresh token at a time.
+//
+// On success, acquired=true and the caller MUST invoke release() when done.
+// On contention, acquired=false; the caller should re-Get the row (the winner
+// has rotated it) and proceed without calling release().
+//
+// The lock is held against a single pooled connection; release() unlocks and
+// returns the connection to the pool.
+func TryRefreshLock(provider, username string) (bool, func(), error) {
+	return tryRefreshLockOnDB(database.Connection(), provider, username)
+}
+
+func tryRefreshLockOnDB(db *sqlx.DB, provider, username string) (bool, func(), error) {
+	ctx := context.Background()
+	conn, err := db.Connx(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("oauthtokens.TryRefreshLock conn: %w", err)
+	}
+	key := lockKey(provider, username)
+	var acquired bool
+	if err := conn.GetContext(ctx, &acquired, "SELECT pg_try_advisory_lock($1)", key); err != nil {
+		_ = conn.Close()
+		return false, nil, fmt.Errorf("oauthtokens.TryRefreshLock acquire: %w", err)
+	}
+	if !acquired {
+		_ = conn.Close()
+		return false, nil, nil
+	}
+	release := func() {
+		// Best-effort unlock; closing the conn releases it regardless.
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key)
+		_ = conn.Close()
+	}
+	return acquired, release, nil
+}
+
+// lockKey hashes the lock identifier into a stable int64 suitable for
+// pg_try_advisory_lock(bigint). The hashtext() approach used elsewhere is
+// 32-bit; we use SHA-256 → first 8 bytes as int64 for a wider key space.
+func lockKey(provider, username string) int64 {
+	h := sha256.Sum256([]byte("oauth_refresh:" + provider + ":" + username))
+	return int64(binary.BigEndian.Uint64(h[:8]))
+}

--- a/pkg/oauthtokens/oauthtokens_test.go
+++ b/pkg/oauthtokens/oauthtokens_test.go
@@ -26,7 +26,7 @@ func sampleToken() Token {
 	return Token{
 		Provider:     "twitch",
 		Username:     "tripbot4000",
-		TwitchUserID: "12345",
+		TwitchUserID: sql.NullString{String: "12345", Valid: true},
 		AccessToken:  "access-abc",
 		RefreshToken: "refresh-xyz",
 		ExpiresAt:    time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),

--- a/pkg/oauthtokens/oauthtokens_test.go
+++ b/pkg/oauthtokens/oauthtokens_test.go
@@ -1,0 +1,215 @@
+package oauthtokens
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+)
+
+func newMockDB(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	// Default matcher is QueryMatcherRegexp; the expected strings below are
+	// substrings/patterns of the real queries.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlx.NewDb(db, "postgres"), mock
+}
+
+func sampleToken() Token {
+	return Token{
+		Provider:     "twitch",
+		Username:     "tripbot4000",
+		TwitchUserID: "12345",
+		AccessToken:  "access-abc",
+		RefreshToken: "refresh-xyz",
+		ExpiresAt:    time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		Scopes:       "chat:read chat:edit channel:read:subscriptions user:edit:broadcast",
+	}
+}
+
+func TestGet_Hit(t *testing.T) {
+	db, mock := newMockDB(t)
+	rows := sqlmock.NewRows([]string{
+		"id", "provider", "username", "twitch_user_id", "access_token", "refresh_token",
+		"expires_at", "scopes", "refresh_fail_count", "last_refresh_at",
+		"date_created", "date_updated",
+	}).AddRow(
+		1, "twitch", "tripbot4000", "12345", "access-abc", "refresh-xyz",
+		time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		"chat:read chat:edit",
+		0, nil,
+		time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+	)
+	mock.ExpectQuery(`SELECT .* FROM oauth_tokens WHERE provider=`).
+		WithArgs("twitch", "tripbot4000").
+		WillReturnRows(rows)
+
+	got, err := getFromDB(db, "twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("getFromDB: %v", err)
+	}
+	if got.Username != "tripbot4000" || got.AccessToken != "access-abc" || got.RefreshToken != "refresh-xyz" {
+		t.Errorf("unexpected token: %+v", got)
+	}
+	if got.RefreshFailCount != 0 {
+		t.Errorf("expected RefreshFailCount=0, got %d", got.RefreshFailCount)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGet_Miss(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery(`SELECT .* FROM oauth_tokens WHERE provider=`).
+		WithArgs("twitch", "ghost").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := getFromDB(db, "twitch", "ghost")
+	if !errors.Is(err, ErrNoToken) {
+		t.Errorf("expected ErrNoToken, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpsert_RunsExpectedQuery(t *testing.T) {
+	db, mock := newMockDB(t)
+	tok := sampleToken()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO oauth_tokens`).
+		WithArgs(
+			tok.Provider, tok.Username, tok.TwitchUserID,
+			tok.AccessToken, tok.RefreshToken, tok.ExpiresAt, tok.Scopes,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := upsertOnDB(db, tok); err != nil {
+		t.Fatalf("upsertOnDB: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpsert_RollsBackOnExecError(t *testing.T) {
+	db, mock := newMockDB(t)
+	tok := sampleToken()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO oauth_tokens`).
+		WillReturnError(errors.New("boom"))
+	mock.ExpectRollback()
+
+	err := upsertOnDB(db, tok)
+	if err == nil {
+		t.Fatal("expected error from upsertOnDB, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIncrementFailCount_UpdatesRow(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec(`UPDATE oauth_tokens`).
+		WithArgs("twitch", "tripbot4000").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := incrementOnDB(db, "twitch", "tripbot4000"); err != nil {
+		t.Fatalf("incrementOnDB: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIncrementFailCount_NoRowReturnsErrNoToken(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectExec(`UPDATE oauth_tokens`).
+		WithArgs("twitch", "ghost").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := incrementOnDB(db, "twitch", "ghost")
+	if !errors.Is(err, ErrNoToken) {
+		t.Errorf("expected ErrNoToken, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTryRefreshLock_Acquired(t *testing.T) {
+	db, mock := newMockDB(t)
+	key := lockKey("twitch", "tripbot4000")
+
+	mock.ExpectQuery(`pg_try_advisory_lock`).
+		WithArgs(key).
+		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(true))
+	mock.ExpectExec(`pg_advisory_unlock`).
+		WithArgs(key).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	acquired, release, err := tryRefreshLockOnDB(db, "twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("tryRefreshLockOnDB: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected acquired=true")
+	}
+	if release == nil {
+		t.Fatal("expected non-nil release fn")
+	}
+	release()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTryRefreshLock_Contended(t *testing.T) {
+	db, mock := newMockDB(t)
+	key := lockKey("twitch", "tripbot4000")
+
+	mock.ExpectQuery(`pg_try_advisory_lock`).
+		WithArgs(key).
+		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(false))
+
+	acquired, release, err := tryRefreshLockOnDB(db, "twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("tryRefreshLockOnDB: %v", err)
+	}
+	if acquired {
+		t.Fatal("expected acquired=false")
+	}
+	if release != nil {
+		t.Fatal("expected nil release fn on contention")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestLockKey_StableAndDistinct(t *testing.T) {
+	a := lockKey("twitch", "tripbot4000")
+	b := lockKey("twitch", "tripbot4000")
+	if a != b {
+		t.Errorf("lockKey not stable: %d vs %d", a, b)
+	}
+	if lockKey("twitch", "tripbot4000") == lockKey("twitch", "adanalife") {
+		t.Error("lockKey collision between distinct usernames")
+	}
+	if lockKey("twitch", "tripbot4000") == lockKey("github", "tripbot4000") {
+		t.Error("lockKey collision between distinct providers")
+	}
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -11,10 +11,21 @@ import (
 	"github.com/adanalife/tripbot/pkg/chatbot"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/logrusorgru/aurora"
+	"github.com/nicklaw5/helix"
 )
+
+// generateUserAccessToken is overridable in tests so the /auth/callback
+// happy path can be exercised without round-tripping to Twitch.
+var generateUserAccessToken = mytwitch.GenerateUserAccessToken
+
+// helixClient is overridable in tests so /auth/init's URL-construction can be
+// exercised without triggering mytwitch.Client()'s lazy network init (which
+// would request a real App Access Token from Twitch).
+var helixClient = mytwitch.Client
 
 // versionTag is set by main via SetVersion; overridden at build time
 // through `-ldflags "-X main.version=..."`.
@@ -149,27 +160,66 @@ func authTwitchHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, twitchAuthJSON())
 }
 
-// oauth callback URL, requests come from Twitch and have a special code
-// we then use that code to generate a User Access Token
+// authCallbackHandler completes the OAuth Authorization Code flow. Validates
+// the CSRF state, exchanges the code for an access+refresh token via helix,
+// and persists the row (mytwitch.GenerateUserAccessToken handles the helix
+// call + Upsert).
 func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
-	codes, ok := r.URL.Query()["code"]
-
-	if !ok || len(codes[0]) < 1 {
-		msg := "no code in response from twitch"
-		terrors.Log(errors.New("code missing"), msg)
-		//TODO: better error than StatusNotFound (404)
-		http.Error(w, msg, http.StatusNotFound)
+	state := r.URL.Query().Get("state")
+	if !oauthstate.Validate(state) {
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
 		return
 	}
-	code := string(codes[0])
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		terrors.Log(errors.New("code missing"), "no code in response from twitch")
+		http.Error(w, "no code in response from twitch", http.StatusBadRequest)
+		return
+	}
+
+	if err := generateUserAccessToken(code); err != nil {
+		terrors.Log(err, "GenerateUserAccessToken failed")
+		http.Error(w, "failed to exchange code: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	log.Println(aurora.Cyan("successfully received token from twitch!"))
-	// use the code to generate an access token
-	mytwitch.GenerateUserAccessToken(code)
-
-	//TODO: return a pretty HTML page here (black background, logo, etc)
-	fmt.Fprintf(w, "Success!")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, authSuccessHTML)
 }
+
+// authInitHandler kicks off an OAuth Authorization Code flow from a browser.
+// Generates a state, redirects (302) to Twitch's authorize URL with the
+// configured Scopes. The cluster pod serves this for emergency re-bootstrap
+// when Dana isn't near a laptop; locally cmd/auth-bootstrap does its own
+// equivalent without going through the public Ingress.
+func authInitHandler(w http.ResponseWriter, r *http.Request) {
+	client, err := helixClient()
+	if err != nil {
+		terrors.Log(err, "helix client unavailable for /auth/init")
+		http.Error(w, "auth unavailable", http.StatusInternalServerError)
+		return
+	}
+	state := oauthstate.New()
+	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
+		Scopes:       mytwitch.Scopes,
+		ResponseType: "code",
+		State:        state,
+	})
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// authSuccessHTML is the body returned after a successful code exchange.
+// Inline so the handler doesn't depend on a template file; if this needs
+// styling beyond a few lines, move to an embed.FS template.
+const authSuccessHTML = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>tripbot — auth success</title>
+<style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>
+</head>
+<body><div><h1>Success</h1><p>You may close this tab.</p></div></body>
+</html>`
 
 // return a favicon if anyone asks for one
 func faviconHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -2,11 +2,14 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 )
 
 func TestHealthHandler(t *testing.T) {
@@ -124,6 +127,123 @@ func TestAuthTwitchHandlerMissingSecretReturns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// withStubGenerateUserAccessToken swaps the package-level generator so the
+// /auth/callback handler can be tested without round-tripping to Twitch.
+func withStubGenerateUserAccessToken(t *testing.T, stub func(string) error) {
+	t.Helper()
+	saved := generateUserAccessToken
+	generateUserAccessToken = stub
+	t.Cleanup(func() { generateUserAccessToken = saved })
+}
+
+func TestAuthCallbackHandler_NoStateReturns400(t *testing.T) {
+	withStubGenerateUserAccessToken(t, func(string) error {
+		t.Fatal("generator should not be called when state is missing")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=anything", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthCallbackHandler_BadStateReturns400(t *testing.T) {
+	withStubGenerateUserAccessToken(t, func(string) error {
+		t.Fatal("generator should not be called when state is invalid")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state=not-real&code=anything", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthCallbackHandler_NoCodeReturns400(t *testing.T) {
+	state := oauthstate.New()
+	withStubGenerateUserAccessToken(t, func(string) error {
+		t.Fatal("generator should not be called when code is missing")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state, nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthCallbackHandler_HappyPath(t *testing.T) {
+	state := oauthstate.New()
+	var gotCode string
+	withStubGenerateUserAccessToken(t, func(code string) error {
+		gotCode = code
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=the-code", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotCode != "the-code" {
+		t.Errorf("generator got code %q, want %q", gotCode, "the-code")
+	}
+	if !strings.Contains(rec.Header().Get("Content-Type"), "text/html") {
+		t.Errorf("Content-Type %q is not html", rec.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(rec.Body.String(), "Success") {
+		t.Errorf("body should contain 'Success'; got %q", rec.Body.String())
+	}
+}
+
+func TestAuthCallbackHandler_GeneratorErrorReturns500(t *testing.T) {
+	state := oauthstate.New()
+	withStubGenerateUserAccessToken(t, func(string) error {
+		return errors.New("twitch broke")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=anything", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAuthCallbackHandler_StateIsSingleUse(t *testing.T) {
+	state := oauthstate.New()
+	withStubGenerateUserAccessToken(t, func(string) error { return nil })
+
+	// First call consumes the state and succeeds.
+	req1 := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=x", nil)
+	rec1 := httptest.NewRecorder()
+	authCallbackHandler(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first call: got status %d, want %d", rec1.Code, http.StatusOK)
+	}
+
+	// Second call with the same state should 400.
+	req2 := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=x", nil)
+	rec2 := httptest.NewRecorder()
+	authCallbackHandler(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("second call: got status %d, want %d (state should be single-use)", rec2.Code, http.StatusBadRequest)
 	}
 }
 

--- a/pkg/server/oauthstate/oauthstate.go
+++ b/pkg/server/oauthstate/oauthstate.go
@@ -1,0 +1,67 @@
+// Package oauthstate generates and validates the `state` query parameter for
+// the OAuth Authorization Code flow. Generators stash a random token before
+// redirecting to the IdP; validators consume it on the callback.
+//
+// State entries auto-expire after a short TTL and are single-use (deleted on
+// successful Validate). The in-memory store is process-local — fine for the
+// callback flow where the same process serves /auth/init and /auth/callback,
+// not designed for distribution.
+package oauthstate
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// TTL is how long a state token remains valid after New.
+const TTL = 5 * time.Minute
+
+var (
+	mu    sync.Mutex
+	store = map[string]time.Time{} // state -> expiry
+	now   = time.Now              // overridable in tests
+)
+
+// New mints a fresh state token, stores it with TTL, and returns it.
+func New() string {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// crypto/rand failure is a process-wide problem; panic is acceptable.
+		panic("oauthstate: crypto/rand: " + err.Error())
+	}
+	state := hex.EncodeToString(buf[:])
+	mu.Lock()
+	store[state] = now().Add(TTL)
+	mu.Unlock()
+	return state
+}
+
+// Validate consumes the state token. Returns true exactly once per New().
+// Subsequent calls (or expired/unknown states) return false.
+func Validate(state string) bool {
+	if state == "" {
+		return false
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	sweepLocked()
+	exp, ok := store[state]
+	if !ok {
+		return false
+	}
+	delete(store, state)
+	return now().Before(exp)
+}
+
+// sweepLocked drops expired entries. Called from Validate so we never grow
+// the store unboundedly when state tokens go unused.
+func sweepLocked() {
+	t := now()
+	for k, exp := range store {
+		if !t.Before(exp) {
+			delete(store, k)
+		}
+	}
+}

--- a/pkg/server/oauthstate/oauthstate_test.go
+++ b/pkg/server/oauthstate/oauthstate_test.go
@@ -1,0 +1,105 @@
+package oauthstate
+
+import (
+	"testing"
+	"time"
+)
+
+func resetStore(t *testing.T) {
+	t.Helper()
+	savedNow := now
+	t.Cleanup(func() {
+		mu.Lock()
+		store = map[string]time.Time{}
+		mu.Unlock()
+		now = savedNow
+	})
+	mu.Lock()
+	store = map[string]time.Time{}
+	mu.Unlock()
+}
+
+func TestNew_GeneratesUniqueStates(t *testing.T) {
+	resetStore(t)
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		s := New()
+		if s == "" {
+			t.Fatal("New returned empty state")
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate state generated: %q", s)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+func TestValidate_Hit(t *testing.T) {
+	resetStore(t)
+	s := New()
+	if !Validate(s) {
+		t.Fatal("expected Validate(New()) to return true")
+	}
+}
+
+func TestValidate_DoubleUseRejected(t *testing.T) {
+	resetStore(t)
+	s := New()
+	if !Validate(s) {
+		t.Fatal("first Validate should succeed")
+	}
+	if Validate(s) {
+		t.Fatal("second Validate of same state should fail (single-use)")
+	}
+}
+
+func TestValidate_ExpiredRejected(t *testing.T) {
+	resetStore(t)
+	t0 := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return t0 }
+	s := New()
+	// advance past TTL
+	now = func() time.Time { return t0.Add(TTL + time.Second) }
+	if Validate(s) {
+		t.Fatal("expired state should not validate")
+	}
+}
+
+func TestValidate_UnknownRejected(t *testing.T) {
+	resetStore(t)
+	if Validate("not-a-real-state") {
+		t.Fatal("unknown state should not validate")
+	}
+}
+
+func TestValidate_EmptyStringRejected(t *testing.T) {
+	resetStore(t)
+	if Validate("") {
+		t.Fatal("empty state should not validate")
+	}
+}
+
+func TestSweepClearsExpiredEntries(t *testing.T) {
+	resetStore(t)
+	t0 := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return t0 }
+	// generate several states that will expire
+	for i := 0; i < 5; i++ {
+		New()
+	}
+	mu.Lock()
+	beforeSweep := len(store)
+	mu.Unlock()
+	if beforeSweep != 5 {
+		t.Fatalf("expected 5 entries before sweep, got %d", beforeSweep)
+	}
+	// jump past TTL, then Validate (which triggers sweep)
+	now = func() time.Time { return t0.Add(TTL + time.Second) }
+	Validate("anything") // miss, but triggers sweep
+	mu.Lock()
+	afterSweep := len(store)
+	mu.Unlock()
+	if afterSweep != 0 {
+		t.Fatalf("expected sweep to clear expired entries, %d remain", afterSweep)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,6 +48,7 @@ func Start() {
 	// auth endpoints
 	auth := r.PathPrefix("/auth").Methods("GET").Subrouter()
 	auth.Handle("/twitch", tagged("/auth/twitch", authTwitchHandler))
+	auth.Handle("/init", tagged("/auth/init", authInitHandler))
 	auth.Handle("/callback", tagged("/auth/callback", authCallbackHandler))
 
 	// static assets

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,9 +1,14 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/nicklaw5/helix"
 )
 
 func TestIsInvalidSecret(t *testing.T) {
@@ -27,5 +32,55 @@ func TestIsInvalidSecret(t *testing.T) {
 				t.Fatalf("isInvalidSecret(%q) = %v, want %v", tt.input, got, tt.wantInvalid)
 			}
 		})
+	}
+}
+
+func TestAuthInit_RedirectsToTwitch(t *testing.T) {
+	// Build a real *helix.Client with non-empty options. GetAuthorizationURL
+	// is pure URL construction (no network), so this works without app tokens.
+	stub, err := helix.NewClient(&helix.Options{
+		ClientID:    "test-client-id",
+		RedirectURI: "http://localhost:8080/auth/callback",
+	})
+	if err != nil {
+		t.Fatalf("helix.NewClient: %v", err)
+	}
+	saved := helixClient
+	helixClient = func() (*helix.Client, error) { return stub, nil }
+	t.Cleanup(func() { helixClient = saved })
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/init", nil)
+	rec := httptest.NewRecorder()
+	authInitHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("got status %d, want %d (302 redirect)", rec.Code, http.StatusFound)
+	}
+	loc := rec.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("Location header empty")
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("Location is not a valid URL: %v", err)
+	}
+	if !strings.Contains(u.Host, "id.twitch.tv") {
+		t.Errorf("redirect host %q does not contain id.twitch.tv", u.Host)
+	}
+	if !strings.HasSuffix(u.Path, "/oauth2/authorize") {
+		t.Errorf("redirect path %q does not end with /oauth2/authorize", u.Path)
+	}
+	q := u.Query()
+	if q.Get("state") == "" {
+		t.Error("redirect URL missing state param")
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q, want %q", q.Get("response_type"), "code")
+	}
+	scopes := q.Get("scope")
+	for _, required := range []string{"chat:read", "chat:edit"} {
+		if !strings.Contains(scopes, required) {
+			t.Errorf("scope param %q missing required scope %q", scopes, required)
+		}
 	}
 }

--- a/pkg/server/twitch.go
+++ b/pkg/server/twitch.go
@@ -28,7 +28,7 @@ func twitchAuthJSON() string {
 	var jsonData []byte
 	auth := TwitchAuthentication{
 		ChannelID:       mytwitch.ChannelID,
-		UserAccessToken: mytwitch.UserAccessToken,
+		UserAccessToken: mytwitch.CurrentUserAccessToken(),
 		ClientID:        mytwitch.ClientID,
 		AppAccessToken:  mytwitch.AppAccessToken,
 	}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -1,127 +1,285 @@
 package twitch
 
 import (
+	"database/sql"
+	"errors"
 	"log"
 	"os"
+	"strings"
+	"sync"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
 	"github.com/logrusorgru/aurora"
 	"github.com/nicklaw5/helix"
 )
 
-// currentTwitchClient is the standard twitch client
+// Scopes is the OAuth scope set requested for the bot account. Single source
+// of truth — referenced by Client() (App Access Token request),
+// GenerateUserAccessToken (initial user-token exchange), and any code that
+// builds an authorize URL (cmd/auth-bootstrap, /auth/init).
+//
+// chat:read + chat:edit are required for IRC. The remaining scopes preserve
+// the broadcast + subscription Helix calls the bot already made.
+var Scopes = []string{
+	"chat:read",
+	"chat:edit",
+	"channel:read:subscriptions",
+	"user:edit:broadcast",
+}
+
+// ErrNoToken signals "no oauth_tokens row for the bot account; run the
+// bootstrap CLI." Re-exported from oauthtokens for caller convenience.
+var ErrNoToken = oauthtokens.ErrNoToken
+
+// currentTwitchClient is the lazy-initialized helix client.
 var currentTwitchClient *helix.Client
 
-// these are used to authenticate to twitch
-var ClientID string
-var ClientSecret string
-var AuthToken string
-var AppAccessToken string
+// ClientID, ClientSecret are set from env at init.
+// AppAccessToken is set in Client() (Client Credentials grant).
+var (
+	ClientID       string
+	ClientSecret   string
+	AppAccessToken string
+)
 
-// these are used to authenticate requests that require user permissions
-var UserAccessToken string
-var UserRefreshToken string
+// tokenMu guards currentUserToken. RWMutex because reads (IRCAuthToken,
+// CurrentUserAccessToken) outnumber writes (LoadFromDB, refresh).
+var (
+	tokenMu          sync.RWMutex
+	currentUserToken oauthtokens.Token
+)
 
-// init makes sure we have all of the require ENV vars
+// init requires the static credentials needed to build a helix client.
+// TWITCH_AUTH_TOKEN is intentionally NOT required — the IRC token now lives
+// in the oauth_tokens table and is loaded via LoadFromDB at boot.
 func init() {
 	requiredVars := []string{
-		"TWITCH_AUTH_TOKEN",
 		"TWITCH_CLIENT_ID",
 		"TWITCH_CLIENT_SECRET",
 	}
 	for _, v := range requiredVars {
-		_, ok := os.LookupEnv(v)
-		if !ok {
+		if _, ok := os.LookupEnv(v); !ok {
 			log.Fatalf("You must set %s", v)
 		}
 	}
-	AuthToken = os.Getenv("TWITCH_AUTH_TOKEN")
 	ClientID = os.Getenv("TWITCH_CLIENT_ID")
 	ClientSecret = os.Getenv("TWITCH_CLIENT_SECRET")
 }
 
-// Client creates a twitch client, or returns the existing one
+// Client returns the shared helix client, lazy-initializing on first call.
+// First-call side effect: requests an App Access Token (Client Credentials).
 func Client() (*helix.Client, error) {
-	// use the existing client if we have one
 	if currentTwitchClient != nil {
 		return currentTwitchClient, nil
 	}
 	client, err := helix.NewClient(&helix.Options{
 		ClientID:     ClientID,
 		ClientSecret: ClientSecret,
-		// this is set at https://dev.twitch.tv/console/apps
+		// Registered at https://dev.twitch.tv/console/apps; matched by
+		// cmd/auth-bootstrap's local HTTP listener.
 		RedirectURI: c.Conf.ExternalURL + "/auth/callback",
 	})
 	if err != nil {
 		terrors.Log(err, "error creating client")
 	}
 
-	//TODO: move to configs lib
-	//TODO: revisit that we need all of these
-	scopes := []string{"openid", "user:edit:broadcast", "channel:read:subscriptions"}
-	// set the AppAccessToken
-	resp, err := client.RequestAppAccessToken(scopes)
+	resp, err := client.RequestAppAccessToken(Scopes)
 	if err != nil {
 		terrors.Log(err, "error getting app access token from twitch")
 	}
 	AppAccessToken = resp.Data.AccessToken
 	client.SetAppAccessToken(AppAccessToken)
 
-	// use this as the shared client
 	currentTwitchClient = client
-
 	return client, err
 }
 
-// GenerateUserAccessToken sends a code to Twitch to generate a
-// user access token. This is called by the web server after
-// going through the OAuth flow
-func GenerateUserAccessToken(code string) {
-	resp, err := currentTwitchClient.RequestUserAccessToken(code)
+// LoadFromDB pulls the row for the configured bot account into in-memory
+// state. cmd/tripbot calls this once at boot before chatbot.Initialize; the
+// returned error is checked for ErrNoToken so the cold-start message points
+// at the bootstrap CLI.
+func LoadFromDB() error {
+	t, err := oauthtokens.Get("twitch", c.Conf.BotUsername)
 	if err != nil {
-		terrors.Log(err, "error getting user access token from twitch")
-		return
+		return err
 	}
+	tokenMu.Lock()
+	currentUserToken = t
+	tokenMu.Unlock()
 
-	UserAccessToken = resp.Data.AccessToken
-	UserRefreshToken = resp.Data.RefreshToken
-
-	// update the current client with the access token
-	currentTwitchClient.SetUserAccessToken(UserAccessToken)
+	// If the helix client is already built, prime its user-access-token so
+	// follow-up Helix calls that need user-scoped permissions work.
+	if currentTwitchClient != nil {
+		currentTwitchClient.SetUserAccessToken(t.AccessToken)
+	}
+	return nil
 }
 
-// RefreshUserAccessToken makes a call to Twitch to generate a
-// fresh user access token. It requires a UserRefreshToken to be
-// set already.
-func RefreshUserAccessToken() {
-	// check to see if we have the required tokens to work with
-	if UserRefreshToken == "" || UserAccessToken == "" {
-		log.Println("no user access token was present, did you log in with OAuth?")
-		authURL := currentTwitchClient.GetAuthorizationURL(&helix.AuthorizationURLParams{
-			//TODO: move to configs lib
-			Scopes:       []string{"openid", "user:edit:broadcast", "channel:read:subscriptions"},
-			ResponseType: "code",
-		})
-		log.Println(aurora.Blue(authURL).Underline())
-		// send a text message cause some features won't work
-		// without a user access token
-		helpers.SendSMS("refreshing user access token failed!")
-		return
+// IRCAuthToken returns the bot's IRC oauth: token, ready for
+// twitch.NewClient. Returns "" if no token has been loaded.
+func IRCAuthToken() string {
+	tokenMu.RLock()
+	defer tokenMu.RUnlock()
+	if currentUserToken.AccessToken == "" {
+		return ""
 	}
+	return "oauth:" + currentUserToken.AccessToken
+}
 
-	resp, err := currentTwitchClient.RefreshUserAccessToken(UserRefreshToken)
+// CurrentUserAccessToken returns the raw access token (no oauth: prefix).
+// Used by pkg/server/twitch.go's /auth/twitch JSON endpoint until that
+// endpoint is deleted in a separate PR.
+func CurrentUserAccessToken() string {
+	tokenMu.RLock()
+	defer tokenMu.RUnlock()
+	return currentUserToken.AccessToken
+}
+
+// GenerateUserAccessToken exchanges a code for an access+refresh token,
+// derives the authenticated username via helix.GetUsers (so bootstrap is
+// account-agnostic — the row is keyed by whoever signed in at consent),
+// and Upserts. If the resulting row matches BOT_USERNAME, also primes the
+// in-memory state so the running bot picks up the rotated token.
+//
+// Returns error (no longer swallows). Callers: /auth/callback handler,
+// cmd/auth-bootstrap.
+func GenerateUserAccessToken(code string) error {
+	client, err := Client()
 	if err != nil {
-		terrors.Log(err, "error refreshing user access token")
+		return err
+	}
+
+	resp, err := client.RequestUserAccessToken(code)
+	if err != nil {
+		return err
+	}
+	if resp == nil || resp.Data.AccessToken == "" {
+		return errors.New("twitch: empty access token in code-exchange response")
+	}
+
+	// Set the access token so GetUsers identifies the caller from the
+	// Authorization header (helix.UsersParams without IDs/Logins returns
+	// the authenticated user).
+	client.SetUserAccessToken(resp.Data.AccessToken)
+	usersResp, err := client.GetUsers(&helix.UsersParams{})
+	if err != nil {
+		return err
+	}
+	if usersResp == nil || len(usersResp.Data.Users) == 0 {
+		return errors.New("twitch: GetUsers returned no users")
+	}
+	u := usersResp.Data.Users[0]
+
+	tok := oauthtokens.Token{
+		Provider:     "twitch",
+		Username:     u.Login,
+		TwitchUserID: sql.NullString{String: u.ID, Valid: u.ID != ""},
+		AccessToken:  resp.Data.AccessToken,
+		RefreshToken: resp.Data.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second),
+		Scopes:       strings.Join(resp.Data.Scopes, " "),
+	}
+	if err := oauthtokens.Upsert(tok); err != nil {
+		return err
+	}
+
+	// Bootstrapping a non-bot account (e.g. the broadcaster) writes the row
+	// but doesn't change the running bot's IRC session.
+	if u.Login == c.Conf.BotUsername {
+		tokenMu.Lock()
+		currentUserToken = tok
+		tokenMu.Unlock()
+	}
+	return nil
+}
+
+// RefreshUserAccessToken is the hourly cron entry point. Reads the bot's row,
+// refreshes if within 30 minutes of expiry, and writes the rotated tokens
+// back. A Postgres advisory lock fences concurrent rotation between local
+// dev and a cluster pod sharing the same Twitch account.
+//
+// TODO: helix client surface should move behind an interface so this
+// function can be unit-tested without a real Twitch round-trip.
+func RefreshUserAccessToken() {
+	botUser := c.Conf.BotUsername
+
+	acquired, release, err := oauthtokens.TryRefreshLock("twitch", botUser)
+	if err != nil {
+		terrors.Log(err, "oauth refresh lock acquisition failed")
+		return
+	}
+	if !acquired {
+		// Another process is rotating. Wait briefly, re-read the rotated
+		// row, sync in-memory.
+		time.Sleep(2 * time.Second)
+		t, gerr := oauthtokens.Get("twitch", botUser)
+		if gerr != nil {
+			terrors.Log(gerr, "post-contention re-read failed")
+			return
+		}
+		tokenMu.Lock()
+		currentUserToken = t
+		tokenMu.Unlock()
+		return
+	}
+	defer release()
+
+	t, err := oauthtokens.Get("twitch", botUser)
+	if err != nil {
+		terrors.Log(err, "no oauth_tokens row to refresh")
 		return
 	}
 
-	UserAccessToken = resp.Data.AccessToken
-	UserRefreshToken = resp.Data.RefreshToken
+	if time.Until(t.ExpiresAt) > 30*time.Minute {
+		return
+	}
 
-	// update the current client with the new access token
-	currentTwitchClient.SetUserAccessToken(UserAccessToken)
+	client, err := Client()
+	if err != nil {
+		terrors.Log(err, "helix client unavailable for refresh")
+		return
+	}
+	resp, err := client.RefreshUserAccessToken(t.RefreshToken)
+	if err != nil {
+		_ = oauthtokens.IncrementFailCount("twitch", botUser)
+		terrors.Log(err, "twitch refresh API failed")
+		return
+	}
+	if resp == nil || resp.Data.AccessToken == "" {
+		// Empty body typically means invalid_grant (refresh token revoked).
+		// Treat as terminal — blank in-memory so IRC reconnect fails loudly,
+		// SMS so Dana sees it on his phone.
+		_ = oauthtokens.IncrementFailCount("twitch", botUser)
+		tokenMu.Lock()
+		currentUserToken.AccessToken = ""
+		tokenMu.Unlock()
+		helpers.SendSMS(botUser + " oauth refresh failed; run task tripbot:auth:bootstrap")
+		terrors.Log(errors.New("empty access token in refresh response"), "oauth refresh failed; need re-bootstrap")
+		return
+	}
 
-	log.Println(aurora.Cyan("successfully updated user access token"))
+	rotated := oauthtokens.Token{
+		Provider:     t.Provider,
+		Username:     t.Username,
+		TwitchUserID: t.TwitchUserID,
+		AccessToken:  resp.Data.AccessToken,
+		RefreshToken: resp.Data.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second),
+		Scopes:       strings.Join(resp.Data.Scopes, " "),
+	}
+	if err := oauthtokens.Upsert(rotated); err != nil {
+		terrors.Log(err, "post-refresh Upsert failed")
+		return
+	}
+
+	tokenMu.Lock()
+	currentUserToken = rotated
+	tokenMu.Unlock()
+	client.SetUserAccessToken(rotated.AccessToken)
+
+	log.Println(aurora.Cyan("successfully refreshed user access token"))
 }

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -1,0 +1,119 @@
+package twitch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
+)
+
+// resetToken restores currentUserToken after a test mutation.
+func resetToken(t *testing.T) {
+	t.Helper()
+	saved := currentUserToken
+	t.Cleanup(func() {
+		tokenMu.Lock()
+		currentUserToken = saved
+		tokenMu.Unlock()
+	})
+}
+
+func TestIRCAuthToken_PrefixesOauth(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{AccessToken: "abc123"}
+	tokenMu.Unlock()
+
+	got := IRCAuthToken()
+	if got != "oauth:abc123" {
+		t.Errorf("IRCAuthToken() = %q, want %q", got, "oauth:abc123")
+	}
+}
+
+func TestIRCAuthToken_EmptyWhenUnloaded(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{}
+	tokenMu.Unlock()
+
+	if got := IRCAuthToken(); got != "" {
+		t.Errorf("IRCAuthToken() with empty token = %q, want \"\"", got)
+	}
+}
+
+func TestCurrentUserAccessToken_ReturnsRaw(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{AccessToken: "raw-no-prefix"}
+	tokenMu.Unlock()
+
+	if got := CurrentUserAccessToken(); got != "raw-no-prefix" {
+		t.Errorf("CurrentUserAccessToken() = %q, want %q", got, "raw-no-prefix")
+	}
+}
+
+func TestScopes_IncludesIRCScopes(t *testing.T) {
+	required := []string{"chat:read", "chat:edit"}
+	have := map[string]bool{}
+	for _, s := range Scopes {
+		have[s] = true
+	}
+	for _, r := range required {
+		if !have[r] {
+			t.Errorf("Scopes missing required IRC scope %q (have %v)", r, Scopes)
+		}
+	}
+}
+
+func TestScopes_NoDuplicates(t *testing.T) {
+	seen := map[string]bool{}
+	for _, s := range Scopes {
+		if seen[s] {
+			t.Errorf("duplicate scope %q in Scopes", s)
+		}
+		seen[s] = true
+	}
+}
+
+func TestScopes_DropsOpenID(t *testing.T) {
+	// openid was in the previous scope set but the bot doesn't read ID
+	// claims; dropping it shrinks the consent screen and reduces surface.
+	for _, s := range Scopes {
+		if s == "openid" {
+			t.Errorf("Scopes still includes openid; expected drop")
+		}
+	}
+}
+
+func TestErrNoToken_AliasesOAuthTokens(t *testing.T) {
+	if ErrNoToken != oauthtokens.ErrNoToken {
+		t.Errorf("ErrNoToken does not match oauthtokens.ErrNoToken; sentinel comparisons will fail")
+	}
+}
+
+// TestIRCAuthToken_ConcurrentReads is a smoke check that the RWMutex doesn't
+// deadlock under parallel reads while a writer takes the lock.
+func TestIRCAuthToken_ConcurrentReads(t *testing.T) {
+	resetToken(t)
+	tokenMu.Lock()
+	currentUserToken = oauthtokens.Token{AccessToken: "race-check"}
+	tokenMu.Unlock()
+
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = IRCAuthToken()
+			}
+			done <- struct{}{}
+		}()
+	}
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < 8; i++ {
+		select {
+		case <-done:
+		case <-deadline:
+			t.Fatal("concurrent IRCAuthToken readers timed out (deadlock?)")
+		}
+	}
+}


### PR DESCRIPTION
Minor release. Replaces the static `TWITCH_AUTH_TOKEN` env var (sourced from a third-party token generator) with a self-owned OAuth Authorization Code flow against tripbot's own Twitch dev app. The bot's IRC refresh token now lives in Postgres and rotates hourly via a `pg_try_advisory_lock`-fenced cron job; one-time bootstrap via a new `cmd/auth-bootstrap` CLI. Plus two CI trigger-path filters.

### What's landing

**Authentication (3 PRs, one logical change)**

- [#452](https://github.com/adanalife/tripbot/pull/452/changes) — `db`: migration `010_create_oauth_tokens` (the table). Keyed by `(provider, username)`; stores refresh + access tokens, expiry, scopes, fail counter.
- [#454](https://github.com/adanalife/tripbot/pull/454/changes) — `oauthtokens`: storage package wrapping the table. sqlx queries + `pg_try_advisory_lock`-backed `TryRefreshLock` so local-dev + cluster pod can't both rotate concurrently.
- [#455](https://github.com/adanalife/tripbot/pull/455/changes) — `twitch`: full auth rewire. `pkg/twitch/authentication.go` drops the static `AuthToken` global in favour of DB-backed `LoadFromDB`/`IRCAuthToken`/`CurrentUserAccessToken`. `/auth/callback` gains CSRF state validation + a small HTML success page; new `/auth/init` for cloud-based re-bootstrap. New `cmd/auth-bootstrap` CLI + `task auth:bootstrap` for the one-time interactive bootstrap (username derived from `helix.GetUsers` so the table is account-agnostic). `pkg/config` layers `infra/docker/env.docker` for host-side runs. CI build job split + seeded `oauth_tokens` placeholder so the build-stack smoke test still passes the cold-start contract.

**CI**

- [#447](https://github.com/adanalife/tripbot/pull/447/changes) — `vlc.yml`: filter push trigger to VLC-impacting paths. Cuts wasted CI runs on develop merges and release tags that don't touch VLC inputs.
- [#448](https://github.com/adanalife/tripbot/pull/448/changes) — `obs.yml`: filter PR trigger to OBS-impacting paths. Same wasted-runner-minute saver, PR side.

### Why minor (v2.3.0)

The auth rewire is a load-bearing architectural change — the bot's IRC credential lifecycle moves from a third-party-issued static token to a self-owned OAuth flow with rotation. No breaking change for chat users, but a fundamentally new shape for how the bot is operated (a one-time bootstrap step is now required on first deploy / after refresh-token revocation). Minor fits.

### Pre-flight

- [x] CHANGELOG.md updated for v2.3.0 (committed direct to develop, in this PR's diff)
- [x] `#minor` in this PR title (and in the CHANGELOG commit message) — auto-tag.yml picks it up

### Release plumbing

- Merge with a **merge commit** (not squash) per `merge-strategy-by-target-branch` — preserves develop's commits as ancestors of master.
- Merging this PR → `auto-tag.yml` sees `#minor` → tags `v2.3.0` → `release.yml` builds + pushes multi-arch images for tripbot, vlc, obs to Docker Hub → `verify-stamped-image.sh` gates each build leg.
- After build green: `kubectl rollout restart deploy/tripbot deploy/vlc-server`; verify pod SHA matches the v2.3.0 commit before doing anything else.

### Post-merge — bootstrap path (one-time, per cluster)

The new code requires an `oauth_tokens` row at boot. Bootstrap the cluster DB BEFORE rolling out v2.3.0 to avoid crashloops:

1. Merge the companion infra PR [adanalife/infra#434](https://github.com/adanalife/infra/pull/434/changes) (adds `task tripbot:db:up`/`down`).
2. `task tripbot:db:up` (in infra) → opens port-forward to cluster postgres.
3. `task auth:bootstrap` (in tripbot on develop / v2.3.0) → browser opens, sign in as `tripbot4000`, "Success" page, row Upserted via the port-forward.
4. `task tripbot:db:down`.
5. `kubectl rollout restart deploy/tripbot` once v2.3.0 images are live; new pod reads the row and connects to IRC.
6. (Follow-up infra PR) drop `TWITCH_AUTH_TOKEN` from the `twitch-external-secret.yaml` mapping; then `aws secretsmanager put-secret-value` to delete the field from the SM JSON.