### PR TITLE
docker: bundle migrate CLI + schema files into runtime image

### DIFF
--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,6 +24,12 @@ RUN apt-get update \
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
+# Bundle the migrate CLI + schema files so a cluster Job can run
+# migrations using the same image — keeps SQL alongside the code that
+# uses it without needing a sibling image.
+COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
+COPY db/migrate /migrations
+
 ARG VERSION=dev
 ARG SHA=unknown
 RUN mkdir -p /etc/tripbot \


### PR DESCRIPTION
## Summary
- Bundle the `migrate/migrate:4` binary (multi-arch upstream, latest stable v4.19.1) and `db/migrate/*.sql` files into the tripbot runtime image
- Lets a k8s Job in infra run schema migrations using the same image — no sibling \`tripbot-migrations\` image to maintain, no cross-repo SQL paths

## Why
The local-k3d stage-1 cluster has never run schema migrations — the original 2026-05-03 cluster work explicitly noted *"nothing in the cluster is durable yet."* Pre-v2.3.0, tripbot logged \`relation does not exist\` as INFO and kept running degraded; v2.3.0's \`LoadFromDB\` boot check turns that into a hard exit-1, so the gap is now load-bearing.

Considered shapes:
- Separate \`adanalife/tripbot-migrations\` image — clean but adds a new build leg + version-lockstep CI gating
- ConfigMap from cross-repo path — fragile assumption about layout
- Bundle into the existing image (this PR) — same git SHA → same image → schema-code skew impossible by construction, no new CI surface

\`migrate\` is a ~10MB Go static binary; \`db/migrate\` is 20 SQL files totaling under 20KB. Negligible image-size impact.

## Follow-up (separate PRs)
- infra: \`k8s/apps/tripbot/base/migrate-job.yaml\` referencing \`adanalife/tripbot:latest\`, runs \`migrate ... up\` against cluster postgres on cluster bring-up
- v2.3.1 release once this merges, so the new image is on Docker Hub before infra references it

## Test plan
- [ ] CI build green on both arches
- [ ] After release, \`docker run --rm adanalife/tripbot:v2.3.1 migrate -version\` returns a v4.x version
- [ ] After release, \`docker run --rm --entrypoint=ls adanalife/tripbot:v2.3.1 /migrations\` lists the 20 .sql files