### PR TITLE
Release v2.3.1: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.3.1] — 2026-05-11
+
+Patch release. Tooling-only — bundles the `migrate` CLI and `db/migrate/*.sql` into the runtime image so a cluster k8s Job can run schema migrations without a sibling image. No behavior change at runtime.
+
+### Docker
+
+- **Bundle `migrate/migrate:4` binary + `db/migrate/*.sql` into the tripbot image.** The local-k3d stage-1 cluster has never run schema migrations — the original 2026-05-03 cluster work explicitly noted *"nothing in the cluster is durable yet."* Pre-v2.3.0 tripbot tolerated missing schema (logged at INFO and ran degraded); v2.3.0's `LoadFromDB` boot check makes that an exit-1, so a cluster migration step is now load-bearing. Bundling rather than shipping a sibling `tripbot-migrations` image keeps schema-code version skew impossible by construction (same git SHA → same image), avoids new CI surface, and adds ~10MB binary + 20KB SQL to the runtime image (rounding error). Follow-up infra PR wires a k8s Job using `adanalife/tripbot:v2.3.1`. ([#458])
+
 ## [v2.3.0] — 2026-05-10
 
 Minor release. Replaces the static `TWITCH_AUTH_TOKEN` env var (sourced from a third-party token generator) with a self-owned OAuth Authorization Code flow against tripbot's own Twitch dev app. The bot's IRC refresh token now lives in Postgres and rotates hourly via a `pg_try_advisory_lock`-fenced cron job; one-time bootstrap via a new `cmd/auth-bootstrap` CLI. Plus two CI trigger-path filters.
@@ -292,3 +300,4 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#452]: https://github.com/adanalife/tripbot/pull/452
 [#454]: https://github.com/adanalife/tripbot/pull/454
 [#455]: https://github.com/adanalife/tripbot/pull/455
+[#458]: https://github.com/adanalife/tripbot/pull/458

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,6 +24,12 @@ RUN apt-get update \
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
+# Bundle the migrate CLI + schema files so a cluster Job can run
+# migrations using the same image — keeps SQL alongside the code that
+# uses it without needing a sibling image.
+COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
+COPY db/migrate /migrations
+
 ARG VERSION=dev
 ARG SHA=unknown
 RUN mkdir -p /etc/tripbot \


### PR DESCRIPTION
Patch release. Tooling-only — bundles the `migrate` CLI and `db/migrate/*.sql` into the runtime image so a cluster k8s Job can run schema migrations without a sibling image. No behavior change at runtime.

### What's landing

- [#458](https://github.com/adanalife/tripbot/pull/458/changes) — `docker`: `COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate` + `COPY db/migrate /migrations` in the runtime stage. Floating `4` major tag per `use-latest-stable-when-adding` (latest stable: v4.19.1). Multi-arch upstream so buildx works on both arches with no extra plumbing.

### Why patch (v2.3.1)

Image bundling only. No Go code change, no runtime behavior change, no new env or migration requirement. Local dev keeps using the compose `migrate:` sidecar; the new artifacts only matter once a cluster Job consumes them in a follow-up infra PR.

### Why this release exists

The local-k3d stage-1 cluster has never run schema migrations — the original 2026-05-03 cluster work explicitly noted *"nothing in the cluster is durable yet."* Pre-v2.3.0 tripbot tolerated missing schema (logged at INFO and ran degraded); v2.3.0's `LoadFromDB` boot check turns that into a hard exit-1, so a cluster migration step is now load-bearing. v2.3.1 ships the image artifacts the cluster Job will need; the Job itself lands in infra after this release publishes.

### Pre-flight

- [x] CHANGELOG.md updated for v2.3.1 (committed direct to develop)
- [x] No `#minor` / `#major` in this PR title → auto-tag.yml defaults to patch bump

### Release plumbing

- Merge with a **merge commit** (not squash) per `merge-strategy-by-target-branch`.
- Merge → `auto-tag.yml` tags `v2.3.1` → `release.yml` builds multi-arch and pushes `adanalife/tripbot:v2.3.1` + `:latest` (and same for vlc, obs).
- Follow-up: [infra#436](https://github.com/adanalife/infra/pull/436/changes) — `k8s/apps/tripbot/base/migrate-job.yaml` referencing `adanalife/tripbot:latest`; then cluster bootstrap test.
