### PR TITLE
docker(tripbot): tighten migrate-bundle comment

### DIFF
--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,9 +24,7 @@ RUN apt-get update \
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
-# Bundle the migrate CLI + schema files so a cluster Job can run
-# migrations using the same image — keeps SQL alongside the code that
-# uses it without needing a sibling image.
+# Bundle the migrate CLI + db/migrate so this image can run schema migrations.
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
 COPY db/migrate /migrations
 


### PR DESCRIPTION
Trim the comment above the migrate-CLI / db/migrate \`COPY\` lines from a three-line design-rationale block down to a single line of what + why. The original mentioned a hypothetical "sibling image" that won't make sense to a future reader without the design-options context from the original PR review.

Comment-only — no Dockerfile semantics change. v2.3.2 picks it up; v2.3.1 image already published is fine since comments aren't in the published artifact.