### PR TITLE
OBS arm64: pre-baked CEF base image (skip ~25 min compile per PR)

### DIFF
--- a/.github/workflows/obs-base.yml
+++ b/.github/workflows/obs-base.yml
@@ -1,0 +1,53 @@
+name: OBS CEF Base Image
+# Bakes adanalife/obs-cef-base:arm64-<OBS>-<CEF> + arm64-latest, which
+# Dockerfile.arm64 then COPYs the OBS install tree out of. Re-runs only when
+# the base Dockerfile or this workflow file changes; manual dispatch
+# available for re-bakes (e.g., chasing a CEF tarball mirror change).
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'infra/docker/obs/Dockerfile.arm64-base'
+      - '.github/workflows/obs-base.yml'
+
+jobs:
+  arm64:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Parse OBS_VERSION / CEF_VERSION out of the Dockerfile so the tag
+      # always matches what was actually built. Single source of truth lives
+      # in the Dockerfile ARG defaults.
+      - name: Extract versions
+        id: vers
+        run: |
+          OBS=$(grep -E '^ARG OBS_VERSION=' infra/docker/obs/Dockerfile.arm64-base | cut -d= -f2)
+          CEF=$(grep -E '^ARG CEF_VERSION=' infra/docker/obs/Dockerfile.arm64-base | cut -d= -f2)
+          echo "obs=$OBS" >> "$GITHUB_OUTPUT"
+          echo "cef=$CEF" >> "$GITHUB_OUTPUT"
+          echo "Building obs-cef-base:arm64-${OBS}-${CEF}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/obs/Dockerfile.arm64-base
+          platforms: linux/arm64
+          push: true
+          tags: |
+            adanalife/obs-cef-base:arm64-${{ steps.vers.outputs.obs }}-${{ steps.vers.outputs.cef }}
+            adanalife/obs-cef-base:arm64-latest
+          cache-from: type=gha,scope=obs-cef-base-arm64
+          cache-to: type=gha,mode=max,scope=obs-cef-base-arm64

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -1,81 +1,17 @@
 # =============================================================================
-# Builder: compile obs-studio from source with CEF for arm64 browser_source.
+# Runtime image for arm64. The OBS install tree (compiled from source against
+# the aarch64 CEF tarball) is pulled from the pre-baked obs-cef-base image —
+# see infra/docker/obs/Dockerfile.arm64-base and .github/workflows/obs-base.yml.
+# Bumping OBS_VERSION/CEF_VERSION = re-bake the base, then bump the FROM tag
+# below.
 #
 # Why from source on arm64: Ubuntu 24.04 universe ships obs-studio without
 # CEF (the +dfsg suffix marks the DFSG-stripped build), so browser_source
 # registers as "Source ID not found" at scene load. The OBS PPA bundles CEF
-# but publishes amd64 only — no arm64 across any Ubuntu release. Building
-# from source against the official aarch64 CEF tarball is the only path to
-# browser sources on arm64. amd64 stays on the PPA build (see Dockerfile).
-#
-# References:
-#   - Build wiki: https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux
-#   - aarch64 CEF: https://cdn-fastly.obsproject.com/downloads/cef_binary_6533_linux_aarch64_v6.tar.xz
+# but publishes amd64 only — no arm64 across any Ubuntu release. amd64 stays
+# on the PPA build (see Dockerfile).
 # =============================================================================
-FROM ubuntu:24.04 AS builder
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-ARG OBS_VERSION=32.1.2
-ARG CEF_VERSION=6533
-
-# Build-system + OBS dependencies, mirroring the Debian-based section of the
-# OBS Build-Instructions-For-Linux wiki page.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      cmake extra-cmake-modules ninja-build pkg-config \
-      clang clang-format build-essential curl ccache git ca-certificates \
-      xz-utils \
-      libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev \
-      libswresample-dev libswscale-dev libx264-dev \
-      libcurl4-openssl-dev libmbedtls-dev \
-      libgl1-mesa-dev libjansson-dev \
-      libluajit-5.1-dev python3-dev \
-      libx11-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-xinerama0-dev \
-      libxcb-composite0-dev libxcomposite-dev libxinerama-dev libxcb1-dev \
-      libx11-xcb-dev libxcb-xfixes0-dev \
-      swig libcmocka-dev libxss-dev libglvnd-dev libgles2-mesa-dev \
-      libwayland-dev librist-dev libsrt-openssl-dev \
-      libpci-dev libpipewire-0.3-dev libqrcodegencpp-dev \
-      uthash-dev libsimde-dev \
-      qt6-base-dev qt6-base-private-dev qt6-svg-dev qt6-wayland qt6-image-formats-plugins \
-      libasound2-dev libfdk-aac-dev libfontconfig-dev libfreetype-dev \
-      libjack-jackd2-dev libpulse-dev libsndio-dev libspeexdsp-dev \
-      libudev-dev libv4l-dev libva-dev libvlc-dev libdrm-dev \
-      nlohmann-json3-dev libwebsocketpp-dev libasio-dev \
-      # CEF link-time deps (chromium pulls in NSS, ATK, AT-SPI2, XDamage, etc.) \
-      libnss3-dev libatk1.0-dev libatk-bridge2.0-dev libatspi2.0-dev \
-      libxdamage-dev libxkbcommon-dev libcups2-dev libpango1.0-dev \
-      libxshmfence-dev libnspr4-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# CEF tarball pinned to aarch64; amd64 builds use the PPA in Dockerfile.
-WORKDIR /opt
-RUN curl -fsSL -o /tmp/cef.tar.xz \
-         "https://cdn-fastly.obsproject.com/downloads/cef_binary_${CEF_VERSION}_linux_aarch64_v6.tar.xz" \
-    && mkdir -p /opt/cef \
-    && tar xf /tmp/cef.tar.xz -C /opt/cef --strip-components=1 \
-    && rm /tmp/cef.tar.xz
-
-# OBS source must be cloned with submodules — the GitHub source tarball is
-# missing required files (per the build wiki).
-WORKDIR /src
-RUN git clone --depth=1 --branch="${OBS_VERSION}" --recurse-submodules --shallow-submodules \
-      https://github.com/obsproject/obs-studio.git \
-    && cd obs-studio && git log --oneline -1
-
-WORKDIR /src/obs-studio
-RUN cmake --preset ubuntu \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -DENABLE_BROWSER=ON \
-    -DCEF_ROOT_DIR=/opt/cef \
-    -DENABLE_AJA=OFF \
-    -DENABLE_NVENC=OFF \
-    -DENABLE_QSV11=OFF \
-    -DOBS_COMPILE_DEPRECATION_AS_WARNING=ON
-
-RUN cmake --build build_ubuntu --parallel
-RUN cmake --install build_ubuntu --prefix /opt/obs-install
+FROM adanalife/obs-cef-base:arm64-32.1.2-6533 AS builder
 
 
 # =============================================================================
@@ -115,9 +51,9 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
       libcups2t64 libxdamage1 libxkbcommon0 libxkbfile1 libexpat1 libpango-1.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the compiled OBS install tree from the builder. cmake --install lays
-# out OBS + plugins under /opt/obs-install (mapped to /usr/local on the
-# runtime side). CEF runtime files are placed by obs-browser's install step.
+# Copy the compiled OBS install tree from the pre-baked base image. cmake
+# --install laid the tree out under /opt/obs-install (mapped to /usr/local on
+# the runtime side); CEF runtime files are placed by obs-browser's install step.
 COPY --from=builder /opt/obs-install/ /usr/local/
 RUN ldconfig
 

--- a/infra/docker/obs/Dockerfile.arm64-base
+++ b/infra/docker/obs/Dockerfile.arm64-base
@@ -1,0 +1,86 @@
+# =============================================================================
+# OBS-from-source builder for arm64. Output: an image carrying just the OBS
+# install tree at /opt/obs-install. Consumed by Dockerfile.arm64 via
+# `FROM adanalife/obs-cef-base:arm64-<OBS>-<CEF> AS builder` so per-PR builds
+# skip the ~25 min CEF/OBS compile.
+#
+# Re-bake when OBS_VERSION or CEF_VERSION changes (publish via the
+# obs-base.yml workflow), then bump the FROM tag in Dockerfile.arm64.
+#
+# References:
+#   - Build wiki: https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux
+#   - aarch64 CEF: https://cdn-fastly.obsproject.com/downloads/cef_binary_6533_linux_aarch64_v6.tar.xz
+# =============================================================================
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG OBS_VERSION=32.1.2
+ARG CEF_VERSION=6533
+
+# Build-system + OBS dependencies, mirroring the Debian-based section of the
+# OBS Build-Instructions-For-Linux wiki page.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cmake extra-cmake-modules ninja-build pkg-config \
+      clang clang-format build-essential curl ccache git ca-certificates \
+      xz-utils \
+      libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev \
+      libswresample-dev libswscale-dev libx264-dev \
+      libcurl4-openssl-dev libmbedtls-dev \
+      libgl1-mesa-dev libjansson-dev \
+      libluajit-5.1-dev python3-dev \
+      libx11-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-xinerama0-dev \
+      libxcb-composite0-dev libxcomposite-dev libxinerama-dev libxcb1-dev \
+      libx11-xcb-dev libxcb-xfixes0-dev \
+      swig libcmocka-dev libxss-dev libglvnd-dev libgles2-mesa-dev \
+      libwayland-dev librist-dev libsrt-openssl-dev \
+      libpci-dev libpipewire-0.3-dev libqrcodegencpp-dev \
+      uthash-dev libsimde-dev \
+      qt6-base-dev qt6-base-private-dev qt6-svg-dev qt6-wayland qt6-image-formats-plugins \
+      libasound2-dev libfdk-aac-dev libfontconfig-dev libfreetype-dev \
+      libjack-jackd2-dev libpulse-dev libsndio-dev libspeexdsp-dev \
+      libudev-dev libv4l-dev libva-dev libvlc-dev libdrm-dev \
+      nlohmann-json3-dev libwebsocketpp-dev libasio-dev \
+      # CEF link-time deps (chromium pulls in NSS, ATK, AT-SPI2, XDamage, etc.) \
+      libnss3-dev libatk1.0-dev libatk-bridge2.0-dev libatspi2.0-dev \
+      libxdamage-dev libxkbcommon-dev libcups2-dev libpango1.0-dev \
+      libxshmfence-dev libnspr4-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# CEF tarball pinned to aarch64; amd64 builds use the PPA in Dockerfile.
+WORKDIR /opt
+RUN curl -fsSL -o /tmp/cef.tar.xz \
+         "https://cdn-fastly.obsproject.com/downloads/cef_binary_${CEF_VERSION}_linux_aarch64_v6.tar.xz" \
+    && mkdir -p /opt/cef \
+    && tar xf /tmp/cef.tar.xz -C /opt/cef --strip-components=1 \
+    && rm /tmp/cef.tar.xz
+
+# OBS source must be cloned with submodules — the GitHub source tarball is
+# missing required files (per the build wiki).
+WORKDIR /src
+RUN git clone --depth=1 --branch="${OBS_VERSION}" --recurse-submodules --shallow-submodules \
+      https://github.com/obsproject/obs-studio.git \
+    && cd obs-studio && git log --oneline -1
+
+WORKDIR /src/obs-studio
+RUN cmake --preset ubuntu \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DENABLE_BROWSER=ON \
+    -DCEF_ROOT_DIR=/opt/cef \
+    -DENABLE_AJA=OFF \
+    -DENABLE_NVENC=OFF \
+    -DENABLE_QSV11=OFF \
+    -DOBS_COMPILE_DEPRECATION_AS_WARNING=ON
+
+RUN cmake --build build_ubuntu --parallel
+RUN cmake --install build_ubuntu --prefix /opt/obs-install
+
+
+# =============================================================================
+# Final stage: ship only the install tree. Downstream `Dockerfile.arm64` will
+# `COPY --from=builder /opt/obs-install/ /usr/local/` and apt-install the
+# runtime dependencies on top of its own ubuntu:24.04 base.
+# =============================================================================
+FROM scratch
+COPY --from=builder /opt/obs-install/ /opt/obs-install/


### PR DESCRIPTION
## Summary

- New `infra/docker/obs/Dockerfile.arm64-base` builds OBS-from-source against the aarch64 CEF tarball and ships a slim image carrying just `/opt/obs-install/`.
- New `.github/workflows/obs-base.yml` builds and pushes `adanalife/obs-cef-base:arm64-32.1.2-6533` and `:arm64-latest` to Docker Hub. Triggers on `workflow_dispatch` + `push` when the base Dockerfile or this workflow itself changes.
- `infra/docker/obs/Dockerfile.arm64` now `FROM`s the base — the arm64 leg of `obs.yml` should drop from ~30 min to ~2 min (apt-install runtime deps + COPY install tree).

Bumping OBS / CEF versions becomes: edit `Dockerfile.arm64-base`'s ARG defaults, fire the workflow (or push the change — it auto-bakes), then bump the FROM tag in `Dockerfile.arm64`.

## Race condition on the first run of this PR

Both `obs-base.yml` and `obs.yml` fire on the initial push. `obs.yml`'s arm64 leg will fail on the first run because `adanalife/obs-cef-base:arm64-32.1.2-6533` doesn't exist on Docker Hub yet. Once `obs-base.yml` completes (~30 min on the arm64 runner), re-run the failed `obs.yml` arm64 job → passes in ~2 min. After merge, future PRs reuse the cached base and never hit this.

## Test plan

- [ ] `obs-base.yml` succeeds and pushes both `arm64-32.1.2-6533` and `arm64-latest` to Docker Hub
- [ ] After base lands, re-run `obs.yml` → arm64 leg pulls the base and finishes well under 10 min
- [ ] arm64 OBS container still comes up healthy in the smoke-test
- [ ] amd64 leg of `obs.yml` unaffected (uses PPA, untouched)