### PR TITLE
ci: replace non-existent main branch with develop/master across workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,9 @@
 name: "CodeQL"
 
 on:
+  pull_request:
   push:
-    branches: [ main ]
+    branches: [ develop, master ]
   schedule:
     #         ┌───────────── minute (0 - 59)
     #         │  ┌───────────── hour (0 - 23)

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - develop
+      - master
     tags:
       - v*
 jobs:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - develop
+      - master
 
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - develop
+      - master
     tags:
       - v*
 

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -24,9 +24,7 @@ RUN apt-get update \
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 
-# Bundle the migrate CLI + schema files so a cluster Job can run
-# migrations using the same image — keeps SQL alongside the code that
-# uses it without needing a sibling image.
+# Bundle the migrate CLI + db/migrate so this image can run schema migrations.
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
 COPY db/migrate /migrations
 


### PR DESCRIPTION
## Summary

Four workflows had `push: branches: [main]` triggers, but this repo uses `develop` → `master`. Push events on the integration branches never fired these workflows.

| Workflow | Change |
|---|---|
| `testing.yml` | `main` → `develop` + `master`. Fixes Coveralls "No base build found for commit X on develop" comments on PRs. |
| `super-linter.yml` | same `main` → `develop` + `master` |
| `linting.yml` | same (tag trigger `v*` preserved) |
| `codeql-analysis.yml` | same, **plus** added `pull_request:` so PRs are scanned (previously only the weekly Thursday cron caught anything) |

Coveralls is the visible win — the others were silently broken.

## Test plan

- [ ] After merge, push to `develop` triggers Testing, super-linter, linting, and CodeQL runs
- [ ] Next PR opened against `develop` gets a Coveralls comment with an actual coverage delta (not "no base build")
- [ ] Next PR also runs CodeQL alongside existing super-linter/linting PR runs
- [ ] No regressions on tag-triggered linting (still fires for `v*` tags)
- [ ] Release PR to `master` (whenever next one cuts) uploads its own base build