### PR TITLE
ci: fix push triggers referencing non-existent main branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,9 @@
 name: "CodeQL"
 
 on:
+  pull_request:
   push:
-    branches: [ main ]
+    branches: [ develop, master ]
   schedule:
     #         ┌───────────── minute (0 - 59)
     #         │  ┌───────────── hour (0 - 23)

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - develop
+      - master
     tags:
       - v*
 jobs:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - develop
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Follow-up to [#462](https://github.com/adanalife/tripbot/pull/462) — same `main` → `develop`/`master` fix for three more workflows that were never running on the integration branch.

| Workflow | Change |
|---|---|
| `super-linter.yml` | `push: branches: - main` → `- develop` + `- master` |
| `linting.yml` | same (tag trigger `v*` preserved) |
| `codeql-analysis.yml` | `push: branches: [main]` → `[develop, master]`, **plus** added `pull_request:` so PRs are scanned (previously only the weekly Thursday cron caught anything) |

CodeQL is the bigger of the three: per-commit baseline scans were silently dropped on every merge, and PRs weren't being scanned at all.

## Test plan

- [ ] After merge, the next push to `develop` triggers super-linter, linting, and CodeQL runs
- [ ] Opening a new PR triggers CodeQL alongside the existing super-linter/linting PR runs
- [ ] No regressions on tag-triggered linting (still fires for `v*` tags)