### PR TITLE
ci: stop pulling LFS in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,8 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - name: Checkout (with LFS)
+      - name: Checkout
         uses: actions/checkout@v6
-        with:
-          lfs: true
 
       - name: Resolve bare version
         id: ver

--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -13,24 +13,8 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     steps:
-      - name: Checkout (without LFS)
+      - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Fetch videos from cache
-        id: restore-videos
-        uses: actions/cache@v5
-        with:
-          path: assets/video
-          key: ${{ runner.os }}-video-${{ hashFiles('assets/video/manifest.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-video-
-
-      - name: Checkout (with LFS)
-        uses: actions/checkout@v6
-        if: steps.restore-videos.outputs.cache-hit != 'true'
-        continue-on-error: true
-        with:
-          lfs: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary

Hit 90% of the 10 GB/mo GitHub LFS bandwidth quota. Audit found the two CI fetches were both unnecessary:

- **`release.yml`** — `tripbot-build` ran `lfs: true` on every tag, on both amd64 and arm64 runners (~432 MB / release). But `.dockerignore` excludes `assets/video`, so the MP4 never enters the build context. Pure waste.
- **`tripbot.yml`** — testing workflow ran `lfs: true` (with an `actions/cache` fallback) on every PR + push to develop. But the smoke test brings up `db`/`migrate`/`tripbot` only (no vlc), and only verifies the container boots + `/version` responds. `findInitialVideo()` logs-and-continues when the dashcam dir is empty; nothing in the test path needs the MP4.

Runtime in k8s already uses a mounted volume — `infra/k8s/apps/vlc-server/overlays/local/dashcam-hostpath.yaml` mounts `/host/dashcam` via k3d, which is wired to the local `assets/video` dir in `k3d-config.bees.yaml`. The video isn't baked into any image and doesn't need to ship through CI.

`*.MP4 filter=lfs` stays in `.gitattributes` as a guardrail for future MP4 commits.

## Test plan

- [ ] Open this PR — `Tripbot` workflow runs without LFS, smoke test still verifies boot + `/version`
- [ ] Confirm release build still produces a working image (next tag cut)
- [ ] LFS bandwidth usage flatlines on next billing cycle