### PR TITLE
obs(amd64): add Intel VAAPI driver + vainfo

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -165,6 +165,30 @@ jobs:
         echo "version: $(docker exec "$cid" cat /etc/tripbot/version)"
         echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
 
+    # GHA runners have no real Intel iGPU, so vaInitialize will fail
+    # ("device not found" or similar). That's expected — the test only
+    # verifies the package set installs cleanly and the binary runs.
+    # Real hw-encode validation happens on the deploy host (e.g., MS-01)
+    # where /dev/dri exposes a real iGPU.
+    - name: Verify VAAPI tooling (amd64)
+      if: matrix.arch == 'amd64'
+      run: |
+        cid=$(docker compose \
+          --project-directory . \
+          -f infra/docker/docker-compose.yml \
+          ${{ matrix.arch_compose }} \
+          -f infra/docker/docker-compose.testing.yml \
+          -f infra/docker/docker-compose.github.yml \
+          ps -q obs)
+        echo "=== which vainfo ==="
+        docker exec "$cid" which vainfo
+        echo "=== libva / intel-media packages installed ==="
+        docker exec "$cid" sh -c "dpkg -l | grep -iE 'libva|intel-media|vainfo' || true"
+        echo "=== vainfo output (vaInitialize will fail without a real iGPU; that's expected on GHA) ==="
+        docker exec "$cid" vainfo --display drm 2>&1 || true
+        echo "=== /dev/dri presence inside container ==="
+        docker exec "$cid" sh -c "ls -la /dev/dri 2>&1 || echo '(no /dev/dri inside container — expected on GHA)'"
+
     - name: Check VLC container logs
       if: always()
       run: |

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -10,6 +10,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 #
 # msttcorefonts wants EULA pre-acceptance for unattended install. Trebuchet
 # MS is referenced by onscreen text sources.
+#
+# intel-media-va-driver-non-free + vainfo enable hardware H.264/H.265
+# encode via VAAPI on Intel iGPU hosts (Gen 11+ Iris Xe / UHD 770).
+# Requires /dev/dri device passthrough at runtime; OBS scenes select
+# "FFmpeg VAAPI" as the output encoder. Software x264 is the fallback
+# when no iGPU is exposed.
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
       | debconf-set-selections \
     && apt-get update \
@@ -28,6 +34,8 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
          x11-utils \
          dbus-x11 \
          libgl1-mesa-dri \
+         intel-media-va-driver-non-free \
+         vainfo \
          fonts-dejavu-core \
          ttf-mscorefonts-installer \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Adds the Intel iGPU userspace VAAPI driver + the `vainfo` CLI to the amd64 OBS image, in preparation for moving OBS onto a host with a real Intel iGPU (a 12th-gen mini PC where QuickSync H.264/H.265 encode dramatically lowers CPU vs. software x264).

- `intel-media-va-driver-non-free` — Intel iHD VAAPI driver covering Gen 11+ iGPUs (Iris Xe / UHD 770). Already-enabled multiverse repo (proof: `ttf-mscorefonts-installer` already in the install list lives there).
- `vainfo` — small CLI for verifying VAAPI initialization + listing supported encode/decode profiles. Used by the new CI smoke test and useful for runtime debugging on the deploy host.
- `obs.yml` grows a "Verify VAAPI tooling (amd64)" step that runs `vainfo --display drm` inside the running container and surfaces the output.

## What's *not* in this PR

- **arm64 changes.** The from-source build already links `libva-dev`, but ARM SBCs use V4L2 M2M (not VAAPI) for hw encode. Plumbing that path is a separate engineering project and isn't on the roadmap.
- **Runtime hookup.** The k8s pod spec needs `/dev/dri` device passthrough + the `render` group in `supplementalGroups`, and the OBS scene config needs to flip the output encoder to "FFmpeg VAAPI". Those are deploy-side changes that land in the infra repo separately when the new host arrives.

## What CI proves (and doesn't)

GHA `ubuntu-latest` runners are virtualized Azure VMs with no real Intel iGPU, so `vaInitialize` will fail in CI ("device not found" or similar) — that's expected. The smoke test's job is narrower: confirm the package set installs cleanly, the binary runs, and `libva` loads. **Real hw-encode validation happens on the deploy host.**

## Test plan

- [ ] CI green on the amd64 build/test job (cached buildx)
- [ ] CI's "Verify VAAPI tooling (amd64)" step output shows the package set installed (look for `libva2`, `intel-media-va-driver-non-free`, `vainfo` in the dpkg listing)
- [ ] CI's vainfo output shows the binary executed (vaInitialize is allowed to fail)
- [ ] arm64 build still passes (untouched, but matrix ensures it stays green)
- [ ] On deploy host with real iGPU (post-merge, when the box arrives): `kubectl exec obs-... -- vainfo --display drm /dev/dri/renderD128` lists encode profiles