### PR TITLE
build: bake postgresql-client + seed files into tripbot image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .env.*
 infra
 !infra/docker/obs
+!infra/docker/bin
 assets/video
 log

--- a/infra/docker/bin/seed-db.sh
+++ b/infra/docker/bin/seed-db.sh
@@ -2,7 +2,12 @@
 
 set -ex
 
-apt update
-apt install -y postgresql
-psql "postgres://$DATABASE_USER:$DATABASE_PASS@$DATABASE_HOST/$DATABASE_DB" \
-  -c "\copy videos FROM 'db/seed/videos.csv' DELIMITER ',' CSV HEADER;"
+DSN="postgres://$DATABASE_USER:$DATABASE_PASS@$DATABASE_HOST/$DATABASE_DB"
+
+COUNT=$(psql "$DSN" -tAc "SELECT COUNT(*) FROM videos;")
+if [ "$COUNT" -gt 0 ]; then
+  echo "videos table already has $COUNT rows — skipping seed"
+  exit 0
+fi
+
+psql "$DSN" -c "\copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;"

--- a/infra/docker/bin/seed-db.sh
+++ b/infra/docker/bin/seed-db.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+apt-get install -y --no-install-recommends postgresql-client
+
 DSN="postgres://$DATABASE_USER:$DATABASE_PASS@$DATABASE_HOST/$DATABASE_DB"
 
 COUNT=$(psql "$DSN" -tAc "SELECT COUNT(*) FROM videos;")

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update \
     ca-certificates \
     tzdata \
     curl \
-    postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
     ca-certificates \
     tzdata \
     curl \
+    postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
@@ -27,6 +28,10 @@ COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 # Bundle the migrate CLI + db/migrate so this image can run schema migrations.
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
 COPY db/migrate /migrations
+
+# Bundle seed script + data so the k8s seed Job is self-contained.
+COPY infra/docker/bin/seed-db.sh /usr/local/bin/seed-db
+COPY db/seed /seed
 
 ARG VERSION=dev
 ARG SHA=unknown


### PR DESCRIPTION
## Summary

- Adds `postgresql-client` to the runtime apt install so `psql` is available in-image without a runtime `apt install`.
- Copies `db/seed/` to `/seed` and `infra/docker/bin/seed-db.sh` to `/usr/local/bin/seed-db` so the k8s seed Job is self-contained (no volume mount needed).
- Removes the runtime `apt install postgresql` from `seed-db.sh`, updates the CSV path to `/seed/videos.csv`, and adds an idempotency check — exits cleanly if `videos` table already has rows.

Companion to adanalife/infra (seed Job + `task tripbot:db:seed`).

## Test plan
- [ ] Build tripbot image (`bin/devenv build`) — verify `psql` present, `/seed/videos.csv` and `/usr/local/bin/seed-db` exist
- [ ] CI green