### PR TITLE
Release v2.4.1: develop → master

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .env.*
 infra
 !infra/docker/obs
+!infra/docker/bin
 assets/video
 log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.4.1] — 2026-05-12
+
+Patch release. Prepares the tripbot image for the k8s one-shot DB seed Job: bakes `db/seed/` and `seed-db.sh` into the image, installs `postgresql-client` on-demand at seed time (rather than in the base image), and un-excludes `infra/docker/bin` from `.dockerignore` so the `COPY` in the Dockerfile resolves correctly in CI.
+
+### Build
+
+- **Bake seed data + script into the tripbot image.** `COPY db/seed /seed` and `COPY infra/docker/bin/seed-db.sh /usr/local/bin/seed-db` added to the Dockerfile so the k8s seed Job is self-contained without a volume mount. The companion infra PR wires up the Job and `task tripbot:db:seed`. ([#473])
+- **Install `postgresql-client` on-demand in `seed-db.sh`.** Keeps the base image lean — `psql` is only needed for the one-time seed Job, so the script installs `postgresql-client --no-install-recommends` at runtime rather than baking it into every container. ([#473])
+- **Un-exclude `infra/docker/bin` from `.dockerignore`.** The ignore file excluded all of `infra/` except `infra/docker/obs`; `infra/docker/bin/seed-db.sh` was invisible to the build context and caused a CI build failure. ([#473])
+
 ## [v2.4.0] — 2026-05-12
 
 Minor release. Migrates chatters and follower lookups off deprecated Twitch endpoints onto Helix v2, upgrades the `nicklaw5/helix` dependency from v1 to v2, removes the broken stream-tags shell-script cron (Twitch removed the automated tags API in 2023), pre-bakes Intel VAAPI support into the amd64 OBS image for the incoming mini-PC host, and kills unnecessary LFS fetches in CI that were burning through the 10 GB/mo bandwidth quota.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,9 +45,17 @@ tasks:
       DATABASE_HOST: '{{.DATABASE_HOST | default "localhost"}}'
       EXTERNAL_URL: '{{.EXTERNAL_URL | default "http://localhost:8080"}}'
     cmds:
+      # Pull Twitch app credentials from SM so they never live in env.docker.
       # `mise exec --` activates the pinned Go toolchain in task's
       # non-interactive subshell (where ~/.zshrc isn't sourced).
-      - mise exec -- go run ./cmd/auth-bootstrap
+      - |
+        secret=$(aws-vault exec adanalife-stage -- \
+          aws secretsmanager get-secret-value \
+          --secret-id k8s/tripbot/twitch-creds \
+          --query SecretString --output text)
+        export TWITCH_CLIENT_ID=$(echo "$secret" | jq -r .TWITCH_CLIENT_ID)
+        export TWITCH_CLIENT_SECRET=$(echo "$secret" | jq -r .TWITCH_CLIENT_SECRET)
+        mise exec -- go run ./cmd/auth-bootstrap
 
   # Release smoke flow — see vault/tripbot/release-checklist.md.
   # Targets the local k3d cluster running the stage-1 overlay

--- a/infra/docker/bin/seed-db.sh
+++ b/infra/docker/bin/seed-db.sh
@@ -2,7 +2,14 @@
 
 set -ex
 
-apt update
-apt install -y postgresql
-psql "postgres://$DATABASE_USER:$DATABASE_PASS@$DATABASE_HOST/$DATABASE_DB" \
-  -c "\copy videos FROM 'db/seed/videos.csv' DELIMITER ',' CSV HEADER;"
+apt-get install -y --no-install-recommends postgresql-client
+
+DSN="postgres://$DATABASE_USER:$DATABASE_PASS@$DATABASE_HOST/$DATABASE_DB"
+
+COUNT=$(psql "$DSN" -tAc "SELECT COUNT(*) FROM videos;")
+if [ "$COUNT" -gt 0 ]; then
+  echo "videos table already has $COUNT rows — skipping seed"
+  exit 0
+fi
+
+psql "$DSN" -c "\copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;"

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -28,6 +28,10 @@ COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
 COPY db/migrate /migrations
 
+# Bundle seed script + data so the k8s seed Job is self-contained.
+COPY infra/docker/bin/seed-db.sh /usr/local/bin/seed-db
+COPY db/seed /seed
+
 ARG VERSION=dev
 ARG SHA=unknown
 RUN mkdir -p /etc/tripbot \


### PR DESCRIPTION
Patch release. Bakes seed data and script into the tripbot image for the k8s one-shot DB seed Job.

## Changes

- Bake `db/seed/` + `seed-db.sh` into the tripbot image (`COPY` in Dockerfile)
- Install `postgresql-client` on-demand in the seed script (not in the base image)
- Un-exclude `infra/docker/bin` from `.dockerignore` (was causing CI build failure)

See CHANGELOG for full detail.

## Merge checklist
- [ ] CI green
- [ ] Merge using **merge commit** (not squash)