### PR TITLE
feat(docker): add auth-bootstrap binary to tripbot image

### DIFF
--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -9,7 +9,8 @@ RUN go mod download
 ARG VERSION=dev
 
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot \
+ && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/auth-bootstrap ./cmd/auth-bootstrap
 
 # Runtime: minimal Ubuntu 24.04 matching the VLC/OBS containers
 FROM ubuntu:24.04
@@ -23,6 +24,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
+COPY --from=builder /out/auth-bootstrap /usr/local/bin/auth-bootstrap
 
 # Bundle the migrate CLI + db/migrate so this image can run schema migrations.
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate


### PR DESCRIPTION
## Summary

- Adds `cmd/auth-bootstrap` to the builder stage's `go build` run
- Copies the binary to `/usr/local/bin/auth-bootstrap` in the final image
- Enables the new `task tripbot:auth:bootstrap` K8s job in [infra#450](https://github.com/adanalife/infra/pull/450/changes) to run the one-time Twitch OAuth bootstrap in-cluster

## Test plan

- [ ] CI build passes with the new binary included
- [ ] Confirm `auth-bootstrap` binary present in the built image: `docker run --rm adanalife/tripbot:latest ls /usr/local/bin/auth-bootstrap`