### PR TITLE
fix(irc): sync IRC client token after each OAuth refresh

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -180,6 +180,14 @@ func connectToTwitch() {
 		err := client.Connect()
 		if err != nil {
 			terrors.Log(err, "unable to connect to twitch")
+			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {
+				// The IRC client holds a stale token. Sync it with the
+				// in-memory token (kept fresh by the hourly refresh cron)
+				// so the next Connect attempt uses the current credentials.
+				if tok := mytwitch.IRCAuthToken(); tok != "" {
+					client.SetIRCToken(tok)
+				}
+			}
 			time.Sleep(time.Minute)
 		}
 	}
@@ -228,7 +236,15 @@ func scheduleBackgroundJobs() {
 	err = background.Cron.AddFunc("@every 5m", tracedJob("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("users.PrintCurrentSession", users.PrintCurrentSession))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetSubscribers", mytwitch.GetSubscribers))
-	err = background.Cron.AddFunc("@every 1h", tracedJob("twitch.RefreshUserAccessToken", mytwitch.RefreshUserAccessToken))
+	err = background.Cron.AddFunc("@every 1h", tracedJob("twitch.RefreshUserAccessToken", func() {
+		mytwitch.RefreshUserAccessToken()
+		// Keep the IRC client's stored token in sync with the rotated credentials.
+		// go-twitch-irc captures the token at construction; without this, any
+		// reconnect after the first rotation replays the original boot-time token.
+		if tok := mytwitch.IRCAuthToken(); tok != "" {
+			client.SetIRCToken(tok)
+		}
+	}))
 	err = background.Cron.AddFunc("@every 2h57m30s", tracedJob("chatbot.Chatter", chatbot.Chatter))
 	err = background.Cron.AddFunc("@every 12h", tracedJob("twitch.UpdateWebhookSubscriptions", mytwitch.UpdateWebhookSubscriptions))
 	if err != nil {

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -9,7 +9,8 @@ RUN go mod download
 ARG VERSION=dev
 
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot \
+ && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/auth-bootstrap ./cmd/auth-bootstrap
 
 # Runtime: minimal Ubuntu 24.04 matching the VLC/OBS containers
 FROM ubuntu:24.04
@@ -23,6 +24,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
+COPY --from=builder /out/auth-bootstrap /usr/local/bin/auth-bootstrap
 
 # Bundle the migrate CLI + db/migrate so this image can run schema migrations.
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate


### PR DESCRIPTION
## Summary

- After each hourly `RefreshUserAccessToken` call, `client.SetIRCToken` is called to keep go-twitch-irc's stored credentials in sync with the rotated token
- On `ErrLoginAuthenticationFailed` in the reconnect loop, `SetIRCToken` is also called as a recovery path before retrying

## Root cause

`go-twitch-irc` stores the token passed to `NewClient` at construction and replays it on every reconnect. The hourly refresh cron kept `currentUserToken` (and the DB) fresh, but never updated the IRC client — so any connection drop after the first token rotation caused an auth failure on reconnect.

Confirmed from logs: refreshes succeeded at 07:56 / 11:56 / 15:56, but IRC auth failed at 16:25 when the connection dropped and reconnected with the original boot-time token.

`SetIRCToken` is the library's own mechanism for this case — its comment reads: *"meant more for 'on next connect, use this new token' in case the old token has expired."*

## Test plan

- [ ] CI passes
- [ ] After merging + rolling out, confirm the pod survives through at least two hourly refresh cycles without IRC auth failures