### PR TITLE
Release v2.4.3: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.4.3] — 2026-05-13
+
+Patch release. Fixes a long-running IRC disconnect bug where the Twitch connection would fail to re-authenticate after the first token rotation, and adds the `auth-bootstrap` binary to the tripbot image for use by the new k8s bootstrap Job.
+
+### Fixed
+
+- **IRC reconnects no longer fail after the first OAuth token rotation.** `go-twitch-irc` stores the token passed to `NewClient` at construction and replays it on every reconnect. The hourly refresh cron kept tokens fresh in memory and in Postgres, but never updated the IRC client — so any connection drop after the first rotation (~4h post-boot) caused a permanent `login authentication failed` loop. Fix: call `client.SetIRCToken` after each successful refresh (proactive) and on `ErrLoginAuthenticationFailed` in the reconnect loop (recovery).
+
+### Build
+
+- **`auth-bootstrap` binary baked into the tripbot image.** Enables the `task tripbot:auth:bootstrap` k8s Job (infra#450) to run the interactive Twitch OAuth bootstrap in-cluster with direct Postgres access, eliminating the need for a separate DB port-forward.
+
 ## [v2.4.2] — 2026-05-12
 
 Patch release. Fixes the k8s seed Job failing with `E: Unable to locate package postgresql-client` by adding `apt-get update` before the install in `seed-db.sh`.

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -180,6 +180,14 @@ func connectToTwitch() {
 		err := client.Connect()
 		if err != nil {
 			terrors.Log(err, "unable to connect to twitch")
+			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {
+				// The IRC client holds a stale token. Sync it with the
+				// in-memory token (kept fresh by the hourly refresh cron)
+				// so the next Connect attempt uses the current credentials.
+				if tok := mytwitch.IRCAuthToken(); tok != "" {
+					client.SetIRCToken(tok)
+				}
+			}
 			time.Sleep(time.Minute)
 		}
 	}
@@ -228,7 +236,15 @@ func scheduleBackgroundJobs() {
 	err = background.Cron.AddFunc("@every 5m", tracedJob("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("users.PrintCurrentSession", users.PrintCurrentSession))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetSubscribers", mytwitch.GetSubscribers))
-	err = background.Cron.AddFunc("@every 1h", tracedJob("twitch.RefreshUserAccessToken", mytwitch.RefreshUserAccessToken))
+	err = background.Cron.AddFunc("@every 1h", tracedJob("twitch.RefreshUserAccessToken", func() {
+		mytwitch.RefreshUserAccessToken()
+		// Keep the IRC client's stored token in sync with the rotated credentials.
+		// go-twitch-irc captures the token at construction; without this, any
+		// reconnect after the first rotation replays the original boot-time token.
+		if tok := mytwitch.IRCAuthToken(); tok != "" {
+			client.SetIRCToken(tok)
+		}
+	}))
 	err = background.Cron.AddFunc("@every 2h57m30s", tracedJob("chatbot.Chatter", chatbot.Chatter))
 	err = background.Cron.AddFunc("@every 12h", tracedJob("twitch.UpdateWebhookSubscriptions", mytwitch.UpdateWebhookSubscriptions))
 	if err != nil {

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -9,7 +9,8 @@ RUN go mod download
 ARG VERSION=dev
 
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tripbot ./cmd/tripbot \
+ && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/auth-bootstrap ./cmd/auth-bootstrap
 
 # Runtime: minimal Ubuntu 24.04 matching the VLC/OBS containers
 FROM ubuntu:24.04
@@ -23,6 +24,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/tripbot /usr/local/bin/tripbot
+COPY --from=builder /out/auth-bootstrap /usr/local/bin/auth-bootstrap
 
 # Bundle the migrate CLI + db/migrate so this image can run schema migrations.
 COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate


### PR DESCRIPTION
## Changes

- **fix(irc):** IRC reconnects no longer fail after the first OAuth token rotation (#477) — `go-twitch-irc` stores the token at construction and replays it on every reconnect; the hourly refresh cron was keeping the DB fresh but never calling `SetIRCToken` on the live client, causing a permanent auth-failure loop after ~4h uptime
- **feat(docker):** `auth-bootstrap` binary baked into the tripbot image (#476) — enables the in-cluster k8s bootstrap Job (infra#450)