### PR TITLE
feat(onscreens): center rotator text on grey-box with shrink-to-fit

### DIFF
--- a/pkg/vlc-server/onscreens_browser.go
+++ b/pkg/vlc-server/onscreens_browser.go
@@ -38,14 +38,26 @@ var onscreenTmpl = template.Must(template.ParseFS(onscreenTemplates, "templates/
 // onscreenStyle controls how a single onscreen renders in its OBS browser source.
 // Keep these in sync with the dimensions / fonts that the previous text_ft2_source
 // and image_source entries in infra/docker/obs/config/Tripbot.json.tmpl used.
+//
+// For text onscreens whose browser-source viewport overhangs a smaller on-canvas
+// overlay box (the bottom-strip rotators sit on a 640px third but their grey-box
+// underlay is narrower — 564px for left, 369px for right), AnchorXPx + FitWidthPx
+// describe the desired "centering window" within the viewport. When both are set,
+// the template switches to an anchored layout and runs a shrink-to-fit pass in JS:
+// content renders at FontSizePx and shrinks down to MinFontSizePx (1px steps) until
+// it fits inside FitWidthPx on a single line, then falls back to wrapping if the
+// floor doesn't fit.
 type onscreenStyle struct {
-	Name       string       // URL slug; matches the key in /onscreens/state.json
-	IsImage    bool         // image vs. text source
-	FontCSS    template.CSS // CSS font-family (only meaningful for text)
-	FontSizePx int          // CSS font-size in px (only meaningful for text)
-	ColorCSS   template.CSS // CSS color (only meaningful for text)
-	DropShadow bool         // text-shadow on/off
-	get        func() *onscreensServer.Onscreen
+	Name          string       // URL slug; matches the key in /onscreens/state.json
+	IsImage       bool         // image vs. text source
+	FontCSS       template.CSS // CSS font-family (only meaningful for text)
+	FontSizePx    int          // default / max font-size in px (only meaningful for text)
+	MinFontSizePx int          // shrink-to-fit floor (only used when FitWidthPx > 0)
+	ColorCSS      template.CSS // CSS color (only meaningful for text)
+	DropShadow    bool         // text-shadow on/off
+	AnchorXPx     int          // center-x within the browser-source viewport (0 = use flex-center fallback)
+	FitWidthPx    int          // single-line width budget for shrink-to-fit (0 = no fit pass)
+	get           func() *onscreensServer.Onscreen
 }
 
 var onscreenRegistry = map[string]onscreenStyle{
@@ -58,11 +70,13 @@ var onscreenRegistry = map[string]onscreenStyle{
 		get: func() *onscreensServer.Onscreen { return onscreensServer.Leaderboard },
 	},
 	"left-message": {
-		Name: "left-message", FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, ColorCSS: "#ffffff",
+		Name: "left-message", FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, MinFontSizePx: 18, ColorCSS: "#ffffff",
+		AnchorXPx: 282, FitWidthPx: 564,
 		get: func() *onscreensServer.Onscreen { return onscreensServer.LeftRotator },
 	},
 	"right-message": {
-		Name: "right-message", FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, ColorCSS: "#ffffff",
+		Name: "right-message", FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, MinFontSizePx: 18, ColorCSS: "#ffffff",
+		AnchorXPx: 456, FitWidthPx: 369,
 		get: func() *onscreensServer.Onscreen { return onscreensServer.RightRotator },
 	},
 	"timewarp": {

--- a/pkg/vlc-server/templates/onscreen.html.tmpl
+++ b/pkg/vlc-server/templates/onscreen.html.tmpl
@@ -12,12 +12,32 @@
     {{if .DropShadow}}text-shadow: 2px 2px 4px rgba(0,0,0,0.7);{{end}}
   }
   #root.hidden { visibility: hidden; }
+  {{if and (not .IsImage) (gt .FitWidthPx 0)}}
+  /* Anchored mode: the browser-source viewport overhangs a smaller on-canvas
+     overlay (the bottom-strip rotators' grey-box). Text centers on AnchorXPx
+     within the viewport and shrinks to fit FitWidthPx. */
+  #root.text {
+    position: relative;
+    width: 100%; height: 100%;
+  }
+  #root.text .content {
+    position: absolute;
+    top: 50%;
+    left: {{.AnchorXPx}}px;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    max-width: {{.FitWidthPx}}px;
+    white-space: nowrap;
+    word-wrap: break-word;
+  }
+  {{else}}
   #root.text {
     width: 100%; height: 100%;
     display: flex; align-items: center; justify-content: center;
     text-align: center; padding: 0 16px; box-sizing: border-box;
     white-space: pre-wrap; word-wrap: break-word;
   }
+  {{end}}
   #root.image { width: 100%; height: 100%; }
   #root.image img { width: 100%; height: 100%; object-fit: contain; display: block; }
 </style>
@@ -25,6 +45,8 @@
 <body>
 {{if .IsImage}}
 <div id="root" class="image hidden" data-name="{{.Name}}" data-image="true"><img src="/onscreens/asset/{{.Name}}" alt=""></div>
+{{else if gt .FitWidthPx 0}}
+<div id="root" class="text hidden" data-name="{{.Name}}" data-image="false" data-anchored="true"><span class="content"></span></div>
 {{else}}
 <div id="root" class="text hidden" data-name="{{.Name}}" data-image="false"></div>
 {{end}}
@@ -33,6 +55,29 @@
   var root = document.getElementById('root');
   var name = root.dataset.name;
   var isImage = root.dataset.image === 'true';
+  var isAnchored = root.dataset.anchored === 'true';
+  var content = isAnchored ? root.querySelector('.content') : root;
+
+  var MAX_FONT_PX = {{.FontSizePx}};
+  var MIN_FONT_PX = {{.MinFontSizePx}};
+  var FIT_WIDTH_PX = {{.FitWidthPx}};
+
+  // Shrink-to-fit on anchored text onscreens: start at MAX_FONT_PX, decrement
+  // 1px at a time until single-line width fits FIT_WIDTH_PX. If the floor is
+  // hit and text still overflows, flip to pre-wrap so a 2nd line shows.
+  function fitText() {
+    if (!isAnchored || !MIN_FONT_PX || !FIT_WIDTH_PX) return;
+    content.style.whiteSpace = 'nowrap';
+    var size = MAX_FONT_PX;
+    root.style.fontSize = size + 'px';
+    while (content.scrollWidth > FIT_WIDTH_PX && size > MIN_FONT_PX) {
+      size -= 1;
+      root.style.fontSize = size + 'px';
+    }
+    if (content.scrollWidth > FIT_WIDTH_PX) {
+      content.style.whiteSpace = 'pre-wrap';
+    }
+  }
 
   function apply(snap) {
     if (!snap || !snap.showing) {
@@ -41,7 +86,8 @@
     }
     root.classList.remove('hidden');
     if (!isImage) {
-      root.textContent = snap.content || '';
+      content.textContent = snap.content || '';
+      fitText();
     }
   }
 


### PR DESCRIPTION
## Summary

Step 2 of the onscreens layout work. [#467](https://github.com/adanalife/tripbot/pull/467) positioned the seven browser-source viewports correctly; this PR styles the text inside them so it visually lands on the grey-box overlays instead of drifting over the dashcam footage.

The left and right rotators sit on 640px viewport thirds whose grey-box underlay is narrower than the viewport itself (left = 564px, right = 369px). Today's centering pivots on the viewport midpoint, which puts text noticeably off-box. This PR pivots on the grey-box midpoint and shrinks the font to fit the grey-box width on long messages.

## Changes

- **`onscreenStyle` gains three fields:** `AnchorXPx`, `FitWidthPx`, `MinFontSizePx`. When `FitWidthPx > 0`, the template switches to an anchored layout: an absolute-positioned `.content` span centered on `AnchorXPx`, with `max-width: FitWidthPx`.
- **JS shrink-to-fit:** every time content updates, the page tries `FontSizePx` (28) and decrements 1px at a time until the rendered single-line width fits `FitWidthPx`. Floors at `MinFontSizePx` (18). If the floor still overflows, flips `white-space` to `pre-wrap` so a 2nd line is at least visible (rotators are 47px tall, so a wrapped 2nd line will clip descenders — acceptable at the floor, not great).
- **Rotator settings:** left = anchor 282 / fit 564, right = anchor 456 / fit 369. Both use max=28 / min=18.
- **Everything else falls through unchanged.** Middle-text, leaderboard, timewarp, GPS, flag have no `FitWidthPx`, so they render via the existing flex-center path. Middle is left alone deliberately — no grey-box underneath it.

## Test plan

- [ ] Verify on the live OBS render that the left rotator text centers on its grey-box (not drifting right into footage).
- [ ] Same for the right rotator (narrower grey-box, 369px).
- [ ] Trigger a long-enough message in each rotator (e.g., a 35+ char chatter message in the right rotator) and confirm the font shrinks visibly toward 18px instead of bleeding past the box.
- [ ] Trigger a *very* long message (50+ chars in right rotator) and confirm it wraps to a 2nd line at the floor instead of overflowing horizontally.
- [ ] Confirm middle-text, leaderboard, timewarp, GPS, and flag render unchanged.