### PR TITLE
chore: migrate aurora v2 → v3

### DIFF
--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -32,7 +32,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -26,7 +26,7 @@ import (
 	_ "github.com/dimiro1/banner/autoload"
 	"github.com/gempir/go-twitch-irc/v2"
 	"github.com/getsentry/sentry-go"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -18,7 +18,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	vlcServer "github.com/adanalife/tripbot/pkg/vlc-server"
 	"github.com/getsentry/sentry-go"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 // version is overridable at build time via -ldflags "-X main.version=...".

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kelvins/geocoder v0.0.0-20231112130812-98d82c75e49b
 	github.com/lib/pq v1.12.3
-	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/nathan-osman/go-sunrise v1.1.0
 	github.com/nicklaw5/helix/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
 github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
-github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
-github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
+github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/pkg/config/tripbot/config.go
+++ b/pkg/config/tripbot/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/config"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/kelseyhightower/envconfig"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 var Conf *TripbotConfig

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/config"
 	"github.com/getsentry/sentry-go"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 var conf config.Config

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -7,7 +7,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 type Event struct {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -20,7 +20,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hako/durafmt"
 	"github.com/kelvins/geocoder"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	"github.com/nathan-osman/go-sunrise"
 	"github.com/skratchdot/open-golang/open"
 )

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -13,7 +13,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 

--- a/pkg/twitch/webhooks.go
+++ b/pkg/twitch/webhooks.go
@@ -6,7 +6,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -9,7 +9,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/jmoiron/sqlx"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 var LifetimeMilesLeaderboard [][]string

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/twitch"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 //TODO: consider moving this whole thing elsewhere (to background perhaps?)

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -8,7 +8,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -12,7 +12,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
-	"github.com/logrusorgru/aurora"
+	"github.com/logrusorgru/aurora/v3"
 )
 
 // CurrentlyPlaying is the video that is currently playing


### PR DESCRIPTION
Bumps `github.com/logrusorgru/aurora` from `v2.0.3+incompatible` to `github.com/logrusorgru/aurora/v3` (v3.0.0).

Updates all 15 import sites across the codebase. The exported API (`aurora.Red`, `aurora.Cyan`, `.Underline()` chaining, etc.) is unchanged in v3. The v2 entry is dropped from `go.mod`.

Part of the module-bump sweep: see #481.

## Test plan

- [x] `go build ./...` passes locally