### PR TITLE
fix(ci): build VLC from source in obs.yml before starting container

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - 'infra/docker/obs/**'
+      - 'infra/docker/vlc/**'
+      - 'script/container_startup.sh'
       - 'infra/docker/docker-compose*.yml'
       - '.github/workflows/obs.yml'
   push:
@@ -90,6 +92,28 @@ jobs:
           -f infra/docker/docker-compose.testing.yml \
           -f infra/docker/docker-compose.github.yml \
           build obs
+
+    - name: Build VLC container (amd64, cached)
+      if: matrix.arch == 'amd64'
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: infra/docker/vlc/Dockerfile
+        tags: adanalife/vlc:latest
+        load: true
+        cache-from: type=gha,scope=vlc-amd64
+        cache-to: type=gha,mode=max,scope=vlc-amd64
+
+    - name: Build VLC container (arm64)
+      if: matrix.arch == 'arm64'
+      run: |
+        docker compose \
+          --project-directory . \
+          -f infra/docker/docker-compose.yml \
+          ${{ matrix.arch_compose }} \
+          -f infra/docker/docker-compose.testing.yml \
+          -f infra/docker/docker-compose.github.yml \
+          build vlc
 
     - name: Start VLC container (RTSP source)
       run: |


### PR DESCRIPTION
## Summary

- **Root cause:** `obs.yml` pulled `adanalife/vlc:latest` from Docker Hub (built at v2.4.3, before [#442](https://github.com/adanalife/tripbot/pull/442)) and started it directly. After #442 baked supervisord configs into the image and removed the heredoc writes from `container_startup.sh`, the Docker Hub image had no conf.d configs, the volume-mounted startup script no longer wrote them, and supervisord launched with no programs — so VLC server never came up. This has been failing on every push to develop since #442 landed.
- **Fix:** add explicit VLC build steps before "Start VLC container" (mirroring the OBS pattern), so the image under test always reflects current source.
- **Also:** add `infra/docker/vlc/**` and `script/container_startup.sh` to the PR paths trigger so future VLC changes fire this workflow on PRs (and catch this class of regression before merge).

## Test plan

- [ ] CI green on this PR (obs.yml runs, VLC becomes ready, OBS becomes healthy)
- [ ] Once merged, rerun [#483](https://github.com/adanalife/tripbot/pull/483) to confirm the release PR passes