### PR TITLE
chatbot: add tests for registry, routing, and dispatch gating

### DIFF
--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -34,20 +34,37 @@ func normalizeCommandPrefix(msg string) string {
 	return msg
 }
 
-func dispatch(cmd *Command, user *users.User, params []string) {
-	incChatCommandCounter(cmd.Trigger)
+// chatUser is the subset of *users.User that dispatch needs for access checks.
+type chatUser interface {
+	HasCommandAvailable() bool
+	IsSubscriber() bool
+}
+
+// checkAccess returns true when the user is allowed to run cmd.
+// It calls sayFn with the appropriate denial message when access is denied.
+func (cmd *Command) checkAccess(user chatUser, sayFn func(string)) bool {
 	if cmd.RequiresFollow && !user.HasCommandAvailable() {
-		Say(followerMsg)
-		return
+		sayFn(followerMsg)
+		return false
 	}
 	if cmd.RequiresSubscriber && !user.IsSubscriber() {
-		Say(subscriberMsg)
+		sayFn(subscriberMsg)
+		return false
+	}
+	return true
+}
+
+func dispatch(cmd *Command, user *users.User, params []string) {
+	incChatCommandCounter(cmd.Trigger)
+	if !cmd.checkAccess(user, Say) {
 		return
 	}
 	cmd.Handler(user, params)
 }
 
-func runCommand(ctx context.Context, user *users.User, message string) {
+// findCommand parses message and returns the matching Command and params.
+// Returns nil if no command matches.
+func findCommand(message string) (*Command, []string) {
 	msg := normalizeCommandPrefix(strings.TrimSpace(message))
 	split := strings.Split(msg, " ")
 
@@ -65,16 +82,9 @@ func runCommand(ctx context.Context, user *users.User, message string) {
 	}
 
 	// handle case where people add a space (like "! location")
-	if command == "!" {
+	if command == "!" && len(params) > 0 {
 		command = command + params[0]
 		params = params[1:]
-	}
-
-	// Tag the active span with the parsed command. Bare-word triggers
-	// (e.g. "hello") aren't included to keep the attribute's cardinality
-	// bounded to the bot's actual command surface (and typos thereof).
-	if strings.HasPrefix(command, "!") {
-		trace.SpanFromContext(ctx).SetAttributes(attribute.String("twitch.command", command))
 	}
 
 	// multi-word alias lookup (e.g. "no audio", "no sound")
@@ -85,13 +95,34 @@ func runCommand(ctx context.Context, user *users.User, message string) {
 			if remainder != "" {
 				mwParams = strings.Split(remainder, " ")
 			}
-			dispatch(cmd, user, mwParams)
-			return
+			return cmd, mwParams
 		}
 	}
 
 	// single-word lookup
 	if cmd, ok := singleWordLookup[command]; ok {
+		return cmd, params
+	}
+	return nil, nil
+}
+
+func runCommand(ctx context.Context, user *users.User, message string) {
+	// parse for otel span attribute (only set for !-prefixed commands)
+	msg := normalizeCommandPrefix(strings.TrimSpace(message))
+	split := strings.Split(msg, " ")
+	command := split[0]
+	if command == "!" && len(split) > 1 {
+		command = "!" + split[1]
+	}
+	// Tag the active span with the parsed command. Bare-word triggers
+	// (e.g. "hello") aren't included to keep the attribute's cardinality
+	// bounded to the bot's actual command surface (and typos thereof).
+	if strings.HasPrefix(command, "!") {
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String("twitch.command", command))
+	}
+
+	cmd, params := findCommand(message)
+	if cmd != nil {
 		dispatch(cmd, user, params)
 		return
 	}

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -1,6 +1,10 @@
 package chatbot
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/adanalife/tripbot/pkg/users"
+)
 
 func TestNormalizeCommandPrefix(t *testing.T) {
 	tests := []struct {
@@ -66,5 +70,178 @@ func TestNormalizeCommandPrefix_DispatchEquivalence(t *testing.T) {
 					c, gotBang, c, gotInverted)
 			}
 		})
+	}
+}
+
+// --- findCommand routing tests ---
+
+func TestFindCommand_SingleWordTrigger(t *testing.T) {
+	cmd, params := findCommand("!help")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!help" {
+		t.Errorf("got trigger %q, want !help", cmd.Trigger)
+	}
+	if len(params) != 0 {
+		t.Errorf("unexpected params: %v", params)
+	}
+}
+
+func TestFindCommand_SingleWordAlias(t *testing.T) {
+	// "hi" is an alias of "hello"
+	cmd, _ := findCommand("hi")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "hello" {
+		t.Errorf("got trigger %q, want hello", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_MultiWordAlias(t *testing.T) {
+	// "no audio" is an alias of !report
+	cmd, params := findCommand("no audio")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!report" {
+		t.Errorf("got trigger %q, want !report", cmd.Trigger)
+	}
+	if len(params) != 0 {
+		t.Errorf("unexpected params: %v", params)
+	}
+}
+
+func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
+	// "frozen since yesterday" — starts with the "frozen" alias
+	cmd, params := findCommand("frozen since yesterday")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!report" {
+		t.Errorf("got trigger %q, want !report", cmd.Trigger)
+	}
+	if len(params) != 2 || params[0] != "since" || params[1] != "yesterday" {
+		t.Errorf("unexpected params: %v", params)
+	}
+}
+
+func TestFindCommand_InvertedBangRoutes(t *testing.T) {
+	// ¡miles should route to the same command as !miles
+	cmd, _ := findCommand("¡miles")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!miles" {
+		t.Errorf("got trigger %q, want !miles", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
+	// "! location" (with a space) should route to !location
+	cmd, _ := findCommand("! location")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!location" {
+		t.Errorf("got trigger %q, want !location", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_WithParams(t *testing.T) {
+	cmd, params := findCommand("!goto 42")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!goto" {
+		t.Errorf("got trigger %q, want !goto", cmd.Trigger)
+	}
+	if len(params) != 1 || params[0] != "42" {
+		t.Errorf("unexpected params: %v", params)
+	}
+}
+
+func TestFindCommand_UnknownCommand(t *testing.T) {
+	cmd, _ := findCommand("!doesnotexist99")
+	if cmd != nil {
+		t.Errorf("expected nil for unknown command, got %q", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_EmptyMessage(t *testing.T) {
+	cmd, _ := findCommand("")
+	if cmd != nil {
+		t.Errorf("expected nil for empty message, got %q", cmd.Trigger)
+	}
+}
+
+// --- checkAccess gating tests ---
+
+// fakeUser implements chatUser for testing without a real DB or Twitch API.
+type fakeUser struct {
+	follower   bool
+	subscriber bool
+}
+
+func (f *fakeUser) HasCommandAvailable() bool { return f.follower }
+func (f *fakeUser) IsSubscriber() bool        { return f.subscriber }
+
+// realUserAsChat wraps *users.User so it satisfies chatUser in tests
+// where we want to pass a struct with known field values.
+var _ chatUser = (*users.User)(nil)
+
+func TestCheckAccess_NoRestrictions(t *testing.T) {
+	cmd := &Command{Trigger: "!test"}
+	var said string
+	if !cmd.checkAccess(&fakeUser{}, func(msg string) { said = msg }) {
+		t.Error("expected true for unrestricted command")
+	}
+	if said != "" {
+		t.Errorf("expected no message, got %q", said)
+	}
+}
+
+func TestCheckAccess_RequiresFollow_NonFollower(t *testing.T) {
+	cmd := &Command{Trigger: "!test", RequiresFollow: true}
+	var said string
+	if cmd.checkAccess(&fakeUser{follower: false}, func(msg string) { said = msg }) {
+		t.Error("expected false for non-follower")
+	}
+	if said != followerMsg {
+		t.Errorf("got %q, want followerMsg", said)
+	}
+}
+
+func TestCheckAccess_RequiresFollow_Follower(t *testing.T) {
+	cmd := &Command{Trigger: "!test", RequiresFollow: true}
+	var said string
+	if !cmd.checkAccess(&fakeUser{follower: true}, func(msg string) { said = msg }) {
+		t.Error("expected true for follower")
+	}
+	if said != "" {
+		t.Errorf("expected no message, got %q", said)
+	}
+}
+
+func TestCheckAccess_RequiresSubscriber_NonSubscriber(t *testing.T) {
+	cmd := &Command{Trigger: "!test", RequiresSubscriber: true}
+	var said string
+	if cmd.checkAccess(&fakeUser{subscriber: false}, func(msg string) { said = msg }) {
+		t.Error("expected false for non-subscriber")
+	}
+	if said != subscriberMsg {
+		t.Errorf("got %q, want subscriberMsg", said)
+	}
+}
+
+func TestCheckAccess_RequiresSubscriber_Subscriber(t *testing.T) {
+	cmd := &Command{Trigger: "!test", RequiresSubscriber: true}
+	var said string
+	if !cmd.checkAccess(&fakeUser{subscriber: true}, func(msg string) { said = msg }) {
+		t.Error("expected true for subscriber")
+	}
+	if said != "" {
+		t.Errorf("expected no message, got %q", said)
 	}
 }

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -1,0 +1,62 @@
+package chatbot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
+	for _, cmd := range commands {
+		if cmd.Trigger == "" {
+			t.Errorf("command has empty Trigger: %+v", cmd)
+		}
+	}
+}
+
+func TestNoDuplicateTriggersOrAliases(t *testing.T) {
+	seen := map[string]string{} // trigger/alias → owning command's Trigger
+	for _, cmd := range commands {
+		all := append([]string{cmd.Trigger}, cmd.Aliases...)
+		for _, token := range all {
+			if owner, clash := seen[token]; clash {
+				t.Errorf("duplicate trigger/alias %q: claimed by %q and %q", token, owner, cmd.Trigger)
+			}
+			seen[token] = cmd.Trigger
+		}
+	}
+}
+
+func TestLookupMapsContainAllTriggers(t *testing.T) {
+	for _, cmd := range commands {
+		all := append([]string{cmd.Trigger}, cmd.Aliases...)
+		for _, token := range all {
+			if strings.Contains(token, " ") {
+				if _, ok := multiWordLookup[token]; !ok {
+					t.Errorf("multi-word trigger %q missing from multiWordLookup", token)
+				}
+			} else {
+				if _, ok := singleWordLookup[token]; !ok {
+					t.Errorf("single-word trigger %q missing from singleWordLookup", token)
+				}
+			}
+		}
+	}
+}
+
+func TestLookupMapsPointToCorrectCommand(t *testing.T) {
+	for i := range commands {
+		cmd := &commands[i]
+		all := append([]string{cmd.Trigger}, cmd.Aliases...)
+		for _, token := range all {
+			var got *Command
+			if strings.Contains(token, " ") {
+				got = multiWordLookup[token]
+			} else {
+				got = singleWordLookup[token]
+			}
+			if got != cmd {
+				t.Errorf("trigger %q maps to %q, want %q", token, got.Trigger, cmd.Trigger)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #494. Adds test coverage for the command registry refactor.

- **`registry_test.go`** (new): asserts that every `Command` has a non-empty `Trigger`, that no trigger or alias appears twice, and that both lookup maps are correctly populated after `init()`.
- **`handlers_test.go`** (expanded): 14 new tests covering `findCommand` routing (single-word trigger, alias, multi-word alias, inverted-bang prefix, space-separated bang, params, unknown command) and `checkAccess` gating (RequiresFollow and RequiresSubscriber, both the allow and deny paths, with a fake `chatUser` — no Twitch API or DB required).

### Small structural change in `handlers.go`

- Extracted `findCommand(message string) (*Command, []string)` from `runCommand` — pure routing logic with no side effects.
- Added `checkAccess(user chatUser, sayFn func(string)) bool` on `Command` — the gating logic from `dispatch`, now injectable for tests.
- Added `chatUser` interface (`HasCommandAvailable`, `IsSubscriber`) so gating tests can pass a fake user without hitting the Twitch API.
- `dispatch` and `runCommand` are simplified wrappers around these extracted pieces; production behavior is unchanged.

### Note on test environment

These tests require the full `ENV=testing` + database/Twitch/Twilio env vars, same as the rest of the test suite — `task test` (Docker) satisfies them all. Running `go test ./pkg/chatbot/...` locally without env vars still fails, which is a pre-existing condition across the whole repo. That's tracked separately in the mise-migration TODO.