### PR TITLE
chatbot: add tests for versionCmd

### DIFF
--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -165,3 +165,33 @@ func TestKilometresCmd_ZeroMiles(t *testing.T) {
 		t.Errorf("expected zero km in output, got %q", out())
 	}
 }
+
+// --- versionCmd ---
+
+func TestVersionCmd_UsesCachedVersion(t *testing.T) {
+	currentVersion = "v1.2.3-test"
+	defer func() { currentVersion = "" }()
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	versionCmd(newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "v1.2.3-test") {
+		t.Errorf("expected cached version in output, got %q", out())
+	}
+}
+
+func TestVersionCmd_MessageFormat(t *testing.T) {
+	currentVersion = "v1.2.3-test"
+	defer func() { currentVersion = "" }()
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	versionCmd(newTestUser("viewer1"), nil)
+
+	if !strings.HasPrefix(out(), "Current version is ") {
+		t.Errorf("unexpected message format: %q", out())
+	}
+}


### PR DESCRIPTION
## Summary

Tests for `versionCmd` using the `sayFn` injection point from the testing infrastructure PRs.

Two cases covering the cached-version path (the only path safely testable without running a shell script):
- Output contains the pre-set version string
- Message starts with `"Current version is "`

The test pre-sets `currentVersion` to a known value and restores it via `defer`, bypassing the `exec.Command` shell call entirely.