### PR TITLE
fix(tripbot): clarify intentional shutdown when oauth token is missing

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -135,7 +135,8 @@ func startCron() {
 func loadTwitchToken() {
 	if err := mytwitch.LoadFromDB(); err != nil {
 		if errors.Is(err, mytwitch.ErrNoToken) {
-			log.Fatalf("no oauth_tokens row for %q — run `task tripbot:auth:bootstrap` against the cluster DB (port-forward via `task tripbot:db:up` in infra)", c.Conf.BotUsername)
+			log.Printf("refusing to start: no oauth_tokens row for %q — tripbot will not run without a Twitch IRC connection", c.Conf.BotUsername)
+			log.Fatal("to fix: run `task tripbot:auth:bootstrap` against the cluster DB (port-forward first via `task tripbot:db:up` in infra)")
 		}
 		terrors.Fatal(err, "failed to load Twitch token from DB")
 	}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -136,7 +136,7 @@ func loadTwitchToken() {
 	if err := mytwitch.LoadFromDB(); err != nil {
 		if errors.Is(err, mytwitch.ErrNoToken) {
 			log.Printf("refusing to start: no oauth_tokens row for %q — tripbot will not run without a Twitch IRC connection", c.Conf.BotUsername)
-			log.Fatal("to fix: run `task tripbot:auth:bootstrap` against the cluster DB (port-forward first via `task tripbot:db:up` in infra)")
+			log.Fatal("to fix: run `task tripbot:auth:bootstrap` from the infra directory")
 		}
 		terrors.Fatal(err, "failed to load Twitch token from DB")
 	}


### PR DESCRIPTION
When `oauth_tokens` has no row for the bot user, `loadTwitchToken` intentionally refuses to start — but the previous single `log.Fatalf` line looked identical to an unexpected crash in pod logs.

Split into two lines:
1. `log.Printf` — states the bot is refusing to start and why (no Twitch IRC connection)
2. `log.Fatal` — the remediation command on its own line, easy to spot when scanning logs