### PR TITLE
chatbot: App struct + Tier 2 command tests

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -11,6 +11,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
+	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gempir/go-twitch-irc/v2"
 	"github.com/kelvins/geocoder"
@@ -20,6 +21,16 @@ import (
 var googleMapsAPIKey string
 var client *twitch.Client
 var Uptime time.Time
+
+// App holds injectable dependencies for the chatbot.
+// Tests instantiate it directly with fakes; production uses defaultApp.
+type App struct {
+	CurrentVideo func() video.Video
+}
+
+var defaultApp = &App{
+	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
+}
 
 // used to determine which help message to display
 // randomized so it starts with a new one every restart

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -35,13 +35,13 @@ const guessScoreboard = "guess_state_total"
 
 //TODO: incorrect guess scoreboard?
 
-func helpCmd(user *users.User, _ []string) {
+func (a *App) helpCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !help")
 	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
 	sayFn(msg)
 }
 
-func helloCmd(user *users.User, params []string) {
+func (a *App) helloCmd(user *users.User, params []string) {
 	log.Println(user.Username, "said hello")
 
 	// check if it was just a one-word hello
@@ -70,12 +70,12 @@ func helloCmd(user *users.User, params []string) {
 	lastHelloTime = time.Now()
 }
 
-func flagCmd(user *users.User, _ []string) {
+func (a *App) flagCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !flag")
 	onscreensClient.ShowFlag(10 * time.Second)
 }
 
-func versionCmd(user *users.User, _ []string) {
+func (a *App) versionCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !version")
 
 	if helpers.RunningOnWindows() {
@@ -99,14 +99,14 @@ func versionCmd(user *users.User, _ []string) {
 	sayFn("Current version is " + currentVersion)
 }
 
-func uptimeCmd(user *users.User, _ []string) {
+func (a *App) uptimeCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !uptime")
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
 	sayFn(msg)
 }
 
-func milesCmd(user *users.User, params []string) {
+func (a *App) milesCmd(user *users.User, params []string) {
 	log.Println(user.Username, "ran !miles")
 	var username string
 	var lifetimeMiles, monthlyMiles float32
@@ -154,7 +154,7 @@ func milesCmd(user *users.User, params []string) {
 	sayFn(msg)
 }
 
-func kilometresCmd(user *users.User, _ []string) {
+func (a *App) kilometresCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !kilometres")
 	km := user.CurrentMiles() * 1.609344
 	msg := "@%s has %.2f kilometres."
@@ -162,10 +162,9 @@ func kilometresCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func sunsetCmd(user *users.User, _ []string) {
+func (a *App) sunsetCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !sunset")
-	// get the currently-playing video
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	if vid.Flagged {
 		sayFn("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next()
@@ -174,10 +173,9 @@ func sunsetCmd(user *users.User, _ []string) {
 	sayFn(helpers.SunsetStr(vid.DateFilmed, lat, lng))
 }
 
-func locationCmd(user *users.User, _ []string) {
+func (a *App) locationCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !location (or similar)")
-	// get the currently-playing video
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	if vid.Flagged {
 		sayFn("I couldn't figure out current GPS coords, using next closest...")
 		//TODO: write something like vid.FindClosest() that
@@ -196,12 +194,10 @@ func locationCmd(user *users.User, _ []string) {
 	msg := fmt.Sprintf("%s %s", address, url)
 	// record that they know the location now
 	user.SetLastLocationTime()
-	// sayFn("Sending the location in a whisper... shh!")
-	// Whisper(user.Username, msg)
 	sayFn(msg)
 }
 
-func monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !leaderboard")
 
 	// select users to show in leaderboard
@@ -226,7 +222,7 @@ func monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !totalleaderboard")
 
 	// select users to show in leaderboard
@@ -250,7 +246,7 @@ func lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !guessleaderboard")
 
 	// select users to show in leaderboard
@@ -290,20 +286,17 @@ func monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func timeCmd(user *users.User, _ []string) {
+func (a *App) timeCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !time")
 	var err error
 	var lat, lng float64
-	// get the currently-playing video
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	if vid.Flagged {
-		// use the location from the next vid
 		lat, lng, err = vid.Next().Location()
 	} else {
 		lat, lng, err = vid.Location()
 	}
 	if err != nil {
-		// why would we get in here?
 		sayFn("I couldn't figure out current GPS coords, sorry!")
 	} else {
 		realDate := helpers.ActualDate(vid.DateFilmed, lat, lng)
@@ -312,20 +305,17 @@ func timeCmd(user *users.User, _ []string) {
 	}
 }
 
-func dateCmd(user *users.User, _ []string) {
+func (a *App) dateCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !date")
 	var err error
 	var lat, lng float64
-	// get the currently-playing video
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	if vid.Flagged {
-		// use the location from the next vid
 		lat, lng, err = vid.Next().Location()
 	} else {
 		lat, lng, err = vid.Location()
 	}
 	if err != nil {
-		// why would we get in here?
 		sayFn("I couldn't figure out current GPS coords, sorry!")
 	} else {
 		realDate := helpers.ActualDate(vid.DateFilmed, lat, lng)
@@ -335,7 +325,7 @@ func dateCmd(user *users.User, _ []string) {
 }
 
 //TODO: refactor to use golang '...' syntax
-func guessCmd(user *users.User, params []string) {
+func (a *App) guessCmd(user *users.User, params []string) {
 	log.Println(user.Username, "ran !guess")
 	var msg string
 
@@ -363,8 +353,7 @@ func guessCmd(user *users.User, params []string) {
 		guess = helpers.StateAbbrevToState(guess)
 	}
 
-	// get the currently-playing video
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	if vid.Flagged {
 		sayFn("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next()
@@ -385,10 +374,9 @@ func guessCmd(user *users.User, params []string) {
 	sayFn(msg)
 }
 
-func stateCmd(user *users.User, _ []string) {
+func (a *App) stateCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !state")
-	// get the currently-playing video
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	if vid.Flagged {
 		sayFn("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next()
@@ -398,14 +386,12 @@ func stateCmd(user *users.User, _ []string) {
 	onscreensClient.ShowFlag(10 * time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
-	// sayFn("Sending the state in a whisper... shh!")
-	// Whisper(user.Username, msg)
 	sayFn(msg)
 }
 
 //TODO: maybe there could be a !cancel command or something
 //TODO: use fancy golang ... syntax?
-func reportCmd(user *users.User, params []string) {
+func (a *App) reportCmd(user *users.User, params []string) {
 	log.Println(user.Username, "ran !report")
 	message := strings.Join(params, " ")
 	message = fmt.Sprintf("Report from Twitch Chat: %s", message)
@@ -413,19 +399,19 @@ func reportCmd(user *users.User, params []string) {
 	sayFn("Thank you, I will look into this ASAP!")
 }
 
-func bonusMilesCmd(user *users.User, _ []string) {
+func (a *App) bonusMilesCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !bonusmiles")
 	bonus := user.BonusMiles()
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
 	sayFn(msg)
 }
 
-func secretInfoCmd(user *users.User, _ []string) {
+func (a *App) secretInfoCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !secretinfo")
 	if !c.UserIsAdmin(user.Username) {
 		return
 	}
-	vid := video.CurrentlyPlaying
+	vid := a.CurrentVideo()
 	msg := fmt.Sprintf("currently playing: %s, playtime: %s", vid, video.CurrentProgress())
 	lat, lng, err := vid.Location()
 	if err != nil {
@@ -437,14 +423,14 @@ func secretInfoCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func shutdownCmd(user *users.User, _ []string) {
+func (a *App) shutdownCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !shutdown")
 	if !c.UserIsAdmin(user.Username) {
 		sayFn("Nice try bucko")
 		return
 	}
 	sayFn("Shutting down...")
-	log.Printf("currently playing: %s", video.CurrentlyPlaying)
+	log.Printf("currently playing: %s", a.CurrentVideo())
 	background.StopCron()
 	users.Shutdown()
 	err := database.Connection().Close()
@@ -457,7 +443,7 @@ func shutdownCmd(user *users.User, _ []string) {
 
 //TODO: this will always be lower case, find out why
 // middleCmd sets the text at the bottom-middle of the stream
-func middleCmd(user *users.User, params []string) {
+func (a *App) middleCmd(user *users.User, params []string) {
 	log.Println(user.Username, "ran !middle")
 	// don't let strangers run this
 	if !c.UserIsAdmin(user.Username) {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -36,7 +36,7 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 }
 
 // newTestApp returns an App with CurrentVideo returning vid.
-// For Tier 1 commands that don't use CurrentVideo, pass a zero-value video.Video.
+// For commands that don't use CurrentVideo, pass a zero-value video.Video.
 func newTestApp(vid video.Video) *App {
 	return &App{CurrentVideo: func() video.Video { return vid }}
 }
@@ -220,7 +220,7 @@ func TestVersionCmd_MessageFormat(t *testing.T) {
 	}
 }
 
-// --- stateCmd (Tier 2) ---
+// --- stateCmd ---
 
 func TestStateCmd_SaysCurrentState(t *testing.T) {
 	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
@@ -248,7 +248,7 @@ func TestStateCmd_MessageFormat(t *testing.T) {
 	}
 }
 
-// --- dateCmd (Tier 2) ---
+// --- dateCmd ---
 
 func TestDateCmd_SaysThisMomentWas(t *testing.T) {
 	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
@@ -279,7 +279,7 @@ func TestDateCmd_IncludesYear(t *testing.T) {
 	}
 }
 
-// --- timeCmd (Tier 2) ---
+// --- timeCmd ---
 
 func TestTimeCmd_SaysThisMomentWas(t *testing.T) {
 	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
@@ -310,7 +310,7 @@ func TestTimeCmd_IncludesAMPM(t *testing.T) {
 	}
 }
 
-// --- sunsetCmd (Tier 2) ---
+// --- sunsetCmd ---
 
 func TestSunsetCmd_SaysSunset(t *testing.T) {
 	// 2pm UTC in Colorado — sunset hasn't happened yet
@@ -327,7 +327,7 @@ func TestSunsetCmd_SaysSunset(t *testing.T) {
 	}
 }
 
-// --- guessCmd (Tier 2) ---
+// --- guessCmd ---
 
 func TestGuessCmd_NoParams_PromptsGuess(t *testing.T) {
 	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/users"
+	"github.com/adanalife/tripbot/pkg/video"
 )
 
 // captureSay swaps sayFn for a recorder and returns helpers to read the
@@ -29,13 +30,25 @@ func newTestUser(name string) *users.User {
 	return &users.User{Username: name}
 }
 
+// newTestVideo returns a non-flagged Video with the given fields set.
+func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
+	return video.Video{State: state, Lat: lat, Lng: lng, DateFilmed: date}
+}
+
+// newTestApp returns an App with CurrentVideo returning vid.
+// For Tier 1 commands that don't use CurrentVideo, pass a zero-value video.Video.
+func newTestApp(vid video.Video) *App {
+	return &App{CurrentVideo: func() video.Video { return vid }}
+}
+
 // --- helpCmd ---
 
 func TestHelpCmd_SaysSomething(t *testing.T) {
+	app := newTestApp(video.Video{})
 	out, restore := captureSay(t)
 	defer restore()
 
-	helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(newTestUser("viewer1"), nil)
 
 	if out() == "" {
 		t.Fatal("expected a help message, got empty output")
@@ -43,10 +56,11 @@ func TestHelpCmd_SaysSomething(t *testing.T) {
 }
 
 func TestHelpCmd_MessageContainsCount(t *testing.T) {
+	app := newTestApp(video.Video{})
 	out, restore := captureSay(t)
 	defer restore()
 
-	helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(newTestUser("viewer1"), nil)
 
 	// message format: "<help text> (N of M)"
 	if !strings.Contains(out(), " of ") {
@@ -55,13 +69,14 @@ func TestHelpCmd_MessageContainsCount(t *testing.T) {
 }
 
 func TestHelpCmd_AdvancesIndex(t *testing.T) {
+	app := newTestApp(video.Video{})
 	out, restore := captureSay(t)
 	defer restore()
 
-	helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(newTestUser("viewer1"), nil)
 	first := out()
 
-	helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(newTestUser("viewer1"), nil)
 	second := out()
 
 	if first == second {
@@ -72,11 +87,12 @@ func TestHelpCmd_AdvancesIndex(t *testing.T) {
 // --- uptimeCmd ---
 
 func TestUptimeCmd_SaysRunningFor(t *testing.T) {
+	app := newTestApp(video.Video{})
 	Uptime = time.Now().Add(-5 * time.Minute)
 	out, restore := captureSay(t)
 	defer restore()
 
-	uptimeCmd(newTestUser("viewer1"), nil)
+	app.uptimeCmd(newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "I have been running for") {
 		t.Errorf("unexpected uptime message: %q", out())
@@ -86,12 +102,13 @@ func TestUptimeCmd_SaysRunningFor(t *testing.T) {
 // --- helloCmd ---
 
 func TestHelloCmd_GreetsNewViewer(t *testing.T) {
+	app := newTestApp(video.Video{})
 	lastHelloTime = time.Time{} // clear rate limiter
 	out, restore := captureSay(t)
 	defer restore()
 
 	// a fresh user with 0 miles gets the newcomer hint appended
-	helloCmd(newTestUser("newviewer"), nil)
+	app.helloCmd(newTestUser("newviewer"), nil)
 
 	msg := out()
 	if msg == "" {
@@ -103,11 +120,12 @@ func TestHelloCmd_GreetsNewViewer(t *testing.T) {
 }
 
 func TestHelloCmd_RateLimitSilencesSecondCall(t *testing.T) {
+	app := newTestApp(video.Video{})
 	lastHelloTime = time.Now() // simulate a very recent greeting
 	out, restore := captureSay(t)
 	defer restore()
 
-	helloCmd(newTestUser("viewer1"), nil)
+	app.helloCmd(newTestUser("viewer1"), nil)
 
 	if out() != "" {
 		t.Errorf("expected silence due to rate limit, got %q", out())
@@ -115,12 +133,13 @@ func TestHelloCmd_RateLimitSilencesSecondCall(t *testing.T) {
 }
 
 func TestHelloCmd_IgnoresMessageWithParams(t *testing.T) {
+	app := newTestApp(video.Video{})
 	lastHelloTime = time.Time{} // not rate limited
 	out, restore := captureSay(t)
 	defer restore()
 
 	// "hello world" — has params so the bot stays quiet
-	helloCmd(newTestUser("viewer1"), []string{"world"})
+	app.helloCmd(newTestUser("viewer1"), []string{"world"})
 
 	if out() != "" {
 		t.Errorf("expected silence for greeting with params, got %q", out())
@@ -130,11 +149,12 @@ func TestHelloCmd_IgnoresMessageWithParams(t *testing.T) {
 // --- kilometresCmd ---
 
 func TestKilometresCmd_ConvertsCorrectly(t *testing.T) {
+	app := newTestApp(video.Video{})
 	out, restore := captureSay(t)
 	defer restore()
 
 	user := &users.User{Username: "viewer1", Miles: 10}
-	kilometresCmd(user, nil)
+	app.kilometresCmd(user, nil)
 
 	// 10 miles * 1.609344 = 16.09344, formatted as "16.09"
 	if !strings.Contains(out(), "16.09") {
@@ -143,11 +163,12 @@ func TestKilometresCmd_ConvertsCorrectly(t *testing.T) {
 }
 
 func TestKilometresCmd_IncludesUsername(t *testing.T) {
+	app := newTestApp(video.Video{})
 	out, restore := captureSay(t)
 	defer restore()
 
 	user := &users.User{Username: "testviewer", Miles: 5}
-	kilometresCmd(user, nil)
+	app.kilometresCmd(user, nil)
 
 	if !strings.Contains(out(), "@testviewer") {
 		t.Errorf("expected @username in output, got %q", out())
@@ -155,11 +176,12 @@ func TestKilometresCmd_IncludesUsername(t *testing.T) {
 }
 
 func TestKilometresCmd_ZeroMiles(t *testing.T) {
+	app := newTestApp(video.Video{})
 	out, restore := captureSay(t)
 	defer restore()
 
 	user := &users.User{Username: "newbie", Miles: 0}
-	kilometresCmd(user, nil)
+	app.kilometresCmd(user, nil)
 
 	if !strings.Contains(out(), "0.00") {
 		t.Errorf("expected zero km in output, got %q", out())
@@ -169,13 +191,14 @@ func TestKilometresCmd_ZeroMiles(t *testing.T) {
 // --- versionCmd ---
 
 func TestVersionCmd_UsesCachedVersion(t *testing.T) {
+	app := newTestApp(video.Video{})
 	currentVersion = "v1.2.3-test"
 	defer func() { currentVersion = "" }()
 
 	out, restore := captureSay(t)
 	defer restore()
 
-	versionCmd(newTestUser("viewer1"), nil)
+	app.versionCmd(newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "v1.2.3-test") {
 		t.Errorf("expected cached version in output, got %q", out())
@@ -183,15 +206,152 @@ func TestVersionCmd_UsesCachedVersion(t *testing.T) {
 }
 
 func TestVersionCmd_MessageFormat(t *testing.T) {
+	app := newTestApp(video.Video{})
 	currentVersion = "v1.2.3-test"
 	defer func() { currentVersion = "" }()
 
 	out, restore := captureSay(t)
 	defer restore()
 
-	versionCmd(newTestUser("viewer1"), nil)
+	app.versionCmd(newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "Current version is ") {
 		t.Errorf("unexpected message format: %q", out())
+	}
+}
+
+// --- stateCmd (Tier 2) ---
+
+func TestStateCmd_SaysCurrentState(t *testing.T) {
+	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.stateCmd(newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "Colorado") {
+		t.Errorf("expected state name in output, got %q", out())
+	}
+}
+
+func TestStateCmd_MessageFormat(t *testing.T) {
+	vid := newTestVideo("Utah", 40.0, -111.0, time.Now())
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.stateCmd(newTestUser("viewer1"), nil)
+
+	if !strings.HasPrefix(out(), "We're in ") {
+		t.Errorf("unexpected state message format: %q", out())
+	}
+}
+
+// --- dateCmd (Tier 2) ---
+
+func TestDateCmd_SaysThisMomentWas(t *testing.T) {
+	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.dateCmd(newTestUser("viewer1"), nil)
+
+	msg := out()
+	if !strings.HasPrefix(msg, "This moment was") {
+		t.Errorf("unexpected date message: %q", msg)
+	}
+}
+
+func TestDateCmd_IncludesYear(t *testing.T) {
+	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.dateCmd(newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "2019") {
+		t.Errorf("expected year 2019 in output, got %q", out())
+	}
+}
+
+// --- timeCmd (Tier 2) ---
+
+func TestTimeCmd_SaysThisMomentWas(t *testing.T) {
+	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.timeCmd(newTestUser("viewer1"), nil)
+
+	if !strings.HasPrefix(out(), "This moment was") {
+		t.Errorf("unexpected time message: %q", out())
+	}
+}
+
+func TestTimeCmd_IncludesAMPM(t *testing.T) {
+	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.timeCmd(newTestUser("viewer1"), nil)
+
+	msg := out()
+	if !strings.Contains(msg, "am") && !strings.Contains(msg, "pm") {
+		t.Errorf("expected am/pm in time output, got %q", msg)
+	}
+}
+
+// --- sunsetCmd (Tier 2) ---
+
+func TestSunsetCmd_SaysSunset(t *testing.T) {
+	// 2pm UTC in Colorado — sunset hasn't happened yet
+	date := time.Date(2019, 6, 15, 20, 0, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.sunsetCmd(newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "Sunset on this day") {
+		t.Errorf("unexpected sunset message: %q", out())
+	}
+}
+
+// --- guessCmd (Tier 2) ---
+
+func TestGuessCmd_NoParams_PromptsGuess(t *testing.T) {
+	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "guess") {
+		t.Errorf("expected guess prompt in output, got %q", out())
+	}
+}
+
+func TestGuessCmd_WrongGuess_SaysTryAgain(t *testing.T) {
+	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
+	app := newTestApp(vid)
+	out, restore := captureSay(t)
+	defer restore()
+
+	// Wyoming != Colorado
+	app.guessCmd(newTestUser("viewer1"), []string{"Wyoming"})
+
+	if !strings.Contains(out(), "Try again") {
+		t.Errorf("expected try-again in output, got %q", out())
 	}
 }

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -38,7 +38,7 @@ func timewarp() {
 	lastTimewarpTime = time.Now()
 }
 
-func timewarpCmd(user *users.User, _ []string) {
+func (a *App) timewarpCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !timewarp")
 
 	// exit early if we're on OS X
@@ -64,7 +64,7 @@ func timewarpCmd(user *users.User, _ []string) {
 	timewarp()
 }
 
-func jumpCmd(user *users.User, params []string) {
+func (a *App) jumpCmd(user *users.User, params []string) {
 	var err error
 	log.Println(user.Username, "ran !jump")
 
@@ -122,7 +122,7 @@ func jumpCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
-func skipCmd(user *users.User, params []string) {
+func (a *App) skipCmd(user *users.User, params []string) {
 	var err error
 	var n int
 	log.Println(user.Username, "ran !skip")
@@ -167,7 +167,7 @@ func skipCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
-func backCmd(user *users.User, params []string) {
+func (a *App) backCmd(user *users.User, params []string) {
 	var err error
 	var n int
 	log.Println(user.Username, "ran !back")

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -6,167 +6,170 @@ import (
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
-var commands = []Command{
-	{
-		Trigger: "!help",
-		Handler: helpCmd,
-	},
-	{
-		Trigger: "hello",
-		Aliases: []string{"hi", "hey", "hallo", "!bot"},
-		Handler: helloCmd,
-	},
-	{
-		Trigger: "!flag",
-		Handler: flagCmd,
-	},
-	{
-		Trigger: "!version",
-		Handler: versionCmd,
-	},
-	{
-		Trigger: "!uptime",
-		Handler: uptimeCmd,
-	},
-	{
-		Trigger:        "!timewarp",
-		Aliases:        []string{"!timewrap", "!timeskip", "!tw", "!timewqrp", "!warp"},
-		Handler:        timewarpCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!goto",
-		Aliases:        []string{"!jump"},
-		Handler:        jumpCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!skip",
-		Handler:        skipCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!back",
-		Handler:        backCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger: "!shutdown",
-		Handler: shutdownCmd,
-	},
-	{
-		Trigger: "!socialmedia",
-		Aliases: []string{"!social", "!socials"},
-		Handler: func(_ *users.User, _ []string) {
-			Say("Find me outside of Twitch: !twitter, !instagram, !facebook, !youtube")
-		},
-	},
-	{
-		Trigger: "!commands",
-		Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
-		Handler: func(_ *users.User, _ []string) {
-			Say("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, and many other hidden commands!")
-		},
-	},
-	{
-		Trigger:            "!bonusmiles",
-		Handler:            bonusMilesCmd,
-		RequiresSubscriber: true,
-	},
-	{
-		Trigger:        "!sunset",
-		Aliases:        []string{"!sunet"},
-		Handler:        sunsetCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!time",
-		Aliases:        []string{"!timr"},
-		Handler:        timeCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!date",
-		Aliases:        []string{"!datw"},
-		Handler:        dateCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!guess",
-		Aliases:        []string{"!guss", "guess", "!gusss", "!guees", "!gues", "!quess", "!guis"},
-		Handler:        guessCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!state",
-		Handler:        stateCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger: "!secretinfo",
-		Handler: secretInfoCmd,
-	},
-	{
-		Trigger: "!gas",
-		Aliases: []string{"!fuel", "!petrol"},
-		Handler: func(_ *users.User, _ []string) {
-			Say("About full, thanks for asking")
-		},
-	},
-	{
-		Trigger: "!middle",
-		Handler: middleCmd,
-	},
-	{
-		Trigger:        "!miles",
-		Aliases:        []string{"!points"},
-		Handler:        milesCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!km",
-		Aliases:        []string{"!kilometres", "!kilometers"},
-		Handler:        kilometresCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!location",
-		Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation"},
-		Handler:        locationCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!leaderboard",
-		Aliases:        []string{"!monthlyleaderboard", "!lb", "!mlb", "!leaderbord", "!ldb", "!ldbd"},
-		Handler:        monthlyMilesLeaderboardCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!totalleaderboard",
-		Aliases:        []string{"!lifetimeleaderboard", "!tlb", "!llb"},
-		Handler:        lifetimeMilesLeaderboardCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!guessleaderboard",
-		Aliases:        []string{"!glb"},
-		Handler:        monthlyGuessLeaderboardCmd,
-		RequiresFollow: true,
-	},
-	{
-		Trigger:        "!report",
-		Aliases:        []string{"no audio", "no sound", "no music", "frozen"},
-		Handler:        reportCmd,
-		RequiresFollow: true,
-	},
-}
-
-// singleWordLookup maps single-word triggers and aliases to their Command.
-// multiWordLookup maps space-containing triggers and aliases to their Command.
+var commands []Command
 var singleWordLookup map[string]*Command
 var multiWordLookup map[string]*Command
 
+// buildRegistry constructs the command slice with handlers bound to a.
+func (a *App) buildRegistry() []Command {
+	return []Command{
+		{
+			Trigger: "!help",
+			Handler: a.helpCmd,
+		},
+		{
+			Trigger: "hello",
+			Aliases: []string{"hi", "hey", "hallo", "!bot"},
+			Handler: a.helloCmd,
+		},
+		{
+			Trigger: "!flag",
+			Handler: a.flagCmd,
+		},
+		{
+			Trigger: "!version",
+			Handler: a.versionCmd,
+		},
+		{
+			Trigger: "!uptime",
+			Handler: a.uptimeCmd,
+		},
+		{
+			Trigger:        "!timewarp",
+			Aliases:        []string{"!timewrap", "!timeskip", "!tw", "!timewqrp", "!warp"},
+			Handler:        a.timewarpCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!goto",
+			Aliases:        []string{"!jump"},
+			Handler:        a.jumpCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!skip",
+			Handler:        a.skipCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!back",
+			Handler:        a.backCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger: "!shutdown",
+			Handler: a.shutdownCmd,
+		},
+		{
+			Trigger: "!socialmedia",
+			Aliases: []string{"!social", "!socials"},
+			Handler: func(_ *users.User, _ []string) {
+				sayFn("Find me outside of Twitch: !twitter, !instagram, !facebook, !youtube")
+			},
+		},
+		{
+			Trigger: "!commands",
+			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
+			Handler: func(_ *users.User, _ []string) {
+				sayFn("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, and many other hidden commands!")
+			},
+		},
+		{
+			Trigger:            "!bonusmiles",
+			Handler:            a.bonusMilesCmd,
+			RequiresSubscriber: true,
+		},
+		{
+			Trigger:        "!sunset",
+			Aliases:        []string{"!sunet"},
+			Handler:        a.sunsetCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!time",
+			Aliases:        []string{"!timr"},
+			Handler:        a.timeCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!date",
+			Aliases:        []string{"!datw"},
+			Handler:        a.dateCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!guess",
+			Aliases:        []string{"!guss", "guess", "!gusss", "!guees", "!gues", "!quess", "!guis"},
+			Handler:        a.guessCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!state",
+			Handler:        a.stateCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger: "!secretinfo",
+			Handler: a.secretInfoCmd,
+		},
+		{
+			Trigger: "!gas",
+			Aliases: []string{"!fuel", "!petrol"},
+			Handler: func(_ *users.User, _ []string) {
+				sayFn("About full, thanks for asking")
+			},
+		},
+		{
+			Trigger: "!middle",
+			Handler: a.middleCmd,
+		},
+		{
+			Trigger:        "!miles",
+			Aliases:        []string{"!points"},
+			Handler:        a.milesCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!km",
+			Aliases:        []string{"!kilometres", "!kilometers"},
+			Handler:        a.kilometresCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!location",
+			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation"},
+			Handler:        a.locationCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!leaderboard",
+			Aliases:        []string{"!monthlyleaderboard", "!lb", "!mlb", "!leaderbord", "!ldb", "!ldbd"},
+			Handler:        a.monthlyMilesLeaderboardCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!totalleaderboard",
+			Aliases:        []string{"!lifetimeleaderboard", "!tlb", "!llb"},
+			Handler:        a.lifetimeMilesLeaderboardCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!guessleaderboard",
+			Aliases:        []string{"!glb"},
+			Handler:        a.monthlyGuessLeaderboardCmd,
+			RequiresFollow: true,
+		},
+		{
+			Trigger:        "!report",
+			Aliases:        []string{"no audio", "no sound", "no music", "frozen"},
+			Handler:        a.reportCmd,
+			RequiresFollow: true,
+		},
+	}
+}
+
 func init() {
+	commands = defaultApp.buildRegistry()
 	singleWordLookup = make(map[string]*Command)
 	multiWordLookup = make(map[string]*Command)
 	for i := range commands {


### PR DESCRIPTION
## Summary

- Introduces `App` struct with `CurrentVideo func() video.Video` as the injectable dependency for video-dependent command handlers
- Migrates all 21 command handlers from package-level functions to App methods; production uses `defaultApp`, tests inject fakes directly
- Adds `buildRegistry()` method on App; `init()` builds the global commands slice from `defaultApp` — existing registry integrity tests are unchanged
- Adds 10 Tier 2 tests covering `stateCmd`, `dateCmd`, `timeCmd`, `sunsetCmd`, and `guessCmd` using injected `video.Video` structs — no network calls, no VLC dependency
- Updates 12 existing Tier 1 tests to call handlers via App method receiver

## Test coverage added

| Command | Tests |
|---------|-------|
| `!state` | message format, state name in output |
| `!date` | message prefix, year in output |
| `!time` | message prefix, am/pm in output |
| `!sunset` | output contains "Sunset on this day" |
| `!guess` | no-params prompt, wrong-guess try-again path |

## What's still deferred

- **Tier 3** (miles, leaderboard) — needs DB injection; `App.DB` field is the next step, same pattern
- `!location` — geocoder API call, integration-only
- `!guess` correct-guess path — calls `user.AddToScore` (DB) + `timewarp()` (VLC)
