### PR TITLE
chatbot: add tests for middleCmd

### DIFF
--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -355,3 +355,33 @@ func TestGuessCmd_WrongGuess_SaysTryAgain(t *testing.T) {
 		t.Errorf("expected try-again in output, got %q", out())
 	}
 }
+
+// --- middleCmd ---
+
+// adminUser matches CHANNEL_NAME in .env.testing, satisfying c.UserIsAdmin.
+const adminUser = "test"
+
+func TestMiddleCmd_NonAdminIsSilent(t *testing.T) {
+	app := newTestApp(video.Video{})
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.middleCmd(newTestUser("viewer1"), []string{"hello"})
+
+	if out() != "" {
+		t.Errorf("expected silence for non-admin, got %q", out())
+	}
+}
+
+func TestMiddleCmd_NoParams_PromptsForText(t *testing.T) {
+	app := newTestApp(video.Video{})
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.middleCmd(newTestUser(adminUser), nil)
+
+	if !strings.Contains(out(), "What do you want to say") {
+		t.Errorf("expected prompt, got %q", out())
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds 2 tests for `middleCmd`: non-admin silenced, admin no-params prompt
- The `hide` and free-text branches call `onscreensClient` which makes HTTP calls that panic in tests without an initialized Sentry client — those paths are integration-only for now

## What's not covered (and why)

| Branch | Reason skipped |
|---|---|
| `!middle hide` | `HideMiddleText()` → HTTP → `terrors.Log` → nil Sentry panic |
| `!middle <text>` | `ShowMiddleText()` → same HTTP path; no `sayFn` output to assert anyway |

To test these cleanly, `App` would need an injectable onscreens client — tracked in vault TODO.
