### PR TITLE
fix(seed): discriminate placeholder rows when deciding to skip

### DIFF
--- a/infra/docker/bin/seed-db.sh
+++ b/infra/docker/bin/seed-db.sh
@@ -6,10 +6,15 @@ apt-get update && apt-get install -y --no-install-recommends postgresql-client
 
 DSN="postgres://$DATABASE_USER:$DATABASE_PASS@$DATABASE_HOST/$DATABASE_DB"
 
-COUNT=$(psql "$DSN" -tAc "SELECT COUNT(*) FROM videos;")
-if [ "$COUNT" -gt 0 ]; then
-  echo "videos table already has $COUNT rows — skipping seed"
+# Skip-or-clobber: a fresh cluster races tripbot's first LoadOrCreate against
+# this seed. Tripbot-inserted rows always have flagged=true (lat/lng=0; see
+# pkg/video/db.go save()), so if every existing row is flagged we know the
+# table only holds race-loss placeholders, not real seeded data — clobber and
+# reseed. If any row has flagged=false, the CSV import is already done.
+REAL=$(psql "$DSN" -tAc "SELECT COUNT(*) FROM videos WHERE NOT flagged;")
+if [ "$REAL" -gt 0 ]; then
+  echo "videos table already has $REAL unflagged rows — skipping seed"
   exit 0
 fi
 
-psql "$DSN" -c "\copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;"
+psql "$DSN" -c "TRUNCATE videos RESTART IDENTITY CASCADE; \copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;"


### PR DESCRIPTION
## Summary

- Seed previously skipped on `COUNT(*) > 0` in `videos`. On a fresh cluster the tripbot Deployment can race ahead and insert a `flagged=true` placeholder row via `LoadOrCreate` before the seed Job's init container finishes retrying postgres DNS. The seed then skips and the 4406-row CSV never loads.
- Switch the skip predicate to `COUNT(*) WHERE NOT flagged`. Tripbot-inserted rows are always `flagged=true` (the `lat=0||lng=0` path in `pkg/video/db.go` `save()`), so "any unflagged row exists" reliably means real CSV data is present.
- `TRUNCATE videos RESTART IDENTITY CASCADE` before `\copy` so any race-loss placeholder rows get cleared rather than appended-to.

The `flagged` semantic is consistent across the codebase: every reader treats it as "no usable GPS coords for this video" (see `pkg/chatbot/commands.go`, `pkg/video/type.go`). The seed CSV itself has 305 historical `flagged=true` rows alongside 4101 unflagged — so "any flagged row" would be a wrong discriminator, but "any unflagged row" is correct.

Pairs with sibling [adanalife/infra#467](https://github.com/adanalife/infra/pull/467/changes), which waits for postgres rollout before applying the seed bundle (reduces the init-container retry storm that exposes this race).

## Test plan

- [ ] Fresh stage-1 bring-up: `task k8s:stage:cluster:rebuild && task tripbot:db:seed` lands ~4406 rows in `videos`, not 1.
- [ ] Idempotency: re-running `task tripbot:db:seed` on a populated DB exits with "videos table already has N unflagged rows — skipping seed", no TRUNCATE.
- [ ] Race-loss recovery: deliberately seed *after* tripbot has inserted a placeholder — seed clobbers and loads the CSV.