### PR TITLE
fix(seed): split TRUNCATE from \copy across psql input

### DIFF
--- a/infra/docker/bin/seed-db.sh
+++ b/infra/docker/bin/seed-db.sh
@@ -17,4 +17,10 @@ if [ "$REAL" -gt 0 ]; then
   exit 0
 fi
 
-psql "$DSN" -c "TRUNCATE videos RESTART IDENTITY CASCADE; \copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;"
+# Heredoc rather than -c because \copy is a psql meta-command and can't
+# share a -c string with SQL. --single-transaction so a failed COPY rolls
+# the TRUNCATE back instead of leaving the table empty.
+psql "$DSN" --single-transaction <<'EOF'
+TRUNCATE videos RESTART IDENTITY CASCADE;
+\copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;
+EOF


### PR DESCRIPTION
## Summary

Follow-up to [#513](https://github.com/adanalife/tripbot/pull/513/changes). The TRUNCATE-then-clobber line shipped in #513 had a psql-syntax bug: `\copy` is a meta-command and can't share a `-c` string with SQL. The seed pod errored with `syntax error at or near "\"` and the table was neither truncated nor reloaded.

- Heredoc instead of `-c` so the meta-command is valid.
- `--single-transaction` so a failed `\copy` rolls the TRUNCATE back rather than leaving the table empty.

Verified the bug live: the seed pod that got past the init container failed at this step with the syntax error in its logs.

## Test plan

- [ ] Fresh stage-1: seed Job reaches Complete, `videos` table has ~4406 rows.
- [ ] Race-loss recovery: with a placeholder row already present, seed clobbers and reloads.
- [ ] Atomicity: simulate a CSV failure (truncate the file) — `videos` retains its prior contents instead of being left empty.

> Note: there's still a separate flake — even with infra#467's postgres-rollout wait, the seed Job's init container retries DNS 3× before the headless-service `postgres` resolves, exhausting the `backoffLimit: 3` retries on the first DNS hiccup variance. Worth tracking as a follow-up (init container that polls `nc -z postgres 5432`, or bump `backoffLimit`).