### PR TITLE
Release v2.6.3: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.6.3] — 2026-05-15
+
+Patch release. Fixes a `\copy` syntax bug in the seed-DB script introduced by #513 in v2.6.2 that caused the seed Job to error before truncating or importing.
+
+### Database
+
+- **Seed-DB `TRUNCATE; \copy` syntax fix.** The combined line shipped in #513 errored with `syntax error at or near "\"` because `\copy` is a psql meta-command and can't share a `-c` string with SQL. Use a heredoc with `--single-transaction` so the two statements run atomically — a failed `\copy` rolls the TRUNCATE back instead of leaving the table empty. Pairs with [adanalife/infra#468](https://github.com/adanalife/infra/pull/468) (wait-for-postgres initContainer in the seed Job manifest). ([#514])
+
 ## [v2.6.2] — 2026-05-15
 
 Patch release. Adds Twitch audience gauges (subscribers + followers) and an OBS media-restart helper for reconnecting dropped RTSP sources via WebSocket. Introduces a pre-commit hygiene baseline (ruff + standard fixers). Internal: bumps `go-twitch-irc` to v4, `urfave/negroni` to v3, and `cloud.google.com/go/logging` to v1.18.0.

--- a/infra/docker/bin/seed-db.sh
+++ b/infra/docker/bin/seed-db.sh
@@ -17,4 +17,10 @@ if [ "$REAL" -gt 0 ]; then
   exit 0
 fi
 
-psql "$DSN" -c "TRUNCATE videos RESTART IDENTITY CASCADE; \copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;"
+# Heredoc rather than -c because \copy is a psql meta-command and can't
+# share a -c string with SQL. --single-transaction so a failed COPY rolls
+# the TRUNCATE back instead of leaving the table empty.
+psql "$DSN" --single-transaction <<'EOF'
+TRUNCATE videos RESTART IDENTITY CASCADE;
+\copy videos FROM '/seed/videos.csv' DELIMITER ',' CSV HEADER;
+EOF


### PR DESCRIPTION
## Summary

Patch release. Fixes the seed-DB `\copy` syntax bug introduced in v2.6.2.

- [#514](https://github.com/adanalife/tripbot/pull/514/changes) — `fix(seed): split TRUNCATE from \copy across psql input`. The combined `TRUNCATE; \copy` line shipped in #513 errored at runtime because `\copy` is a psql meta-command and can't share a `-c` string with SQL. Heredoc + `--single-transaction` so the two statements run atomically.

Pairs with [adanalife/infra#468](https://github.com/adanalife/infra/pull/468) (wait-for-postgres initContainer in the seed Job manifest), already merged.

## Test plan

- [ ] After release: `task k8s:stage:cluster:rebuild && task tripbot:db:seed` from `~/adanalife/infra` produces a single seed-pod attempt with no `Init:Error` retries; `videos` table holds ~4406 rows.