### PR TITLE
obs: disable program preview by default

### DIFF
--- a/infra/docker/obs/config/user.ini
+++ b/infra/docker/obs/config/user.ini
@@ -2,7 +2,12 @@
 FirstRun=true
 LastVersion=503316482
 [BasicWindow]
-PreviewEnabled=true
+; The program preview is the in-app render OBS draws to its main window
+; on top of the encoder pipeline. Source rendering still happens for the
+; stream output regardless; disabling the preview skips the extra
+; composite+blit to the Xvfb framebuffer. VNC into :5900 still shows the
+; OBS UI (just no live preview pane).
+PreviewEnabled=false
 WarnBeforeStoppingStream=false
 [Basic]
 Profile=ADanaLife


### PR DESCRIPTION
## Summary

- Flip `PreviewEnabled` in `infra/docker/obs/config/user.ini` from `true` to `false`.
- The program preview is the in-app render OBS draws to its main window on top of the encoder pipeline. Source rendering happens for the stream output regardless; disabling the preview skips the extra composite+blit to the Xvfb framebuffer.
- VNC into `:5900` still shows the OBS UI when debugging — just without a live preview pane.

Companion to [#516](https://github.com/adanalife/tripbot/pull/516/changes) (VLC headless) in trimming work the container does that nothing consumes.

## Test plan

- [ ] Deploy to stage-1, confirm OBS boots and begins streaming.
- [ ] VNC into the OBS container at `:5900` and confirm the UI is reachable but the preview pane is dark / disabled.
- [ ] Twitch stream output is unaffected (Dashcam source + overlays still composed correctly).
- [ ] `kubectl top pod obs-...` before/after to measure the CPU drop.