### PR TITLE
Set Sentry Release tag from build-time version

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -103,7 +103,7 @@ func initializeTelemetry() {
 
 // initializeErrorLogger makes sure the logger is configured
 func initializeErrorLogger() {
-	terrors.Initialize(c.Conf)
+	terrors.Initialize(c.Conf, version)
 }
 
 // startHttpServer starts a webserver, which is

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -89,7 +89,7 @@ func initializeTelemetry() {
 
 // initializeErrorLogger makes sure the logger is configured
 func initializeErrorLogger() {
-	terrors.Initialize(c.Conf)
+	terrors.Initialize(c.Conf, version)
 }
 
 // listenForShutdown creates a background job that listens for a graceful shutdown request

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -12,10 +12,18 @@ import (
 
 var conf config.Config
 
-// Initialize takes a Config interface and sets up a logger
-func Initialize(c config.Config) {
-	// sentry options are picked up through ENV vars
+// Initialize takes a Config interface and sets up a logger.
+//
+// version is the build-time version string (typically set via -ldflags
+// "-X main.version=..." in cmd/tripbot and cmd/vlc-server). It's passed
+// to sentry as the Release tag so Sentry can group issues by release
+// and surface "this regression started in vX.Y.Z."
+func Initialize(c config.Config, version string) {
+	// Most sentry options (DSN, environment) are picked up through ENV
+	// vars; Release is wired in explicitly so it tracks the same
+	// build-time value the /version endpoint exposes.
 	err := sentry.Init(sentry.ClientOptions{
+		Release: version,
 		// enable tracing
 		TracesSampleRate: 0.2,
 	})

--- a/pkg/server/setup_test.go
+++ b/pkg/server/setup_test.go
@@ -9,5 +9,5 @@ import (
 // config.Config interface until Initialize is called — without this,
 // any handler test that walks an error path NPEs in the logger.
 func init() {
-	terrors.Initialize(*c.Conf)
+	terrors.Initialize(*c.Conf, "test")
 }

--- a/pkg/vlc-server/setup_test.go
+++ b/pkg/vlc-server/setup_test.go
@@ -9,5 +9,5 @@ import (
 // config.Config interface that's nil until Initialize is called — without
 // this, any handler test that walks an error path NPEs in the logger.
 func init() {
-	terrors.Initialize(*c.Conf)
+	terrors.Initialize(*c.Conf, "test")
 }


### PR DESCRIPTION
## Summary
- Set Sentry `Release` field in tripbot + vlc-server `sentry.Init()` to the build-time version
- Uses the same version source already wired up by #419 (the `/version` endpoint) — the `version` package var in `cmd/tripbot` and `cmd/vlc-server`, populated via `-ldflags "-X main.version=..."`
- `terrors.Initialize` now takes a `version string` parameter that gets passed to `sentry.ClientOptions.Release`; no new env-var contract or deploy-manifest changes needed

## Test plan
- [x] Build passes locally / CI green
- [ ] Verify in Sentry that new events carry a `release` tag matching the deployed version