### PR TITLE
config: silence expected .env-missing log in cluster contexts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,10 @@ func SetEnvironment() {
 	// load ENV vars from .env file
 	err = godotenv.Load(".env." + env)
 
-	if err != nil {
+	// In cluster contexts (staging/production) the .env file is not shipped —
+	// env values come from envconfig instead — so the missing-file error is
+	// expected and noise. Only surface it for local-dev workflows.
+	if err != nil && (env == "development" || env == "testing") {
 		log.Println("Error loading .env file:", err)
 		log.Println("Continuing anyway...")
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -24,7 +24,10 @@ func init() {
 	var err error
 
 	err = godotenv.Load(".env." + c.Conf.Environment)
-	if err != nil {
+	// In cluster contexts (staging/production) the .env file is not shipped —
+	// env values come from envconfig instead — so the missing-file error is
+	// expected and noise. Only surface it for local-dev workflows.
+	if err != nil && (c.Conf.Environment == "development" || c.Conf.Environment == "testing") {
 		log.Println("Error loading .env file:", err)
 		log.Println("Continuing anyway...")
 	}


### PR DESCRIPTION
## Summary

The `.env.<env>` file is only shipped for local-dev workflows; the bot, vlc-server, and auth-bootstrap CLI all source env values from envconfig (k8s overlay / cluster Secrets) in staging/production. The "Error loading .env file" + "Continuing anyway..." pair fired at error-level on every cold start in cluster contexts even though it's a successful no-op.

Gate the message on the resolved env (`development` / `testing` only) so it stays useful for catching local typos but goes silent in cluster contexts. Same fix applied to `pkg/database` init, which had the identical four-line block. Implements option (1) from the open vault TODO.

## Test plan

- [x] `go vet ./pkg/config/ ./pkg/database/` passes
- [ ] Confirm staging/prod pod logs no longer carry the "Error loading .env file: open .env.staging: no such file or directory" line on cold start
- [ ] Local-dev run (`ENV=development`) still surfaces the message if a `.env.development` is genuinely missing