### PR TITLE
ci: demote errcheck reviewdog to level: warning

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -41,3 +41,4 @@ jobs:
           github_token: ${{ secrets.github_token }}
           golangci_lint_version: v2.12.1
           golangci_lint_flags: "--default=none --enable=errcheck"
+          level: warning # GitHub Status Check won't become failure with this level.


### PR DESCRIPTION
## Summary
- Demote `errcheck` reviewdog level from blocking-failure to `level: warning`, matching the `revive` job in the same workflow
- Stops the noisy red check status caused by libvlc-go's import being unresolvable on the linting runner (no libvlc-dev installed)
- Likely throwaway once super-linter's VALIDATE_GO comes back and linting.yml retires

## Test plan
- [x] CI green
- [ ] Future PRs touching Go: errcheck still reports findings, but as warnings rather than failures