### PR TITLE
config: drop spew.Dump that leaked secrets to stdout

### DIFF
--- a/pkg/config/tripbot/config.go
+++ b/pkg/config/tripbot/config.go
@@ -4,7 +4,6 @@ import (
 	"log"
 
 	"github.com/adanalife/tripbot/pkg/config"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/logrusorgru/aurora/v3"
 )
@@ -26,8 +25,6 @@ func init() {
 	config.SetEnvironment()
 
 	Conf = LoadTripbotConfig()
-
-	spew.Dump(Conf)
 
 	//TODO: consider using strings.ToLower() on channel name here and removing elsewhere
 

--- a/pkg/config/vlc-server/config.go
+++ b/pkg/config/vlc-server/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/adanalife/tripbot/pkg/config"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -26,8 +25,6 @@ func init() {
 	config.SetEnvironment()
 
 	Conf = LoadVlcServerConfig()
-
-	spew.Dump(Conf)
 
 	//TODO: consider using strings.ToLower() on channel name here and removing elsewhere
 


### PR DESCRIPTION
## Summary
- Drop the unconditional `spew.Dump(Conf)` from `pkg/config/tripbot/config.go` and `pkg/config/vlc-server/config.go` `init()` funcs that printed the parsed Config struct to stdout on every process start
- The dump leaked sensitive env values: `GOOGLE_MAPS_API_KEY`, `TWITCH_CLIENT_SECRET`, `SENTRY_DSN`, Twilio credentials, `GOOGLE_APPLICATION_CREDENTIALS` path — ending up in shell scrollback, asciinema recordings, and any CI logs
- Affected binaries: `cmd/tripbot`, `cmd/auth-bootstrap`, `cmd/vlc-server` (all import one of the two config packages for their `init()` side-effects)
- The bot / CLI don't depend on echoing config; removal is safe
- Neither dump was DEBUG-gated — both fire unconditionally

## Test plan
- [x] CI green
- [ ] `auth-bootstrap` cold start no longer prints the `*config.TripbotConfig` block
- [ ] `tripbot` cold start no longer prints the `*config.TripbotConfig` block
- [ ] `vlc-server` cold start no longer prints the `*config.VlcServerConfig` block