### PR TITLE
vlc-server: bind via VLC_SERVER_BIND_ADDRESS, drop VLC_SERVER_HOST requirement

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -48,7 +48,10 @@ EXTERNAL_URL=http://localhost:8080
 DISABLE_TWITCH_WEBHOOKS=true
 
 # --- vlc-server ---
+# Where the bot reaches vlc-server upstream.
 VLC_SERVER_HOST=vlc:8080
+# Address vlc-server's HTTP listener binds to (optional; defaults to :8080).
+# VLC_SERVER_BIND_ADDRESS=:8080
 
 # --- streamtest TUI (PR C) ---
 # pick one of your non-adanalife Twitch handles; oauth from twitchapps.com/tmi

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ DISABLE_TWITCH_WEBHOOKS="false"
 
 TRIPBOT_SERVER_PORT="8080"
 EXTERNAL_URL=""
+# Where the bot reaches vlc-server upstream.
 VLC_SERVER_HOST=localhost:8080
+# Address vlc-server's HTTP listener binds to (optional; defaults to :8080).
+# VLC_SERVER_BIND_ADDRESS=":8080"
 
 OBS_START_STREAMING="false"

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -43,6 +43,9 @@ type VlcServerConfig struct {
 	// VLCPidFile is where the vlc-server PID file lives
 	VLCPidFile string `default:"/opt/data/run/vlc-server.pid" envconfig:"VLC_PIDFILE"`
 
-	// VlcServerHost is used to specify the host for the VLC webserver
-	VlcServerHost string `required:"true" envconfig:"VLC_SERVER_HOST"`
+	// VlcServerBindAddress is the address (host:port or :port) the
+	// vlc-server HTTP listener binds to. Defaults to :8080 so the pod
+	// boots without being told its own address; override when running
+	// multiple instances on one host or to pin to a specific interface.
+	VlcServerBindAddress string `default:":8080" envconfig:"VLC_SERVER_BIND_ADDRESS"`
 }

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -1,10 +1,8 @@
 package vlcServer
 
 import (
-	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
@@ -25,7 +23,7 @@ import (
 
 // Start starts the web server
 func Start() {
-	log.Println("Starting VLC web server on host", c.Conf.VlcServerHost)
+	log.Println("Starting VLC web server on", c.Conf.VlcServerBindAddress)
 
 	r := mux.NewRouter()
 
@@ -102,11 +100,8 @@ func Start() {
 	// attaching routes to handler happens last
 	app.UseHandler(r)
 
-	//TODO: error if there's no colon to split on
-	port := strings.Split(c.Conf.VlcServerHost, ":")[1]
-
 	srv := &http.Server{
-		Addr: fmt.Sprintf("0.0.0.0:%s", port),
+		Addr: c.Conf.VlcServerBindAddress,
 		// Good practice to set timeouts to avoid Slowloris attacks.
 		WriteTimeout:   time.Second * 15,
 		ReadTimeout:    time.Second * 15,


### PR DESCRIPTION
## Summary
- vlc-server now reads `VLC_SERVER_BIND_ADDRESS` (optional, defaults to `:8080`)
- vlc-server pods boot cleanly without being told their own address
- The bot's reading of `VLC_SERVER_HOST` (upstream URL) is unchanged

## Out of scope
- k8s manifests in `infra/` still pass `VLC_SERVER_HOST` to vlc-server pods. vlc-server now ignores it harmlessly; cleaning the infra side up is a follow-up PR there.

## Test plan
- [x] go vet passes
- [ ] vlc-server boots locally without VLC_SERVER_BIND_ADDRESS set (binds `:8080`)
- [ ] vlc-server binds where expected when VLC_SERVER_BIND_ADDRESS=:8081 is set explicitly
- [ ] Bot still reaches vlc-server via VLC_SERVER_HOST (unchanged)