### PR TITLE
feat(chatbot): inject Onscreens and DB on App for testability

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -8,6 +8,7 @@ import (
 
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
@@ -16,6 +17,7 @@ import (
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/kelvins/geocoder"
 	"github.com/nicklaw5/helix/v2"
+	"gorm.io/gorm"
 )
 
 var googleMapsAPIKey string
@@ -26,10 +28,29 @@ var Uptime time.Time
 // Tests instantiate it directly with fakes; production uses defaultApp.
 type App struct {
 	CurrentVideo func() video.Video
+	// DB is the GORM handle used by commands that need to read or write the
+	// database. nil in tests that don't exercise the DB; otherwise either the
+	// real database.GormDB() or a sqlmock-backed gorm.DB.
+	DB *gorm.DB
+	// Onscreens drives the OBS browser-source overlays for chat-triggered
+	// effects (leaderboards, flags, middle-text). Tests inject a no-op fake.
+	Onscreens Onscreens
+}
+
+// db returns the DB handle the App should use. Prefers an explicit a.DB
+// (which tests set to a sqlmock-backed gorm.DB), otherwise falls back to the
+// process-wide singleton. Lazy so package init never touches the DB.
+func (a *App) db() *gorm.DB {
+	if a.DB != nil {
+		return a.DB
+	}
+	return database.GormDB()
 }
 
 var defaultApp = &App{
 	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
+	// DB stays nil; commands use a.db() which falls back to database.GormDB().
+	Onscreens: realOnscreens{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	terrors "github.com/adanalife/tripbot/pkg/errors"
-	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 
 	"github.com/adanalife/tripbot/pkg/background"
@@ -72,7 +71,7 @@ func (a *App) helloCmd(user *users.User, params []string) {
 
 func (a *App) flagCmd(user *users.User, _ []string) {
 	log.Println(user.Username, "ran !flag")
-	onscreensClient.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(10 * time.Second)
 }
 
 func (a *App) versionCmd(user *users.User, _ []string) {
@@ -209,7 +208,7 @@ func (a *App) monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
 	leaderboard = leaderboard[:size]
 
 	// display leaderboard on screen
-	onscreensClient.ShowLeaderboard("Monthly Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard("Monthly Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d miles this month: ", size)
@@ -233,7 +232,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
 	leaderboard := users.LifetimeMilesLeaderboard[:size]
 
 	// display leaderboard on screen
-	onscreensClient.ShowLeaderboard("Total Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard("Total Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d lifetime miles: ", size)
@@ -273,7 +272,7 @@ func (a *App) monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
 	}
 
 	// display leaderboard on screen
-	onscreensClient.ShowLeaderboard("Correct Guesses This Month", intLeaderboard)
+	a.Onscreens.ShowLeaderboard("Correct Guesses This Month", intLeaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d correct guesses this month: ", size)
@@ -362,12 +361,12 @@ func (a *App) guessCmd(user *users.User, params []string) {
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
 		msg = fmt.Sprintf("@%s got it! We're in %s", user.Username, vid.State)
 		// show the flag for the state
-		onscreensClient.ShowFlag(10 * time.Second)
+		a.Onscreens.ShowFlag(10 * time.Second)
 		// increase their guess score
 		user.AddToScore(guessScoreboard, 1.0)
 		user.AddToScore(scoreboards.CurrentGuessScoreboard(), 1.0)
 		// do a timewarp
-		timewarp()
+		a.timewarp()
 	} else {
 		msg = "Try again! EarthDay"
 	}
@@ -383,7 +382,7 @@ func (a *App) stateCmd(user *users.User, _ []string) {
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state
-	onscreensClient.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(10 * time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
 	sayFn(msg)
@@ -459,7 +458,7 @@ func (a *App) middleCmd(user *users.User, params []string) {
 	// if the arg was "hide", hide the text from view
 	if len(params) == 1 && strings.ToLower(params[0]) == "hide" {
 		sayFn("Got it! Hiding the message.")
-		onscreensClient.HideMiddleText()
+		a.Onscreens.HideMiddleText()
 		return
 	}
 
@@ -469,5 +468,5 @@ func (a *App) middleCmd(user *users.User, params []string) {
 	// just to help debug
 	log.Printf("setting middle text to: %s", text)
 
-	onscreensClient.ShowMiddleText(text)
+	a.Onscreens.ShowMiddleText(text)
 }

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -35,10 +35,15 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 	return video.Video{State: state, Lat: lat, Lng: lng, DateFilmed: date}
 }
 
-// newTestApp returns an App with CurrentVideo returning vid.
-// For commands that don't use CurrentVideo, pass a zero-value video.Video.
+// newTestApp returns an App with CurrentVideo returning vid and a no-op
+// Onscreens fake. For commands that don't use CurrentVideo, pass a zero-value
+// video.Video. To assert on Onscreens calls, replace app.Onscreens with a
+// recording fake (see fakeOnscreens in onscreens_test.go).
 func newTestApp(vid video.Video) *App {
-	return &App{CurrentVideo: func() video.Video { return vid }}
+	return &App{
+		CurrentVideo: func() video.Video { return vid },
+		Onscreens:    noopOnscreens{},
+	}
 }
 
 // --- helpCmd ---

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -1,0 +1,29 @@
+package chatbot
+
+import (
+	"time"
+
+	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
+)
+
+// Onscreens is the subset of the onscreens-client surface that chatbot
+// commands depend on. Tests inject a fake; production uses the package-backed
+// realOnscreens adapter wired in defaultApp.
+type Onscreens interface {
+	ShowFlag(dur time.Duration) error
+	ShowLeaderboard(title string, leaderboard [][]string) error
+	HideMiddleText() error
+	ShowMiddleText(msg string) error
+	ShowTimewarp() error
+}
+
+// realOnscreens delegates to pkg/onscreens-client.
+type realOnscreens struct{}
+
+func (realOnscreens) ShowFlag(dur time.Duration) error { return onscreensClient.ShowFlag(dur) }
+func (realOnscreens) ShowLeaderboard(title string, lb [][]string) error {
+	return onscreensClient.ShowLeaderboard(title, lb)
+}
+func (realOnscreens) HideMiddleText() error          { return onscreensClient.HideMiddleText() }
+func (realOnscreens) ShowMiddleText(msg string) error { return onscreensClient.ShowMiddleText(msg) }
+func (realOnscreens) ShowTimewarp() error            { return onscreensClient.ShowTimewarp() }

--- a/pkg/chatbot/onscreens_test.go
+++ b/pkg/chatbot/onscreens_test.go
@@ -1,0 +1,44 @@
+package chatbot
+
+import (
+	"fmt"
+	"time"
+)
+
+// noopOnscreens satisfies Onscreens for tests that don't care about the
+// overlay surface — it just swallows every call.
+type noopOnscreens struct{}
+
+func (noopOnscreens) ShowFlag(_ time.Duration) error                      { return nil }
+func (noopOnscreens) ShowLeaderboard(_ string, _ [][]string) error        { return nil }
+func (noopOnscreens) HideMiddleText() error                               { return nil }
+func (noopOnscreens) ShowMiddleText(_ string) error                       { return nil }
+func (noopOnscreens) ShowTimewarp() error                                 { return nil }
+
+// recordingOnscreens captures every call made to it so tests can assert
+// the chatbot invoked the expected overlay method with the expected args.
+// All call records are appended in order to Calls.
+type recordingOnscreens struct {
+	Calls []string
+}
+
+func (r *recordingOnscreens) ShowFlag(dur time.Duration) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("ShowFlag(%s)", dur))
+	return nil
+}
+func (r *recordingOnscreens) ShowLeaderboard(title string, lb [][]string) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("ShowLeaderboard(%q, %d rows)", title, len(lb)))
+	return nil
+}
+func (r *recordingOnscreens) HideMiddleText() error {
+	r.Calls = append(r.Calls, "HideMiddleText()")
+	return nil
+}
+func (r *recordingOnscreens) ShowMiddleText(msg string) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("ShowMiddleText(%q)", msg))
+	return nil
+}
+func (r *recordingOnscreens) ShowTimewarp() error {
+	r.Calls = append(r.Calls, "ShowTimewarp()")
+	return nil
+}

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -11,7 +11,6 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/helpers"
-	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
@@ -23,9 +22,9 @@ import (
 var lastTimewarpTime time.Time
 
 // timewarp jumps the playhead to a random video in the loop
-func timewarp() {
+func (a *App) timewarp() {
 	// show timewarp onscreen
-	onscreensClient.ShowTimewarp()
+	a.Onscreens.ShowTimewarp()
 
 	// shuffle to a new video
 	err := vlcClient.PlayRandom()
@@ -61,7 +60,7 @@ func (a *App) timewarpCmd(user *users.User, _ []string) {
 	}
 
 	// do the timewarp
-	timewarp()
+	a.timewarp()
 }
 
 func (a *App) jumpCmd(user *users.User, params []string) {
@@ -117,7 +116,7 @@ func (a *App) jumpCmd(user *users.User, params []string) {
 	// update the currently-playing video
 	video.GetCurrentlyPlaying()
 	// show the flag for the state
-	onscreensClient.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(10 * time.Second)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -111,6 +111,17 @@ func GormDB() *gorm.DB {
 	return gormConn
 }
 
+// SetGormDB swaps the singleton *gorm.DB for tests. Pair it with a sqlmock-
+// backed gorm.DB to assert on the SQL emitted by package-level callers (e.g.
+// users.Find, scoreboards.TopUsers) without needing a live postgres. Restore
+// to nil in test teardown so other tests don't inherit the mock.
+//
+// Not safe for parallel tests in the same package — run with t.Setenv-style
+// per-test setup and avoid t.Parallel() when using this.
+func SetGormDB(db *gorm.DB) {
+	gormConn = db
+}
+
 func connectGorm() *gorm.DB {
 	// Reuse the otelsql-instrumented *sql.DB so both layers share one connection pool.
 	sqlDB := Connection().DB


### PR DESCRIPTION
## Summary

Phase 1 of the testing/instrumentation pass. Plumbs two injectable dependencies into `App` so the Tier 3 and Tier 4 chatbot tests can land without a live postgres or a real OBS onscreen surface.

- **`Onscreens` interface** in `pkg/chatbot/onscreens.go` — covers `ShowFlag`, `ShowLeaderboard`, `HideMiddleText`, `ShowMiddleText`, `ShowTimewarp`. `defaultApp` wires the `realOnscreens` adapter (delegates to `pkg/onscreens-client`); tests pick from `noopOnscreens` (swallows everything) or `recordingOnscreens` (captures calls for assertions).
- **`DB *gorm.DB`** on `App` — populated lazily via `a.db()`, which prefers an explicit override and falls back to the process-wide `database.GormDB()`. Lets future tests pass a sqlmock-backed `*gorm.DB`.
- **`database.SetGormDB(db)`** — swap-the-singleton entry point for tests where a command goes through a package-level helper (`users.Find`, `scoreboards.TopUsers`) that uses the global.
- `timewarp()` is now `(a *App).timewarp()` so it picks up the App's `Onscreens` — previously a package-level function that hit `onscreensClient` directly.

After this PR, follow-ups can sqlmock-test `milesCmd` / leaderboard commands (Tier 3) and assert overlay calls for `middleCmd` / `flagCmd` / `stateCmd` (Tier 4) without service infra.

## Why sqlmock, not real postgres

See the vault TODO `chatbot: Tier 3 command tests` (sqlmock pattern) and `Upgrade DB tests from sqlmock to a real postgres in CI` (the longer-term upgrade). sqlmock keeps CI fast and infra-free for command-level tests; repo-level tests in `pkg/users` / `pkg/scoreboards` / etc. are the natural place to graduate to a real DB later.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [x] `mise exec -- go vet ./...` clean
- [x] `mise exec -- go test ./pkg/chatbot/...` passes (existing Tier 1-2 tests all green with the new `noopOnscreens` baked into `newTestApp`)
- [ ] Manual: run the bot, confirm `!miles`, `!totalleaderboard`, `!flag`, `!middle hello`, `!middle hide` still behave as before