### PR TITLE
feat(twitch): surface non-2xx helix responses with metric + log

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -39,8 +39,9 @@ func Log(e error, msg string) {
 	if e == nil {
 		e = errors.New(msg)
 	}
-	// only log to sentry on production or staging
-	if conf.IsProduction() || conf.IsStaging() {
+	// only log to sentry on production or staging; conf is nil in tests and
+	// any binary that didn't call Initialize, so guard before the method call.
+	if conf != nil && (conf.IsProduction() || conf.IsStaging()) {
 		sentry.AddBreadcrumb(&sentry.Breadcrumb{
 			Message: msg,
 		})
@@ -53,8 +54,9 @@ func Fatal(e error, msg string) {
 	if e == nil {
 		e = errors.New(msg)
 	}
-	// only log to sentry on production or staging
-	if conf.IsProduction() || conf.IsStaging() {
+	// only log to sentry on production or staging; conf is nil in tests and
+	// any binary that didn't call Initialize, so guard before the method call.
+	if conf != nil && (conf.IsProduction() || conf.IsStaging()) {
 		sentry.AddBreadcrumb(&sentry.Breadcrumb{
 			Message: msg,
 		})

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -15,6 +15,7 @@ var (
 	chatCommands      = mustCounter("tripbot_chat_commands", "The total number of chat commands")
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
+	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
 	obsStreamingGauge = mustGauge("obs_streaming_active", "1 if OBS is actively streaming, 0 otherwise")
 )
 
@@ -28,6 +29,11 @@ var ChatCommands = chatCommandCounterIface{counter: chatCommands}
 
 // TwitchAudience exposes subscriber and follower gauge recording.
 var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followers: twitchFollowers}
+
+// TwitchHelixErrors exposes the helix-error counter; record by calling
+// TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
+// like "GetUsers"; statusCode is the HTTP status reported by Twitch.
+var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
 
 // OBSStreaming exposes the streaming-active gauge.
 var OBSStreaming = obsStreamingIface{g: obsStreamingGauge}
@@ -55,6 +61,15 @@ func (a twitchAudienceIface) SetSubscribers(n int64) {
 
 func (a twitchAudienceIface) SetFollowers(n int64) {
 	a.followers.Record(context.Background(), n)
+}
+
+type twitchHelixErrorsIface struct{ counter metric.Int64Counter }
+
+func (h twitchHelixErrorsIface) Inc(endpoint string, statusCode int) {
+	h.counter.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("endpoint", endpoint),
+		attribute.Int("status_code", statusCode),
+	))
 }
 
 type obsStreamingIface struct{ g metric.Int64Gauge }

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -3,6 +3,7 @@ package twitch
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -171,7 +172,13 @@ func GenerateUserAccessToken(code string) error {
 	if err != nil {
 		return err
 	}
-	if usersResp == nil || len(usersResp.Data.Users) == 0 {
+	if usersResp == nil {
+		return errors.New("twitch: nil response from GetUsers")
+	}
+	if checkHelixResp("GetUsers", &usersResp.ResponseCommon) {
+		return fmt.Errorf("twitch: GetUsers returned %d during bootstrap", usersResp.StatusCode)
+	}
+	if len(usersResp.Data.Users) == 0 {
 		return errors.New("twitch: GetUsers returned no users")
 	}
 	u := usersResp.Data.Users[0]

--- a/pkg/twitch/helix_resp.go
+++ b/pkg/twitch/helix_resp.go
@@ -1,0 +1,32 @@
+package twitch
+
+import (
+	"fmt"
+
+	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/nicklaw5/helix/v2"
+)
+
+// checkHelixResp returns true when the Twitch Helix API responded with a
+// non-2xx status. The Helix SDK reports those as (resp, nil) with the
+// response's Data field left empty — callers that only check err were
+// treating them as success, which lets configuration bugs (bot missing
+// moderator:read:chatters, expired token, wrong client_id) silently evict
+// cached state.
+//
+// Concrete prior incident (2026-05-15): the bot lost mod on adanalife_staging,
+// UpdateChatters got back a 403 with empty Data, the session map cleared
+// every 61s, and !miles drifted to ~0 with no log or metric to point at.
+//
+// When this returns true, callers should log + early-return rather than
+// trust resp.Data. endpoint is a short label used as the metric attribute
+// (e.g. "GetUsers"); it should match the helix client method name.
+func checkHelixResp(endpoint string, resp *helix.ResponseCommon) bool {
+	if resp == nil || resp.StatusCode < 400 {
+		return false
+	}
+	terrors.Log(nil, fmt.Sprintf("helix %s returned %d: %s", endpoint, resp.StatusCode, resp.ErrorMessage))
+	instrumentation.TwitchHelixErrors.Inc(endpoint, resp.StatusCode)
+	return true
+}

--- a/pkg/twitch/helix_resp_test.go
+++ b/pkg/twitch/helix_resp_test.go
@@ -1,0 +1,44 @@
+package twitch
+
+import (
+	"testing"
+
+	"github.com/nicklaw5/helix/v2"
+)
+
+func TestCheckHelixResp_NilResponse(t *testing.T) {
+	if checkHelixResp("GetUsers", nil) {
+		t.Fatal("nil response should not be treated as an error")
+	}
+}
+
+func TestCheckHelixResp_Success(t *testing.T) {
+	rc := &helix.ResponseCommon{StatusCode: 200}
+	if checkHelixResp("GetUsers", rc) {
+		t.Fatal("200 should not be treated as an error")
+	}
+}
+
+func TestCheckHelixResp_NoContent(t *testing.T) {
+	// 204 is still success — guard against >= 400, not != 200
+	rc := &helix.ResponseCommon{StatusCode: 204}
+	if checkHelixResp("GetUsers", rc) {
+		t.Fatal("204 should not be treated as an error")
+	}
+}
+
+func TestCheckHelixResp_ClientError(t *testing.T) {
+	// 403 was the concrete 2026-05-15 incident: bot lost mod scope on the
+	// channel, GetChannelChatChatters returned 403 with empty Data.
+	rc := &helix.ResponseCommon{StatusCode: 403, ErrorMessage: "insufficient scope"}
+	if !checkHelixResp("GetChannelChatChatters", rc) {
+		t.Fatal("403 should be treated as an error")
+	}
+}
+
+func TestCheckHelixResp_ServerError(t *testing.T) {
+	rc := &helix.ResponseCommon{StatusCode: 503, ErrorMessage: "unavailable"}
+	if !checkHelixResp("GetSubscriptions", rc) {
+		t.Fatal("5xx should be treated as an error")
+	}
+}

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -25,10 +25,13 @@ func getChannelID(username string) string {
 	})
 	if err != nil {
 		terrors.Log(err, "error getting user info from twitch")
+		return ""
 	}
-
 	if resp == nil {
-		terrors.Log(err, "empty response from twitch")
+		terrors.Log(nil, "empty response from twitch")
+		return ""
+	}
+	if checkHelixResp("GetUsers", &resp.ResponseCommon) {
 		return ""
 	}
 
@@ -50,6 +53,11 @@ func GetSubscribers() {
 	})
 	if err != nil {
 		terrors.Log(err, "error getting subscriptions from twitch")
+		return
+	}
+	if checkHelixResp("GetSubscriptions", &resp.ResponseCommon) {
+		// keep the prior subscriber list rather than zeroing it out
+		return
 	}
 
 	// spew.Dump(resp)
@@ -83,6 +91,9 @@ func GetFollowerCount() {
 		terrors.Log(err, "error getting follower count from twitch")
 		return
 	}
+	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+		return
+	}
 	instrumentation.TwitchAudience.SetFollowers(int64(resp.Data.Total))
 	log.Printf("%s has %d followers", c.Conf.ChannelName, resp.Data.Total)
 }
@@ -113,6 +124,10 @@ func UserIsFollower(username string) bool {
 	})
 	if err != nil {
 		terrors.Log(err, "error getting user follows")
+		return false
+	}
+	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+		// fail closed: when we can't verify follow status, treat as non-follower
 		return false
 	}
 

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -50,6 +50,12 @@ func UpdateChatters() {
 		terrors.Log(err, "error getting chatters from twitch")
 		return
 	}
+	if checkHelixResp("GetChannelChatChatters", &resp.ResponseCommon) {
+		// don't overwrite cached chatter state with an empty response —
+		// 4xx here means the bot lost a scope or moderator role and the
+		// next call probably succeeds once that's fixed.
+		return
+	}
 
 	currentChatters = resp.Data.Chatters
 	chatterCount = resp.Data.Total


### PR DESCRIPTION
## Summary

Closes the silent-failure path on the Twitch Helix client surfaced by the 2026-05-15 incident.

**The problem:** `nicklaw5/helix/v2` reports 4xx/5xx as `(resp, nil)` with empty `Data`. Every call site in `pkg/twitch` was only checking `err != nil` and trusting the empty response, so silent config failures (bot lost a scope, expired token, wrong client_id) overwrote cached state with zeros.

**The 2026-05-15 incident:** bot lost the moderator role on `adanalife_staging` → `UpdateChatters` got 403 with empty `Data` → `UpdateSession` evicted every chatter every 61s → `!miles` drifted to ~0 with no log or metric to point at.

## What's in the PR

Two commits:

1. **`fix(errors): guard against nil conf in Log and Fatal`** — pkg/errors panics if `terrors.Log` is called before `Initialize` (tests + any binary that doesn't init). Adds a `conf != nil` guard around the sentry-reporting branch. No production behavior change.

2. **`feat(twitch): surface non-2xx helix responses with metric + log`** — adds `checkHelixResp(endpoint, *ResponseCommon)` in `pkg/twitch/helix_resp.go` that logs via `terrors.Log` and increments `twitch_helix_errors_total{endpoint, status_code}` when `StatusCode >= 400`. Wires it into every helix call site:
   - `viewers.go` — `UpdateChatters` (the original incident path)
   - `twitch.go` — `getChannelID`, `GetSubscribers`, `GetFollowerCount`, `UserIsFollower`
   - `authentication.go` — bootstrap `GetUsers`

   Call sites preserve cached state rather than zeroing on error. `UserIsFollower` fails closed (treats as non-follower).

## Metric

```
twitch_helix_errors_total{endpoint="GetChannelChatChatters", status_code="403"}
```

## Tests

5 new tests for the helper itself (`pkg/twitch/helix_resp_test.go`): nil response, 200/204 success, 403 (the incident), 5xx.

```
ok  	github.com/adanalife/tripbot/pkg/twitch	0.237s
ok  	github.com/adanalife/tripbot/pkg/chatbot	0.414s
```

## Out of scope

Webhook calls in `webhooks.go` are intentionally not wired — that file targets the deprecated webhook API gated off by `DISABLE_TWITCH_WEBHOOKS` and is queued for retirement / EventSub migration (vault TODO).

## Closes

- `vault/tripbot/tripbot/TODO.md` "Surface non-2xx helix responses in pkg/twitch"

## Test plan

- [x] `mise exec -- go build ./...` clean
- [x] `mise exec -- go vet ./pkg/twitch/... ./pkg/errors/... ./pkg/instrumentation/...` clean
- [x] `go test ./pkg/twitch/...` — 5 new + existing tests pass
- [ ] After merge, watch the `twitch_helix_errors_total` metric in Grafana — should be 0 in normal operation; spikes on any of the configurations that previously failed silently