### PR TITLE
feat(instrumentation): add business metrics — command latency, events, scoreboard writes

### DIFF
--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -59,7 +60,9 @@ func dispatch(cmd *Command, user *users.User, params []string) {
 	if !cmd.checkAccess(user, sayFn) {
 		return
 	}
+	start := time.Now()
 	cmd.Handler(user, params)
+	instrumentation.ChatCommandDuration.Observe(cmd.Trigger, time.Since(start).Seconds())
 }
 
 // findCommand parses message and returns the matching Command and params.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -7,6 +7,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/google/uuid"
 	"github.com/logrusorgru/aurora/v3"
 )
@@ -24,7 +25,11 @@ func Login(user string, sessionID uuid.UUID) error {
 		log.Printf("Not logging in %s because we're in read-only mode", aurora.Magenta(user))
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
-	return database.GormDB().Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error
+	if err := database.GormDB().Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
+		return err
+	}
+	instrumentation.Events.Inc("login")
+	return nil
 }
 
 func Logout(user string, sessionID uuid.UUID) error {
@@ -32,5 +37,9 @@ func Logout(user string, sessionID uuid.UUID) error {
 		log.Printf("Not logging out %s because we're in read-only mode", aurora.Magenta(user))
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
-	return database.GormDB().Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error
+	if err := database.GormDB().Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {
+		return err
+	}
+	instrumentation.Events.Inc("logout")
+	return nil
 }

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -11,8 +11,18 @@ import (
 var meter = otel.Meter("github.com/adanalife/tripbot")
 
 var (
-	chatMessages      = mustCounter("tripbot_chat_messages", "The total number of chat messages")
-	chatCommands      = mustCounter("tripbot_chat_commands", "The total number of chat commands")
+	chatMessages        = mustCounter("tripbot_chat_messages", "The total number of chat messages")
+	chatCommands        = mustCounter("tripbot_chat_commands", "The total number of chat commands")
+	chatCommandDuration = mustHistogram(
+		"tripbot_command_duration_seconds",
+		"Chat command handler duration in seconds, labeled by command",
+		// Standard Prometheus-style HTTP-latency buckets; covers fast in-memory
+		// commands (helpCmd) up through slow DB-fanout commands (milesCmd with
+		// the 4-query GetScore chain).
+		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+	)
+	tripbotEvents     = mustCounter("tripbot_events_total", "Total login/logout events written to the events table, labeled by event")
+	scoreboardWrites  = mustCounter("tripbot_scoreboard_writes_total", "Total successful scoreboard score writes, labeled by scoreboard")
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
@@ -26,6 +36,20 @@ var ChatMessages = chatCounterIface{counter: chatMessages}
 // ChatCommands exposes the chat-command counter; record by calling
 // ChatCommands.Inc(commandName).
 var ChatCommands = chatCommandCounterIface{counter: chatCommands}
+
+// ChatCommandDuration exposes the per-command latency histogram. Record by
+// calling ChatCommandDuration.Observe(commandName, seconds) — typically with
+// time.Since(start).Seconds() right after the handler returns.
+var ChatCommandDuration = chatCommandDurationIface{h: chatCommandDuration}
+
+// Events exposes the login/logout event counter. Record by calling
+// Events.Inc("login") or Events.Inc("logout") right after the row is
+// persisted.
+var Events = eventsIface{counter: tripbotEvents}
+
+// ScoreboardWrites exposes the scoreboard-write counter. Record by calling
+// ScoreboardWrites.Inc(scoreboardName) right after the row is persisted.
+var ScoreboardWrites = scoreboardWritesIface{counter: scoreboardWrites}
 
 // TwitchAudience exposes subscriber and follower gauge recording.
 var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followers: twitchFollowers}
@@ -48,6 +72,24 @@ type chatCommandCounterIface struct{ counter metric.Int64Counter }
 
 func (c chatCommandCounterIface) Inc(command string) {
 	c.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("command", command)))
+}
+
+type chatCommandDurationIface struct{ h metric.Float64Histogram }
+
+func (d chatCommandDurationIface) Observe(command string, seconds float64) {
+	d.h.Record(context.Background(), seconds, metric.WithAttributes(attribute.String("command", command)))
+}
+
+type eventsIface struct{ counter metric.Int64Counter }
+
+func (e eventsIface) Inc(event string) {
+	e.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("event", event)))
+}
+
+type scoreboardWritesIface struct{ counter metric.Int64Counter }
+
+func (s scoreboardWritesIface) Inc(scoreboard string) {
+	s.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("scoreboard", scoreboard)))
 }
 
 type twitchAudienceIface struct {
@@ -96,4 +138,16 @@ func mustGauge(name, desc string) metric.Int64Gauge {
 		panic(err)
 	}
 	return g
+}
+
+func mustHistogram(name, desc string, buckets ...float64) metric.Float64Histogram {
+	opts := []metric.Float64HistogramOption{metric.WithDescription(desc)}
+	if len(buckets) > 0 {
+		opts = append(opts, metric.WithExplicitBucketBoundaries(buckets...))
+	}
+	h, err := meter.Float64Histogram(name, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return h
 }

--- a/pkg/scoreboards/scores.go
+++ b/pkg/scoreboards/scores.go
@@ -8,6 +8,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"gorm.io/gorm"
 )
 
@@ -60,7 +61,11 @@ func AddToScoreByName(username, scoreboardName string, scoreToAdd float32) error
 		return err
 	}
 	score.Value += scoreToAdd
-	return score.save()
+	if err := score.save(); err != nil {
+		return err
+	}
+	instrumentation.ScoreboardWrites.Inc(scoreboardName)
+	return nil
 }
 
 // findOrCreateScore will look up the username in the DB, and return a Score if possible


### PR DESCRIPTION
## Summary

Phase 5 of the testing/instrumentation pass — fills the three biggest visibility gaps the 2026-05-15 audit flagged.

| Metric | Type | Labels | Where |
|---|---|---|---|
| `tripbot_command_duration_seconds` | histogram | `command` | `pkg/chatbot/handlers.go:dispatch` wraps `cmd.Handler(...)` with `time.Since(start)` |
| `tripbot_events_total` | counter | `event` (login\|logout) | `pkg/events/events.go` `Login` / `Logout` after the row writes |
| `tripbot_scoreboard_writes_total` | counter | `scoreboard` | `pkg/scoreboards/scores.go:AddToScoreByName` after `score.save()` |

Each increment fires only after the corresponding DB write succeeds, so the metric counts shipped state — not attempts. Counters that go up without a matching events table row would be a bug; that's the design.

## Why a histogram for `command_duration_seconds`

We already have `tripbot_chat_commands{command}` for counts. The histogram tells us *which* commands are slow, p50/p95/p99 over time, and whether `milesCmd` (a 4-query GetScore chain) is the latency tail it looks like on paper. Buckets are Prometheus-standard HTTP-latency: `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10` — covers fast in-memory commands (`helpCmd`) through slow DB fan-out commands.

## What's not in this PR

- `vlc_state_transitions_total` / `obs_scene_transitions_total` — needs a separate exploration pass into vlc-server / obs surface to find clean signal points. Stretch from the original plan, deferred.
- Tests — each new line is `metric.Inc(label)` after a known-good operation. The OTel SDK doesn't make read-back assertions ergonomic; the meaningful verification is the `/metrics` endpoint at runtime.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [x] `mise exec -- go vet ./pkg/instrumentation/... ./pkg/chatbot/... ./pkg/events/... ./pkg/scoreboards/...` clean
- [x] `go test ./pkg/chatbot/... ./pkg/scoreboards/... ./pkg/events/...` — all existing tests pass
- [ ] After merge, watch the three new metrics in Grafana — should populate within seconds of the bot serving traffic