### PR TITLE
feat(tracing): wrap chat-command dispatch in a span; instrument helix client

### DIFF
--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -60,6 +60,16 @@ func dispatch(cmd *Command, user *users.User, params []string) {
 	if !cmd.checkAccess(user, sayFn) {
 		return
 	}
+	// Wrap the handler in a span so each chat command shows up as a trace
+	// in Tempo. SQL queries (via otelsql) and outbound HTTP (via otelhttp)
+	// will nest under this once the HandlerFunc signature grows a
+	// context.Context — until then they stay as sibling traces, but the
+	// command-level span alone is already useful for "which command is slow"
+	// and for cross-referencing the tripbot_command_duration_seconds metric.
+	_, span := tracer.Start(context.Background(), "chat.command",
+		trace.WithAttributes(attribute.String("command", cmd.Trigger)))
+	defer span.End()
+
 	start := time.Now()
 	cmd.Handler(user, params)
 	instrumentation.ChatCommandDuration.Observe(cmd.Trigger, time.Since(start).Seconds())

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -15,7 +16,15 @@ import (
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+// helixHTTPClient is the otelhttp-instrumented HTTP client passed to every
+// helix.NewClient call. Without this, outbound Twitch Helix requests leave
+// no trail in Tempo; with it, each helix.GetUsers / GetSubscriptions / etc.
+// shows up as a span. Pairs with the otelhttp transports already used by
+// pkg/vlc-client and pkg/onscreens-client.
+var helixHTTPClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
 // Scopes is the OAuth scope set requested for the bot account. Single source
 // of truth — referenced by Client() (App Access Token request),
@@ -84,6 +93,7 @@ func Client() (*helix.Client, error) {
 		// Registered at https://dev.twitch.tv/console/apps; matched by
 		// cmd/auth-bootstrap's local HTTP listener.
 		RedirectURI: c.Conf.ExternalURL + "/auth/callback",
+		HTTPClient:  helixHTTPClient,
 	})
 	if err != nil {
 		terrors.Log(err, "error creating client")


### PR DESCRIPTION
## Summary

Two small unlocks that turn the existing OTel plumbing into actually-useful traces in Tempo.

1. **Wrap `cmd.Handler(...)` in a span** (`pkg/chatbot/handlers.go:dispatch`). The `tracer` var at the top of the file has been declared since the chatbot refactor but never used — this is its first caller. Span name `chat.command`, attribute `command={trigger}`. Each IRC message that resolves to a known command now shows up as a trace.
2. **Pass an `otelhttp`-instrumented `*http.Client` to `helix.NewClient`** (`pkg/twitch/authentication.go`). Without it, outbound Twitch Helix requests (`GetUsers`, `GetSubscriptions`, `GetChannelFollows`, `GetChannelChatChatters`) leave no trail in Tempo. Pairs with the otelhttp transports already used by `pkg/vlc-client` and `pkg/onscreens-client`.

## The next-PR caveat

SQL queries (via `otelsql`) and outbound HTTP spans (via `otelhttp`) won't nest *under* the `chat.command` span until the `HandlerFunc` signature grows a `context.Context`. Until then they're sibling traces. The command-level span on its own is already useful for:

- "which command is slow" — searchable in Tempo by `command={trigger}`
- One-to-one cross-reference with the `tripbot_command_duration_seconds` histogram
- Clicking from a slow point in Grafana → trace in Tempo

Follow-up PR will plumb `ctx` through `HandlerFunc` so every command's children chain into one tree.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [x] `mise exec -- go vet ./pkg/chatbot/... ./pkg/twitch/...` clean
- [x] `go test ./pkg/chatbot/... ./pkg/twitch/...` — all pass
- [ ] After deploy, search Tempo for `service.name=tripbot operation.name=chat.command`; should see one span per command invocation
- [ ] Trigger a helix call (`!leaderboard` runs `GetUsers` indirectly) and confirm an `HTTP GET ... api.twitch.tv` span shows up in Tempo