### PR TITLE
feat(tracing): thread context through HandlerFunc and DB helpers (stacked on #533)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -48,6 +48,19 @@ func tracedJob(name string, fn func()) func() {
 	}
 }
 
+// tracedJobCtx is the ctx-aware variant of tracedJob. The span's ctx is
+// threaded into fn so DB queries (otelsql) and outbound HTTP (otelhttp)
+// nest under cron.<name> in Tempo, giving each cron tick a tree of children
+// rather than orphan spans.
+func tracedJobCtx(name string, fn func(context.Context)) func() {
+	return func() {
+		ctx, span := cronTracer.Start(context.Background(), "cron."+name,
+			trace.WithAttributes(attribute.String("cron.job", name)))
+		defer span.End()
+		fn(ctx)
+	}
+}
+
 // version is overridable at build time via -ldflags "-X main.version=...".
 var version = "dev"
 
@@ -65,7 +78,7 @@ func main() {
 	server.SetVersion(version)
 	startHttpServer()
 	findInitialVideo()
-	users.InitLeaderboard()
+	users.InitLeaderboard(context.Background())
 	startCron()
 	startOBSPolling()
 	loadTwitchToken()   // must precede chatbot.Initialize — provides the IRC token
@@ -166,7 +179,7 @@ func updateSubscribers() {
 // getCurrentUsers gets the users watching the stream
 func getCurrentUsers() {
 	// fetch initial session
-	users.UpdateSession()
+	users.UpdateSession(context.Background())
 	users.PrintCurrentSession()
 }
 
@@ -215,7 +228,7 @@ func gracefulShutdown() {
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
 	log.Printf("Last played video: %s", aurora.Yellow(video.CurrentlyPlaying.File()))
-	users.Shutdown()
+	users.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {
 		terrors.Log(err, "error closing DB connection")
@@ -240,9 +253,9 @@ func scheduleBackgroundJobs() {
 
 	// schedule these functions
 	err = background.Cron.AddFunc("@every 60s", tracedJob("video.GetCurrentlyPlaying", video.GetCurrentlyPlaying))
-	err = background.Cron.AddFunc("@every 61s", tracedJob("users.UpdateSession", users.UpdateSession))
+	err = background.Cron.AddFunc("@every 61s", tracedJobCtx("users.UpdateSession", users.UpdateSession))
 	err = background.Cron.AddFunc("@every 62s", tracedJob("users.UpdateLeaderboard", users.UpdateLeaderboard))
-	err = background.Cron.AddFunc("@every 5m", tracedJob("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
+	err = background.Cron.AddFunc("@every 5m", tracedJobCtx("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("users.PrintCurrentSession", users.PrintCurrentSession))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetSubscribers", mytwitch.GetSubscribers))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetFollowerCount", mytwitch.GetFollowerCount))

--- a/pkg/chatbot/command.go
+++ b/pkg/chatbot/command.go
@@ -1,9 +1,16 @@
 package chatbot
 
-import "github.com/adanalife/tripbot/pkg/users"
+import (
+	"context"
 
-// HandlerFunc is the common signature for all chat command handlers.
-type HandlerFunc func(user *users.User, params []string)
+	"github.com/adanalife/tripbot/pkg/users"
+)
+
+// HandlerFunc is the common signature for all chat command handlers. The
+// ctx carries the chat.command span started in dispatch() so SQL queries
+// (via otelsql) and outbound HTTP (via otelhttp) nest under the command
+// span in Tempo.
+type HandlerFunc func(ctx context.Context, user *users.User, params []string)
 
 // Command is a first-class representation of a single chat command.
 type Command struct {

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -34,13 +35,13 @@ const guessScoreboard = "guess_state_total"
 
 //TODO: incorrect guess scoreboard?
 
-func (a *App) helpCmd(user *users.User, _ []string) {
+func (a *App) helpCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !help")
 	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
 	sayFn(msg)
 }
 
-func (a *App) helloCmd(user *users.User, params []string) {
+func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "said hello")
 
 	// check if it was just a one-word hello
@@ -69,12 +70,12 @@ func (a *App) helloCmd(user *users.User, params []string) {
 	lastHelloTime = time.Now()
 }
 
-func (a *App) flagCmd(user *users.User, _ []string) {
+func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !flag")
 	a.Onscreens.ShowFlag(10 * time.Second)
 }
 
-func (a *App) versionCmd(user *users.User, _ []string) {
+func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !version")
 
 	if helpers.RunningOnWindows() {
@@ -98,14 +99,14 @@ func (a *App) versionCmd(user *users.User, _ []string) {
 	sayFn("Current version is " + currentVersion)
 }
 
-func (a *App) uptimeCmd(user *users.User, _ []string) {
+func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !uptime")
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
 	sayFn(msg)
 }
 
-func (a *App) milesCmd(user *users.User, params []string) {
+func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !miles")
 	var username string
 	var lifetimeMiles, monthlyMiles float32
@@ -114,10 +115,10 @@ func (a *App) milesCmd(user *users.User, params []string) {
 	if len(params) == 0 {
 		username = user.Username
 		lifetimeMiles = user.CurrentMiles()
-		monthlyMiles = user.CurrentMonthlyMiles()
+		monthlyMiles = user.CurrentMonthlyMiles(ctx)
 	} else {
 		username = helpers.StripAtSign(params[0])
-		u := users.Find(username)
+		u := users.Find(ctx, username)
 
 		// check to see if they are in our DB
 		if u.ID == 0 {
@@ -126,7 +127,7 @@ func (a *App) milesCmd(user *users.User, params []string) {
 		}
 
 		lifetimeMiles = u.CurrentMiles()
-		monthlyMiles = u.CurrentMonthlyMiles()
+		monthlyMiles = u.CurrentMonthlyMiles(ctx)
 	}
 
 	msg := "@%s has %.2fmi this month"
@@ -153,7 +154,7 @@ func (a *App) milesCmd(user *users.User, params []string) {
 	sayFn(msg)
 }
 
-func (a *App) kilometresCmd(user *users.User, _ []string) {
+func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !kilometres")
 	km := user.CurrentMiles() * 1.609344
 	msg := "@%s has %.2f kilometres."
@@ -161,7 +162,7 @@ func (a *App) kilometresCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) sunsetCmd(user *users.User, _ []string) {
+func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !sunset")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
@@ -172,7 +173,7 @@ func (a *App) sunsetCmd(user *users.User, _ []string) {
 	sayFn(helpers.SunsetStr(vid.DateFilmed, lat, lng))
 }
 
-func (a *App) locationCmd(user *users.User, _ []string) {
+func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !location (or similar)")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
@@ -196,12 +197,12 @@ func (a *App) locationCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !leaderboard")
 
 	// select users to show in leaderboard
 	size := 10
-	leaderboard := scoreboards.TopUsers(scoreboards.CurrentMilesScoreboard(), size)
+	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentMilesScoreboard(), size)
 	if size > len(leaderboard) {
 		size = len(leaderboard)
 	}
@@ -221,7 +222,7 @@ func (a *App) monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !totalleaderboard")
 
 	// select users to show in leaderboard
@@ -245,12 +246,12 @@ func (a *App) lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !guessleaderboard")
 
 	// select users to show in leaderboard
 	size := 10
-	leaderboard := scoreboards.TopUsers(scoreboards.CurrentGuessScoreboard(), size)
+	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
 
 	// special message if the leaderboard is empty
 	if len(leaderboard) == 0 {
@@ -285,7 +286,7 @@ func (a *App) monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) timeCmd(user *users.User, _ []string) {
+func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !time")
 	var err error
 	var lat, lng float64
@@ -304,7 +305,7 @@ func (a *App) timeCmd(user *users.User, _ []string) {
 	}
 }
 
-func (a *App) dateCmd(user *users.User, _ []string) {
+func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !date")
 	var err error
 	var lat, lng float64
@@ -324,7 +325,7 @@ func (a *App) dateCmd(user *users.User, _ []string) {
 }
 
 //TODO: refactor to use golang '...' syntax
-func (a *App) guessCmd(user *users.User, params []string) {
+func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !guess")
 	var msg string
 
@@ -363,8 +364,8 @@ func (a *App) guessCmd(user *users.User, params []string) {
 		// show the flag for the state
 		a.Onscreens.ShowFlag(10 * time.Second)
 		// increase their guess score
-		user.AddToScore(guessScoreboard, 1.0)
-		user.AddToScore(scoreboards.CurrentGuessScoreboard(), 1.0)
+		user.AddToScore(ctx, guessScoreboard, 1.0)
+		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
 		// do a timewarp
 		a.timewarp()
 	} else {
@@ -373,7 +374,7 @@ func (a *App) guessCmd(user *users.User, params []string) {
 	sayFn(msg)
 }
 
-func (a *App) stateCmd(user *users.User, _ []string) {
+func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !state")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
@@ -390,7 +391,7 @@ func (a *App) stateCmd(user *users.User, _ []string) {
 
 //TODO: maybe there could be a !cancel command or something
 //TODO: use fancy golang ... syntax?
-func (a *App) reportCmd(user *users.User, params []string) {
+func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !report")
 	message := strings.Join(params, " ")
 	// Route the report through Sentry so it lands somewhere visible.
@@ -400,14 +401,14 @@ func (a *App) reportCmd(user *users.User, params []string) {
 	sayFn("Thank you, I will look into this ASAP!")
 }
 
-func (a *App) bonusMilesCmd(user *users.User, _ []string) {
+func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !bonusmiles")
 	bonus := user.BonusMiles()
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
 	sayFn(msg)
 }
 
-func (a *App) secretInfoCmd(user *users.User, _ []string) {
+func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !secretinfo")
 	if !c.UserIsAdmin(user.Username) {
 		return
@@ -424,7 +425,7 @@ func (a *App) secretInfoCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) shutdownCmd(user *users.User, _ []string) {
+func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !shutdown")
 	if !c.UserIsAdmin(user.Username) {
 		sayFn("Nice try bucko")
@@ -433,7 +434,7 @@ func (a *App) shutdownCmd(user *users.User, _ []string) {
 	sayFn("Shutting down...")
 	log.Printf("currently playing: %s", a.CurrentVideo())
 	background.StopCron()
-	users.Shutdown()
+	users.Shutdown(ctx)
 	err := database.Connection().Close()
 	if err != nil {
 		log.Println(err)
@@ -444,7 +445,7 @@ func (a *App) shutdownCmd(user *users.User, _ []string) {
 
 //TODO: this will always be lower case, find out why
 // middleCmd sets the text at the bottom-middle of the stream
-func (a *App) middleCmd(user *users.User, params []string) {
+func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !middle")
 	// don't let strangers run this
 	if !c.UserIsAdmin(user.Username) {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -54,7 +55,7 @@ func TestHelpCmd_SaysSomething(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if out() == "" {
 		t.Fatal("expected a help message, got empty output")
@@ -66,7 +67,7 @@ func TestHelpCmd_MessageContainsCount(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	// message format: "<help text> (N of M)"
 	if !strings.Contains(out(), " of ") {
@@ -79,10 +80,10 @@ func TestHelpCmd_AdvancesIndex(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 	first := out()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 	second := out()
 
 	if first == second {
@@ -98,7 +99,7 @@ func TestUptimeCmd_SaysRunningFor(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.uptimeCmd(newTestUser("viewer1"), nil)
+	app.uptimeCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "I have been running for") {
 		t.Errorf("unexpected uptime message: %q", out())
@@ -114,7 +115,7 @@ func TestHelloCmd_GreetsNewViewer(t *testing.T) {
 	defer restore()
 
 	// a fresh user with 0 miles gets the newcomer hint appended
-	app.helloCmd(newTestUser("newviewer"), nil)
+	app.helloCmd(context.Background(), newTestUser("newviewer"), nil)
 
 	msg := out()
 	if msg == "" {
@@ -131,7 +132,7 @@ func TestHelloCmd_RateLimitSilencesSecondCall(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helloCmd(newTestUser("viewer1"), nil)
+	app.helloCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if out() != "" {
 		t.Errorf("expected silence due to rate limit, got %q", out())
@@ -145,7 +146,7 @@ func TestHelloCmd_IgnoresMessageWithParams(t *testing.T) {
 	defer restore()
 
 	// "hello world" — has params so the bot stays quiet
-	app.helloCmd(newTestUser("viewer1"), []string{"world"})
+	app.helloCmd(context.Background(), newTestUser("viewer1"), []string{"world"})
 
 	if out() != "" {
 		t.Errorf("expected silence for greeting with params, got %q", out())
@@ -160,7 +161,7 @@ func TestKilometresCmd_ConvertsCorrectly(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "viewer1", Miles: 10}
-	app.kilometresCmd(user, nil)
+	app.kilometresCmd(context.Background(), user, nil)
 
 	// 10 miles * 1.609344 = 16.09344, formatted as "16.09"
 	if !strings.Contains(out(), "16.09") {
@@ -174,7 +175,7 @@ func TestKilometresCmd_IncludesUsername(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "testviewer", Miles: 5}
-	app.kilometresCmd(user, nil)
+	app.kilometresCmd(context.Background(), user, nil)
 
 	if !strings.Contains(out(), "@testviewer") {
 		t.Errorf("expected @username in output, got %q", out())
@@ -187,7 +188,7 @@ func TestKilometresCmd_ZeroMiles(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "newbie", Miles: 0}
-	app.kilometresCmd(user, nil)
+	app.kilometresCmd(context.Background(), user, nil)
 
 	if !strings.Contains(out(), "0.00") {
 		t.Errorf("expected zero km in output, got %q", out())
@@ -204,7 +205,7 @@ func TestVersionCmd_UsesCachedVersion(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.versionCmd(newTestUser("viewer1"), nil)
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "v1.2.3-test") {
 		t.Errorf("expected cached version in output, got %q", out())
@@ -219,7 +220,7 @@ func TestVersionCmd_MessageFormat(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.versionCmd(newTestUser("viewer1"), nil)
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "Current version is ") {
 		t.Errorf("unexpected message format: %q", out())
@@ -234,7 +235,7 @@ func TestStateCmd_SaysCurrentState(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.stateCmd(newTestUser("viewer1"), nil)
+	app.stateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "Colorado") {
 		t.Errorf("expected state name in output, got %q", out())
@@ -247,7 +248,7 @@ func TestStateCmd_MessageFormat(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.stateCmd(newTestUser("viewer1"), nil)
+	app.stateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "We're in ") {
 		t.Errorf("unexpected state message format: %q", out())
@@ -263,7 +264,7 @@ func TestStateCmd_DrivesShowFlagOverlay(t *testing.T) {
 	_, restore := captureSay(t)
 	defer restore()
 
-	app.stateCmd(newTestUser("viewer1"), nil)
+	app.stateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if len(rec.Calls) != 1 || !strings.HasPrefix(rec.Calls[0], "ShowFlag(") {
 		t.Errorf("expected one ShowFlag overlay call, got %v", rec.Calls)
@@ -280,7 +281,7 @@ func TestFlagCmd_DrivesShowFlagOverlay(t *testing.T) {
 	_, restore := captureSay(t)
 	defer restore()
 
-	app.flagCmd(newTestUser("viewer1"), nil)
+	app.flagCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if len(rec.Calls) != 1 || rec.Calls[0] != "ShowFlag(10s)" {
 		t.Errorf("expected ShowFlag(10s) overlay call, got %v", rec.Calls)
@@ -292,7 +293,7 @@ func TestFlagCmd_DoesNotSayInChat(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.flagCmd(newTestUser("viewer1"), nil)
+	app.flagCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if out() != "" {
 		t.Errorf("expected flagCmd to be silent in chat, got %q", out())
@@ -308,7 +309,7 @@ func TestDateCmd_SaysThisMomentWas(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.dateCmd(newTestUser("viewer1"), nil)
+	app.dateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	msg := out()
 	if !strings.HasPrefix(msg, "This moment was") {
@@ -323,7 +324,7 @@ func TestDateCmd_IncludesYear(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.dateCmd(newTestUser("viewer1"), nil)
+	app.dateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "2019") {
 		t.Errorf("expected year 2019 in output, got %q", out())
@@ -339,7 +340,7 @@ func TestTimeCmd_SaysThisMomentWas(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.timeCmd(newTestUser("viewer1"), nil)
+	app.timeCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "This moment was") {
 		t.Errorf("unexpected time message: %q", out())
@@ -353,7 +354,7 @@ func TestTimeCmd_IncludesAMPM(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.timeCmd(newTestUser("viewer1"), nil)
+	app.timeCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "am") && !strings.Contains(msg, "pm") {
@@ -371,7 +372,7 @@ func TestSunsetCmd_SaysSunset(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.sunsetCmd(newTestUser("viewer1"), nil)
+	app.sunsetCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "Sunset on this day") {
 		t.Errorf("unexpected sunset message: %q", out())
@@ -386,7 +387,7 @@ func TestGuessCmd_NoParams_PromptsGuess(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.guessCmd(newTestUser("viewer1"), nil)
+	app.guessCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "guess") {
 		t.Errorf("expected guess prompt in output, got %q", out())
@@ -400,7 +401,7 @@ func TestGuessCmd_WrongGuess_SaysTryAgain(t *testing.T) {
 	defer restore()
 
 	// Wyoming != Colorado
-	app.guessCmd(newTestUser("viewer1"), []string{"Wyoming"})
+	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"Wyoming"})
 
 	if !strings.Contains(out(), "Try again") {
 		t.Errorf("expected try-again in output, got %q", out())
@@ -417,7 +418,7 @@ func TestMiddleCmd_NonAdminIsSilent(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser("viewer1"), []string{"hello"})
+	app.middleCmd(context.Background(), newTestUser("viewer1"), []string{"hello"})
 
 	if out() != "" {
 		t.Errorf("expected silence for non-admin, got %q", out())
@@ -429,7 +430,7 @@ func TestMiddleCmd_NoParams_PromptsForText(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser(adminUser), nil)
+	app.middleCmd(context.Background(), newTestUser(adminUser), nil)
 
 	if !strings.Contains(out(), "What do you want to say") {
 		t.Errorf("expected prompt, got %q", out())
@@ -444,7 +445,7 @@ func TestMiddleCmd_Hide_DrivesHideOverlay(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser(adminUser), []string{"hide"})
+	app.middleCmd(context.Background(), newTestUser(adminUser), []string{"hide"})
 
 	if !strings.Contains(out(), "Hiding the message") {
 		t.Errorf("expected hide confirmation in chat, got %q", out())
@@ -463,7 +464,7 @@ func TestMiddleCmd_Hide_CaseInsensitive(t *testing.T) {
 	_, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser(adminUser), []string{"HIDE"})
+	app.middleCmd(context.Background(), newTestUser(adminUser), []string{"HIDE"})
 
 	if len(rec.Calls) != 1 || rec.Calls[0] != "HideMiddleText()" {
 		t.Errorf("expected one HideMiddleText overlay call for 'HIDE', got %v", rec.Calls)
@@ -479,7 +480,7 @@ func TestMiddleCmd_Text_DrivesShowOverlay(t *testing.T) {
 	defer restore()
 
 	// Multiple words get joined with a space into the overlay text.
-	app.middleCmd(newTestUser(adminUser), []string{"hello", "everyone"})
+	app.middleCmd(context.Background(), newTestUser(adminUser), []string{"hello", "everyone"})
 
 	if len(rec.Calls) != 1 || rec.Calls[0] != `ShowMiddleText("hello everyone")` {
 		t.Errorf("expected ShowMiddleText with joined text, got %v", rec.Calls)
@@ -495,8 +496,8 @@ func TestMiddleCmd_NonAdmin_DoesNotDriveOverlay(t *testing.T) {
 	defer restore()
 
 	// A non-admin's params should be ignored — no chat, no overlay call.
-	app.middleCmd(newTestUser("viewer1"), []string{"hide"})
-	app.middleCmd(newTestUser("viewer1"), []string{"hello"})
+	app.middleCmd(context.Background(), newTestUser("viewer1"), []string{"hide"})
+	app.middleCmd(context.Background(), newTestUser("viewer1"), []string{"hello"})
 
 	if len(rec.Calls) != 0 {
 		t.Errorf("expected no overlay calls for non-admin, got %v", rec.Calls)
@@ -517,7 +518,7 @@ func TestLifetimeMilesLeaderboardCmd_Empty(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.lifetimeMilesLeaderboardCmd(newTestUser("viewer1"), nil)
+	app.lifetimeMilesLeaderboardCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "Top 0 lifetime miles") {
@@ -539,7 +540,7 @@ func TestLifetimeMilesLeaderboardCmd_WithUsers(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.lifetimeMilesLeaderboardCmd(newTestUser("caller"), nil)
+	app.lifetimeMilesLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "viewer1") || !strings.Contains(msg, "200.0mi") {
@@ -575,7 +576,7 @@ func TestMonthlyMilesLeaderboardCmd_RendersTopUsers(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.monthlyMilesLeaderboardCmd(newTestUser("caller"), nil)
+	app.monthlyMilesLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "viewer1") || !strings.Contains(msg, "42.5") {
@@ -608,7 +609,7 @@ func TestMonthlyGuessLeaderboardCmd_Empty_SaysNoneYet(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.monthlyGuessLeaderboardCmd(newTestUser("caller"), nil)
+	app.monthlyGuessLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	if !strings.Contains(out(), "No one is on that leaderboard yet") {
 		t.Errorf("expected empty-leaderboard message, got %q", out())
@@ -636,7 +637,7 @@ func TestMonthlyGuessLeaderboardCmd_WithGuesses_StripsDecimals(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.monthlyGuessLeaderboardCmd(newTestUser("caller"), nil)
+	app.monthlyGuessLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	msg := out()
 	// guess scores are formatted as integers in the chat message
@@ -671,7 +672,7 @@ func TestMilesCmd_OtherUser_NotInDB(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.milesCmd(newTestUser("caller"), []string{"ghost"})
+	app.milesCmd(context.Background(), newTestUser("caller"), []string{"ghost"})
 
 	if !strings.Contains(out(), "I don't know them") {
 		t.Errorf("expected unknown-user message, got %q", out())
@@ -698,7 +699,7 @@ func TestMilesCmd_Self_WithMiles(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "viewer1", Miles: 50.0}
-	app.milesCmd(user, nil)
+	app.milesCmd(context.Background(), user, nil)
 
 	msg := out()
 	if !strings.Contains(msg, "@viewer1 has 8.00mi this month") {
@@ -730,7 +731,7 @@ func TestMilesCmd_Self_NewcomerHint(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "newbie", Miles: 0.0}
-	app.milesCmd(user, nil)
+	app.milesCmd(context.Background(), user, nil)
 
 	msg := out()
 	if !strings.Contains(msg, "You'll earn more miles") {
@@ -771,7 +772,7 @@ func TestMilesCmd_OtherUser_Found(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.milesCmd(newTestUser("caller"), []string{"viewer1"})
+	app.milesCmd(context.Background(), newTestUser("caller"), []string{"viewer1"})
 
 	msg := out()
 	// monthly is 15.5, lifetime 120 → both should appear (rounded to int for total)
@@ -798,7 +799,7 @@ func TestMilesCmd_OtherUser_StripsAtSign(t *testing.T) {
 	defer restore()
 
 	// "@ghost" should be normalized to "ghost" before the lookup
-	app.milesCmd(newTestUser("caller"), []string{"@ghost"})
+	app.milesCmd(context.Background(), newTestUser("caller"), []string{"@ghost"})
 
 	if !strings.Contains(out(), "I don't know them") {
 		t.Errorf("expected unknown-user message, got %q", out())

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -60,6 +60,16 @@ func dispatch(cmd *Command, user *users.User, params []string) {
 	if !cmd.checkAccess(user, sayFn) {
 		return
 	}
+	// Wrap the handler in a span so each chat command shows up as a trace
+	// in Tempo. SQL queries (via otelsql) and outbound HTTP (via otelhttp)
+	// will nest under this once the HandlerFunc signature grows a
+	// context.Context — until then they stay as sibling traces, but the
+	// command-level span alone is already useful for "which command is slow"
+	// and for cross-referencing the tripbot_command_duration_seconds metric.
+	_, span := tracer.Start(context.Background(), "chat.command",
+		trace.WithAttributes(attribute.String("command", cmd.Trigger)))
+	defer span.End()
+
 	start := time.Now()
 	cmd.Handler(user, params)
 	instrumentation.ChatCommandDuration.Observe(cmd.Trigger, time.Since(start).Seconds())

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -55,23 +55,21 @@ func (cmd *Command) checkAccess(user chatUser, sayFn func(string)) bool {
 	return true
 }
 
-func dispatch(cmd *Command, user *users.User, params []string) {
+func dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)
 	if !cmd.checkAccess(user, sayFn) {
 		return
 	}
-	// Wrap the handler in a span so each chat command shows up as a trace
-	// in Tempo. SQL queries (via otelsql) and outbound HTTP (via otelhttp)
-	// will nest under this once the HandlerFunc signature grows a
-	// context.Context — until then they stay as sibling traces, but the
-	// command-level span alone is already useful for "which command is slow"
-	// and for cross-referencing the tripbot_command_duration_seconds metric.
-	_, span := tracer.Start(context.Background(), "chat.command",
+	// Start a child span under the chatbot.handle_message span from
+	// PrivateMessage. SQL queries (via otelsql) and outbound HTTP (via
+	// otelhttp) nest under chat.command in Tempo, so a single !miles
+	// shows up as one trace with all 4 GetScore-chain SQL spans nested.
+	ctx, span := tracer.Start(ctx, "chat.command",
 		trace.WithAttributes(attribute.String("command", cmd.Trigger)))
 	defer span.End()
 
 	start := time.Now()
-	cmd.Handler(user, params)
+	cmd.Handler(ctx, user, params)
 	instrumentation.ChatCommandDuration.Observe(cmd.Trigger, time.Since(start).Seconds())
 }
 
@@ -136,7 +134,7 @@ func runCommand(ctx context.Context, user *users.User, message string) {
 
 	cmd, params := findCommand(message)
 	if cmd != nil {
-		dispatch(cmd, user, params)
+		dispatch(ctx, cmd, user, params)
 		return
 	}
 
@@ -166,19 +164,19 @@ func PrivateMessage(msg twitch.PrivateMessage) {
 	// check to see if the message is a command
 	//TODO: also include ones prefixed with whitespace?
 	// log in the user
-	user := users.LoginIfNecessary(username)
+	user := users.LoginIfNecessary(ctx, username)
 
 	runCommand(ctx, user, message)
 }
 
 // this event fires when a user joins the channel
 func UserJoin(joinMessage twitch.UserJoinMessage) {
-	users.LoginIfNecessary(joinMessage.User)
+	users.LoginIfNecessary(context.Background(), joinMessage.User)
 }
 
 // this event fires when a user leaves the channel
 func UserPart(partMessage twitch.UserPartMessage) {
-	users.LogoutIfNecessary(partMessage.User)
+	users.LogoutIfNecessary(context.Background(), partMessage.User)
 }
 
 // send message to chat if someone subs

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -37,7 +38,7 @@ func (a *App) timewarp() {
 	lastTimewarpTime = time.Now()
 }
 
-func (a *App) timewarpCmd(user *users.User, _ []string) {
+func (a *App) timewarpCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !timewarp")
 
 	// exit early if we're on OS X
@@ -63,7 +64,7 @@ func (a *App) timewarpCmd(user *users.User, _ []string) {
 	a.timewarp()
 }
 
-func (a *App) jumpCmd(user *users.User, params []string) {
+func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	log.Println(user.Username, "ran !jump")
 
@@ -121,7 +122,7 @@ func (a *App) jumpCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
-func (a *App) skipCmd(user *users.User, params []string) {
+func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	var n int
 	log.Println(user.Username, "ran !skip")
@@ -166,7 +167,7 @@ func (a *App) skipCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
-func (a *App) backCmd(user *users.User, params []string) {
+func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	var n int
 	log.Println(user.Username, "ran !back")

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"strings"
 
 	"github.com/adanalife/tripbot/pkg/users"
@@ -63,20 +64,20 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!socialmedia",
 			Aliases: []string{"!social", "!socials"},
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("Find me outside of Twitch: !twitter, !instagram, !facebook, !youtube")
 			},
 		},
 		{
 			Trigger: "!discord",
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("Join us on Discord: https://discord.gg/Bk9EuGdMX")
 			},
 		},
 		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, and many other hidden commands!")
 			},
 		},
@@ -121,7 +122,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!gas",
 			Aliases: []string{"!fuel", "!petrol"},
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("About full, thanks for asking")
 			},
 		},

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -20,24 +21,24 @@ type Event struct {
 	DateCreated time.Time
 }
 
-func Login(user string, sessionID uuid.UUID) error {
+func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
 		log.Printf("Not logging in %s because we're in read-only mode", aurora.Magenta(user))
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
-	if err := database.GormDB().Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
+	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
 		return err
 	}
 	instrumentation.Events.Inc("login")
 	return nil
 }
 
-func Logout(user string, sessionID uuid.UUID) error {
+func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
 		log.Printf("Not logging out %s because we're in read-only mode", aurora.Magenta(user))
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
-	if err := database.GormDB().Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {
+	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {
 		return err
 	}
 	instrumentation.Events.Inc("logout")

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -1,6 +1,7 @@
 package onscreensClient
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -56,10 +57,10 @@ func ShowLeaderboard(title string, leaderboard [][]string) error {
 }
 
 //TODO: this is taken right from the !guessleaderboard command, DRY it?
-func ShowGuessLeaderboard() {
+func ShowGuessLeaderboard(ctx context.Context) {
 	// select users to show in leaderboard
 	size := 10
-	leaderboard := scoreboards.TopUsers(scoreboards.CurrentGuessScoreboard(), size)
+	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
 	if size > len(leaderboard) {
 		size = len(leaderboard)
 	}

--- a/pkg/scoreboards/scoreboards.go
+++ b/pkg/scoreboards/scoreboards.go
@@ -1,6 +1,7 @@
 package scoreboards
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -23,13 +24,13 @@ type topUserResult struct {
 	Value    float32
 }
 
-func TopUsers(scoreboardName string, size int) [][]string {
+func TopUsers(ctx context.Context, scoreboardName string, size int) [][]string {
 	var leaderboard [][]string
 
 	ignoredUsers := append(c.IgnoredUsers, strings.ToLower(c.Conf.ChannelName))
 
 	var results []topUserResult
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Table("scores").
 		Select("users.username, scores.value").
 		Joins("JOIN scoreboards ON scores.scoreboard_id = scoreboards.id").
@@ -51,18 +52,18 @@ func TopUsers(scoreboardName string, size int) [][]string {
 }
 
 // findOrCreateScoreboard will find a Scoreboard in the DB or create one
-func findOrCreateScoreboard(name string) (Scoreboard, error) {
+func findOrCreateScoreboard(ctx context.Context, name string) (Scoreboard, error) {
 	var scoreboard Scoreboard
-	result := database.GormDB().Where(Scoreboard{Name: name}).FirstOrCreate(&scoreboard)
+	result := database.GormDB().WithContext(ctx).Where(Scoreboard{Name: name}).FirstOrCreate(&scoreboard)
 	return scoreboard, result.Error
 }
 
 // createScoreboard() will actually create the DB record
-func createScoreboard(name string) (Scoreboard, error) {
+func createScoreboard(ctx context.Context, name string) (Scoreboard, error) {
 	if c.Conf.Verbose {
 		log.Println("creating scoreboard", name)
 	}
 	scoreboard := Scoreboard{Name: name}
-	result := database.GormDB().Create(&scoreboard)
+	result := database.GormDB().WithContext(ctx).Create(&scoreboard)
 	return scoreboard, result.Error
 }

--- a/pkg/scoreboards/scores.go
+++ b/pkg/scoreboards/scores.go
@@ -1,6 +1,7 @@
 package scoreboards
 
 import (
+	"context"
 	"errors"
 	"log"
 	"time"
@@ -23,18 +24,18 @@ type Score struct {
 
 // GetScoreByName returns the score value for a given username and scoreboard name
 //TODO: this could be achieved with a single query
-func GetScoreByName(username, scoreboardName string) (float32, error) {
-	userID, err := getUserIDByName(username)
+func GetScoreByName(ctx context.Context, username, scoreboardName string) (float32, error) {
+	userID, err := getUserIDByName(ctx, username)
 	if err != nil {
 		terrors.Log(err, "error getting user ID")
 		return -1.0, err
 	}
-	scoreboard, err := findOrCreateScoreboard(scoreboardName)
+	scoreboard, err := findOrCreateScoreboard(ctx, scoreboardName)
 	if err != nil {
 		terrors.Log(err, "error finding or creating scoreboard")
 		return -1.0, err
 	}
-	score, err := findOrCreateScore(userID, scoreboard.ID)
+	score, err := findOrCreateScore(ctx, userID, scoreboard.ID)
 	if err != nil {
 		terrors.Log(err, "error finding score")
 		return -1.0, err
@@ -44,24 +45,24 @@ func GetScoreByName(username, scoreboardName string) (float32, error) {
 
 // AddToScoreByName increases the score value for a given username and scoreboard name
 //TODO: this could be achieved with less queries
-func AddToScoreByName(username, scoreboardName string, scoreToAdd float32) error {
-	userID, err := getUserIDByName(username)
+func AddToScoreByName(ctx context.Context, username, scoreboardName string, scoreToAdd float32) error {
+	userID, err := getUserIDByName(ctx, username)
 	if err != nil {
 		terrors.Log(err, "error getting userID for user")
 		return err
 	}
-	scoreboard, err := findOrCreateScoreboard(scoreboardName)
+	scoreboard, err := findOrCreateScoreboard(ctx, scoreboardName)
 	if err != nil {
 		terrors.Log(err, "error finding or creating scoreboard")
 		return err
 	}
-	score, err := findOrCreateScore(userID, scoreboard.ID)
+	score, err := findOrCreateScore(ctx, userID, scoreboard.ID)
 	if err != nil {
 		terrors.Log(err, "error finding score")
 		return err
 	}
 	score.Value += scoreToAdd
-	if err := score.save(); err != nil {
+	if err := score.save(ctx); err != nil {
 		return err
 	}
 	instrumentation.ScoreboardWrites.Inc(scoreboardName)
@@ -69,9 +70,9 @@ func AddToScoreByName(username, scoreboardName string, scoreToAdd float32) error
 }
 
 // findOrCreateScore will look up the username in the DB, and return a Score if possible
-func findOrCreateScore(userID, scoreboardID uint16) (Score, error) {
+func findOrCreateScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	var score Score
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Where(Score{UserID: userID, ScoreboardID: scoreboardID}).
 		FirstOrCreate(&score)
 	return score, result.Error
@@ -79,9 +80,9 @@ func findOrCreateScore(userID, scoreboardID uint16) (Score, error) {
 
 // findScore will look up the score in the DB
 //TODO: this shouldn't be necessary, join the tables instead
-func findScore(userID, scoreboardID uint16) (Score, error) {
+func findScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	var score Score
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Where("user_id = ? AND scoreboard_id = ?", userID, scoreboardID).
 		First(&score)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -91,19 +92,19 @@ func findScore(userID, scoreboardID uint16) (Score, error) {
 }
 
 // createScore() will actually create the DB record
-func createScore(userID, scoreboardID uint16) (Score, error) {
+func createScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	log.Printf("creating score user_id:%d, scoreboard_id:%d", userID, scoreboardID)
 	score := Score{UserID: userID, ScoreboardID: scoreboardID}
-	result := database.GormDB().Create(&score)
+	result := database.GormDB().WithContext(ctx).Create(&score)
 	return score, result.Error
 }
 
 // save() will take the given score and store it in the DB
-func (s Score) save() error {
+func (s Score) save(ctx context.Context) error {
 	if c.Conf.Verbose {
 		log.Println("saving score", s)
 	}
-	err := database.GormDB().Model(&s).Update("value", s.Value).Error
+	err := database.GormDB().WithContext(ctx).Model(&s).Update("value", s.Value).Error
 	if err != nil {
 		terrors.Log(err, "error saving score")
 	}
@@ -112,9 +113,9 @@ func (s Score) save() error {
 
 // getUserIDByName fetches the user ID for a given username
 //TODO: this shouldn't be necessary, join the tables instead
-func getUserIDByName(username string) (uint16, error) {
+func getUserIDByName(ctx context.Context, username string) (uint16, error) {
 	var result struct{ ID uint16 }
-	err := database.GormDB().Raw("SELECT id FROM users WHERE username = ?", username).Scan(&result).Error
+	err := database.GormDB().WithContext(ctx).Raw("SELECT id FROM users WHERE username = ?", username).Scan(&result).Error
 	if err != nil {
 		terrors.Log(err, "error fetching user ID")
 	}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -111,7 +111,7 @@ func webhooksTwitchUsersFollowsHandler(w http.ResponseWriter, r *http.Request) {
 	for _, follower := range resp.Data.Follows {
 		username := follower.FromName
 		log.Println("got webhook for new follower:", username)
-		users.LoginIfNecessary(username)
+		users.LoginIfNecessary(r.Context(), username)
 		// announce new follower in chat
 		chatbot.AnnounceNewFollower(username)
 	}
@@ -137,7 +137,7 @@ func webhooksTwitchSubscriptionsEventsHandler(w http.ResponseWriter, r *http.Req
 	for _, event := range resp.Data.Events {
 		username := event.Subscription.UserName
 		log.Println("got webhook for new sub:", username)
-		users.LoginIfNecessary(username)
+		users.LoginIfNecessary(r.Context(), username)
 		// announce new sub in chat
 		chatbot.AnnounceSubscriber(event.Subscription)
 	}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -15,7 +16,15 @@ import (
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+// helixHTTPClient is the otelhttp-instrumented HTTP client passed to every
+// helix.NewClient call. Without this, outbound Twitch Helix requests leave
+// no trail in Tempo; with it, each helix.GetUsers / GetSubscriptions / etc.
+// shows up as a span. Pairs with the otelhttp transports already used by
+// pkg/vlc-client and pkg/onscreens-client.
+var helixHTTPClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
 // Scopes is the OAuth scope set requested for the bot account. Single source
 // of truth — referenced by Client() (App Access Token request),
@@ -84,6 +93,7 @@ func Client() (*helix.Client, error) {
 		// Registered at https://dev.twitch.tv/console/apps; matched by
 		// cmd/auth-bootstrap's local HTTP listener.
 		RedirectURI: c.Conf.ExternalURL + "/auth/callback",
+		HTTPClient:  helixHTTPClient,
 	})
 	if err != nil {
 		terrors.Log(err, "error creating client")

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,11 +17,11 @@ var initLeaderboardSize = 25
 var maxLeaderboardSize = 50
 
 // InitLeaderboard creates the initial leaderboard
-func InitLeaderboard() {
+func InitLeaderboard(ctx context.Context) {
 	var users []User
 
 	ignoredUsers := append(c.IgnoredUsers, strings.ToLower(c.Conf.ChannelName))
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Where("miles != 0 AND is_bot = false AND username NOT IN ?", ignoredUsers).
 		Order("miles DESC").
 		Limit(initLeaderboardSize).

--- a/pkg/users/scores.go
+++ b/pkg/users/scores.go
@@ -1,12 +1,14 @@
 package users
 
 import (
+	"context"
+
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 )
 
-func (u User) GetScore(scoreboardName string) float32 {
-	value, err := scoreboards.GetScoreByName(u.Username, scoreboardName)
+func (u User) GetScore(ctx context.Context, scoreboardName string) float32 {
+	value, err := scoreboards.GetScoreByName(ctx, u.Username, scoreboardName)
 	if err != nil {
 		terrors.Log(err, "error getting score for user")
 		return -1.0
@@ -14,8 +16,8 @@ func (u User) GetScore(scoreboardName string) float32 {
 	return value
 }
 
-func (u User) AddToScore(scoreboardName string, valueToAdd float32) {
-	err := scoreboards.AddToScoreByName(u.Username, scoreboardName, valueToAdd)
+func (u User) AddToScore(ctx context.Context, scoreboardName string, valueToAdd float32) {
+	err := scoreboards.AddToScoreByName(ctx, u.Username, scoreboardName, valueToAdd)
 	if err != nil {
 		terrors.Log(err, "error setting score for user")
 	}

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -29,7 +30,7 @@ var LoggedIn = make(map[string]*User)
 
 // UpdateSession will use the data from the Twitch API to maintain a list
 // of currently-logged-in users
-func UpdateSession() {
+func UpdateSession(ctx context.Context) {
 	// fetch the latest chatters from Twitch
 	twitch.UpdateChatters()
 	currentChatters := twitch.Chatters()
@@ -41,7 +42,7 @@ func UpdateSession() {
 			continue
 		} else {
 			// they're logged in and NOT a current chatter, so log them out
-			user.logout()
+			user.logout(ctx)
 			continue
 		}
 	}
@@ -49,7 +50,7 @@ func UpdateSession() {
 	// log in everybody else
 	//TODO: this could get slow, maybe make a list of users that need to be logged in?
 	for chatter, _ := range currentChatters {
-		LoginIfNecessary(chatter)
+		LoginIfNecessary(ctx, chatter)
 	}
 
 	// PrintCurrentSession()
@@ -58,29 +59,29 @@ func UpdateSession() {
 
 // LoginIfNecessary checks the list of currently-logged in users and will
 // run login() if this user isn't currently logged in
-func LoginIfNecessary(username string) *User {
+func LoginIfNecessary(ctx context.Context, username string) *User {
 	// check if the user is currently logged in
 	if isLoggedIn(username) {
 		return LoggedIn[username]
 	}
 	// they weren't logged in, so note in the DB
-	return login(username)
+	return login(ctx, username)
 }
 
 // LogoutIfNecessary will log out the user if it finds them in the session
-func LogoutIfNecessary(username string) {
+func LogoutIfNecessary(ctx context.Context, username string) {
 	if isLoggedIn(username) {
 		user := *LoggedIn[username]
-		user.logout()
+		user.logout(ctx)
 	}
 }
 
 // login will record the users presence in the DB
 //TODO: do we want to make a DB update here? we could do it on logout()
-func login(username string) *User {
+func login(ctx context.Context, username string) *User {
 	now := time.Now()
 
-	user := FindOrCreate(username)
+	user := FindOrCreate(ctx, username)
 	// increment the number of visits
 	user.NumVisits = user.NumVisits + 1
 	// set the login time
@@ -93,7 +94,7 @@ func login(username string) *User {
 	user.lastCmd = now.AddDate(0, 0, -1)
 	// set their last !location date to yesterday
 	user.lastLocation = now.AddDate(0, 0, -1)
-	user.save()
+	user.save(ctx)
 
 	// raise an error if a user is supposed to be a bot
 	if c.UserIsIgnored(username) && !user.IsBot {
@@ -109,7 +110,7 @@ func login(username string) *User {
 	// add them to the session
 	LoggedIn[username] = &user
 
-	if err := events.Login(username, user.sessionID); err != nil {
+	if err := events.Login(ctx, username, user.sessionID); err != nil {
 		terrors.Log(err, "error creating login event")
 	}
 
@@ -118,7 +119,7 @@ func login(username string) *User {
 
 // User.logout() removes the user from the list of currently-logged in users,
 // and updates the DB with their most up-to-date values
-func (u User) logout() {
+func (u User) logout(ctx context.Context) {
 	sessionMiles := u.sessionMiles()
 
 	// print logout message if they're human
@@ -127,8 +128,8 @@ func (u User) logout() {
 		prettyDur := durafmt.ParseShort(loggedInDur)
 		dur := fmt.Sprintf("(%s)", aurora.Green(prettyDur))
 		miles := fmt.Sprintf("(%1.2fmi)", aurora.Yellow(sessionMiles))
-		monthlyMiles := fmt.Sprintf("(%1.2fmi this month)", aurora.Yellow(u.CurrentMonthlyMiles()))
-		guessScore := fmt.Sprintf("(%1.0f guesses)", aurora.Cyan(u.GetScore(scoreboards.CurrentGuessScoreboard())))
+		monthlyMiles := fmt.Sprintf("(%1.2fmi this month)", aurora.Yellow(u.CurrentMonthlyMiles(ctx)))
+		guessScore := fmt.Sprintf("(%1.0f guesses)", aurora.Cyan(u.GetScore(ctx, scoreboards.CurrentGuessScoreboard())))
 		log.Println("logging out", u, dur, miles, monthlyMiles, guessScore)
 	}
 
@@ -137,12 +138,12 @@ func (u User) logout() {
 	// update the last seen date
 	u.LastSeen = time.Now()
 	// store the user in the db
-	u.save()
+	u.save(ctx)
 
 	// update the monthly scoreboard
-	u.AddToScore(scoreboards.CurrentMilesScoreboard(), sessionMiles)
+	u.AddToScore(ctx, scoreboards.CurrentMilesScoreboard(), sessionMiles)
 
-	if err := events.Logout(u.Username, u.sessionID); err != nil {
+	if err := events.Logout(ctx, u.Username, u.sessionID); err != nil {
 		terrors.Log(err, "error creating logout event")
 	}
 
@@ -159,13 +160,13 @@ func isLoggedIn(username string) bool {
 }
 
 // ShutDown loops through all of the logged-in users and logs them out
-func Shutdown() {
+func Shutdown(ctx context.Context) {
 	if c.Conf.Verbose {
 		log.Println("these were the logged-in users")
 		spew.Dump(LoggedIn)
 	}
 	for _, user := range LoggedIn {
-		user.logout()
+		user.logout(ctx)
 	}
 }
 

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"errors"
 	"log"
 	"time"
@@ -77,16 +78,16 @@ func (u User) BonusMiles() float32 {
 	return 0.0
 }
 
-func (u User) CurrentMonthlyMiles() float32 {
-	return u.GetScore(scoreboards.CurrentMilesScoreboard()) + u.sessionMiles()
+func (u User) CurrentMonthlyMiles(ctx context.Context) float32 {
+	return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard()) + u.sessionMiles()
 }
 
 // User.save() will take the given user and store it in the DB
-func (u User) save() {
+func (u User) save(ctx context.Context) {
 	if c.Conf.Verbose {
 		log.Println("saving user", u)
 	}
-	err := database.GormDB().Model(&u).Updates(map[string]any{
+	err := database.GormDB().WithContext(ctx).Model(&u).Updates(map[string]any{
 		"last_seen":  u.LastSeen,
 		"num_visits": u.NumVisits,
 		"miles":      u.Miles,
@@ -118,22 +119,22 @@ func (u User) String() string {
 }
 
 // FindOrCreate will try to find the user in the DB, otherwise it will create a new user
-func FindOrCreate(username string) User {
+func FindOrCreate(ctx context.Context, username string) User {
 	if c.Conf.Verbose {
 		log.Printf("FindOrCreate(%s)", username)
 	}
-	user := Find(username)
+	user := Find(ctx, username)
 	if user.ID != 0 {
 		return user
 	}
 	// create the user in the DB
-	return create(username)
+	return create(ctx, username)
 }
 
 // Find will look up the username in the DB, and return a User if possible
-func Find(username string) User {
+func Find(ctx context.Context, username string) User {
 	var user User
-	result := database.GormDB().Where("username = ?", username).First(&user)
+	result := database.GormDB().WithContext(ctx).Where("username = ?", username).First(&user)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		//TODO: is there a better way to do this?
 		return User{ID: 0}
@@ -197,12 +198,12 @@ func (u *User) SetLastLocationTime() {
 
 //TODO: maybe return an err here?
 // create() will actually create the DB record
-func create(username string) User {
+func create(ctx context.Context, username string) User {
 	log.Println("creating user", username)
 	// create a new row, using default vals and creating a single visit
 	newUser := User{Username: username, NumVisits: 1}
-	if err := database.GormDB().Create(&newUser).Error; err != nil {
+	if err := database.GormDB().WithContext(ctx).Create(&newUser).Error; err != nil {
 		terrors.Log(err, "error creating user")
 	}
-	return Find(username)
+	return Find(ctx, username)
 }


### PR DESCRIPTION
## Summary

Builds on #533 by plumbing `context.Context` through every layer the chat-command flow touches. Once both PRs land, a single `!miles` in Tempo is a tree:

```
chat.command [command=!miles]
├── SELECT * FROM "users" WHERE username = ?
├── SELECT id FROM users WHERE username = ?
├── SELECT * FROM "scoreboards" WHERE ...
└── SELECT * FROM "scores" WHERE ...
```

Today (with just #533) those four SQL spans are sibling traces, untethered from the command span.

## What changed (mechanical, broad)

- **HandlerFunc grows ctx.** `func(ctx context.Context, user *users.User, params []string)`. Every `(a *App).xxxCmd` method picks up the new arg. `dispatch()` starts the `chat.command` span and passes its ctx down.
- **All DB-touching helpers grow ctx + `.WithContext(ctx)`** on their gorm calls:
  - `pkg/users`: `Find`, `FindOrCreate`, `create`, `User.save`, `InitLeaderboard`, `UpdateSession`, `LoginIfNecessary`, `LogoutIfNecessary`, `Shutdown`, `User.logout`, `User.GetScore`, `User.AddToScore`, `User.CurrentMonthlyMiles`
  - `pkg/scoreboards`: `TopUsers`, `GetScoreByName`, `AddToScoreByName`, `findOrCreate{Scoreboard,Score}`, `getUserIDByName`, `Score.save`
  - `pkg/events`: `Login`, `Logout`
  - `pkg/onscreens-client`: `ShowGuessLeaderboard`
- **Server webhook handlers** pass `r.Context()` to `LoginIfNecessary`.
- **Cron jobs** that propagate ctx get a sibling `tracedJobCtx` wrapper (`UpdateSession`, `ShowGuessLeaderboard`). Pure no-DB jobs keep the existing `tracedJob`.
- **Tests** updated at 42 call sites via a one-shot regex sweep — every test passes `context.Background()` at the call boundary.

## Why it matters

Trace nesting is the difference between "this command was slow" (chat.command span alone, from #533) and "this command was slow because the `scores` lookup took 800ms" (full tree with the slow query identified). The instrumentation backend (otelsql + otelgorm + otelhttp) was already capable; the only missing piece was ctx flow.

## Test plan

- [x] `mise exec -- go build ./...` clean (modulo pre-existing libvlc cgo issue on this dev machine)
- [x] All test packages still pass:
  ```
  ok  	pkg/chatbot      1.413s
  ok  	pkg/scoreboards  1.048s
  ok  	pkg/users        1.590s
  ok  	pkg/twitch       0.370s
  ok  	pkg/oauthtokens  0.614s
  ok  	pkg/video        0.836s
  ok  	pkg/server       0.946s
  ```
- [ ] After deploy + #533 merged, open a Tempo trace for `chat.command` and confirm SQL spans nest as children
- [ ] Click a slow `!miles` point in the `tripbot_command_duration_seconds` Grafana panel → should jump straight to the Tempo trace showing the slow query