### PR TITLE
feat(chatbot): inject VLC client on App; cover guessCmd correct-guess

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -35,6 +35,9 @@ type App struct {
 	// Onscreens drives the OBS browser-source overlays for chat-triggered
 	// effects (leaderboards, flags, middle-text). Tests inject a no-op fake.
 	Onscreens Onscreens
+	// VLC drives playback operations (timewarp, jump, skip, back). Tests
+	// inject a no-op fake; production uses the realVLC adapter.
+	VLC VLC
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -51,6 +54,7 @@ var defaultApp = &App{
 	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
 	Onscreens: realOnscreens{},
+	VLC:       realVLC{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -36,14 +36,15 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 	return video.Video{State: state, Lat: lat, Lng: lng, DateFilmed: date}
 }
 
-// newTestApp returns an App with CurrentVideo returning vid and a no-op
-// Onscreens fake. For commands that don't use CurrentVideo, pass a zero-value
-// video.Video. To assert on Onscreens calls, replace app.Onscreens with a
-// recording fake (see fakeOnscreens in onscreens_test.go).
+// newTestApp returns an App with CurrentVideo returning vid, plus no-op
+// Onscreens and VLC fakes. For commands that don't use CurrentVideo, pass a
+// zero-value video.Video. To assert on Onscreens or VLC calls, replace
+// app.Onscreens / app.VLC with a recordingOnscreens / recordingVLC.
 func newTestApp(vid video.Video) *App {
 	return &App{
 		CurrentVideo: func() video.Video { return vid },
 		Onscreens:    noopOnscreens{},
+		VLC:          noopVLC{},
 	}
 }
 
@@ -404,6 +405,113 @@ func TestGuessCmd_WrongGuess_SaysTryAgain(t *testing.T) {
 
 	if !strings.Contains(out(), "Try again") {
 		t.Errorf("expected try-again in output, got %q", out())
+	}
+}
+
+// expectAddToScoreChain queues sqlmock expectations for one user.AddToScore
+// call: getUserIDByName + findOrCreateScoreboard + findOrCreateScore + the
+// UPDATE on Score.save. AddToScore fires twice on a correct guess (once for
+// the lifetime "guess_state_total" scoreboard, once for the monthly one), so
+// callers queue it twice.
+func expectAddToScoreChain(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "guess_sb"))
+	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
+			AddRow(99, 42, 7, 5.0))
+	mock.ExpectExec(`UPDATE "scores" SET`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func TestGuessCmd_CorrectGuess_DrivesOverlayAndPlayback(t *testing.T) {
+	mock := installMockDB(t)
+	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
+	app := newTestApp(vid)
+	recOverlay := &recordingOnscreens{}
+	recVLC := &recordingVLC{}
+	app.Onscreens = recOverlay
+	app.VLC = recVLC
+
+	// Two AddToScore calls — lifetime ("guess_state_total") + monthly.
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), []string{"Colorado"})
+
+	msg := out()
+	if !strings.Contains(msg, "@viewer1 got it") || !strings.Contains(msg, "Colorado") {
+		t.Errorf("expected correct-guess chat message, got %q", msg)
+	}
+
+	// Overlay sequence: ShowFlag (state flag) then ShowTimewarp (from a.timewarp()).
+	wantOverlay := []string{"ShowFlag(10s)", "ShowTimewarp()"}
+	if len(recOverlay.Calls) != len(wantOverlay) {
+		t.Fatalf("expected %d overlay calls, got %d: %v", len(wantOverlay), len(recOverlay.Calls), recOverlay.Calls)
+	}
+	for i, want := range wantOverlay {
+		if recOverlay.Calls[i] != want {
+			t.Errorf("overlay call %d: want %q, got %q", i, want, recOverlay.Calls[i])
+		}
+	}
+
+	// VLC: PlayRandom fires inside a.timewarp().
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "PlayRandom()" {
+		t.Errorf("expected single PlayRandom call, got %v", recVLC.Calls)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGuessCmd_CorrectGuess_FullStateName(t *testing.T) {
+	// guessCmd converts 2-letter codes to long-form before comparing; pass
+	// the long form directly to confirm the equality branch works without
+	// the abbrev lookup.
+	mock := installMockDB(t)
+	vid := newTestVideo("Massachusetts", 42.3, -71.0, time.Now())
+	app := newTestApp(vid)
+
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), []string{"Massachusetts"})
+
+	if !strings.Contains(out(), "got it") {
+		t.Errorf("expected correct-guess msg, got %q", out())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGuessCmd_CorrectGuess_TwoLetterCode(t *testing.T) {
+	// Two-letter codes get expanded via helpers.StateAbbrevToState.
+	mock := installMockDB(t)
+	vid := newTestVideo("California", 36.7, -119.4, time.Now())
+	app := newTestApp(vid)
+
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), []string{"CA"})
+
+	if !strings.Contains(out(), "got it") {
+		t.Errorf("expected correct-guess msg from CA, got %q", out())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -13,7 +13,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
-	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
 // lastTimewarpTime is used to rate-limit users so they can't
@@ -27,7 +26,7 @@ func (a *App) timewarp() {
 	a.Onscreens.ShowTimewarp()
 
 	// shuffle to a new video
-	err := vlcClient.PlayRandom()
+	err := a.VLC.PlayRandom()
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}
@@ -106,7 +105,7 @@ func (a *App) jumpCmd(user *users.User, params []string) {
 		return
 	}
 	// tell VLC to play it
-	err = vlcClient.PlayFileInPlaylist(randomVid.File())
+	err = a.VLC.PlayFileInPlaylist(randomVid.File())
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 		Say("Usage: !jump [state]")
@@ -156,7 +155,7 @@ func (a *App) skipCmd(user *users.User, params []string) {
 	}
 
 	// skip to a new video
-	err = vlcClient.Skip(n)
+	err = a.VLC.Skip(n)
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}
@@ -201,7 +200,7 @@ func (a *App) backCmd(user *users.User, params []string) {
 	}
 
 	// back to an old video
-	err = vlcClient.Back(n)
+	err = a.VLC.Back(n)
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -1,0 +1,24 @@
+package chatbot
+
+import (
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
+)
+
+// VLC is the subset of the vlc-client surface that chatbot commands depend
+// on (timewarp, jump, skip, back). Tests inject a fake; production uses the
+// package-backed realVLC adapter wired in defaultApp. Mirrors the Onscreens
+// injection pattern.
+type VLC interface {
+	PlayRandom() error
+	PlayFileInPlaylist(filename string) error
+	Skip(n int) error
+	Back(n int) error
+}
+
+// realVLC delegates to pkg/vlc-client.
+type realVLC struct{}
+
+func (realVLC) PlayRandom() error                     { return vlcClient.PlayRandom() }
+func (realVLC) PlayFileInPlaylist(filename string) error { return vlcClient.PlayFileInPlaylist(filename) }
+func (realVLC) Skip(n int) error                      { return vlcClient.Skip(n) }
+func (realVLC) Back(n int) error                      { return vlcClient.Back(n) }

--- a/pkg/chatbot/vlc_test.go
+++ b/pkg/chatbot/vlc_test.go
@@ -1,0 +1,36 @@
+package chatbot
+
+import "fmt"
+
+// noopVLC satisfies VLC for tests that don't care about playback transitions
+// — it just swallows every call.
+type noopVLC struct{}
+
+func (noopVLC) PlayRandom() error                     { return nil }
+func (noopVLC) PlayFileInPlaylist(_ string) error     { return nil }
+func (noopVLC) Skip(_ int) error                      { return nil }
+func (noopVLC) Back(_ int) error                      { return nil }
+
+// recordingVLC captures every call made to it so tests can assert that
+// the chatbot drove playback as expected. All call records are appended
+// in order to Calls.
+type recordingVLC struct {
+	Calls []string
+}
+
+func (r *recordingVLC) PlayRandom() error {
+	r.Calls = append(r.Calls, "PlayRandom()")
+	return nil
+}
+func (r *recordingVLC) PlayFileInPlaylist(filename string) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("PlayFileInPlaylist(%q)", filename))
+	return nil
+}
+func (r *recordingVLC) Skip(n int) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("Skip(%d)", n))
+	return nil
+}
+func (r *recordingVLC) Back(n int) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("Back(%d)", n))
+	return nil
+}


### PR DESCRIPTION
## Summary

Mirrors the Onscreens injection pattern (#526) for the VLC client, closing out the deferred `guessCmd` correct-guess test from #528.

### The interface

`pkg/chatbot/vlc.go` defines a `VLC` interface covering exactly the four `vlc-client` methods chatbot commands depend on:

```go
type VLC interface {
    PlayRandom() error
    PlayFileInPlaylist(filename string) error
    Skip(n int) error
    Back(n int) error
}
```

`realVLC` (in the same file) delegates to `pkg/vlc-client`. `defaultApp` is updated to populate `App.VLC` with `realVLC{}`. Every `vlcClient.X(...)` call in `playback.go` becomes `a.VLC.X(...)` — four call sites total.

### The tests

`pkg/chatbot/vlc_test.go` adds `noopVLC` and `recordingVLC` test fakes following the Onscreens pattern. `newTestApp` wires `noopVLC{}` by default; tests that want to assert on playback calls swap in `recordingVLC`.

Three new correct-guess tests in `commands_test.go`:

| Test | Asserts |
|---|---|
| `TestGuessCmd_CorrectGuess_DrivesOverlayAndPlayback` | Full sequence: `ShowFlag` → 2× `AddToScore` (sqlmock'd 4 queries each) → `ShowTimewarp` → `PlayRandom` → correct-guess chat |
| `TestGuessCmd_CorrectGuess_FullStateName` | Long-form name branch (`Massachusetts`) |
| `TestGuessCmd_CorrectGuess_TwoLetterCode` | Abbrev → long-form via `helpers.StateAbbrevToState` (`CA`) |

An `expectAddToScoreChain` helper queues the 4 sqlmock expectations for one `user.AddToScore` call; correct-guess fires it twice (lifetime + monthly scoreboards).

## What's still not covered

`video.GetCurrentlyPlaying()` runs inside `a.timewarp()` and makes an HTTP call to vlc-server. In tests it fails silently (returns `""`, logs an error). Threading a video getter onto `App` would be the next refactor — out of scope here.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [x] `mise exec -- go test ./pkg/chatbot/...` — 3 new + all existing tests pass
- [x] `mise exec -- go vet ./pkg/chatbot/...` clean

## Closes

- `vault/tripbot/tripbot/TODO.md` "chatbot: inject VLC client on App to unlock guessCmd correct-guess test"