### PR TITLE
ci(obs): drop VLC build/start steps from obs.yml

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - 'infra/docker/obs/**'
-      - 'infra/docker/vlc/**'
-      - 'script/container_startup.sh'
       - 'infra/docker/docker-compose*.yml'
       - '.github/workflows/obs.yml'
   push:
@@ -93,59 +91,13 @@ jobs:
           -f infra/docker/docker-compose.github.yml \
           build obs
 
-    - name: Build VLC container (amd64, cached)
-      if: matrix.arch == 'amd64'
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        file: infra/docker/vlc/Dockerfile
-        tags: adanalife/vlc:latest
-        load: true
-        cache-from: type=gha,scope=vlc-amd64
-        cache-to: type=gha,mode=max,scope=vlc-amd64
-
-    - name: Build VLC container (arm64)
-      if: matrix.arch == 'arm64'
-      run: |
-        docker compose \
-          --project-directory . \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          build vlc
-
-    - name: Start VLC container (RTSP source)
-      run: |
-        docker compose \
-          --project-directory . \
-          --env-file infra/docker/env.docker \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          up -d vlc
-
-    - name: Wait for VLC to be ready
-      run: |
-        cid=$(docker compose \
-          --project-directory . \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          ps -q vlc)
-        for i in $(seq 1 30); do
-          if docker exec "$cid" curl -sf http://localhost:8080/health/ready >/dev/null; then
-            echo "VLC is ready"
-            exit 0
-          fi
-          echo "Waiting for VLC... ($i/30)"
-          sleep 2
-        done
-        echo "VLC failed to become ready" >&2
-        exit 1
-
+    # OBS doesn't need VLC to start or pass its healthcheck — the
+    # healthcheck (infra/docker/obs/healthcheck.sh) only verifies the
+    # OBS process, X server, and absence of the safe-mode crash modal.
+    # RTSP and browser sources retry on missing peers without crashing
+    # OBS. VLC has its own dedicated workflow (vlc.yml) that exercises
+    # it end-to-end. `--no-deps` keeps the compose `depends_on: vlc`
+    # (load-bearing for local dev) from dragging VLC into this job.
     - name: Start OBS container (no STREAM_KEY)
       run: |
         docker compose \
@@ -155,7 +107,7 @@ jobs:
           ${{ matrix.arch_compose }} \
           -f infra/docker/docker-compose.testing.yml \
           -f infra/docker/docker-compose.github.yml \
-          up -d obs
+          up -d --no-deps obs
 
     - name: Wait for healthcheck
       run: |
@@ -188,17 +140,6 @@ jobs:
         docker exec "$cid" test -s /etc/tripbot/sha
         echo "version: $(docker exec "$cid" cat /etc/tripbot/version)"
         echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
-
-    - name: Check VLC container logs
-      if: always()
-      run: |
-        docker compose \
-          --project-directory . \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          logs vlc
 
     - name: Check container logs
       if: always()


### PR DESCRIPTION
## Summary

OBS doesn't need VLC to start or stay healthy — verified by reading the current healthcheck and entrypoint:

- **`infra/docker/obs/healthcheck.sh`** only checks: `pgrep -x obs`, `xdpyinfo`, and absence of the "Crash Detected" safe-mode modal. It never touches VLC.
- **`infra/docker/obs/entrypoint.sh`** boots Xvfb / fluxbox / x11vnc / OBS and never waits on VLC.
- RTSP and browser sources retry on missing peers without crashing OBS or triggering the safe-mode modal.
- VLC has its own dedicated workflow (`vlc.yml`) that exercises it standalone end-to-end.

So `obs.yml` was building VLC, starting it, and waiting for `/health/ready` purely to satisfy a `depends_on: vlc` that doesn't actually gate OBS's health signal. Strip it.

## Changes

- Drop the per-arch VLC build steps, the `up -d vlc`, and the `Wait for VLC to be ready` loop.
- Drop the `Check VLC container logs` step.
- Add `--no-deps` to `up -d obs` so the compose `depends_on: vlc` (kept for local dev convenience via `bin/devenv`) doesn't drag VLC into the CI job.
- Drop `infra/docker/vlc/**` and `script/container_startup.sh` from the PR paths trigger; `vlc.yml` already covers them.

`docker-compose.yml`'s `depends_on: vlc` is intentionally **kept** so `bin/devenv up obs` still pulls VLC up locally — the comment "vlc must be up so RTSP source resolves" is honest about the dev intent even though it's not load-bearing for the OBS process itself.

Net diff: `-67 / +8` lines in `obs.yml`, dropping ~30s of CI wall time per arch (no VLC build cache restore, no VLC startup, no readiness wait).

Effectively reverses [#487](https://github.com/adanalife/tripbot/pull/487)'s build-VLC fix by removing the underlying need for it.

## Test plan

- [ ] obs.yml CI passes on this PR (amd64 always, arm64 since `infra/docker/obs/**` isn't touched here — wait, `.github/workflows/obs.yml` is — so the matrix should still trigger arm64 via the paths-filter on the workflow file itself; verify in the run)
- [ ] OBS becomes healthy without VLC running
- [ ] `bin/devenv up obs` locally still brings up VLC alongside (compose `depends_on` unchanged)