### PR TITLE
feat: pipeline stats — vlc-server + OBS runtime stats to OTel

### DIFF
--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -56,6 +56,10 @@ func main() {
 	vlcServer.InitPlayer()
 	vlcServer.PlayRandom() // play a random video
 
+	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
+	// surface them as OTel gauges. No-op when telemetry is disabled.
+	vlcServer.StartStatsPoller(context.Background(), 5*time.Second)
+
 	// start the webserver
 	vlcServer.SetVersion(version)
 	vlcServer.Start()

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -151,3 +151,11 @@ func mustHistogram(name, desc string, buckets ...float64) metric.Float64Histogra
 	}
 	return h
 }
+
+func mustFloat64Gauge(name, desc string) metric.Float64Gauge {
+	g, err := meter.Float64Gauge(name, metric.WithDescription(desc))
+	if err != nil {
+		panic(err)
+	}
+	return g
+}

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -27,6 +27,21 @@ var (
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
 	obsStreamingGauge = mustGauge("obs_streaming_active", "1 if OBS is actively streaming, 0 otherwise")
+
+	obsActiveFPS              = mustFloat64Gauge("obs_active_fps", "Current FPS being rendered by OBS")
+	obsAverageFrameRenderMS   = mustFloat64Gauge("obs_average_frame_render_time_ms", "Average time in milliseconds OBS spends rendering a frame")
+	obsCPUUsage               = mustFloat64Gauge("obs_cpu_usage_percent", "Current OBS CPU usage (percent)")
+	obsMemoryUsage            = mustFloat64Gauge("obs_memory_usage_mb", "Current OBS memory usage in MB")
+	obsRenderSkippedFrames    = mustFloat64Gauge("obs_render_skipped_frames", "Render-thread skipped frames since OBS started")
+	obsRenderTotalFrames      = mustFloat64Gauge("obs_render_total_frames", "Render-thread total frames since OBS started")
+	obsOutputSkippedFrames    = mustFloat64Gauge("obs_output_skipped_frames", "Output-thread skipped frames since OBS started")
+	obsOutputTotalFrames      = mustFloat64Gauge("obs_output_total_frames", "Output-thread total frames since OBS started")
+	obsStreamOutputBytes      = mustFloat64Gauge("obs_stream_output_bytes", "Bytes sent by the stream output (cumulative since stream start)")
+	obsStreamOutputDurationMS = mustFloat64Gauge("obs_stream_output_duration_ms", "Current stream output duration in milliseconds")
+	obsStreamCongestion       = mustFloat64Gauge("obs_stream_output_congestion", "Stream output congestion (0..1)")
+	obsStreamReconnecting     = mustGauge("obs_stream_output_reconnecting", "1 if the stream output is currently reconnecting, 0 otherwise")
+	obsStreamSkippedFrames    = mustFloat64Gauge("obs_stream_output_skipped_frames", "Stream-output skipped frames since stream start")
+	obsStreamTotalFrames      = mustFloat64Gauge("obs_stream_output_total_frames", "Stream-output total frames since stream start")
 )
 
 // ChatMessages exposes the chat-message counter through a tiny stable API
@@ -61,6 +76,49 @@ var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
 
 // OBSStreaming exposes the streaming-active gauge.
 var OBSStreaming = obsStreamingIface{g: obsStreamingGauge}
+
+// OBSStatsSnapshot bundles OBS performance + stream-output stats so the
+// poller can publish in a single call without coupling instrumentation to
+// goobs types.
+type OBSStatsSnapshot struct {
+	ActiveFPS              float64
+	AverageFrameRenderTime float64 // ms
+	CPUUsage               float64 // percent
+	MemoryUsage            float64 // MB
+	RenderSkippedFrames    float64
+	RenderTotalFrames      float64
+	OutputSkippedFrames    float64
+	OutputTotalFrames      float64
+}
+
+// OBSStreamSnapshot is the stream-output side (only meaningful while
+// streaming, but always safe to publish — fields are zero when idle).
+type OBSStreamSnapshot struct {
+	OutputBytes       float64
+	OutputDurationMS  float64
+	OutputCongestion  float64
+	Reconnecting      bool
+	SkippedFrames     float64
+	TotalFrames       float64
+}
+
+// OBSStats exposes the OBS performance + stream-output gauges.
+var OBSStats = obsStatsIface{
+	activeFPS:           obsActiveFPS,
+	averageFrameRender:  obsAverageFrameRenderMS,
+	cpuUsage:            obsCPUUsage,
+	memoryUsage:         obsMemoryUsage,
+	renderSkippedFrames: obsRenderSkippedFrames,
+	renderTotalFrames:   obsRenderTotalFrames,
+	outputSkippedFrames: obsOutputSkippedFrames,
+	outputTotalFrames:   obsOutputTotalFrames,
+	streamBytes:         obsStreamOutputBytes,
+	streamDuration:      obsStreamOutputDurationMS,
+	streamCongestion:    obsStreamCongestion,
+	streamReconnecting:  obsStreamReconnecting,
+	streamSkipped:       obsStreamSkippedFrames,
+	streamTotal:         obsStreamTotalFrames,
+}
 
 type chatCounterIface struct{ counter metric.Int64Counter }
 
@@ -122,6 +180,49 @@ func (o obsStreamingIface) Set(active bool) {
 		v = 1
 	}
 	o.g.Record(context.Background(), v)
+}
+
+type obsStatsIface struct {
+	activeFPS           metric.Float64Gauge
+	averageFrameRender  metric.Float64Gauge
+	cpuUsage            metric.Float64Gauge
+	memoryUsage         metric.Float64Gauge
+	renderSkippedFrames metric.Float64Gauge
+	renderTotalFrames   metric.Float64Gauge
+	outputSkippedFrames metric.Float64Gauge
+	outputTotalFrames   metric.Float64Gauge
+	streamBytes         metric.Float64Gauge
+	streamDuration      metric.Float64Gauge
+	streamCongestion    metric.Float64Gauge
+	streamReconnecting  metric.Int64Gauge
+	streamSkipped       metric.Float64Gauge
+	streamTotal         metric.Float64Gauge
+}
+
+func (o obsStatsIface) Update(s OBSStatsSnapshot) {
+	ctx := context.Background()
+	o.activeFPS.Record(ctx, s.ActiveFPS)
+	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime)
+	o.cpuUsage.Record(ctx, s.CPUUsage)
+	o.memoryUsage.Record(ctx, s.MemoryUsage)
+	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames)
+	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames)
+	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames)
+	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames)
+}
+
+func (o obsStatsIface) UpdateStream(s OBSStreamSnapshot) {
+	ctx := context.Background()
+	o.streamBytes.Record(ctx, s.OutputBytes)
+	o.streamDuration.Record(ctx, s.OutputDurationMS)
+	o.streamCongestion.Record(ctx, s.OutputCongestion)
+	v := int64(0)
+	if s.Reconnecting {
+		v = 1
+	}
+	o.streamReconnecting.Record(ctx, v)
+	o.streamSkipped.Record(ctx, s.SkippedFrames)
+	o.streamTotal.Record(ctx, s.TotalFrames)
 }
 
 func mustCounter(name, desc string) metric.Int64Counter {

--- a/pkg/instrumentation/vlc_server.go
+++ b/pkg/instrumentation/vlc_server.go
@@ -1,0 +1,67 @@
+package instrumentation
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	vlcInputBitRate        = mustFloat64Gauge("vlc_player_input_bitrate", "libvlc input bitrate (libvlc-native units, ~bytes/µs)")
+	vlcDemuxBitRate        = mustFloat64Gauge("vlc_player_demux_bitrate", "libvlc demux bitrate (libvlc-native units, ~bytes/µs)")
+	vlcDisplayedFPS        = mustFloat64Gauge("vlc_player_displayed_fps", "Derived frames-per-second: delta of displayed pictures over the poll interval")
+	vlcDecodedVideo        = mustFloat64Gauge("vlc_player_decoded_video_frames", "Total decoded video blocks since the current Media started (resets on media change)")
+	vlcDisplayedPictures   = mustFloat64Gauge("vlc_player_displayed_pictures", "Total displayed frames since the current Media started (resets on media change)")
+	vlcLostPictures        = mustFloat64Gauge("vlc_player_lost_pictures", "Total lost (dropped) frames since the current Media started (resets on media change)")
+	vlcDemuxCorrupted      = mustFloat64Gauge("vlc_player_demux_corrupted", "Demux corruptions discarded since the current Media started")
+	vlcDemuxDiscontinuity  = mustFloat64Gauge("vlc_player_demux_discontinuity", "Demux discontinuities dropped since the current Media started")
+)
+
+// VLCPlayerStatsSnapshot is the shape vlc-server hands to instrumentation
+// each poll tick. Decouples the gauges from libvlc-go's MediaStats type.
+type VLCPlayerStatsSnapshot struct {
+	InputBitRate       float64
+	DemuxBitRate       float64
+	DisplayedFPS       float64 // derived by the caller from delta of DisplayedPictures
+	DecodedVideo       float64
+	DisplayedPictures  float64
+	LostPictures       float64
+	DemuxCorrupted     float64
+	DemuxDiscontinuity float64
+}
+
+// VLCPlayerStats exposes the libvlc playback stats. Call Update on every
+// poll tick with a fresh snapshot.
+var VLCPlayerStats = vlcPlayerStatsIface{
+	inputBitRate:       vlcInputBitRate,
+	demuxBitRate:       vlcDemuxBitRate,
+	displayedFPS:       vlcDisplayedFPS,
+	decodedVideo:       vlcDecodedVideo,
+	displayedPictures:  vlcDisplayedPictures,
+	lostPictures:       vlcLostPictures,
+	demuxCorrupted:     vlcDemuxCorrupted,
+	demuxDiscontinuity: vlcDemuxDiscontinuity,
+}
+
+type vlcPlayerStatsIface struct {
+	inputBitRate       metric.Float64Gauge
+	demuxBitRate       metric.Float64Gauge
+	displayedFPS       metric.Float64Gauge
+	decodedVideo       metric.Float64Gauge
+	displayedPictures  metric.Float64Gauge
+	lostPictures       metric.Float64Gauge
+	demuxCorrupted     metric.Float64Gauge
+	demuxDiscontinuity metric.Float64Gauge
+}
+
+func (v vlcPlayerStatsIface) Update(s VLCPlayerStatsSnapshot) {
+	ctx := context.Background()
+	v.inputBitRate.Record(ctx, s.InputBitRate)
+	v.demuxBitRate.Record(ctx, s.DemuxBitRate)
+	v.displayedFPS.Record(ctx, s.DisplayedFPS)
+	v.decodedVideo.Record(ctx, s.DecodedVideo)
+	v.displayedPictures.Record(ctx, s.DisplayedPictures)
+	v.lostPictures.Record(ctx, s.LostPictures)
+	v.demuxCorrupted.Record(ctx, s.DemuxCorrupted)
+	v.demuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity)
+}

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -70,6 +70,32 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 				return // trigger reconnect
 			}
 			instrumentation.OBSStreaming.Set(resp.OutputActive)
+			instrumentation.OBSStats.UpdateStream(instrumentation.OBSStreamSnapshot{
+				OutputBytes:      resp.OutputBytes,
+				OutputDurationMS: resp.OutputDuration,
+				OutputCongestion: resp.OutputCongestion,
+				Reconnecting:     resp.OutputReconnecting,
+				SkippedFrames:    resp.OutputSkippedFrames,
+				TotalFrames:      resp.OutputTotalFrames,
+			})
+
+			stats, err := client.General.GetStats()
+			if err != nil {
+				// Non-fatal — keep the connection alive; stream-side
+				// gauges already published this tick.
+				log.Printf("obs: GetStats error: %v", err)
+				continue
+			}
+			instrumentation.OBSStats.Update(instrumentation.OBSStatsSnapshot{
+				ActiveFPS:              stats.ActiveFps,
+				AverageFrameRenderTime: stats.AverageFrameRenderTime,
+				CPUUsage:               stats.CpuUsage,
+				MemoryUsage:            stats.MemoryUsage,
+				RenderSkippedFrames:    stats.RenderSkippedFrames,
+				RenderTotalFrames:      stats.RenderTotalFrames,
+				OutputSkippedFrames:    stats.OutputSkippedFrames,
+				OutputTotalFrames:      stats.OutputTotalFrames,
+			})
 		}
 	}
 }

--- a/pkg/vlc-server/stats.go
+++ b/pkg/vlc-server/stats.go
@@ -1,0 +1,81 @@
+package vlcServer
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+)
+
+// PollStats polls libvlc for playback statistics every interval and pushes
+// them through pkg/instrumentation. Intended to run as a long-lived
+// goroutine started after InitPlayer.
+//
+// libvlc resets these counters when the current Media changes; we detect
+// that by watching for a negative delta in DisplayedPictures and skip the
+// FPS sample on that tick to avoid a phantom dip.
+func PollStats(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var (
+		prevDisplayed float64
+		prevTime      time.Time
+		havePrev      bool
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if player == nil {
+				continue
+			}
+			media, err := player.Media()
+			if err != nil || media == nil {
+				havePrev = false
+				continue
+			}
+			stats, err := media.Stats()
+			if err != nil || stats == nil {
+				havePrev = false
+				continue
+			}
+
+			displayed := float64(stats.DisplayedPictures)
+			var fps float64
+			if havePrev {
+				dt := now.Sub(prevTime).Seconds()
+				delta := displayed - prevDisplayed
+				if dt > 0 && delta >= 0 {
+					fps = delta / dt
+				}
+				// delta < 0 means libvlc rolled over to a new Media —
+				// skip this sample's FPS and let the next tick reseed.
+			}
+			prevDisplayed = displayed
+			prevTime = now
+			havePrev = true
+
+			instrumentation.VLCPlayerStats.Update(instrumentation.VLCPlayerStatsSnapshot{
+				InputBitRate:       stats.InputBitRate,
+				DemuxBitRate:       stats.DemuxBitRate,
+				DisplayedFPS:       fps,
+				DecodedVideo:       float64(stats.DecodedVideo),
+				DisplayedPictures:  displayed,
+				LostPictures:       float64(stats.LostPictures),
+				DemuxCorrupted:     float64(stats.DemuxCorrupted),
+				DemuxDiscontinuity: float64(stats.DemuxDiscontinuity),
+			})
+		}
+	}
+}
+
+// StartStatsPoller is a tiny launcher wrapper so cmd/vlc-server can `go
+// vlcServer.StartStatsPoller(...)` without juggling its own goroutine.
+func StartStatsPoller(ctx context.Context, interval time.Duration) {
+	log.Printf("vlc-server: starting libvlc stats poller, interval=%s", interval)
+	go PollStats(ctx, interval)
+}


### PR DESCRIPTION
## Summary

Surfaces runtime stats from both ends of the dashcam pipeline (vlc-server → OBS) as OTel gauges, so Grafana Cloud can show end-to-end pipeline health and we can alert on dropped frames / congestion.

**Dashboards + alerts**: [adanalife/infra#474](https://github.com/adanalife/infra/pull/474/changes)

**vlc-server side** (`pkg/vlc-server/stats.go`, `pkg/instrumentation/vlc_server.go`)
Polls `player.Media().Stats()` every 5s. Publishes:
- `vlc_player_input_bitrate` / `vlc_player_demux_bitrate` — libvlc-native bitrate fields
- `vlc_player_displayed_fps` — derived from delta of displayed pictures over the poll interval; skips ticks where libvlc rolled to a new Media (negative delta)
- `vlc_player_decoded_video_frames` / `vlc_player_displayed_pictures` / `vlc_player_lost_pictures` — per-Media counters
- `vlc_player_demux_corrupted` / `vlc_player_demux_discontinuity` — corruption / discontinuity counts

**OBS side** (`pkg/obs/streaming.go`, `pkg/instrumentation/tripbot.go`)
Extends the existing obs-websocket poll to call `General.GetStats` alongside the existing `Stream.GetStreamStatus`. Publishes:
- `obs_active_fps`, `obs_average_frame_render_time_ms`, `obs_cpu_usage_percent`, `obs_memory_usage_mb`
- `obs_render_skipped_frames` / `obs_render_total_frames` — render thread
- `obs_output_skipped_frames` / `obs_output_total_frames` — output thread
- `obs_stream_output_bytes` / `obs_stream_output_duration_ms` — derive output bitrate via Δbytes/Δt in PromQL
- `obs_stream_output_congestion`, `obs_stream_output_reconnecting`
- `obs_stream_output_skipped_frames` / `obs_stream_output_total_frames` — stream output

GetStats errors are non-fatal — stream-side gauges have already been published this tick.

Closes the matching TODOs in `vault/tripbot/vlc-server/TODO.md` and `vault/tripbot/obs/TODO.md`.

## Test plan

- [x] `go build ./cmd/vlc-server` (with libvlc CGO flags) succeeds
- [x] `go build ./cmd/tripbot` succeeds
- [x] `go vet ./pkg/obs/... ./pkg/instrumentation/... ./pkg/vlc-server/...` clean
- [ ] Merge + deploy to stage, confirm new `vlc_player_*` and `obs_*` series land in Grafana Cloud
- [ ] Then apply adanalife/infra#474 to land dashboards + alerts