### PR TITLE
Release v2.7.1: develop → master

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - 'infra/docker/obs/**'
-      - 'infra/docker/vlc/**'
-      - 'script/container_startup.sh'
       - 'infra/docker/docker-compose*.yml'
       - '.github/workflows/obs.yml'
   push:
@@ -93,59 +91,13 @@ jobs:
           -f infra/docker/docker-compose.github.yml \
           build obs
 
-    - name: Build VLC container (amd64, cached)
-      if: matrix.arch == 'amd64'
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        file: infra/docker/vlc/Dockerfile
-        tags: adanalife/vlc:latest
-        load: true
-        cache-from: type=gha,scope=vlc-amd64
-        cache-to: type=gha,mode=max,scope=vlc-amd64
-
-    - name: Build VLC container (arm64)
-      if: matrix.arch == 'arm64'
-      run: |
-        docker compose \
-          --project-directory . \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          build vlc
-
-    - name: Start VLC container (RTSP source)
-      run: |
-        docker compose \
-          --project-directory . \
-          --env-file infra/docker/env.docker \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          up -d vlc
-
-    - name: Wait for VLC to be ready
-      run: |
-        cid=$(docker compose \
-          --project-directory . \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          ps -q vlc)
-        for i in $(seq 1 30); do
-          if docker exec "$cid" curl -sf http://localhost:8080/health/ready >/dev/null; then
-            echo "VLC is ready"
-            exit 0
-          fi
-          echo "Waiting for VLC... ($i/30)"
-          sleep 2
-        done
-        echo "VLC failed to become ready" >&2
-        exit 1
-
+    # OBS doesn't need VLC to start or pass its healthcheck — the
+    # healthcheck (infra/docker/obs/healthcheck.sh) only verifies the
+    # OBS process, X server, and absence of the safe-mode crash modal.
+    # RTSP and browser sources retry on missing peers without crashing
+    # OBS. VLC has its own dedicated workflow (vlc.yml) that exercises
+    # it end-to-end. `--no-deps` keeps the compose `depends_on: vlc`
+    # (load-bearing for local dev) from dragging VLC into this job.
     - name: Start OBS container (no STREAM_KEY)
       run: |
         docker compose \
@@ -155,7 +107,7 @@ jobs:
           ${{ matrix.arch_compose }} \
           -f infra/docker/docker-compose.testing.yml \
           -f infra/docker/docker-compose.github.yml \
-          up -d obs
+          up -d --no-deps obs
 
     - name: Wait for healthcheck
       run: |
@@ -188,17 +140,6 @@ jobs:
         docker exec "$cid" test -s /etc/tripbot/sha
         echo "version: $(docker exec "$cid" cat /etc/tripbot/version)"
         echo "sha:     $(docker exec "$cid" cat /etc/tripbot/sha)"
-
-    - name: Check VLC container logs
-      if: always()
-      run: |
-        docker compose \
-          --project-directory . \
-          -f infra/docker/docker-compose.yml \
-          ${{ matrix.arch_compose }} \
-          -f infra/docker/docker-compose.testing.yml \
-          -f infra/docker/docker-compose.github.yml \
-          logs vlc
 
     - name: Check container logs
       if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.7.1] — 2026-05-15
+
+Patch release. End-to-end runtime visibility lands on both ends of the dashcam pipeline (vlc-server + OBS publish OTel gauges to Grafana Cloud), and the chat-command path becomes a single trace tree in Tempo — `chat.command` spans wrap the dispatcher, child SQL queries from GORM and outbound Twitch Helix calls nest underneath. Chatbot picks up an injectable `VLC` dependency, the HTTP server now shuts down gracefully on SIGTERM instead of cutting in-flight requests, and the OBS CI workflow stops building/booting VLC since OBS doesn't actually depend on it for health.
+
+### Observability
+
+- **Pipeline stats: vlc-server and OBS runtime gauges.** vlc-server polls `player.Media().Stats()` every 5s and publishes `vlc_player_input_bitrate` / `demux_bitrate` / `displayed_fps` / `decoded_video_frames` / `displayed_pictures` / `lost_pictures` / `demux_corrupted` / `demux_discontinuity`. OBS's existing WebSocket poll now also calls `General.GetStats` and publishes `obs_active_fps`, `obs_average_frame_render_time_ms`, `obs_cpu_usage_percent`, `obs_memory_usage_mb`, render/output skipped+total frame counters, and stream-side bytes/duration/congestion/reconnecting gauges. Dashboards + alerts in [adanalife/infra#474](https://github.com/adanalife/infra/pull/474). ([#538])
+
+### Tracing
+
+- **`chat.command` span wraps chat-command dispatch; Twitch Helix client gets `otelhttp` transport.** Each IRC message that resolves to a known command now shows up as a span (`command={trigger}` attribute), searchable in Tempo. Helix calls (`GetUsers`, `GetSubscriptions`, `GetChannelFollows`, `GetChannelChatChatters`) now emit outbound HTTP spans, matching the existing `otelhttp` wiring in `pkg/vlc-client` and `pkg/onscreens-client`. ([#533])
+- **Thread `context.Context` through `HandlerFunc` and DB helpers.** Builds on #533 so SQL queries (`otelsql`) and outbound HTTP spans nest *under* the `chat.command` span instead of trailing as siblings. `HandlerFunc` grows `ctx`; every `(a *App).xxxCmd` method picks it up; all DB-touching helpers in `pkg/users` / `pkg/scoreboards` / `pkg/events` / `pkg/onscreens-client` grow `ctx` and call `.WithContext(ctx)` on their GORM ops. Server webhook handlers pass `r.Context()`; cron jobs that propagate ctx use a new `tracedJobCtx` wrapper. A single `!miles` is now one tree in Tempo. ([#535])
+
+### Chatbot
+
+- **Inject `VLC` on `App` for testability.** Mirrors the Onscreens injection pattern from #526 — `VLC` interface in `pkg/chatbot/vlc.go` covers the four playback methods chatbot commands use (`PlayRandom`, `PlayFileInPlaylist`, `Skip`, `Back`); `realVLC` delegates to `pkg/vlc-client`. Unlocks the deferred `guessCmd` correct-guess test from #528 — three new tests assert overlay + playback behavior on right-answer / cooldown / new-round transitions via `recordingVLC` + `recordingOnscreens`. ([#536])
+
+### Server
+
+- **Graceful HTTP shutdown via signal-derived context.** `pkg/server/server.go` runs `ListenAndServe` in a goroutine, waits on a context derived from `signal.NotifyContext` on SIGINT/SIGTERM, then calls `srv.Shutdown(ctx)` with a 15s timeout so in-flight requests complete instead of being cut. Resolves the `//TODO: add graceful shutdown` comment that's been there since closed PR #46 (2020). `pkg/vlc-server/server.go` has the same gap and is left as a follow-up. ([#440])
+
+### CI
+
+- **Drop VLC build/start steps from `obs.yml`.** OBS's healthcheck (`pgrep obs`, `xdpyinfo`, safe-mode-modal check) and entrypoint never touch VLC, and RTSP/browser sources retry on missing peers without crashing OBS. Strips the per-arch VLC build, the `up -d vlc`, and the readiness wait; adds `--no-deps` to `up -d obs`. Net `-67/+8` lines, drops ~30s of CI wall time per arch. `docker-compose.yml`'s `depends_on: vlc` is kept so `bin/devenv up obs` still pulls VLC up locally. ([#537])
+
 ## [v2.7.0] — 2026-05-15
 
 Minor release. Big one. The database layer migrates from raw `sqlx` to GORM across most packages, Twilio comes out entirely, and three new business metrics land alongside surfaced visibility on non-2xx Twitch Helix responses. Chatbot gains injectable `Onscreens` and `DB` dependencies, unlocking two more rounds of test coverage. Sentry events now carry the build-time version as their `Release` tag, a startup-time `spew.Dump` that was leaking secrets to stdout is gone, and the rotator retires `!survey` while picking up `!discord`.
@@ -547,3 +572,9 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#530]: https://github.com/adanalife/tripbot/pull/530
 [#531]: https://github.com/adanalife/tripbot/pull/531
 [#532]: https://github.com/adanalife/tripbot/pull/532
+[#440]: https://github.com/adanalife/tripbot/pull/440
+[#533]: https://github.com/adanalife/tripbot/pull/533
+[#535]: https://github.com/adanalife/tripbot/pull/535
+[#536]: https://github.com/adanalife/tripbot/pull/536
+[#537]: https://github.com/adanalife/tripbot/pull/537
+[#538]: https://github.com/adanalife/tripbot/pull/538

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -48,6 +48,19 @@ func tracedJob(name string, fn func()) func() {
 	}
 }
 
+// tracedJobCtx is the ctx-aware variant of tracedJob. The span's ctx is
+// threaded into fn so DB queries (otelsql) and outbound HTTP (otelhttp)
+// nest under cron.<name> in Tempo, giving each cron tick a tree of children
+// rather than orphan spans.
+func tracedJobCtx(name string, fn func(context.Context)) func() {
+	return func() {
+		ctx, span := cronTracer.Start(context.Background(), "cron."+name,
+			trace.WithAttributes(attribute.String("cron.job", name)))
+		defer span.End()
+		fn(ctx)
+	}
+}
+
 // version is overridable at build time via -ldflags "-X main.version=...".
 var version = "dev"
 
@@ -65,7 +78,7 @@ func main() {
 	server.SetVersion(version)
 	startHttpServer()
 	findInitialVideo()
-	users.InitLeaderboard()
+	users.InitLeaderboard(context.Background())
 	startCron()
 	startOBSPolling()
 	loadTwitchToken()   // must precede chatbot.Initialize — provides the IRC token
@@ -166,7 +179,7 @@ func updateSubscribers() {
 // getCurrentUsers gets the users watching the stream
 func getCurrentUsers() {
 	// fetch initial session
-	users.UpdateSession()
+	users.UpdateSession(context.Background())
 	users.PrintCurrentSession()
 }
 
@@ -215,7 +228,7 @@ func gracefulShutdown() {
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
 	log.Printf("Last played video: %s", aurora.Yellow(video.CurrentlyPlaying.File()))
-	users.Shutdown()
+	users.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {
 		terrors.Log(err, "error closing DB connection")
@@ -240,9 +253,9 @@ func scheduleBackgroundJobs() {
 
 	// schedule these functions
 	err = background.Cron.AddFunc("@every 60s", tracedJob("video.GetCurrentlyPlaying", video.GetCurrentlyPlaying))
-	err = background.Cron.AddFunc("@every 61s", tracedJob("users.UpdateSession", users.UpdateSession))
+	err = background.Cron.AddFunc("@every 61s", tracedJobCtx("users.UpdateSession", users.UpdateSession))
 	err = background.Cron.AddFunc("@every 62s", tracedJob("users.UpdateLeaderboard", users.UpdateLeaderboard))
-	err = background.Cron.AddFunc("@every 5m", tracedJob("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
+	err = background.Cron.AddFunc("@every 5m", tracedJobCtx("onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("users.PrintCurrentSession", users.PrintCurrentSession))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetSubscribers", mytwitch.GetSubscribers))
 	err = background.Cron.AddFunc("@every 5m", tracedJob("twitch.GetFollowerCount", mytwitch.GetFollowerCount))

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -72,11 +72,17 @@ var telemetryShutdown telemetry.ShutdownFunc
 func main() {
 	log.Println(aurora.Cyan(fmt.Sprintf("tripbot version %s", version)))
 	createRandomSeed()
+	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
+	// to trigger a graceful shutdown so in-flight requests aren't cut.
+	// listenForShutdown's gracefulShutdown goroutine handles the rest of
+	// the app cleanup off the same signals.
+	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
 	listenForShutdown()
 	initializeTelemetry()
 	initializeErrorLogger()
 	server.SetVersion(version)
-	startHttpServer()
+	startHttpServer(shutdownCtx)
 	findInitialVideo()
 	users.InitLeaderboard(context.Background())
 	startCron()
@@ -120,10 +126,13 @@ func initializeErrorLogger() {
 }
 
 // startHttpServer starts a webserver, which is
-// used for admin tools and receiving webhooks
-func startHttpServer() {
+// used for admin tools and receiving webhooks. The passed context is
+// honored by the server for graceful shutdown — when it's canceled,
+// the server stops accepting new connections and drains in-flight
+// requests up to its shutdown timeout.
+func startHttpServer(ctx context.Context) {
 	// start the HTTP server
-	go server.Start()
+	go server.Start(ctx)
 }
 
 // findInitialVideo will determine the vido that is currently-playing

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -56,6 +56,10 @@ func main() {
 	vlcServer.InitPlayer()
 	vlcServer.PlayRandom() // play a random video
 
+	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
+	// surface them as OTel gauges. No-op when telemetry is disabled.
+	vlcServer.StartStatsPoller(context.Background(), 5*time.Second)
+
 	// start the webserver
 	vlcServer.SetVersion(version)
 	vlcServer.Start()

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -35,6 +35,9 @@ type App struct {
 	// Onscreens drives the OBS browser-source overlays for chat-triggered
 	// effects (leaderboards, flags, middle-text). Tests inject a no-op fake.
 	Onscreens Onscreens
+	// VLC drives playback operations (timewarp, jump, skip, back). Tests
+	// inject a no-op fake; production uses the realVLC adapter.
+	VLC VLC
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -51,6 +54,7 @@ var defaultApp = &App{
 	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
 	Onscreens: realOnscreens{},
+	VLC:       realVLC{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/command.go
+++ b/pkg/chatbot/command.go
@@ -1,9 +1,16 @@
 package chatbot
 
-import "github.com/adanalife/tripbot/pkg/users"
+import (
+	"context"
 
-// HandlerFunc is the common signature for all chat command handlers.
-type HandlerFunc func(user *users.User, params []string)
+	"github.com/adanalife/tripbot/pkg/users"
+)
+
+// HandlerFunc is the common signature for all chat command handlers. The
+// ctx carries the chat.command span started in dispatch() so SQL queries
+// (via otelsql) and outbound HTTP (via otelhttp) nest under the command
+// span in Tempo.
+type HandlerFunc func(ctx context.Context, user *users.User, params []string)
 
 // Command is a first-class representation of a single chat command.
 type Command struct {

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -34,13 +35,13 @@ const guessScoreboard = "guess_state_total"
 
 //TODO: incorrect guess scoreboard?
 
-func (a *App) helpCmd(user *users.User, _ []string) {
+func (a *App) helpCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !help")
 	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
 	sayFn(msg)
 }
 
-func (a *App) helloCmd(user *users.User, params []string) {
+func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "said hello")
 
 	// check if it was just a one-word hello
@@ -69,12 +70,12 @@ func (a *App) helloCmd(user *users.User, params []string) {
 	lastHelloTime = time.Now()
 }
 
-func (a *App) flagCmd(user *users.User, _ []string) {
+func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !flag")
 	a.Onscreens.ShowFlag(10 * time.Second)
 }
 
-func (a *App) versionCmd(user *users.User, _ []string) {
+func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !version")
 
 	if helpers.RunningOnWindows() {
@@ -98,14 +99,14 @@ func (a *App) versionCmd(user *users.User, _ []string) {
 	sayFn("Current version is " + currentVersion)
 }
 
-func (a *App) uptimeCmd(user *users.User, _ []string) {
+func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !uptime")
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
 	sayFn(msg)
 }
 
-func (a *App) milesCmd(user *users.User, params []string) {
+func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !miles")
 	var username string
 	var lifetimeMiles, monthlyMiles float32
@@ -114,10 +115,10 @@ func (a *App) milesCmd(user *users.User, params []string) {
 	if len(params) == 0 {
 		username = user.Username
 		lifetimeMiles = user.CurrentMiles()
-		monthlyMiles = user.CurrentMonthlyMiles()
+		monthlyMiles = user.CurrentMonthlyMiles(ctx)
 	} else {
 		username = helpers.StripAtSign(params[0])
-		u := users.Find(username)
+		u := users.Find(ctx, username)
 
 		// check to see if they are in our DB
 		if u.ID == 0 {
@@ -126,7 +127,7 @@ func (a *App) milesCmd(user *users.User, params []string) {
 		}
 
 		lifetimeMiles = u.CurrentMiles()
-		monthlyMiles = u.CurrentMonthlyMiles()
+		monthlyMiles = u.CurrentMonthlyMiles(ctx)
 	}
 
 	msg := "@%s has %.2fmi this month"
@@ -153,7 +154,7 @@ func (a *App) milesCmd(user *users.User, params []string) {
 	sayFn(msg)
 }
 
-func (a *App) kilometresCmd(user *users.User, _ []string) {
+func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !kilometres")
 	km := user.CurrentMiles() * 1.609344
 	msg := "@%s has %.2f kilometres."
@@ -161,7 +162,7 @@ func (a *App) kilometresCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) sunsetCmd(user *users.User, _ []string) {
+func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !sunset")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
@@ -172,7 +173,7 @@ func (a *App) sunsetCmd(user *users.User, _ []string) {
 	sayFn(helpers.SunsetStr(vid.DateFilmed, lat, lng))
 }
 
-func (a *App) locationCmd(user *users.User, _ []string) {
+func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !location (or similar)")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
@@ -196,12 +197,12 @@ func (a *App) locationCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !leaderboard")
 
 	// select users to show in leaderboard
 	size := 10
-	leaderboard := scoreboards.TopUsers(scoreboards.CurrentMilesScoreboard(), size)
+	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentMilesScoreboard(), size)
 	if size > len(leaderboard) {
 		size = len(leaderboard)
 	}
@@ -221,7 +222,7 @@ func (a *App) monthlyMilesLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !totalleaderboard")
 
 	// select users to show in leaderboard
@@ -245,12 +246,12 @@ func (a *App) lifetimeMilesLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
+func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !guessleaderboard")
 
 	// select users to show in leaderboard
 	size := 10
-	leaderboard := scoreboards.TopUsers(scoreboards.CurrentGuessScoreboard(), size)
+	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
 
 	// special message if the leaderboard is empty
 	if len(leaderboard) == 0 {
@@ -285,7 +286,7 @@ func (a *App) monthlyGuessLeaderboardCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) timeCmd(user *users.User, _ []string) {
+func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !time")
 	var err error
 	var lat, lng float64
@@ -304,7 +305,7 @@ func (a *App) timeCmd(user *users.User, _ []string) {
 	}
 }
 
-func (a *App) dateCmd(user *users.User, _ []string) {
+func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !date")
 	var err error
 	var lat, lng float64
@@ -324,7 +325,7 @@ func (a *App) dateCmd(user *users.User, _ []string) {
 }
 
 //TODO: refactor to use golang '...' syntax
-func (a *App) guessCmd(user *users.User, params []string) {
+func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !guess")
 	var msg string
 
@@ -363,8 +364,8 @@ func (a *App) guessCmd(user *users.User, params []string) {
 		// show the flag for the state
 		a.Onscreens.ShowFlag(10 * time.Second)
 		// increase their guess score
-		user.AddToScore(guessScoreboard, 1.0)
-		user.AddToScore(scoreboards.CurrentGuessScoreboard(), 1.0)
+		user.AddToScore(ctx, guessScoreboard, 1.0)
+		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
 		// do a timewarp
 		a.timewarp()
 	} else {
@@ -373,7 +374,7 @@ func (a *App) guessCmd(user *users.User, params []string) {
 	sayFn(msg)
 }
 
-func (a *App) stateCmd(user *users.User, _ []string) {
+func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !state")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
@@ -390,7 +391,7 @@ func (a *App) stateCmd(user *users.User, _ []string) {
 
 //TODO: maybe there could be a !cancel command or something
 //TODO: use fancy golang ... syntax?
-func (a *App) reportCmd(user *users.User, params []string) {
+func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !report")
 	message := strings.Join(params, " ")
 	// Route the report through Sentry so it lands somewhere visible.
@@ -400,14 +401,14 @@ func (a *App) reportCmd(user *users.User, params []string) {
 	sayFn("Thank you, I will look into this ASAP!")
 }
 
-func (a *App) bonusMilesCmd(user *users.User, _ []string) {
+func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !bonusmiles")
 	bonus := user.BonusMiles()
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
 	sayFn(msg)
 }
 
-func (a *App) secretInfoCmd(user *users.User, _ []string) {
+func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !secretinfo")
 	if !c.UserIsAdmin(user.Username) {
 		return
@@ -424,7 +425,7 @@ func (a *App) secretInfoCmd(user *users.User, _ []string) {
 	sayFn(msg)
 }
 
-func (a *App) shutdownCmd(user *users.User, _ []string) {
+func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !shutdown")
 	if !c.UserIsAdmin(user.Username) {
 		sayFn("Nice try bucko")
@@ -433,7 +434,7 @@ func (a *App) shutdownCmd(user *users.User, _ []string) {
 	sayFn("Shutting down...")
 	log.Printf("currently playing: %s", a.CurrentVideo())
 	background.StopCron()
-	users.Shutdown()
+	users.Shutdown(ctx)
 	err := database.Connection().Close()
 	if err != nil {
 		log.Println(err)
@@ -444,7 +445,7 @@ func (a *App) shutdownCmd(user *users.User, _ []string) {
 
 //TODO: this will always be lower case, find out why
 // middleCmd sets the text at the bottom-middle of the stream
-func (a *App) middleCmd(user *users.User, params []string) {
+func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) {
 	log.Println(user.Username, "ran !middle")
 	// don't let strangers run this
 	if !c.UserIsAdmin(user.Username) {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -54,7 +55,7 @@ func TestHelpCmd_SaysSomething(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if out() == "" {
 		t.Fatal("expected a help message, got empty output")
@@ -66,7 +67,7 @@ func TestHelpCmd_MessageContainsCount(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	// message format: "<help text> (N of M)"
 	if !strings.Contains(out(), " of ") {
@@ -79,10 +80,10 @@ func TestHelpCmd_AdvancesIndex(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 	first := out()
 
-	app.helpCmd(newTestUser("viewer1"), nil)
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
 	second := out()
 
 	if first == second {
@@ -98,7 +99,7 @@ func TestUptimeCmd_SaysRunningFor(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.uptimeCmd(newTestUser("viewer1"), nil)
+	app.uptimeCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "I have been running for") {
 		t.Errorf("unexpected uptime message: %q", out())
@@ -114,7 +115,7 @@ func TestHelloCmd_GreetsNewViewer(t *testing.T) {
 	defer restore()
 
 	// a fresh user with 0 miles gets the newcomer hint appended
-	app.helloCmd(newTestUser("newviewer"), nil)
+	app.helloCmd(context.Background(), newTestUser("newviewer"), nil)
 
 	msg := out()
 	if msg == "" {
@@ -131,7 +132,7 @@ func TestHelloCmd_RateLimitSilencesSecondCall(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.helloCmd(newTestUser("viewer1"), nil)
+	app.helloCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if out() != "" {
 		t.Errorf("expected silence due to rate limit, got %q", out())
@@ -145,7 +146,7 @@ func TestHelloCmd_IgnoresMessageWithParams(t *testing.T) {
 	defer restore()
 
 	// "hello world" — has params so the bot stays quiet
-	app.helloCmd(newTestUser("viewer1"), []string{"world"})
+	app.helloCmd(context.Background(), newTestUser("viewer1"), []string{"world"})
 
 	if out() != "" {
 		t.Errorf("expected silence for greeting with params, got %q", out())
@@ -160,7 +161,7 @@ func TestKilometresCmd_ConvertsCorrectly(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "viewer1", Miles: 10}
-	app.kilometresCmd(user, nil)
+	app.kilometresCmd(context.Background(), user, nil)
 
 	// 10 miles * 1.609344 = 16.09344, formatted as "16.09"
 	if !strings.Contains(out(), "16.09") {
@@ -174,7 +175,7 @@ func TestKilometresCmd_IncludesUsername(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "testviewer", Miles: 5}
-	app.kilometresCmd(user, nil)
+	app.kilometresCmd(context.Background(), user, nil)
 
 	if !strings.Contains(out(), "@testviewer") {
 		t.Errorf("expected @username in output, got %q", out())
@@ -187,7 +188,7 @@ func TestKilometresCmd_ZeroMiles(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "newbie", Miles: 0}
-	app.kilometresCmd(user, nil)
+	app.kilometresCmd(context.Background(), user, nil)
 
 	if !strings.Contains(out(), "0.00") {
 		t.Errorf("expected zero km in output, got %q", out())
@@ -204,7 +205,7 @@ func TestVersionCmd_UsesCachedVersion(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.versionCmd(newTestUser("viewer1"), nil)
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "v1.2.3-test") {
 		t.Errorf("expected cached version in output, got %q", out())
@@ -219,7 +220,7 @@ func TestVersionCmd_MessageFormat(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.versionCmd(newTestUser("viewer1"), nil)
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "Current version is ") {
 		t.Errorf("unexpected message format: %q", out())
@@ -234,7 +235,7 @@ func TestStateCmd_SaysCurrentState(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.stateCmd(newTestUser("viewer1"), nil)
+	app.stateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "Colorado") {
 		t.Errorf("expected state name in output, got %q", out())
@@ -247,7 +248,7 @@ func TestStateCmd_MessageFormat(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.stateCmd(newTestUser("viewer1"), nil)
+	app.stateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "We're in ") {
 		t.Errorf("unexpected state message format: %q", out())
@@ -263,7 +264,7 @@ func TestStateCmd_DrivesShowFlagOverlay(t *testing.T) {
 	_, restore := captureSay(t)
 	defer restore()
 
-	app.stateCmd(newTestUser("viewer1"), nil)
+	app.stateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if len(rec.Calls) != 1 || !strings.HasPrefix(rec.Calls[0], "ShowFlag(") {
 		t.Errorf("expected one ShowFlag overlay call, got %v", rec.Calls)
@@ -280,7 +281,7 @@ func TestFlagCmd_DrivesShowFlagOverlay(t *testing.T) {
 	_, restore := captureSay(t)
 	defer restore()
 
-	app.flagCmd(newTestUser("viewer1"), nil)
+	app.flagCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if len(rec.Calls) != 1 || rec.Calls[0] != "ShowFlag(10s)" {
 		t.Errorf("expected ShowFlag(10s) overlay call, got %v", rec.Calls)
@@ -292,7 +293,7 @@ func TestFlagCmd_DoesNotSayInChat(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.flagCmd(newTestUser("viewer1"), nil)
+	app.flagCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if out() != "" {
 		t.Errorf("expected flagCmd to be silent in chat, got %q", out())
@@ -308,7 +309,7 @@ func TestDateCmd_SaysThisMomentWas(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.dateCmd(newTestUser("viewer1"), nil)
+	app.dateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	msg := out()
 	if !strings.HasPrefix(msg, "This moment was") {
@@ -323,7 +324,7 @@ func TestDateCmd_IncludesYear(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.dateCmd(newTestUser("viewer1"), nil)
+	app.dateCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "2019") {
 		t.Errorf("expected year 2019 in output, got %q", out())
@@ -339,7 +340,7 @@ func TestTimeCmd_SaysThisMomentWas(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.timeCmd(newTestUser("viewer1"), nil)
+	app.timeCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.HasPrefix(out(), "This moment was") {
 		t.Errorf("unexpected time message: %q", out())
@@ -353,7 +354,7 @@ func TestTimeCmd_IncludesAMPM(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.timeCmd(newTestUser("viewer1"), nil)
+	app.timeCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "am") && !strings.Contains(msg, "pm") {
@@ -371,7 +372,7 @@ func TestSunsetCmd_SaysSunset(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.sunsetCmd(newTestUser("viewer1"), nil)
+	app.sunsetCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "Sunset on this day") {
 		t.Errorf("unexpected sunset message: %q", out())
@@ -386,7 +387,7 @@ func TestGuessCmd_NoParams_PromptsGuess(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.guessCmd(newTestUser("viewer1"), nil)
+	app.guessCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	if !strings.Contains(out(), "guess") {
 		t.Errorf("expected guess prompt in output, got %q", out())
@@ -400,7 +401,7 @@ func TestGuessCmd_WrongGuess_SaysTryAgain(t *testing.T) {
 	defer restore()
 
 	// Wyoming != Colorado
-	app.guessCmd(newTestUser("viewer1"), []string{"Wyoming"})
+	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"Wyoming"})
 
 	if !strings.Contains(out(), "Try again") {
 		t.Errorf("expected try-again in output, got %q", out())
@@ -417,7 +418,7 @@ func TestMiddleCmd_NonAdminIsSilent(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser("viewer1"), []string{"hello"})
+	app.middleCmd(context.Background(), newTestUser("viewer1"), []string{"hello"})
 
 	if out() != "" {
 		t.Errorf("expected silence for non-admin, got %q", out())
@@ -429,7 +430,7 @@ func TestMiddleCmd_NoParams_PromptsForText(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser(adminUser), nil)
+	app.middleCmd(context.Background(), newTestUser(adminUser), nil)
 
 	if !strings.Contains(out(), "What do you want to say") {
 		t.Errorf("expected prompt, got %q", out())
@@ -444,7 +445,7 @@ func TestMiddleCmd_Hide_DrivesHideOverlay(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser(adminUser), []string{"hide"})
+	app.middleCmd(context.Background(), newTestUser(adminUser), []string{"hide"})
 
 	if !strings.Contains(out(), "Hiding the message") {
 		t.Errorf("expected hide confirmation in chat, got %q", out())
@@ -463,7 +464,7 @@ func TestMiddleCmd_Hide_CaseInsensitive(t *testing.T) {
 	_, restore := captureSay(t)
 	defer restore()
 
-	app.middleCmd(newTestUser(adminUser), []string{"HIDE"})
+	app.middleCmd(context.Background(), newTestUser(adminUser), []string{"HIDE"})
 
 	if len(rec.Calls) != 1 || rec.Calls[0] != "HideMiddleText()" {
 		t.Errorf("expected one HideMiddleText overlay call for 'HIDE', got %v", rec.Calls)
@@ -479,7 +480,7 @@ func TestMiddleCmd_Text_DrivesShowOverlay(t *testing.T) {
 	defer restore()
 
 	// Multiple words get joined with a space into the overlay text.
-	app.middleCmd(newTestUser(adminUser), []string{"hello", "everyone"})
+	app.middleCmd(context.Background(), newTestUser(adminUser), []string{"hello", "everyone"})
 
 	if len(rec.Calls) != 1 || rec.Calls[0] != `ShowMiddleText("hello everyone")` {
 		t.Errorf("expected ShowMiddleText with joined text, got %v", rec.Calls)
@@ -495,8 +496,8 @@ func TestMiddleCmd_NonAdmin_DoesNotDriveOverlay(t *testing.T) {
 	defer restore()
 
 	// A non-admin's params should be ignored — no chat, no overlay call.
-	app.middleCmd(newTestUser("viewer1"), []string{"hide"})
-	app.middleCmd(newTestUser("viewer1"), []string{"hello"})
+	app.middleCmd(context.Background(), newTestUser("viewer1"), []string{"hide"})
+	app.middleCmd(context.Background(), newTestUser("viewer1"), []string{"hello"})
 
 	if len(rec.Calls) != 0 {
 		t.Errorf("expected no overlay calls for non-admin, got %v", rec.Calls)
@@ -517,7 +518,7 @@ func TestLifetimeMilesLeaderboardCmd_Empty(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.lifetimeMilesLeaderboardCmd(newTestUser("viewer1"), nil)
+	app.lifetimeMilesLeaderboardCmd(context.Background(), newTestUser("viewer1"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "Top 0 lifetime miles") {
@@ -539,7 +540,7 @@ func TestLifetimeMilesLeaderboardCmd_WithUsers(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.lifetimeMilesLeaderboardCmd(newTestUser("caller"), nil)
+	app.lifetimeMilesLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "viewer1") || !strings.Contains(msg, "200.0mi") {
@@ -575,7 +576,7 @@ func TestMonthlyMilesLeaderboardCmd_RendersTopUsers(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.monthlyMilesLeaderboardCmd(newTestUser("caller"), nil)
+	app.monthlyMilesLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	msg := out()
 	if !strings.Contains(msg, "viewer1") || !strings.Contains(msg, "42.5") {
@@ -608,7 +609,7 @@ func TestMonthlyGuessLeaderboardCmd_Empty_SaysNoneYet(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.monthlyGuessLeaderboardCmd(newTestUser("caller"), nil)
+	app.monthlyGuessLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	if !strings.Contains(out(), "No one is on that leaderboard yet") {
 		t.Errorf("expected empty-leaderboard message, got %q", out())
@@ -636,7 +637,7 @@ func TestMonthlyGuessLeaderboardCmd_WithGuesses_StripsDecimals(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.monthlyGuessLeaderboardCmd(newTestUser("caller"), nil)
+	app.monthlyGuessLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
 
 	msg := out()
 	// guess scores are formatted as integers in the chat message
@@ -671,7 +672,7 @@ func TestMilesCmd_OtherUser_NotInDB(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.milesCmd(newTestUser("caller"), []string{"ghost"})
+	app.milesCmd(context.Background(), newTestUser("caller"), []string{"ghost"})
 
 	if !strings.Contains(out(), "I don't know them") {
 		t.Errorf("expected unknown-user message, got %q", out())
@@ -698,7 +699,7 @@ func TestMilesCmd_Self_WithMiles(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "viewer1", Miles: 50.0}
-	app.milesCmd(user, nil)
+	app.milesCmd(context.Background(), user, nil)
 
 	msg := out()
 	if !strings.Contains(msg, "@viewer1 has 8.00mi this month") {
@@ -730,7 +731,7 @@ func TestMilesCmd_Self_NewcomerHint(t *testing.T) {
 	defer restore()
 
 	user := &users.User{Username: "newbie", Miles: 0.0}
-	app.milesCmd(user, nil)
+	app.milesCmd(context.Background(), user, nil)
 
 	msg := out()
 	if !strings.Contains(msg, "You'll earn more miles") {
@@ -771,7 +772,7 @@ func TestMilesCmd_OtherUser_Found(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.milesCmd(newTestUser("caller"), []string{"viewer1"})
+	app.milesCmd(context.Background(), newTestUser("caller"), []string{"viewer1"})
 
 	msg := out()
 	// monthly is 15.5, lifetime 120 → both should appear (rounded to int for total)
@@ -798,7 +799,7 @@ func TestMilesCmd_OtherUser_StripsAtSign(t *testing.T) {
 	defer restore()
 
 	// "@ghost" should be normalized to "ghost" before the lookup
-	app.milesCmd(newTestUser("caller"), []string{"@ghost"})
+	app.milesCmd(context.Background(), newTestUser("caller"), []string{"@ghost"})
 
 	if !strings.Contains(out(), "I don't know them") {
 		t.Errorf("expected unknown-user message, got %q", out())

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -37,14 +37,15 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 	return video.Video{State: state, Lat: lat, Lng: lng, DateFilmed: date}
 }
 
-// newTestApp returns an App with CurrentVideo returning vid and a no-op
-// Onscreens fake. For commands that don't use CurrentVideo, pass a zero-value
-// video.Video. To assert on Onscreens calls, replace app.Onscreens with a
-// recording fake (see fakeOnscreens in onscreens_test.go).
+// newTestApp returns an App with CurrentVideo returning vid, plus no-op
+// Onscreens and VLC fakes. For commands that don't use CurrentVideo, pass a
+// zero-value video.Video. To assert on Onscreens or VLC calls, replace
+// app.Onscreens / app.VLC with a recordingOnscreens / recordingVLC.
 func newTestApp(vid video.Video) *App {
 	return &App{
 		CurrentVideo: func() video.Video { return vid },
 		Onscreens:    noopOnscreens{},
+		VLC:          noopVLC{},
 	}
 }
 
@@ -405,6 +406,113 @@ func TestGuessCmd_WrongGuess_SaysTryAgain(t *testing.T) {
 
 	if !strings.Contains(out(), "Try again") {
 		t.Errorf("expected try-again in output, got %q", out())
+	}
+}
+
+// expectAddToScoreChain queues sqlmock expectations for one user.AddToScore
+// call: getUserIDByName + findOrCreateScoreboard + findOrCreateScore + the
+// UPDATE on Score.save. AddToScore fires twice on a correct guess (once for
+// the lifetime "guess_state_total" scoreboard, once for the monthly one), so
+// callers queue it twice.
+func expectAddToScoreChain(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "guess_sb"))
+	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
+			AddRow(99, 42, 7, 5.0))
+	mock.ExpectExec(`UPDATE "scores" SET`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func TestGuessCmd_CorrectGuess_DrivesOverlayAndPlayback(t *testing.T) {
+	mock := installMockDB(t)
+	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
+	app := newTestApp(vid)
+	recOverlay := &recordingOnscreens{}
+	recVLC := &recordingVLC{}
+	app.Onscreens = recOverlay
+	app.VLC = recVLC
+
+	// Two AddToScore calls — lifetime ("guess_state_total") + monthly.
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), []string{"Colorado"})
+
+	msg := out()
+	if !strings.Contains(msg, "@viewer1 got it") || !strings.Contains(msg, "Colorado") {
+		t.Errorf("expected correct-guess chat message, got %q", msg)
+	}
+
+	// Overlay sequence: ShowFlag (state flag) then ShowTimewarp (from a.timewarp()).
+	wantOverlay := []string{"ShowFlag(10s)", "ShowTimewarp()"}
+	if len(recOverlay.Calls) != len(wantOverlay) {
+		t.Fatalf("expected %d overlay calls, got %d: %v", len(wantOverlay), len(recOverlay.Calls), recOverlay.Calls)
+	}
+	for i, want := range wantOverlay {
+		if recOverlay.Calls[i] != want {
+			t.Errorf("overlay call %d: want %q, got %q", i, want, recOverlay.Calls[i])
+		}
+	}
+
+	// VLC: PlayRandom fires inside a.timewarp().
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "PlayRandom()" {
+		t.Errorf("expected single PlayRandom call, got %v", recVLC.Calls)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGuessCmd_CorrectGuess_FullStateName(t *testing.T) {
+	// guessCmd converts 2-letter codes to long-form before comparing; pass
+	// the long form directly to confirm the equality branch works without
+	// the abbrev lookup.
+	mock := installMockDB(t)
+	vid := newTestVideo("Massachusetts", 42.3, -71.0, time.Now())
+	app := newTestApp(vid)
+
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), []string{"Massachusetts"})
+
+	if !strings.Contains(out(), "got it") {
+		t.Errorf("expected correct-guess msg, got %q", out())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGuessCmd_CorrectGuess_TwoLetterCode(t *testing.T) {
+	// Two-letter codes get expanded via helpers.StateAbbrevToState.
+	mock := installMockDB(t)
+	vid := newTestVideo("California", 36.7, -119.4, time.Now())
+	app := newTestApp(vid)
+
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(newTestUser("viewer1"), []string{"CA"})
+
+	if !strings.Contains(out(), "got it") {
+		t.Errorf("expected correct-guess msg from CA, got %q", out())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -60,6 +60,16 @@ func dispatch(cmd *Command, user *users.User, params []string) {
 	if !cmd.checkAccess(user, sayFn) {
 		return
 	}
+	// Wrap the handler in a span so each chat command shows up as a trace
+	// in Tempo. SQL queries (via otelsql) and outbound HTTP (via otelhttp)
+	// will nest under this once the HandlerFunc signature grows a
+	// context.Context — until then they stay as sibling traces, but the
+	// command-level span alone is already useful for "which command is slow"
+	// and for cross-referencing the tripbot_command_duration_seconds metric.
+	_, span := tracer.Start(context.Background(), "chat.command",
+		trace.WithAttributes(attribute.String("command", cmd.Trigger)))
+	defer span.End()
+
 	start := time.Now()
 	cmd.Handler(user, params)
 	instrumentation.ChatCommandDuration.Observe(cmd.Trigger, time.Since(start).Seconds())

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -55,23 +55,21 @@ func (cmd *Command) checkAccess(user chatUser, sayFn func(string)) bool {
 	return true
 }
 
-func dispatch(cmd *Command, user *users.User, params []string) {
+func dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)
 	if !cmd.checkAccess(user, sayFn) {
 		return
 	}
-	// Wrap the handler in a span so each chat command shows up as a trace
-	// in Tempo. SQL queries (via otelsql) and outbound HTTP (via otelhttp)
-	// will nest under this once the HandlerFunc signature grows a
-	// context.Context — until then they stay as sibling traces, but the
-	// command-level span alone is already useful for "which command is slow"
-	// and for cross-referencing the tripbot_command_duration_seconds metric.
-	_, span := tracer.Start(context.Background(), "chat.command",
+	// Start a child span under the chatbot.handle_message span from
+	// PrivateMessage. SQL queries (via otelsql) and outbound HTTP (via
+	// otelhttp) nest under chat.command in Tempo, so a single !miles
+	// shows up as one trace with all 4 GetScore-chain SQL spans nested.
+	ctx, span := tracer.Start(ctx, "chat.command",
 		trace.WithAttributes(attribute.String("command", cmd.Trigger)))
 	defer span.End()
 
 	start := time.Now()
-	cmd.Handler(user, params)
+	cmd.Handler(ctx, user, params)
 	instrumentation.ChatCommandDuration.Observe(cmd.Trigger, time.Since(start).Seconds())
 }
 
@@ -136,7 +134,7 @@ func runCommand(ctx context.Context, user *users.User, message string) {
 
 	cmd, params := findCommand(message)
 	if cmd != nil {
-		dispatch(cmd, user, params)
+		dispatch(ctx, cmd, user, params)
 		return
 	}
 
@@ -166,19 +164,19 @@ func PrivateMessage(msg twitch.PrivateMessage) {
 	// check to see if the message is a command
 	//TODO: also include ones prefixed with whitespace?
 	// log in the user
-	user := users.LoginIfNecessary(username)
+	user := users.LoginIfNecessary(ctx, username)
 
 	runCommand(ctx, user, message)
 }
 
 // this event fires when a user joins the channel
 func UserJoin(joinMessage twitch.UserJoinMessage) {
-	users.LoginIfNecessary(joinMessage.User)
+	users.LoginIfNecessary(context.Background(), joinMessage.User)
 }
 
 // this event fires when a user leaves the channel
 func UserPart(partMessage twitch.UserPartMessage) {
-	users.LogoutIfNecessary(partMessage.User)
+	users.LogoutIfNecessary(context.Background(), partMessage.User)
 }
 
 // send message to chat if someone subs

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -14,7 +14,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
-	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
 // lastTimewarpTime is used to rate-limit users so they can't
@@ -28,7 +27,7 @@ func (a *App) timewarp() {
 	a.Onscreens.ShowTimewarp()
 
 	// shuffle to a new video
-	err := vlcClient.PlayRandom()
+	err := a.VLC.PlayRandom()
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}
@@ -107,7 +106,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 		return
 	}
 	// tell VLC to play it
-	err = vlcClient.PlayFileInPlaylist(randomVid.File())
+	err = a.VLC.PlayFileInPlaylist(randomVid.File())
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 		Say("Usage: !jump [state]")
@@ -157,7 +156,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 	}
 
 	// skip to a new video
-	err = vlcClient.Skip(n)
+	err = a.VLC.Skip(n)
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}
@@ -202,7 +201,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 	}
 
 	// back to an old video
-	err = vlcClient.Back(n)
+	err = a.VLC.Back(n)
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
 	}

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -37,7 +38,7 @@ func (a *App) timewarp() {
 	lastTimewarpTime = time.Now()
 }
 
-func (a *App) timewarpCmd(user *users.User, _ []string) {
+func (a *App) timewarpCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !timewarp")
 
 	// exit early if we're on OS X
@@ -63,7 +64,7 @@ func (a *App) timewarpCmd(user *users.User, _ []string) {
 	a.timewarp()
 }
 
-func (a *App) jumpCmd(user *users.User, params []string) {
+func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	log.Println(user.Username, "ran !jump")
 
@@ -121,7 +122,7 @@ func (a *App) jumpCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
-func (a *App) skipCmd(user *users.User, params []string) {
+func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	var n int
 	log.Println(user.Username, "ran !skip")
@@ -166,7 +167,7 @@ func (a *App) skipCmd(user *users.User, params []string) {
 	lastTimewarpTime = time.Now()
 }
 
-func (a *App) backCmd(user *users.User, params []string) {
+func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	var n int
 	log.Println(user.Username, "ran !back")

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"strings"
 
 	"github.com/adanalife/tripbot/pkg/users"
@@ -63,20 +64,20 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!socialmedia",
 			Aliases: []string{"!social", "!socials"},
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("Find me outside of Twitch: !twitter, !instagram, !facebook, !youtube")
 			},
 		},
 		{
 			Trigger: "!discord",
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("Join us on Discord: https://discord.gg/Bk9EuGdMX")
 			},
 		},
 		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, and many other hidden commands!")
 			},
 		},
@@ -121,7 +122,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!gas",
 			Aliases: []string{"!fuel", "!petrol"},
-			Handler: func(_ *users.User, _ []string) {
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				sayFn("About full, thanks for asking")
 			},
 		},

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -1,0 +1,24 @@
+package chatbot
+
+import (
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
+)
+
+// VLC is the subset of the vlc-client surface that chatbot commands depend
+// on (timewarp, jump, skip, back). Tests inject a fake; production uses the
+// package-backed realVLC adapter wired in defaultApp. Mirrors the Onscreens
+// injection pattern.
+type VLC interface {
+	PlayRandom() error
+	PlayFileInPlaylist(filename string) error
+	Skip(n int) error
+	Back(n int) error
+}
+
+// realVLC delegates to pkg/vlc-client.
+type realVLC struct{}
+
+func (realVLC) PlayRandom() error                     { return vlcClient.PlayRandom() }
+func (realVLC) PlayFileInPlaylist(filename string) error { return vlcClient.PlayFileInPlaylist(filename) }
+func (realVLC) Skip(n int) error                      { return vlcClient.Skip(n) }
+func (realVLC) Back(n int) error                      { return vlcClient.Back(n) }

--- a/pkg/chatbot/vlc_test.go
+++ b/pkg/chatbot/vlc_test.go
@@ -1,0 +1,36 @@
+package chatbot
+
+import "fmt"
+
+// noopVLC satisfies VLC for tests that don't care about playback transitions
+// — it just swallows every call.
+type noopVLC struct{}
+
+func (noopVLC) PlayRandom() error                     { return nil }
+func (noopVLC) PlayFileInPlaylist(_ string) error     { return nil }
+func (noopVLC) Skip(_ int) error                      { return nil }
+func (noopVLC) Back(_ int) error                      { return nil }
+
+// recordingVLC captures every call made to it so tests can assert that
+// the chatbot drove playback as expected. All call records are appended
+// in order to Calls.
+type recordingVLC struct {
+	Calls []string
+}
+
+func (r *recordingVLC) PlayRandom() error {
+	r.Calls = append(r.Calls, "PlayRandom()")
+	return nil
+}
+func (r *recordingVLC) PlayFileInPlaylist(filename string) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("PlayFileInPlaylist(%q)", filename))
+	return nil
+}
+func (r *recordingVLC) Skip(n int) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("Skip(%d)", n))
+	return nil
+}
+func (r *recordingVLC) Back(n int) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("Back(%d)", n))
+	return nil
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -20,24 +21,24 @@ type Event struct {
 	DateCreated time.Time
 }
 
-func Login(user string, sessionID uuid.UUID) error {
+func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
 		log.Printf("Not logging in %s because we're in read-only mode", aurora.Magenta(user))
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
-	if err := database.GormDB().Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
+	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
 		return err
 	}
 	instrumentation.Events.Inc("login")
 	return nil
 }
 
-func Logout(user string, sessionID uuid.UUID) error {
+func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
 		log.Printf("Not logging out %s because we're in read-only mode", aurora.Magenta(user))
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
-	if err := database.GormDB().Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {
+	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {
 		return err
 	}
 	instrumentation.Events.Inc("logout")

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -27,6 +27,21 @@ var (
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
 	obsStreamingGauge = mustGauge("obs_streaming_active", "1 if OBS is actively streaming, 0 otherwise")
+
+	obsActiveFPS              = mustFloat64Gauge("obs_active_fps", "Current FPS being rendered by OBS")
+	obsAverageFrameRenderMS   = mustFloat64Gauge("obs_average_frame_render_time_ms", "Average time in milliseconds OBS spends rendering a frame")
+	obsCPUUsage               = mustFloat64Gauge("obs_cpu_usage_percent", "Current OBS CPU usage (percent)")
+	obsMemoryUsage            = mustFloat64Gauge("obs_memory_usage_mb", "Current OBS memory usage in MB")
+	obsRenderSkippedFrames    = mustFloat64Gauge("obs_render_skipped_frames", "Render-thread skipped frames since OBS started")
+	obsRenderTotalFrames      = mustFloat64Gauge("obs_render_total_frames", "Render-thread total frames since OBS started")
+	obsOutputSkippedFrames    = mustFloat64Gauge("obs_output_skipped_frames", "Output-thread skipped frames since OBS started")
+	obsOutputTotalFrames      = mustFloat64Gauge("obs_output_total_frames", "Output-thread total frames since OBS started")
+	obsStreamOutputBytes      = mustFloat64Gauge("obs_stream_output_bytes", "Bytes sent by the stream output (cumulative since stream start)")
+	obsStreamOutputDurationMS = mustFloat64Gauge("obs_stream_output_duration_ms", "Current stream output duration in milliseconds")
+	obsStreamCongestion       = mustFloat64Gauge("obs_stream_output_congestion", "Stream output congestion (0..1)")
+	obsStreamReconnecting     = mustGauge("obs_stream_output_reconnecting", "1 if the stream output is currently reconnecting, 0 otherwise")
+	obsStreamSkippedFrames    = mustFloat64Gauge("obs_stream_output_skipped_frames", "Stream-output skipped frames since stream start")
+	obsStreamTotalFrames      = mustFloat64Gauge("obs_stream_output_total_frames", "Stream-output total frames since stream start")
 )
 
 // ChatMessages exposes the chat-message counter through a tiny stable API
@@ -61,6 +76,49 @@ var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
 
 // OBSStreaming exposes the streaming-active gauge.
 var OBSStreaming = obsStreamingIface{g: obsStreamingGauge}
+
+// OBSStatsSnapshot bundles OBS performance + stream-output stats so the
+// poller can publish in a single call without coupling instrumentation to
+// goobs types.
+type OBSStatsSnapshot struct {
+	ActiveFPS              float64
+	AverageFrameRenderTime float64 // ms
+	CPUUsage               float64 // percent
+	MemoryUsage            float64 // MB
+	RenderSkippedFrames    float64
+	RenderTotalFrames      float64
+	OutputSkippedFrames    float64
+	OutputTotalFrames      float64
+}
+
+// OBSStreamSnapshot is the stream-output side (only meaningful while
+// streaming, but always safe to publish — fields are zero when idle).
+type OBSStreamSnapshot struct {
+	OutputBytes       float64
+	OutputDurationMS  float64
+	OutputCongestion  float64
+	Reconnecting      bool
+	SkippedFrames     float64
+	TotalFrames       float64
+}
+
+// OBSStats exposes the OBS performance + stream-output gauges.
+var OBSStats = obsStatsIface{
+	activeFPS:           obsActiveFPS,
+	averageFrameRender:  obsAverageFrameRenderMS,
+	cpuUsage:            obsCPUUsage,
+	memoryUsage:         obsMemoryUsage,
+	renderSkippedFrames: obsRenderSkippedFrames,
+	renderTotalFrames:   obsRenderTotalFrames,
+	outputSkippedFrames: obsOutputSkippedFrames,
+	outputTotalFrames:   obsOutputTotalFrames,
+	streamBytes:         obsStreamOutputBytes,
+	streamDuration:      obsStreamOutputDurationMS,
+	streamCongestion:    obsStreamCongestion,
+	streamReconnecting:  obsStreamReconnecting,
+	streamSkipped:       obsStreamSkippedFrames,
+	streamTotal:         obsStreamTotalFrames,
+}
 
 type chatCounterIface struct{ counter metric.Int64Counter }
 
@@ -124,6 +182,49 @@ func (o obsStreamingIface) Set(active bool) {
 	o.g.Record(context.Background(), v)
 }
 
+type obsStatsIface struct {
+	activeFPS           metric.Float64Gauge
+	averageFrameRender  metric.Float64Gauge
+	cpuUsage            metric.Float64Gauge
+	memoryUsage         metric.Float64Gauge
+	renderSkippedFrames metric.Float64Gauge
+	renderTotalFrames   metric.Float64Gauge
+	outputSkippedFrames metric.Float64Gauge
+	outputTotalFrames   metric.Float64Gauge
+	streamBytes         metric.Float64Gauge
+	streamDuration      metric.Float64Gauge
+	streamCongestion    metric.Float64Gauge
+	streamReconnecting  metric.Int64Gauge
+	streamSkipped       metric.Float64Gauge
+	streamTotal         metric.Float64Gauge
+}
+
+func (o obsStatsIface) Update(s OBSStatsSnapshot) {
+	ctx := context.Background()
+	o.activeFPS.Record(ctx, s.ActiveFPS)
+	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime)
+	o.cpuUsage.Record(ctx, s.CPUUsage)
+	o.memoryUsage.Record(ctx, s.MemoryUsage)
+	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames)
+	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames)
+	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames)
+	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames)
+}
+
+func (o obsStatsIface) UpdateStream(s OBSStreamSnapshot) {
+	ctx := context.Background()
+	o.streamBytes.Record(ctx, s.OutputBytes)
+	o.streamDuration.Record(ctx, s.OutputDurationMS)
+	o.streamCongestion.Record(ctx, s.OutputCongestion)
+	v := int64(0)
+	if s.Reconnecting {
+		v = 1
+	}
+	o.streamReconnecting.Record(ctx, v)
+	o.streamSkipped.Record(ctx, s.SkippedFrames)
+	o.streamTotal.Record(ctx, s.TotalFrames)
+}
+
 func mustCounter(name, desc string) metric.Int64Counter {
 	c, err := meter.Int64Counter(name, metric.WithDescription(desc))
 	if err != nil {
@@ -150,4 +251,12 @@ func mustHistogram(name, desc string, buckets ...float64) metric.Float64Histogra
 		panic(err)
 	}
 	return h
+}
+
+func mustFloat64Gauge(name, desc string) metric.Float64Gauge {
+	g, err := meter.Float64Gauge(name, metric.WithDescription(desc))
+	if err != nil {
+		panic(err)
+	}
+	return g
 }

--- a/pkg/instrumentation/vlc_server.go
+++ b/pkg/instrumentation/vlc_server.go
@@ -1,0 +1,67 @@
+package instrumentation
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	vlcInputBitRate        = mustFloat64Gauge("vlc_player_input_bitrate", "libvlc input bitrate (libvlc-native units, ~bytes/µs)")
+	vlcDemuxBitRate        = mustFloat64Gauge("vlc_player_demux_bitrate", "libvlc demux bitrate (libvlc-native units, ~bytes/µs)")
+	vlcDisplayedFPS        = mustFloat64Gauge("vlc_player_displayed_fps", "Derived frames-per-second: delta of displayed pictures over the poll interval")
+	vlcDecodedVideo        = mustFloat64Gauge("vlc_player_decoded_video_frames", "Total decoded video blocks since the current Media started (resets on media change)")
+	vlcDisplayedPictures   = mustFloat64Gauge("vlc_player_displayed_pictures", "Total displayed frames since the current Media started (resets on media change)")
+	vlcLostPictures        = mustFloat64Gauge("vlc_player_lost_pictures", "Total lost (dropped) frames since the current Media started (resets on media change)")
+	vlcDemuxCorrupted      = mustFloat64Gauge("vlc_player_demux_corrupted", "Demux corruptions discarded since the current Media started")
+	vlcDemuxDiscontinuity  = mustFloat64Gauge("vlc_player_demux_discontinuity", "Demux discontinuities dropped since the current Media started")
+)
+
+// VLCPlayerStatsSnapshot is the shape vlc-server hands to instrumentation
+// each poll tick. Decouples the gauges from libvlc-go's MediaStats type.
+type VLCPlayerStatsSnapshot struct {
+	InputBitRate       float64
+	DemuxBitRate       float64
+	DisplayedFPS       float64 // derived by the caller from delta of DisplayedPictures
+	DecodedVideo       float64
+	DisplayedPictures  float64
+	LostPictures       float64
+	DemuxCorrupted     float64
+	DemuxDiscontinuity float64
+}
+
+// VLCPlayerStats exposes the libvlc playback stats. Call Update on every
+// poll tick with a fresh snapshot.
+var VLCPlayerStats = vlcPlayerStatsIface{
+	inputBitRate:       vlcInputBitRate,
+	demuxBitRate:       vlcDemuxBitRate,
+	displayedFPS:       vlcDisplayedFPS,
+	decodedVideo:       vlcDecodedVideo,
+	displayedPictures:  vlcDisplayedPictures,
+	lostPictures:       vlcLostPictures,
+	demuxCorrupted:     vlcDemuxCorrupted,
+	demuxDiscontinuity: vlcDemuxDiscontinuity,
+}
+
+type vlcPlayerStatsIface struct {
+	inputBitRate       metric.Float64Gauge
+	demuxBitRate       metric.Float64Gauge
+	displayedFPS       metric.Float64Gauge
+	decodedVideo       metric.Float64Gauge
+	displayedPictures  metric.Float64Gauge
+	lostPictures       metric.Float64Gauge
+	demuxCorrupted     metric.Float64Gauge
+	demuxDiscontinuity metric.Float64Gauge
+}
+
+func (v vlcPlayerStatsIface) Update(s VLCPlayerStatsSnapshot) {
+	ctx := context.Background()
+	v.inputBitRate.Record(ctx, s.InputBitRate)
+	v.demuxBitRate.Record(ctx, s.DemuxBitRate)
+	v.displayedFPS.Record(ctx, s.DisplayedFPS)
+	v.decodedVideo.Record(ctx, s.DecodedVideo)
+	v.displayedPictures.Record(ctx, s.DisplayedPictures)
+	v.lostPictures.Record(ctx, s.LostPictures)
+	v.demuxCorrupted.Record(ctx, s.DemuxCorrupted)
+	v.demuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity)
+}

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -70,6 +70,32 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 				return // trigger reconnect
 			}
 			instrumentation.OBSStreaming.Set(resp.OutputActive)
+			instrumentation.OBSStats.UpdateStream(instrumentation.OBSStreamSnapshot{
+				OutputBytes:      resp.OutputBytes,
+				OutputDurationMS: resp.OutputDuration,
+				OutputCongestion: resp.OutputCongestion,
+				Reconnecting:     resp.OutputReconnecting,
+				SkippedFrames:    resp.OutputSkippedFrames,
+				TotalFrames:      resp.OutputTotalFrames,
+			})
+
+			stats, err := client.General.GetStats()
+			if err != nil {
+				// Non-fatal — keep the connection alive; stream-side
+				// gauges already published this tick.
+				log.Printf("obs: GetStats error: %v", err)
+				continue
+			}
+			instrumentation.OBSStats.Update(instrumentation.OBSStatsSnapshot{
+				ActiveFPS:              stats.ActiveFps,
+				AverageFrameRenderTime: stats.AverageFrameRenderTime,
+				CPUUsage:               stats.CpuUsage,
+				MemoryUsage:            stats.MemoryUsage,
+				RenderSkippedFrames:    stats.RenderSkippedFrames,
+				RenderTotalFrames:      stats.RenderTotalFrames,
+				OutputSkippedFrames:    stats.OutputSkippedFrames,
+				OutputTotalFrames:      stats.OutputTotalFrames,
+			})
 		}
 	}
 }

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -1,6 +1,7 @@
 package onscreensClient
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -56,10 +57,10 @@ func ShowLeaderboard(title string, leaderboard [][]string) error {
 }
 
 //TODO: this is taken right from the !guessleaderboard command, DRY it?
-func ShowGuessLeaderboard() {
+func ShowGuessLeaderboard(ctx context.Context) {
 	// select users to show in leaderboard
 	size := 10
-	leaderboard := scoreboards.TopUsers(scoreboards.CurrentGuessScoreboard(), size)
+	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
 	if size > len(leaderboard) {
 		size = len(leaderboard)
 	}

--- a/pkg/scoreboards/scoreboards.go
+++ b/pkg/scoreboards/scoreboards.go
@@ -1,6 +1,7 @@
 package scoreboards
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -23,13 +24,13 @@ type topUserResult struct {
 	Value    float32
 }
 
-func TopUsers(scoreboardName string, size int) [][]string {
+func TopUsers(ctx context.Context, scoreboardName string, size int) [][]string {
 	var leaderboard [][]string
 
 	ignoredUsers := append(c.IgnoredUsers, strings.ToLower(c.Conf.ChannelName))
 
 	var results []topUserResult
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Table("scores").
 		Select("users.username, scores.value").
 		Joins("JOIN scoreboards ON scores.scoreboard_id = scoreboards.id").
@@ -51,18 +52,18 @@ func TopUsers(scoreboardName string, size int) [][]string {
 }
 
 // findOrCreateScoreboard will find a Scoreboard in the DB or create one
-func findOrCreateScoreboard(name string) (Scoreboard, error) {
+func findOrCreateScoreboard(ctx context.Context, name string) (Scoreboard, error) {
 	var scoreboard Scoreboard
-	result := database.GormDB().Where(Scoreboard{Name: name}).FirstOrCreate(&scoreboard)
+	result := database.GormDB().WithContext(ctx).Where(Scoreboard{Name: name}).FirstOrCreate(&scoreboard)
 	return scoreboard, result.Error
 }
 
 // createScoreboard() will actually create the DB record
-func createScoreboard(name string) (Scoreboard, error) {
+func createScoreboard(ctx context.Context, name string) (Scoreboard, error) {
 	if c.Conf.Verbose {
 		log.Println("creating scoreboard", name)
 	}
 	scoreboard := Scoreboard{Name: name}
-	result := database.GormDB().Create(&scoreboard)
+	result := database.GormDB().WithContext(ctx).Create(&scoreboard)
 	return scoreboard, result.Error
 }

--- a/pkg/scoreboards/scores.go
+++ b/pkg/scoreboards/scores.go
@@ -1,6 +1,7 @@
 package scoreboards
 
 import (
+	"context"
 	"errors"
 	"log"
 	"time"
@@ -23,18 +24,18 @@ type Score struct {
 
 // GetScoreByName returns the score value for a given username and scoreboard name
 //TODO: this could be achieved with a single query
-func GetScoreByName(username, scoreboardName string) (float32, error) {
-	userID, err := getUserIDByName(username)
+func GetScoreByName(ctx context.Context, username, scoreboardName string) (float32, error) {
+	userID, err := getUserIDByName(ctx, username)
 	if err != nil {
 		terrors.Log(err, "error getting user ID")
 		return -1.0, err
 	}
-	scoreboard, err := findOrCreateScoreboard(scoreboardName)
+	scoreboard, err := findOrCreateScoreboard(ctx, scoreboardName)
 	if err != nil {
 		terrors.Log(err, "error finding or creating scoreboard")
 		return -1.0, err
 	}
-	score, err := findOrCreateScore(userID, scoreboard.ID)
+	score, err := findOrCreateScore(ctx, userID, scoreboard.ID)
 	if err != nil {
 		terrors.Log(err, "error finding score")
 		return -1.0, err
@@ -44,24 +45,24 @@ func GetScoreByName(username, scoreboardName string) (float32, error) {
 
 // AddToScoreByName increases the score value for a given username and scoreboard name
 //TODO: this could be achieved with less queries
-func AddToScoreByName(username, scoreboardName string, scoreToAdd float32) error {
-	userID, err := getUserIDByName(username)
+func AddToScoreByName(ctx context.Context, username, scoreboardName string, scoreToAdd float32) error {
+	userID, err := getUserIDByName(ctx, username)
 	if err != nil {
 		terrors.Log(err, "error getting userID for user")
 		return err
 	}
-	scoreboard, err := findOrCreateScoreboard(scoreboardName)
+	scoreboard, err := findOrCreateScoreboard(ctx, scoreboardName)
 	if err != nil {
 		terrors.Log(err, "error finding or creating scoreboard")
 		return err
 	}
-	score, err := findOrCreateScore(userID, scoreboard.ID)
+	score, err := findOrCreateScore(ctx, userID, scoreboard.ID)
 	if err != nil {
 		terrors.Log(err, "error finding score")
 		return err
 	}
 	score.Value += scoreToAdd
-	if err := score.save(); err != nil {
+	if err := score.save(ctx); err != nil {
 		return err
 	}
 	instrumentation.ScoreboardWrites.Inc(scoreboardName)
@@ -69,9 +70,9 @@ func AddToScoreByName(username, scoreboardName string, scoreToAdd float32) error
 }
 
 // findOrCreateScore will look up the username in the DB, and return a Score if possible
-func findOrCreateScore(userID, scoreboardID uint16) (Score, error) {
+func findOrCreateScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	var score Score
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Where(Score{UserID: userID, ScoreboardID: scoreboardID}).
 		FirstOrCreate(&score)
 	return score, result.Error
@@ -79,9 +80,9 @@ func findOrCreateScore(userID, scoreboardID uint16) (Score, error) {
 
 // findScore will look up the score in the DB
 //TODO: this shouldn't be necessary, join the tables instead
-func findScore(userID, scoreboardID uint16) (Score, error) {
+func findScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	var score Score
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Where("user_id = ? AND scoreboard_id = ?", userID, scoreboardID).
 		First(&score)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -91,19 +92,19 @@ func findScore(userID, scoreboardID uint16) (Score, error) {
 }
 
 // createScore() will actually create the DB record
-func createScore(userID, scoreboardID uint16) (Score, error) {
+func createScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	log.Printf("creating score user_id:%d, scoreboard_id:%d", userID, scoreboardID)
 	score := Score{UserID: userID, ScoreboardID: scoreboardID}
-	result := database.GormDB().Create(&score)
+	result := database.GormDB().WithContext(ctx).Create(&score)
 	return score, result.Error
 }
 
 // save() will take the given score and store it in the DB
-func (s Score) save() error {
+func (s Score) save(ctx context.Context) error {
 	if c.Conf.Verbose {
 		log.Println("saving score", s)
 	}
-	err := database.GormDB().Model(&s).Update("value", s.Value).Error
+	err := database.GormDB().WithContext(ctx).Model(&s).Update("value", s.Value).Error
 	if err != nil {
 		terrors.Log(err, "error saving score")
 	}
@@ -112,9 +113,9 @@ func (s Score) save() error {
 
 // getUserIDByName fetches the user ID for a given username
 //TODO: this shouldn't be necessary, join the tables instead
-func getUserIDByName(username string) (uint16, error) {
+func getUserIDByName(ctx context.Context, username string) (uint16, error) {
 	var result struct{ ID uint16 }
-	err := database.GormDB().Raw("SELECT id FROM users WHERE username = ?", username).Scan(&result).Error
+	err := database.GormDB().WithContext(ctx).Raw("SELECT id FROM users WHERE username = ?", username).Scan(&result).Error
 	if err != nil {
 		terrors.Log(err, "error fetching user ID")
 	}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -111,7 +111,7 @@ func webhooksTwitchUsersFollowsHandler(w http.ResponseWriter, r *http.Request) {
 	for _, follower := range resp.Data.Follows {
 		username := follower.FromName
 		log.Println("got webhook for new follower:", username)
-		users.LoginIfNecessary(username)
+		users.LoginIfNecessary(r.Context(), username)
 		// announce new follower in chat
 		chatbot.AnnounceNewFollower(username)
 	}
@@ -137,7 +137,7 @@ func webhooksTwitchSubscriptionsEventsHandler(w http.ResponseWriter, r *http.Req
 	for _, event := range resp.Data.Events {
 		username := event.Subscription.UserName
 		log.Println("got webhook for new sub:", username)
-		users.LoginIfNecessary(username)
+		users.LoginIfNecessary(r.Context(), username)
 		// announce new sub in chat
 		chatbot.AnnounceSubscriber(event.Subscription)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -24,8 +26,17 @@ import (
 
 var server *http.Server
 
-// Start starts the web server
-func Start() {
+// shutdownTimeout is how long Shutdown waits for in-flight requests to
+// finish before forcing connections closed. 15s is the typical sweet spot:
+// long enough that healthy requests complete, short enough that a stuck
+// handler doesn't block process exit indefinitely.
+const shutdownTimeout = 15 * time.Second
+
+// Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
+// via signal.NotifyContext) the server stops accepting new connections and
+// waits up to shutdownTimeout for in-flight requests to complete before
+// returning.
+func Start(ctx context.Context) {
 	log.Println("Starting web server on port", c.Conf.TripbotServerPort)
 
 	r := mux.NewRouter()
@@ -97,9 +108,29 @@ func Start() {
 		Handler:        otelhttp.NewHandler(app, c.Conf.ServerType),
 	}
 
-	//TODO: add graceful shutdown
-	if err := srv.ListenAndServe(); err != nil {
-		terrors.Fatal(err, "couldn't start server")
+	// Run ListenAndServe in a goroutine so we can block on ctx.Done() and
+	// trigger a graceful shutdown when a signal arrives. ErrServerClosed is
+	// the expected return after Shutdown is called and is not an error.
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			terrors.Fatal(err, "couldn't start server")
+		}
+	case <-ctx.Done():
+		log.Println("shutting down web server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			terrors.Log(err, "error during web server shutdown")
+		}
 	}
 }
 

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -15,7 +16,15 @@ import (
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+// helixHTTPClient is the otelhttp-instrumented HTTP client passed to every
+// helix.NewClient call. Without this, outbound Twitch Helix requests leave
+// no trail in Tempo; with it, each helix.GetUsers / GetSubscriptions / etc.
+// shows up as a span. Pairs with the otelhttp transports already used by
+// pkg/vlc-client and pkg/onscreens-client.
+var helixHTTPClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
 // Scopes is the OAuth scope set requested for the bot account. Single source
 // of truth — referenced by Client() (App Access Token request),
@@ -84,6 +93,7 @@ func Client() (*helix.Client, error) {
 		// Registered at https://dev.twitch.tv/console/apps; matched by
 		// cmd/auth-bootstrap's local HTTP listener.
 		RedirectURI: c.Conf.ExternalURL + "/auth/callback",
+		HTTPClient:  helixHTTPClient,
 	})
 	if err != nil {
 		terrors.Log(err, "error creating client")

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,11 +17,11 @@ var initLeaderboardSize = 25
 var maxLeaderboardSize = 50
 
 // InitLeaderboard creates the initial leaderboard
-func InitLeaderboard() {
+func InitLeaderboard(ctx context.Context) {
 	var users []User
 
 	ignoredUsers := append(c.IgnoredUsers, strings.ToLower(c.Conf.ChannelName))
-	result := database.GormDB().
+	result := database.GormDB().WithContext(ctx).
 		Where("miles != 0 AND is_bot = false AND username NOT IN ?", ignoredUsers).
 		Order("miles DESC").
 		Limit(initLeaderboardSize).

--- a/pkg/users/scores.go
+++ b/pkg/users/scores.go
@@ -1,12 +1,14 @@
 package users
 
 import (
+	"context"
+
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 )
 
-func (u User) GetScore(scoreboardName string) float32 {
-	value, err := scoreboards.GetScoreByName(u.Username, scoreboardName)
+func (u User) GetScore(ctx context.Context, scoreboardName string) float32 {
+	value, err := scoreboards.GetScoreByName(ctx, u.Username, scoreboardName)
 	if err != nil {
 		terrors.Log(err, "error getting score for user")
 		return -1.0
@@ -14,8 +16,8 @@ func (u User) GetScore(scoreboardName string) float32 {
 	return value
 }
 
-func (u User) AddToScore(scoreboardName string, valueToAdd float32) {
-	err := scoreboards.AddToScoreByName(u.Username, scoreboardName, valueToAdd)
+func (u User) AddToScore(ctx context.Context, scoreboardName string, valueToAdd float32) {
+	err := scoreboards.AddToScoreByName(ctx, u.Username, scoreboardName, valueToAdd)
 	if err != nil {
 		terrors.Log(err, "error setting score for user")
 	}

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -29,7 +30,7 @@ var LoggedIn = make(map[string]*User)
 
 // UpdateSession will use the data from the Twitch API to maintain a list
 // of currently-logged-in users
-func UpdateSession() {
+func UpdateSession(ctx context.Context) {
 	// fetch the latest chatters from Twitch
 	twitch.UpdateChatters()
 	currentChatters := twitch.Chatters()
@@ -41,7 +42,7 @@ func UpdateSession() {
 			continue
 		} else {
 			// they're logged in and NOT a current chatter, so log them out
-			user.logout()
+			user.logout(ctx)
 			continue
 		}
 	}
@@ -49,7 +50,7 @@ func UpdateSession() {
 	// log in everybody else
 	//TODO: this could get slow, maybe make a list of users that need to be logged in?
 	for chatter, _ := range currentChatters {
-		LoginIfNecessary(chatter)
+		LoginIfNecessary(ctx, chatter)
 	}
 
 	// PrintCurrentSession()
@@ -58,29 +59,29 @@ func UpdateSession() {
 
 // LoginIfNecessary checks the list of currently-logged in users and will
 // run login() if this user isn't currently logged in
-func LoginIfNecessary(username string) *User {
+func LoginIfNecessary(ctx context.Context, username string) *User {
 	// check if the user is currently logged in
 	if isLoggedIn(username) {
 		return LoggedIn[username]
 	}
 	// they weren't logged in, so note in the DB
-	return login(username)
+	return login(ctx, username)
 }
 
 // LogoutIfNecessary will log out the user if it finds them in the session
-func LogoutIfNecessary(username string) {
+func LogoutIfNecessary(ctx context.Context, username string) {
 	if isLoggedIn(username) {
 		user := *LoggedIn[username]
-		user.logout()
+		user.logout(ctx)
 	}
 }
 
 // login will record the users presence in the DB
 //TODO: do we want to make a DB update here? we could do it on logout()
-func login(username string) *User {
+func login(ctx context.Context, username string) *User {
 	now := time.Now()
 
-	user := FindOrCreate(username)
+	user := FindOrCreate(ctx, username)
 	// increment the number of visits
 	user.NumVisits = user.NumVisits + 1
 	// set the login time
@@ -93,7 +94,7 @@ func login(username string) *User {
 	user.lastCmd = now.AddDate(0, 0, -1)
 	// set their last !location date to yesterday
 	user.lastLocation = now.AddDate(0, 0, -1)
-	user.save()
+	user.save(ctx)
 
 	// raise an error if a user is supposed to be a bot
 	if c.UserIsIgnored(username) && !user.IsBot {
@@ -109,7 +110,7 @@ func login(username string) *User {
 	// add them to the session
 	LoggedIn[username] = &user
 
-	if err := events.Login(username, user.sessionID); err != nil {
+	if err := events.Login(ctx, username, user.sessionID); err != nil {
 		terrors.Log(err, "error creating login event")
 	}
 
@@ -118,7 +119,7 @@ func login(username string) *User {
 
 // User.logout() removes the user from the list of currently-logged in users,
 // and updates the DB with their most up-to-date values
-func (u User) logout() {
+func (u User) logout(ctx context.Context) {
 	sessionMiles := u.sessionMiles()
 
 	// print logout message if they're human
@@ -127,8 +128,8 @@ func (u User) logout() {
 		prettyDur := durafmt.ParseShort(loggedInDur)
 		dur := fmt.Sprintf("(%s)", aurora.Green(prettyDur))
 		miles := fmt.Sprintf("(%1.2fmi)", aurora.Yellow(sessionMiles))
-		monthlyMiles := fmt.Sprintf("(%1.2fmi this month)", aurora.Yellow(u.CurrentMonthlyMiles()))
-		guessScore := fmt.Sprintf("(%1.0f guesses)", aurora.Cyan(u.GetScore(scoreboards.CurrentGuessScoreboard())))
+		monthlyMiles := fmt.Sprintf("(%1.2fmi this month)", aurora.Yellow(u.CurrentMonthlyMiles(ctx)))
+		guessScore := fmt.Sprintf("(%1.0f guesses)", aurora.Cyan(u.GetScore(ctx, scoreboards.CurrentGuessScoreboard())))
 		log.Println("logging out", u, dur, miles, monthlyMiles, guessScore)
 	}
 
@@ -137,12 +138,12 @@ func (u User) logout() {
 	// update the last seen date
 	u.LastSeen = time.Now()
 	// store the user in the db
-	u.save()
+	u.save(ctx)
 
 	// update the monthly scoreboard
-	u.AddToScore(scoreboards.CurrentMilesScoreboard(), sessionMiles)
+	u.AddToScore(ctx, scoreboards.CurrentMilesScoreboard(), sessionMiles)
 
-	if err := events.Logout(u.Username, u.sessionID); err != nil {
+	if err := events.Logout(ctx, u.Username, u.sessionID); err != nil {
 		terrors.Log(err, "error creating logout event")
 	}
 
@@ -159,13 +160,13 @@ func isLoggedIn(username string) bool {
 }
 
 // ShutDown loops through all of the logged-in users and logs them out
-func Shutdown() {
+func Shutdown(ctx context.Context) {
 	if c.Conf.Verbose {
 		log.Println("these were the logged-in users")
 		spew.Dump(LoggedIn)
 	}
 	for _, user := range LoggedIn {
-		user.logout()
+		user.logout(ctx)
 	}
 }
 

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"errors"
 	"log"
 	"time"
@@ -77,16 +78,16 @@ func (u User) BonusMiles() float32 {
 	return 0.0
 }
 
-func (u User) CurrentMonthlyMiles() float32 {
-	return u.GetScore(scoreboards.CurrentMilesScoreboard()) + u.sessionMiles()
+func (u User) CurrentMonthlyMiles(ctx context.Context) float32 {
+	return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard()) + u.sessionMiles()
 }
 
 // User.save() will take the given user and store it in the DB
-func (u User) save() {
+func (u User) save(ctx context.Context) {
 	if c.Conf.Verbose {
 		log.Println("saving user", u)
 	}
-	err := database.GormDB().Model(&u).Updates(map[string]any{
+	err := database.GormDB().WithContext(ctx).Model(&u).Updates(map[string]any{
 		"last_seen":  u.LastSeen,
 		"num_visits": u.NumVisits,
 		"miles":      u.Miles,
@@ -118,22 +119,22 @@ func (u User) String() string {
 }
 
 // FindOrCreate will try to find the user in the DB, otherwise it will create a new user
-func FindOrCreate(username string) User {
+func FindOrCreate(ctx context.Context, username string) User {
 	if c.Conf.Verbose {
 		log.Printf("FindOrCreate(%s)", username)
 	}
-	user := Find(username)
+	user := Find(ctx, username)
 	if user.ID != 0 {
 		return user
 	}
 	// create the user in the DB
-	return create(username)
+	return create(ctx, username)
 }
 
 // Find will look up the username in the DB, and return a User if possible
-func Find(username string) User {
+func Find(ctx context.Context, username string) User {
 	var user User
-	result := database.GormDB().Where("username = ?", username).First(&user)
+	result := database.GormDB().WithContext(ctx).Where("username = ?", username).First(&user)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		//TODO: is there a better way to do this?
 		return User{ID: 0}
@@ -197,12 +198,12 @@ func (u *User) SetLastLocationTime() {
 
 //TODO: maybe return an err here?
 // create() will actually create the DB record
-func create(username string) User {
+func create(ctx context.Context, username string) User {
 	log.Println("creating user", username)
 	// create a new row, using default vals and creating a single visit
 	newUser := User{Username: username, NumVisits: 1}
-	if err := database.GormDB().Create(&newUser).Error; err != nil {
+	if err := database.GormDB().WithContext(ctx).Create(&newUser).Error; err != nil {
 		terrors.Log(err, "error creating user")
 	}
-	return Find(username)
+	return Find(ctx, username)
 }

--- a/pkg/vlc-server/stats.go
+++ b/pkg/vlc-server/stats.go
@@ -1,0 +1,81 @@
+package vlcServer
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+)
+
+// PollStats polls libvlc for playback statistics every interval and pushes
+// them through pkg/instrumentation. Intended to run as a long-lived
+// goroutine started after InitPlayer.
+//
+// libvlc resets these counters when the current Media changes; we detect
+// that by watching for a negative delta in DisplayedPictures and skip the
+// FPS sample on that tick to avoid a phantom dip.
+func PollStats(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var (
+		prevDisplayed float64
+		prevTime      time.Time
+		havePrev      bool
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if player == nil {
+				continue
+			}
+			media, err := player.Media()
+			if err != nil || media == nil {
+				havePrev = false
+				continue
+			}
+			stats, err := media.Stats()
+			if err != nil || stats == nil {
+				havePrev = false
+				continue
+			}
+
+			displayed := float64(stats.DisplayedPictures)
+			var fps float64
+			if havePrev {
+				dt := now.Sub(prevTime).Seconds()
+				delta := displayed - prevDisplayed
+				if dt > 0 && delta >= 0 {
+					fps = delta / dt
+				}
+				// delta < 0 means libvlc rolled over to a new Media —
+				// skip this sample's FPS and let the next tick reseed.
+			}
+			prevDisplayed = displayed
+			prevTime = now
+			havePrev = true
+
+			instrumentation.VLCPlayerStats.Update(instrumentation.VLCPlayerStatsSnapshot{
+				InputBitRate:       stats.InputBitRate,
+				DemuxBitRate:       stats.DemuxBitRate,
+				DisplayedFPS:       fps,
+				DecodedVideo:       float64(stats.DecodedVideo),
+				DisplayedPictures:  displayed,
+				LostPictures:       float64(stats.LostPictures),
+				DemuxCorrupted:     float64(stats.DemuxCorrupted),
+				DemuxDiscontinuity: float64(stats.DemuxDiscontinuity),
+			})
+		}
+	}
+}
+
+// StartStatsPoller is a tiny launcher wrapper so cmd/vlc-server can `go
+// vlcServer.StartStatsPoller(...)` without juggling its own goroutine.
+func StartStatsPoller(ctx context.Context, interval time.Duration) {
+	log.Printf("vlc-server: starting libvlc stats poller, interval=%s", interval)
+	go PollStats(ctx, interval)
+}


### PR DESCRIPTION
## Summary

Patch release. Two threads of work land together: **end-to-end runtime visibility** on the dashcam pipeline + chat-command tracing tree in Tempo, and a few smaller correctness/CI fixes.

- **Pipeline stats** — vlc-server polls `Media().Stats()` every 5s and publishes libvlc-native gauges (input/demux bitrate, displayed FPS, decoded/displayed/lost pictures, corrupted/discontinuity counts); OBS WebSocket poll picks up `General.GetStats` and publishes `obs_active_fps` / render+output skipped+total / stream output bytes/duration/congestion. Pairs with dashboards + alerts in [adanalife/infra#474](https://github.com/adanalife/infra/pull/474/changes). ([#538](https://github.com/adanalife/tripbot/pull/538/changes))
- **Chat-command tracing tree.** `chat.command` span wraps `cmd.Handler(...)` in the chatbot dispatcher; Twitch Helix client gets the `otelhttp` transport so its outbound HTTP calls finally show up in Tempo. ([#533](https://github.com/adanalife/tripbot/pull/533/changes)) Then `context.Context` gets threaded through `HandlerFunc` and every DB-touching helper in `pkg/users` / `pkg/scoreboards` / `pkg/events` / `pkg/onscreens-client` so GORM's `otelsql` spans nest *under* the `chat.command` span rather than trailing as siblings — a single `!miles` is now one tree. ([#535](https://github.com/adanalife/tripbot/pull/535/changes))
- **`VLC` injection on `App`.** Mirrors the Onscreens injection pattern from #526 — `VLC` interface in `pkg/chatbot/vlc.go`, `realVLC` delegates to `pkg/vlc-client`. Unlocks the deferred `guessCmd` correct-guess tests from #528. ([#536](https://github.com/adanalife/tripbot/pull/536/changes))
- **Graceful HTTP shutdown.** `pkg/server/server.go` runs `ListenAndServe` in a goroutine and calls `srv.Shutdown(ctx)` with a 15s timeout on SIGTERM. Resolves the `//TODO: add graceful shutdown` comment from closed PR #46 (2020). `pkg/vlc-server/server.go` has the same gap and is left as a follow-up. ([#440](https://github.com/adanalife/tripbot/pull/440/changes))
- **CI: drop VLC build/start from `obs.yml`.** OBS's healthcheck and entrypoint never touch VLC; `obs.yml` was building VLC and waiting on `/health/ready` for nothing. Strips it; adds `--no-deps` to `up -d obs`. `-67/+8` lines, ~30s less wall time per arch. ([#537](https://github.com/adanalife/tripbot/pull/537/changes))

Includes a `Merge branch 'master'` to clear the existing CHANGELOG phantom divergence (v2.7.0 entry was on master but not develop) per [merge-strategy-by-target-branch](https://github.com/adanalife/tripbot/blob/develop/CHANGELOG.md#L0). See [CHANGELOG.md](https://github.com/adanalife/tripbot/blob/release/v2.8.0/CHANGELOG.md) for the full v2.7.1 entry.

> Branch name is `release/v2.8.0` from when this was scoped as a minor bump — re-cut as a patch instead. Branch left as-is.

## Test plan

- [ ] Merge as a merge-commit (not squash) per the develop → master flow.
- [ ] auto-tag.yml bumps to **v2.7.1** (no `#minor` / `#major` in the CHANGELOG commit message → default patch).
- [ ] release.yml triggers on the tag and publishes multi-arch images for tripbot / vlc / obs.
- [ ] Stage-1 picks up new tripbot image; `/version` reports v2.7.1; Sentry events tagged `release: v2.7.1`.
- [ ] Tempo shows a single tree per `!miles` (chat.command → SQL children + helix HTTP children), not sibling spans.
- [ ] Grafana shows `vlc_player_*` and `obs_*` runtime gauges flowing in from the staging cluster.
- [ ] Send SIGTERM to the running tripbot; in-flight HTTP requests complete (or get a 15s grace) rather than being cut.