### PR TITLE
feat(chatbot): inject Video on App; cover playback callsites

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -38,6 +38,11 @@ type App struct {
 	// VLC drives playback operations (timewarp, jump, skip, back). Tests
 	// inject a no-op fake; production uses the realVLC adapter.
 	VLC VLC
+	// Video reads / refreshes the currently-playing dashcam video. Tests
+	// inject a no-op fake; production uses the realVideo adapter.
+	// CurrentVideo (above) is the older closure-based seam; both live on
+	// App for now and a follow-up will subsume CurrentVideo into Video.
+	Video Video
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -55,6 +60,7 @@ var defaultApp = &App{
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
 	Onscreens: realOnscreens{},
 	VLC:       realVLC{},
+	Video:     realVideo{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -442,7 +442,7 @@ func TestGuessCmd_CorrectGuess_DrivesOverlayAndPlayback(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.guessCmd(newTestUser("viewer1"), []string{"Colorado"})
+	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"Colorado"})
 
 	msg := out()
 	if !strings.Contains(msg, "@viewer1 got it") || !strings.Contains(msg, "Colorado") {
@@ -484,7 +484,7 @@ func TestGuessCmd_CorrectGuess_FullStateName(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.guessCmd(newTestUser("viewer1"), []string{"Massachusetts"})
+	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"Massachusetts"})
 
 	if !strings.Contains(out(), "got it") {
 		t.Errorf("expected correct-guess msg, got %q", out())
@@ -506,7 +506,7 @@ func TestGuessCmd_CorrectGuess_TwoLetterCode(t *testing.T) {
 	out, restore := captureSay(t)
 	defer restore()
 
-	app.guessCmd(newTestUser("viewer1"), []string{"CA"})
+	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"CA"})
 
 	if !strings.Contains(out(), "got it") {
 		t.Errorf("expected correct-guess msg from CA, got %q", out())

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -38,14 +38,16 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 }
 
 // newTestApp returns an App with CurrentVideo returning vid, plus no-op
-// Onscreens and VLC fakes. For commands that don't use CurrentVideo, pass a
-// zero-value video.Video. To assert on Onscreens or VLC calls, replace
-// app.Onscreens / app.VLC with a recordingOnscreens / recordingVLC.
+// Onscreens, VLC, and Video fakes. For commands that don't use CurrentVideo,
+// pass a zero-value video.Video. To assert on Onscreens / VLC / Video calls,
+// replace app.Onscreens / app.VLC / app.Video with a recordingOnscreens /
+// recordingVLC / recordingVideo.
 func newTestApp(vid video.Video) *App {
 	return &App{
 		CurrentVideo: func() video.Video { return vid },
 		Onscreens:    noopOnscreens{},
 		VLC:          noopVLC{},
+		Video:        noopVideo{},
 	}
 }
 

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -32,7 +32,7 @@ func (a *App) timewarp() {
 		terrors.Log(err, "error from VLC client")
 	}
 	// update the currently-playing video
-	video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying()
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -114,7 +114,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	}
 	Say(fmt.Sprintf("Jumping to %s...!", titlecaseState))
 	// update the currently-playing video
-	video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying()
 	// show the flag for the state
 	a.Onscreens.ShowFlag(10 * time.Second)
 	// update our record of last time it ran
@@ -161,7 +161,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 		terrors.Log(err, "error from VLC client")
 	}
 	// update the currently-playing video
-	video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying()
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -206,7 +206,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 		terrors.Log(err, "error from VLC client")
 	}
 	// update the currently-playing video
-	video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying()
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -1,0 +1,150 @@
+package chatbot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// These tests cover the four playback commands that refresh pkg/video state
+// after telling vlc-server to change tracks. Before App.Video was injectable,
+// the refresh was an unobserved package-level call into video.GetCurrentlyPlaying
+// (which in turn hit vlc-server over HTTP). Now we can assert it fires.
+//
+// The *Cmd handlers early-return on Darwin via helpers.RunningOnDarwin(); the
+// canonical test invocation is `task test` (Linux container, ENV=testing), so
+// the Darwin branch is not exercised here.
+
+// runAsAdmin runs fn with lastTimewarpTime cleared so rate limiting is not a
+// concern, plus captureSay's restore wired up automatically. The admin
+// shortcut still goes through helpers.RunningOnDarwin, but in CI that's false.
+func runAsAdmin(t *testing.T, fn func()) {
+	t.Helper()
+	lastTimewarpTime = time.Time{}
+	_, restore := captureSay(t)
+	defer restore()
+	fn()
+}
+
+// --- timewarpCmd ---
+
+func TestTimewarpCmd_AdminDrivesPlaybackChain(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recOverlay := &recordingOnscreens{}
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{}
+	app.Onscreens = recOverlay
+	app.VLC = recVLC
+	app.Video = recVideo
+
+	runAsAdmin(t, func() {
+		app.timewarpCmd(context.Background(), newTestUser(adminUser), nil)
+	})
+
+	// Overlay: ShowTimewarp is the only call.
+	if len(recOverlay.Calls) != 1 || recOverlay.Calls[0] != "ShowTimewarp()" {
+		t.Errorf("expected one ShowTimewarp overlay call, got %v", recOverlay.Calls)
+	}
+	// VLC: PlayRandom shuffles to a new video.
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "PlayRandom()" {
+		t.Errorf("expected one PlayRandom VLC call, got %v", recVLC.Calls)
+	}
+	// Video: GetCurrentlyPlaying refreshes pkg/video state after the shuffle.
+	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
+		t.Errorf("expected one GetCurrentlyPlaying call on Video, got %v", recVideo.Calls)
+	}
+}
+
+// --- skipCmd ---
+
+func TestSkipCmd_AdminDrivesPlaybackChain(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{}
+	app.VLC = recVLC
+	app.Video = recVideo
+
+	runAsAdmin(t, func() {
+		// No params → n = 1.
+		app.skipCmd(context.Background(), newTestUser(adminUser), nil)
+	})
+
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "Skip(1)" {
+		t.Errorf("expected one Skip(1) VLC call, got %v", recVLC.Calls)
+	}
+	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
+		t.Errorf("expected one GetCurrentlyPlaying call on Video, got %v", recVideo.Calls)
+	}
+}
+
+func TestSkipCmd_AdminPassesParamCountThrough(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{}
+	app.VLC = recVLC
+	app.Video = recVideo
+
+	runAsAdmin(t, func() {
+		app.skipCmd(context.Background(), newTestUser(adminUser), []string{"3"})
+	})
+
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "Skip(3)" {
+		t.Errorf("expected one Skip(3) VLC call, got %v", recVLC.Calls)
+	}
+	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
+		t.Errorf("expected one GetCurrentlyPlaying call on Video, got %v", recVideo.Calls)
+	}
+}
+
+// --- backCmd ---
+
+func TestBackCmd_AdminDrivesPlaybackChain(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{}
+	app.VLC = recVLC
+	app.Video = recVideo
+
+	runAsAdmin(t, func() {
+		app.backCmd(context.Background(), newTestUser(adminUser), nil)
+	})
+
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "Back(1)" {
+		t.Errorf("expected one Back(1) VLC call, got %v", recVLC.Calls)
+	}
+	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
+		t.Errorf("expected one GetCurrentlyPlaying call on Video, got %v", recVideo.Calls)
+	}
+}
+
+// --- guessCmd (correct guess re-exercise) ---
+//
+// The correct-guess path in commands.go calls a.timewarp() internally, which
+// now goes through a.Video.GetCurrentlyPlaying() instead of the package-level
+// call. Re-asserting here makes the Video injection a first-class concern of
+// the correct-guess chain rather than just a side effect.
+
+func TestGuessCmd_CorrectGuess_RefreshesVideoAfterTimewarp(t *testing.T) {
+	mock := installMockDB(t)
+	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
+	app := newTestApp(vid)
+	recVideo := &recordingVideo{}
+	app.Video = recVideo
+
+	expectAddToScoreChain(mock)
+	expectAddToScoreChain(mock)
+
+	_, restore := captureSay(t)
+	defer restore()
+
+	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"Colorado"})
+
+	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
+		t.Errorf("expected timewarp to refresh Video via GetCurrentlyPlaying, got %v", recVideo.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -1,0 +1,27 @@
+package chatbot
+
+import (
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// Video is the subset of the pkg/video surface that chatbot commands depend
+// on. Tests inject a fake; production uses the package-backed realVideo
+// adapter wired in defaultApp. Mirrors the Onscreens/VLC injection pattern.
+type Video interface {
+	// Current returns the video the system believes is currently playing,
+	// without making any I/O calls. Reads pkg/video's package-level state.
+	Current() video.Video
+	// GetCurrentlyPlaying refreshes pkg/video's notion of what's currently
+	// playing (an HTTP call to vlc-server in production), updates the
+	// package-level state, and returns the resulting Video.
+	GetCurrentlyPlaying() video.Video
+}
+
+// realVideo delegates to pkg/video.
+type realVideo struct{}
+
+func (realVideo) Current() video.Video { return video.CurrentlyPlaying }
+func (realVideo) GetCurrentlyPlaying() video.Video {
+	video.GetCurrentlyPlaying()
+	return video.CurrentlyPlaying
+}

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -1,0 +1,30 @@
+package chatbot
+
+import (
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// noopVideo satisfies Video for tests that don't care about the currently-
+// playing video — it just returns the zero value for every call.
+type noopVideo struct{}
+
+func (noopVideo) Current() video.Video             { return video.Video{} }
+func (noopVideo) GetCurrentlyPlaying() video.Video { return video.Video{} }
+
+// recordingVideo captures every call made to it so tests can assert that the
+// chatbot driver asked for the current video (or refreshed it). Vid is
+// returned from both methods; leave it zero-valued unless a test cares.
+// All call records are appended in order to Calls.
+type recordingVideo struct {
+	Calls []string
+	Vid   video.Video
+}
+
+func (r *recordingVideo) Current() video.Video {
+	r.Calls = append(r.Calls, "Current()")
+	return r.Vid
+}
+func (r *recordingVideo) GetCurrentlyPlaying() video.Video {
+	r.Calls = append(r.Calls, "GetCurrentlyPlaying()")
+	return r.Vid
+}


### PR DESCRIPTION
## Summary

Adds an `App.Video` interface following the same chatbot-app-injection pattern as Onscreens ([#526](https://github.com/adanalife/tripbot/pull/526/changes)) and VLC ([#536](https://github.com/adanalife/tripbot/pull/536/changes)).

The `pkg/video` package's `GetCurrentlyPlaying()` call inside the four playback handlers (`timewarp`, `jumpCmd`, `skipCmd`, `backCmd`) was the last unobserved package-level call in the playback chain — flagged as a known gap in [#536](https://github.com/adanalife/tripbot/pull/536/changes)'s description. Now it's an injectable seam.

## What's in the interface

```go
type Video interface {
    Current() video.Video             // read-only: returns video.CurrentlyPlaying
    GetCurrentlyPlaying() video.Video // refresh from vlc-server + return
}
```

Two methods because the chatbot needs both shapes — a cheap read for "what's playing right now?" and an explicit refresh after telling vlc-server to change tracks.

## Callsites refactored

Four `video.GetCurrentlyPlaying()` calls in `pkg/chatbot/playback.go`:

- `(a *App).timewarp()` — fires from `timewarpCmd` and `guessCmd` correct-guess
- `(a *App).jumpCmd()`
- `(a *App).skipCmd()`
- `(a *App).backCmd()`

All replaced with `a.Video.GetCurrentlyPlaying()`.

## New tests

`pkg/chatbot/playback_test.go`:

- `TestTimewarpCmd_AdminDrivesPlaybackChain` — asserts the full chain: `ShowTimewarp()` overlay -> `PlayRandom()` VLC -> `GetCurrentlyPlaying()` refresh.
- `TestSkipCmd_AdminDrivesPlaybackChain` — `Skip(1)` + refresh.
- `TestSkipCmd_AdminPassesParamCountThrough` — `Skip(3)` + refresh.
- `TestBackCmd_AdminDrivesPlaybackChain` — `Back(1)` + refresh.
- `TestGuessCmd_CorrectGuess_RefreshesVideoAfterTimewarp` — re-exercises the guessCmd correct-guess chain through the new Video seam.

`jumpCmd` is **not** covered. It calls `video.FindRandomByState`, which needs a DB-backed video lookup that isn't injectable yet. Deferred until a follow-up extends `Video` (or introduces a sibling interface) to cover state-based lookup.

## Note on `App.CurrentVideo`

The existing `App.CurrentVideo` closure is intentionally retained. Subsuming it into `Video.Current` is a planned follow-up; doing it in this PR would collide with the in-flight `App.IRC` injection PR. Both seams coexisting for one release is fine.

## Drive-by fix in a separate commit

`pkg/chatbot/commands_test.go` had three pre-existing build breaks from #536 + #535 race — `app.guessCmd` callsites missed the context arg added by the tracing PR. Split into its own commit (`fix(chatbot): pass context to guessCmd ...`) per atomic-commit convention.

## Test plan

- [x] `task test` -> `pkg/chatbot` passes (locally, twice — once before commits, once after)
- [x] `git diff origin/develop --stat` only touches `pkg/chatbot/`
- [x] No file outside `pkg/chatbot/` modified
- [ ] CI green on this branch