### PR TITLE
feat(chatbot): inject IRC on App; migrate command Say() callsites

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -43,6 +43,10 @@ type App struct {
 	// CurrentVideo (above) is the older closure-based seam; both live on
 	// App for now and a follow-up will subsume CurrentVideo into Video.
 	Video Video
+	// IRC sends chat output (Say, Whisper). Tests inject a recordingIRC
+	// to assert on chat messages; production uses the realIRC adapter
+	// which delegates to the package-level twitch client.
+	IRC IRC
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -61,6 +65,7 @@ var defaultApp = &App{
 	Onscreens: realOnscreens{},
 	VLC:       realVLC{},
 	Video:     realVideo{},
+	IRC:       realIRC{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -38,7 +38,7 @@ const guessScoreboard = "guess_state_total"
 func (a *App) helpCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !help")
 	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
@@ -65,7 +65,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 		msg += " I'm Tripbot, your adventure companion. Try using !commands to interact with me."
 	}
 
-	sayFn(msg)
+	a.IRC.Say(msg)
 	// update our record of last time it ran
 	lastHelloTime = time.Now()
 }
@@ -79,7 +79,7 @@ func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !version")
 
 	if helpers.RunningOnWindows() {
-		sayFn("Sorry, I can't answer that right now")
+		a.IRC.Say("Sorry, I can't answer that right now")
 		return
 	}
 
@@ -90,20 +90,20 @@ func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
 		out, err := exec.Command(scriptPath).Output()
 		if err != nil {
 			terrors.Log(err, "failed to get current version")
-			sayFn("Failed to get current version :(")
+			a.IRC.Say("Failed to get current version :(")
 			return
 		}
 		currentVersion = strings.TrimSpace(string(out))
 	}
 
-	sayFn("Current version is " + currentVersion)
+	a.IRC.Say("Current version is " + currentVersion)
 }
 
 func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !uptime")
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
@@ -159,7 +159,7 @@ func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 	km := user.CurrentMiles() * 1.609344
 	msg := "@%s has %.2f kilometres."
 	msg = fmt.Sprintf(msg, user.Username, km)
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
@@ -378,7 +378,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !state")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		sayFn("I couldn't figure out current GPS coords, using next closest...")
+		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next()
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
@@ -386,7 +386,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	a.Onscreens.ShowFlag(10 * time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 //TODO: maybe there could be a !cancel command or something

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -38,16 +38,76 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 }
 
 // newTestApp returns an App with CurrentVideo returning vid, plus no-op
-// Onscreens, VLC, and Video fakes. For commands that don't use CurrentVideo,
-// pass a zero-value video.Video. To assert on Onscreens / VLC / Video calls,
-// replace app.Onscreens / app.VLC / app.Video with a recordingOnscreens /
-// recordingVLC / recordingVideo.
+// Onscreens, VLC, Video, and IRC fakes. For commands that don't use
+// CurrentVideo, pass a zero-value video.Video. To assert on any of those
+// surfaces, replace the corresponding field with a recording fake
+// (recordingOnscreens / recordingVLC / recordingVideo / recordingIRC).
 func newTestApp(vid video.Video) *App {
 	return &App{
 		CurrentVideo: func() video.Video { return vid },
 		Onscreens:    noopOnscreens{},
 		VLC:          noopVLC{},
 		Video:        noopVideo{},
+		IRC:          noopIRC{},
+	}
+}
+
+// --- App.IRC seam ---
+//
+// These tests exercise the new App.IRC injection point introduced alongside
+// the legacy sayFn-based captureSay() helper. Pick a command that's been
+// migrated to a.IRC.Say(...) and assert via a recordingIRC. Once all command
+// callsites flow through a.IRC, the captureSay()-based tests above can be
+// rewritten in this shape and the global Say()/sayFn collapsed.
+
+func TestHelpCmd_SaysSomething_ViaIRC(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+
+	app.helpCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if len(rec.Says) == 0 {
+		t.Fatal("expected a help message via IRC, got none")
+	}
+	if !strings.Contains(rec.Says[0], " of ") {
+		t.Errorf("expected count like '(N of M)' in help message, got %q", rec.Says[0])
+	}
+}
+
+func TestUptimeCmd_SaysRunningFor_ViaIRC(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	Uptime = time.Now().Add(-5 * time.Minute)
+
+	app.uptimeCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one Say() call, got %d: %v", len(rec.Says), rec.Says)
+	}
+	if !strings.HasPrefix(rec.Says[0], "I have been running for") {
+		t.Errorf("unexpected uptime message via IRC: %q", rec.Says[0])
+	}
+}
+
+func TestKilometresCmd_SaysViaIRC(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+
+	user := &users.User{Username: "viewer1", Miles: 10}
+	app.kilometresCmd(context.Background(), user, nil)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one Say() call, got %d: %v", len(rec.Says), rec.Says)
+	}
+	// 10 miles * 1.609344 = 16.09344, formatted as "16.09"
+	if !strings.Contains(rec.Says[0], "16.09") {
+		t.Errorf("expected km conversion in IRC output, got %q", rec.Says[0])
+	}
+	if !strings.Contains(rec.Says[0], "@viewer1") {
+		t.Errorf("expected @username in IRC output, got %q", rec.Says[0])
 	}
 }
 

--- a/pkg/chatbot/irc.go
+++ b/pkg/chatbot/irc.go
@@ -1,0 +1,42 @@
+package chatbot
+
+import (
+	"fmt"
+	"log"
+
+	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+)
+
+// IRC is the subset of the IRC client surface chatbot commands depend on
+// to send chat output. Tests inject a fake; production uses the package-backed
+// realIRC adapter wired in defaultApp. Mirrors the Onscreens/VLC pattern.
+type IRC interface {
+	Say(msg string)               // post a message in chat
+	Whisper(username, msg string) // whisper to a specific user
+}
+
+// realIRC delegates to the package-level twitch IRC client.
+// Mirrors the existing Say()/Whisper() free functions in chatbot.go.
+type realIRC struct{}
+
+func (realIRC) Say(msg string) {
+	// include the message in the log
+	mylog.ChatMsg(c.Conf.BotUsername, msg)
+	// figure out what channel to speak to
+	speakTo := c.Conf.ChannelName
+	if c.Conf.OutputChannel != "" {
+		speakTo = c.Conf.OutputChannel
+	}
+	// say the message to chat
+	client.Say(speakTo, msg)
+}
+
+func (realIRC) Whisper(username, msg string) {
+	//TODO: include whispers in log
+	log.Println("sending whisper to", username, ":", msg)
+	// go-twitch-irc v4 removed the Whisper() send method; replicate the
+	// v2 behavior by sending the raw IRC /w command via PRIVMSG on the
+	// bot's own channel.
+	client.Say(c.Conf.BotUsername, fmt.Sprintf("/w %s %s", username, msg))
+}

--- a/pkg/chatbot/irc_test.go
+++ b/pkg/chatbot/irc_test.go
@@ -1,0 +1,39 @@
+package chatbot
+
+import "strings"
+
+// noopIRC satisfies IRC for tests that don't care about chat output.
+// Say() delegates to the package-level sayFn so the legacy captureSay()
+// helper still intercepts chat output from commands that have been
+// migrated to a.IRC.Say(...). Once all callsites flow through a.IRC and
+// captureSay is retired, this can collapse to a true no-op.
+type noopIRC struct{}
+
+func (noopIRC) Say(msg string)      { sayFn(msg) }
+func (noopIRC) Whisper(_, _ string) {}
+
+// recordingIRC captures every Say/Whisper call so tests can assert on
+// chat output. All call records are appended in order.
+type recordingIRC struct {
+	Says     []string          // ordered list of Say() messages
+	Whispers []recordedWhisper // ordered list of Whisper() calls
+}
+
+type recordedWhisper struct {
+	Username string
+	Msg      string
+}
+
+func (r *recordingIRC) Say(msg string) {
+	r.Says = append(r.Says, msg)
+}
+
+func (r *recordingIRC) Whisper(username, msg string) {
+	r.Whispers = append(r.Whispers, recordedWhisper{Username: username, Msg: msg})
+}
+
+// Output returns all Say() messages joined by newline, mirroring the
+// shape of captureSay()'s output() helper for easy migration.
+func (r *recordingIRC) Output() string {
+	return strings.Join(r.Says, "\n")
+}


### PR DESCRIPTION
## Summary

Adds an `App.IRC` interface field alongside `App.Onscreens` and `App.VLC`, following the same chatbot-app-injection pattern established in #526 (Onscreens + DB) and #536 (VLC). Production wires a `realIRC{}` adapter that delegates to the package-level twitch client; tests wire `noopIRC{}` (default) or `recordingIRC{}` when asserting on chat output directly.

This is **additive, not a replacement (yet)** — the package-level `Say()`, `Whisper()`, and `var sayFn` test seam all still exist, because the AnnounceNewFollower / AnnounceSubscriber / Chatter / handlers.go callsites don't yet have access to an App. Collapsing those is a separate, larger change.

To keep existing `captureSay()`-based tests green during the transition, `noopIRC.Say()` delegates to `sayFn` rather than truly no-op'ing. Once all callsites flow through `a.IRC` and `captureSay` is retired, that delegation collapses too.

## Migrated to a.IRC.Say(...)

In `pkg/chatbot/commands.go` (App-method receivers only):

- `helpCmd` (1 callsite)
- `helloCmd` (1 callsite)
- `versionCmd` (3 callsites)
- `uptimeCmd` (1 callsite)
- `kilometresCmd` (1 callsite)
- `stateCmd` (2 callsites)

That's 9 callsites across 6 commands — a representative subset, per the iterative pattern. The remaining ~25 `sayFn(...)` calls in `commands.go` stay on the old seam for follow-up PRs.

## Intentionally left on the global Say() / sayFn

- All of `pkg/chatbot/handlers.go` (parallel-PR territory — App.IRC's natural next callsite, but separate PR to keep merge clean).
- All of `pkg/chatbot/playback.go` (parallel-PR territory for App.Video).
- `pkg/chatbot/chatbot.go` free functions (`AnnounceNewFollower`, `AnnounceSubscriber`, `Chatter`) — those aren't on App.
- `pkg/chatbot/registry.go` — also not on App.
- `commands.go` callsites not listed above — incremental migration, follow-up work.

## Drive-by fix

`commands_test.go` failed to build on `origin/develop` due to three pre-existing `app.guessCmd(...)` calls missing a `context.Background()` first arg (introduced in #536). Fixed inline so the new tests could be verified. Trivial test-only change, unrelated to the IRC pattern.

## New tests

Three IRC-seam tests demonstrating `recordingIRC`:

- `TestHelpCmd_SaysSomething_ViaIRC`
- `TestUptimeCmd_SaysRunningFor_ViaIRC`
- `TestKilometresCmd_SaysViaIRC`

All existing `captureSay`-based tests continue to pass.

## Verification

- `task test` — all packages pass (chatbot 0.464s)
- `ENV=testing bin/devenv run --rm test go vet ./...` — only pre-existing warning in `cmd/vlc-server/vlc-server.go:108` (unrelated, dates to 2020)
- Pre-commit hooks pass

## Follow-up

- Migrate remaining `commands.go` `sayFn(...)` callsites to `a.IRC.Say(...)`
- Once handlers.go / playback.go land their App-method migrations, collapse `Say()` / `Whisper()` / `var sayFn` from `chatbot.go` and retire `captureSay()` + `noopIRC.Say`'s sayFn delegation