### PR TITLE
refactor: migrate stdlib log to slog with structured fields

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -4,6 +4,7 @@ package database
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
-	"github.com/logrusorgru/aurora/v3"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -32,8 +32,7 @@ func init() {
 	// env values come from envconfig instead — so the missing-file error is
 	// expected and noise. Only surface it for local-dev workflows.
 	if err != nil && (c.Conf.Environment == "development" || c.Conf.Environment == "testing") {
-		log.Println("Error loading .env file:", err)
-		log.Println("Continuing anyway...")
+		slog.Warn("error loading .env file, continuing anyway", "err", err)
 	}
 
 	// first we have to check we have all of the right ENV vars
@@ -57,17 +56,17 @@ func connectToDB() *sqlx.DB {
 		otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
 	)
 	if err != nil {
-		log.Println(aurora.Red("connection to DB failed:"), err.Error())
+		slog.Error("DB connection failed", "err", err)
 		return nil
 	}
 	if err := db.Ping(); err != nil {
-		log.Println(aurora.Red("connection to DB failed:"), err.Error())
+		slog.Error("DB connection failed", "err", err)
 		return nil
 	}
 	if _, err := otelsql.RegisterDBStatsMetrics(db,
 		otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
 	); err != nil {
-		log.Println(aurora.Yellow("could not register DB stats metrics:"), err.Error())
+		slog.Warn("could not register DB stats metrics", "err", err)
 	}
 	return sqlx.NewDb(db, "postgres")
 }
@@ -79,12 +78,12 @@ func Connection() *sqlx.DB {
 	}
 	connected := isAlive()
 	for connected != true { // reconnect if we lost connection
-		log.Print("Connection to DB was lost. Waiting...")
+		slog.Warn("connection to DB was lost, waiting to reconnect")
 		time.Sleep(5 * time.Second)
 		dbConnection = connectToDB()
 		connected = isAlive()
 		if connected {
-			log.Println(aurora.Green("connection made!"))
+			slog.Info("DB connection made")
 		}
 	}
 	return dbConnection
@@ -130,7 +129,7 @@ func connectGorm() *gorm.DB {
 		log.Fatal("GORM init failed:", err)
 	}
 	if err := gdb.Use(otelgorm.NewPlugin()); err != nil {
-		log.Println(aurora.Yellow("otelgorm plugin:"), err)
+		slog.Warn("otelgorm plugin install failed", "err", err)
 	}
 	return gdb
 }


### PR DESCRIPTION
## Summary

Sweep migration of stdlib \`log.*\` calls to \`log/slog\` across the tripbot codebase. One commit per package per [atomic-commits ADR](https://github.com/adanalife/vault).

## Why

Stdlib \`log\` *already* flowed through slog/otelslog via the \`slogWriter\` adapter in [\`pkg/telemetry/telemetry.go\`](../blob/develop/pkg/telemetry/telemetry.go), so logs were reaching Grafana. But every record was an opaque string — no levels above info, no structured fields to filter on, and \`aurora\` ANSI color escapes were polluting the JSON payload.

This PR upgrades fidelity at the call sites:

- \`log.Println\` / \`log.Printf\` → \`slog.Info\` / \`slog.Warn\` / \`slog.Error\` at the level the message actually warrants.
- Extract structured fields from format verbs where they map to named variables (\`log.Printf("user %s joined", u)\` → \`slog.Info("user joined", "username", u)\`).
- Drop \`aurora.Red\` / \`aurora.Yellow\` / \`aurora.Green\` wrappers — ANSI escapes don't belong in structured logs (and they're terminal-only anyway).
- Use \`slog.InfoContext(ctx, ...)\` opportunistically where ctx is already in scope (HTTP handlers, chatbot commands post-#535, cron jobs post-#541) so log lines get a clickable \`trace_id\` linking to Tempo.

## What's kept stdlib

- **\`log.Fatal*\`** stays as \`log.Fatal*\` — it has \`os.Exit(1)\` semantics that slog can't replicate cleanly, and the slogWriter adapter still routes the message to OTel before exit.
- **The \`slogWriter\` adapter itself** stays — third-party libraries (libvlc-go, gorilla/mux, etc.) still write to stdlib \`log\` and need the bridge.

## Out of scope (follow-up)

Full ctx threading at sites where the function signature doesn't currently take ctx — captured as a vault TODO. This PR opportunistically uses \`InfoContext\` where ctx is already available, but doesn't force signature changes.

## Test plan

- [ ] \`mise exec -- go build ./...\` clean
- [ ] \`go test ./...\` passes
- [ ] CI green
- [ ] After deploy: confirm in Grafana Loki that log records carry structured attrs (\`err\`, \`username\`, etc.) and that errors land with \`detected_level=error\`