### PR TITLE
feat(taskfile): ring bell before auth:bootstrap waits

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,6 +55,7 @@ tasks:
           --query SecretString --output text)
         export TWITCH_CLIENT_ID=$(echo "$secret" | jq -r .TWITCH_CLIENT_ID)
         export TWITCH_CLIENT_SECRET=$(echo "$secret" | jq -r .TWITCH_CLIENT_SECRET)
+        printf '\a'
         mise exec -- go run ./cmd/auth-bootstrap
 
   # Release smoke flow — see vault/tripbot/release-checklist.md.


### PR DESCRIPTION
## Summary
- `task auth:bootstrap` opens a browser and blocks waiting for the Twitch OAuth callback. If the terminal is in a backgrounded tab, it's easy to miss that it's waiting.
- Emit a `printf '\a'` (BEL) right before `go run ./cmd/auth-bootstrap` so the OS / terminal flags the tab.

## Test plan
- [ ] Run `task auth:bootstrap` from a backgrounded terminal tab; confirm the tab surfaces as needing attention before the browser opens.