### PR TITLE
refactor: thread ctx through cron-target functions (follow-up to #541)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -170,7 +170,7 @@ func setUpTwitchClient() {
 // updateSubscribers gets the list of current subscribers
 func updateSubscribers() {
 	// update subscribers list
-	mytwitch.GetSubscribers()
+	mytwitch.GetSubscribers(context.Background())
 }
 
 // getCurrentUsers gets the users watching the stream
@@ -183,7 +183,7 @@ func getCurrentUsers() {
 //updateWebhookSubscriptions makes sure webhooks are being sent to the bot
 func updateWebhookSubscriptions() {
 	// create webhook subscriptions
-	mytwitch.UpdateWebhookSubscriptions()
+	mytwitch.UpdateWebhookSubscriptions(context.Background())
 }
 
 // connectToTwitch joins Twitch chat and starts listening
@@ -254,10 +254,10 @@ func scheduleBackgroundJobs() {
 	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
 	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard)
 	addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
-	addJob(5*time.Minute, "twitch.GetSubscribers", func(_ context.Context) { mytwitch.GetSubscribers() })
-	addJob(5*time.Minute, "twitch.GetFollowerCount", func(_ context.Context) { mytwitch.GetFollowerCount() })
-	addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(_ context.Context) {
-		mytwitch.RefreshUserAccessToken()
+	addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
+	addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
+	addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {
+		mytwitch.RefreshUserAccessToken(ctx)
 		// Keep the IRC client's stored token in sync with the rotated credentials.
 		// go-twitch-irc captures the token at construction; without this, any
 		// reconnect after the first rotation replays the original boot-time token.
@@ -266,7 +266,7 @@ func scheduleBackgroundJobs() {
 		}
 	})
 	addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", func(_ context.Context) { chatbot.Chatter() })
-	addJob(12*time.Hour, "twitch.UpdateWebhookSubscriptions", func(_ context.Context) { mytwitch.UpdateWebhookSubscriptions() })
+	addJob(12*time.Hour, "twitch.UpdateWebhookSubscriptions", mytwitch.UpdateWebhookSubscriptions)
 }
 
 // addJob registers a gocron job at the given interval, wrapping fn with

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -265,7 +265,7 @@ func scheduleBackgroundJobs() {
 			client.SetIRCToken(tok)
 		}
 	})
-	addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", func(_ context.Context) { chatbot.Chatter() })
+	addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", chatbot.Chatter)
 	addJob(12*time.Hour, "twitch.UpdateWebhookSubscriptions", mytwitch.UpdateWebhookSubscriptions)
 }
 

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -177,7 +177,7 @@ func updateSubscribers() {
 func getCurrentUsers() {
 	// fetch initial session
 	users.UpdateSession(context.Background())
-	users.PrintCurrentSession()
+	users.PrintCurrentSession(context.Background())
 }
 
 //updateWebhookSubscriptions makes sure webhooks are being sent to the bot
@@ -251,9 +251,9 @@ func scheduleBackgroundJobs() {
 	// tracedJob but no ctx-aware child linking until threaded.
 	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
 	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
-	addJob(62*time.Second, "users.UpdateLeaderboard", func(_ context.Context) { users.UpdateLeaderboard() })
+	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
 	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard)
-	addJob(5*time.Minute, "users.PrintCurrentSession", func(_ context.Context) { users.PrintCurrentSession() })
+	addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
 	addJob(5*time.Minute, "twitch.GetSubscribers", func(_ context.Context) { mytwitch.GetSubscribers() })
 	addJob(5*time.Minute, "twitch.GetFollowerCount", func(_ context.Context) { mytwitch.GetFollowerCount() })
 	addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(_ context.Context) {

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -246,9 +246,6 @@ func gracefulShutdown() {
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
 func scheduleBackgroundJobs() {
-	// Functions that haven't been ctx-threaded yet get adapter closures
-	// (func(_ context.Context) { fn() }) — they still get a parent span via
-	// tracedJob but no ctx-aware child linking until threaded.
 	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
 	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -126,7 +126,7 @@ func startHttpServer(ctx context.Context) {
 // findInitialVideo will determine the vido that is currently-playing
 // we want to run this early, otherwise it will be unset until the first cron job runs
 func findInitialVideo() {
-	video.GetCurrentlyPlaying()
+	video.GetCurrentlyPlaying(context.Background())
 	v := video.CurrentlyPlaying
 	_, err := video.LoadOrCreate(v.String())
 	if err != nil {
@@ -249,7 +249,7 @@ func scheduleBackgroundJobs() {
 	// Functions that haven't been ctx-threaded yet get adapter closures
 	// (func(_ context.Context) { fn() }) — they still get a parent span via
 	// tracedJob but no ctx-aware child linking until threaded.
-	addJob(60*time.Second, "video.GetCurrentlyPlaying", func(_ context.Context) { video.GetCurrentlyPlaying() })
+	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
 	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	addJob(62*time.Second, "users.UpdateLeaderboard", func(_ context.Context) { users.UpdateLeaderboard() })
 	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard)

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand"
@@ -128,7 +129,10 @@ func Whisper(username, msg string) {
 
 // Chatter is designed to post a randomized message on a timer.
 // Right now it just posts random "help messages."
-func Chatter() {
+// ctx is forward-compat plumbing — sayFn (the package-level chat-send
+// indirection) doesn't take ctx yet, so it's not propagated into the IRC
+// write.
+func Chatter(_ context.Context) {
 	// use twitch emote feature to add some color
 	sayFn("/me " + help())
 }

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -1,6 +1,8 @@
 package chatbot
 
 import (
+	"context"
+
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -22,6 +24,9 @@ type realVideo struct{}
 
 func (realVideo) Current() video.Video { return video.CurrentlyPlaying }
 func (realVideo) GetCurrentlyPlaying() video.Video {
-	video.GetCurrentlyPlaying()
+	// chat-command callers don't currently propagate ctx through the
+	// chatbot.Video interface — Background is fine until that interface
+	// grows ctx-aware methods.
+	video.GetCurrentlyPlaying(context.Background())
 	return video.CurrentlyPlaying
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -143,7 +143,7 @@ func webhooksTwitchSubscriptionsEventsHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// update the internal subscribers list
-	mytwitch.GetSubscribers()
+	mytwitch.GetSubscribers(r.Context())
 
 	fmt.Fprintf(w, "OK")
 }

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -1,6 +1,7 @@
 package twitch
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -222,7 +223,7 @@ func GenerateUserAccessToken(code string) error {
 //
 // TODO: helix client surface should move behind an interface so this
 // function can be unit-tested without a real Twitch round-trip.
-func RefreshUserAccessToken() {
+func RefreshUserAccessToken(_ context.Context) {
 	botUser := c.Conf.BotUsername
 
 	acquired, release, err := oauthtokens.TryRefreshLock("twitch", botUser)

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -1,6 +1,7 @@
 package twitch
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -42,8 +43,12 @@ func getChannelID(username string) string {
 	return resp.Data.Users[0].ID
 }
 
-// GetSubscribers pulls down the most recent list of subscribers
-func GetSubscribers() {
+// GetSubscribers pulls down the most recent list of subscribers.
+// ctx is forward-compat plumbing — the helix client doesn't accept ctx
+// yet, so the Helix HTTP call isn't currently linked under the parent
+// cron span. Threading it now lets future ctx-aware helix wrappers nest
+// automatically.
+func GetSubscribers(_ context.Context) {
 	//TODO: should we do this elsewhere as well?
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
@@ -79,8 +84,9 @@ func GetSubscribers() {
 	}
 }
 
-// GetFollowerCount fetches the current total follower count for the channel.
-func GetFollowerCount() {
+// GetFollowerCount fetches the current total follower count for the
+// channel. ctx is forward-compat plumbing (see GetSubscribers).
+func GetFollowerCount(_ context.Context) {
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
 	}

--- a/pkg/twitch/webhooks.go
+++ b/pkg/twitch/webhooks.go
@@ -1,6 +1,7 @@
 package twitch
 
 import (
+	"context"
 	"log"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -19,8 +20,9 @@ var subsTopic = []string{
 	"/webhooks/twitch/subscriptions/events",
 }
 
-// UpdateWebhookSubscriptions will create new webhook subscriptions
-func UpdateWebhookSubscriptions() {
+// UpdateWebhookSubscriptions will create new webhook subscriptions.
+// ctx is forward-compat plumbing (see GetSubscribers).
+func UpdateWebhookSubscriptions(_ context.Context) {
 	if c.Conf.DisableTwitchWebhooks {
 		return
 	}

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -37,7 +37,11 @@ func InitLeaderboard(ctx context.Context) {
 	}
 }
 
-func UpdateLeaderboard() {
+// UpdateLeaderboard rebuilds the lifetime-miles leaderboard from the
+// LoggedIn map. ctx is forward-compat plumbing — the work is in-memory
+// and CurrentMiles doesn't take ctx yet; once it does the cron-tick span
+// will nest the DB reads as children.
+func UpdateLeaderboard(_ context.Context) {
 	for _, user := range LoggedIn {
 		// skip adding this user if they're a bot or ignored
 		if user.IsBot || c.UserIsIgnored(user.Username) || c.UserIsAdmin(user.Username) {

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -235,8 +235,10 @@ func countBots() int {
 	return len(bots())
 }
 
-// PrintCurrentSession simply prints info about the current session
-func PrintCurrentSession() {
+// PrintCurrentSession simply prints info about the current session.
+// ctx is forward-compat plumbing — twitch.ChatterCount doesn't take ctx
+// yet, so the parameter is currently unused.
+func PrintCurrentSession(_ context.Context) {
 	usernames := sortedUsernameList()
 	coloredUsernames := colorizeUsernames(usernames)
 

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -1,6 +1,7 @@
 package video
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os/exec"
@@ -23,9 +24,13 @@ var curVid, preVid string
 var timeStarted time.Time
 
 // GetCurrentlyPlaying will use lsof to figure out
-// which dashcam video is currently playing (seriously)
+// which dashcam video is currently playing (seriously).
+// ctx is forward-compat plumbing — vlc-client and onscreens-client don't
+// take ctx yet, so it's not propagated into their HTTP calls. Once they do,
+// trace spans for cron.video.GetCurrentlyPlaying ticks will nest the
+// underlying VLC poll and GPS-image toggles as children.
 //TODO: consider making this return a video struct
-func GetCurrentlyPlaying() {
+func GetCurrentlyPlaying(_ context.Context) {
 	var err error
 
 	// save the video we used last time

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -40,7 +41,7 @@ func main() {
 			log.Fatal("you cannot use -current and -file at the same time")
 		}
 		// preload the currently-playing vid
-		video.GetCurrentlyPlaying()
+		video.GetCurrentlyPlaying(context.Background())
 		videoFile = video.CurrentlyPlaying.String()
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to [#541](https://github.com/adanalife/tripbot/pull/541). Now that the cron scheduler runs on `gocron/v2` and the `tracedJob` wrapper hands the scheduler's job ctx down to every callback, this PR threads `ctx context.Context` through the 8 remaining cron-target functions and drops their adapter closures.

The two functions that already took ctx (`users.UpdateSession`, `onscreensClient.ShowGuessLeaderboard`) are unaffected.

## Commit-by-commit

1. **`refactor(video): thread ctx into GetCurrentlyPlaying`** — drops the adapter; updates `cmd/tripbot.findInitialVideo`, `script/collect-gps`, and the `realVideo` adapter in `pkg/chatbot/video.go` (which now uses `context.Background()` until the chatbot `Video` interface grows ctx-aware methods).
2. **`refactor(users): thread ctx into UpdateLeaderboard and PrintCurrentSession`** — drops adapters; updates `cmd/tripbot.getCurrentUsers`.
3. **`refactor(twitch): thread ctx into Helix-call cron targets`** — `GetSubscribers`, `GetFollowerCount`, `UpdateWebhookSubscriptions`, `RefreshUserAccessToken`. Non-cron callers: `cmd/tripbot` (`context.Background()`), `pkg/server/handlers.go` Twitch subs webhook (`r.Context()` so the in-flight HTTP request ctx propagates).
4. **`refactor(chatbot): thread ctx into Chatter`** — drops the last adapter.
5. **`chore: drop stale adapter-closure comment in scheduleBackgroundJobs`** — the comment described the intermediate state.

## Scope of breaking-signature changes

The following functions grow `ctx context.Context` as a new first parameter:

- `video.GetCurrentlyPlaying`
- `users.UpdateLeaderboard`, `users.PrintCurrentSession`
- `twitch.GetSubscribers`, `twitch.GetFollowerCount`, `twitch.UpdateWebhookSubscriptions`, `twitch.RefreshUserAccessToken`
- `chatbot.Chatter`

Most use `_ context.Context` for now — the underlying helpers (helix client, vlc-client, twitch.ChatterCount) don't take ctx yet, so the parameter is forward-compat plumbing. Future PRs that ctx-fy those helpers will get auto-nested spans without revisiting these call sites.

## Chat-command path (deliberate non-scope)

`(a *App).timewarp` and the four `a.Video.GetCurrentlyPlaying()` callsites in `pkg/chatbot/playback.go` are routed through the `chatbot.Video` injection interface (added by #543). The interface itself isn't ctx-aware yet, so the realVideo adapter calls the underlying `video.GetCurrentlyPlaying(context.Background())`. Threading ctx through the chatbot Video interface is a separate concern — chat-command ctx (from #535) → video-update nesting can be a later PR.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [ ] CI green
- [ ] After merge + deploy: confirm in Grafana that all 10 `cron.<name>` spans still tick on schedule (cancellation semantics unchanged for short, idempotent ticks)