### PR TITLE
chore(errors): drop Sentry tracing, link Sentry errors to OTel traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gempir/go-twitch-irc/v4 v4.4.1
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/getsentry/sentry-go/negroni v0.46.2
+	github.com/getsentry/sentry-go/otel v0.46.2
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK
 github.com/getsentry/sentry-go v0.46.2/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/getsentry/sentry-go/negroni v0.46.2 h1:fE4hZv1TH9r2oN+2gBvlDFF3vSpd5m6vy6qTxdnJz3M=
 github.com/getsentry/sentry-go/negroni v0.46.2/go.mod h1:kuxP9EffSbcFHXEUIdB0tH8OQmPhinbmN906fpVCELE=
+github.com/getsentry/sentry-go/otel v0.46.2 h1:HRrTS2neFXRPzGFDV4T6qqjnSeKsaBeCfBn0nbRPHmk=
+github.com/getsentry/sentry-go/otel v0.46.2/go.mod h1:S5zULL1K9SLjY/l3/0v8IRZ9rBUQFS8l50nWLl/TS5E=
 github.com/go-co-op/gocron/v2 v2.21.2 h1:bD8/YwkojYHgXFr3iEulL148KBdTbKVxUZzFKpXcdbY=
 github.com/go-co-op/gocron/v2 v2.21.2/go.mod h1:5lEiCKk1oVJV39Zg7/YG10OnaVrDAV5GGR6O0663k6U=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/config"
 	"github.com/getsentry/sentry-go"
+	sentryotel "github.com/getsentry/sentry-go/otel"
 	"github.com/logrusorgru/aurora/v3"
 )
 
@@ -24,8 +25,14 @@ func Initialize(c config.Config, version string) {
 	// build-time value the /version endpoint exposes.
 	err := sentry.Init(sentry.ClientOptions{
 		Release: version,
-		// enable tracing
-		TracesSampleRate: 0.2,
+		// OTel is the source of truth for tracing (otelhttp + otelsql + manual
+		// spans → OTLP → Tempo). Sentry's own tracer is left at the default
+		// off-state to avoid double-tracking; the linking integration below
+		// stamps the active OTel trace_id onto captured Sentry events so
+		// errors clickthrough to their Tempo trace.
+		Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+			return append(integrations, sentryotel.NewOtelIntegration())
+		},
 	})
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
## Summary

Sentry's `TracesSampleRate: 0.2` was creating a Sentry transaction per HTTP request in parallel with `otelhttp.NewHandler`'s OTel span — duplicate work, with no cross-correlation between the two. OTel (otelhttp + otelsql auto-emitted `db.client.operation.duration` + manual chatbot-dispatch spans → Tempo) is the source of truth for tracing in this codebase.

Switch Sentry to error-capture only:

- Drop `TracesSampleRate` (defaults to `0` — Sentry's own tracer becomes a no-op).
- Add `sentryotel.NewOtelIntegration()` to integrations. On `CaptureException`, this stamps the active OTel `trace_id` / `span_id` onto the Sentry event, so clicking an error in Sentry jumps to its Tempo trace.

The `sentrynegroni` middleware stays in place — it still does panic recovery and Sentry-scope request enrichment. The transactions it creates are no longer sampled and never reach the wire.

## Notes

- The deprecated `sentryotel.NewSentrySpanProcessor` (which mirrors OTel spans into Sentry's span model) was deliberately *not* used — it's slated for removal in sentry-go 0.47.0 and reintroduces the double-tracking we're getting rid of. `NewOtelIntegration` is the modern linking-only path.
- This is a follow-up to the Go-deps bulk-bump (#548) — the audit was item 3 of the "what can we take advantage of in new module versions" sweep.

## Test plan

- [ ] CI green (build/test/lint)
- [ ] After deploy, confirm Sentry events show `trace_id` field and link out to Tempo
- [ ] No Sentry transactions land in the Performance tab (ensures double-tracking is gone)