### PR TITLE
feat(chatbot): finish App.IRC migration; close jumpCmd test gap via Video.FindRandomByState

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -122,7 +122,7 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 
 		// check to see if they are in our DB
 		if u.ID == 0 {
-			sayFn("I don't know them, sorry!")
+			a.IRC.Say("I don't know them, sorry!")
 			return
 		}
 
@@ -151,7 +151,7 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 		}
 	}
 
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
@@ -166,18 +166,18 @@ func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !sunset")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		sayFn("I couldn't figure out current GPS coords, using next closest...")
+		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next()
 	}
 	lat, lng, _ := vid.Location()
-	sayFn(helpers.SunsetStr(vid.DateFilmed, lat, lng))
+	a.IRC.Say(helpers.SunsetStr(vid.DateFilmed, lat, lng))
 }
 
 func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !location (or similar)")
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		sayFn("I couldn't figure out current GPS coords, using next closest...")
+		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		//TODO: write something like vid.FindClosest() that
 		// chooses whether or not to use Next() vs Prev()
 		vid = vid.Next()
@@ -194,7 +194,7 @@ func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 	msg := fmt.Sprintf("%s %s", address, url)
 	// record that they know the location now
 	user.SetLastLocationTime()
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
@@ -219,7 +219,7 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 			msg += ", "
 		}
 	}
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
@@ -244,7 +244,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 			msg += ", "
 		}
 	}
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
@@ -256,7 +256,7 @@ func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, 
 
 	// special message if the leaderboard is empty
 	if len(leaderboard) == 0 {
-		sayFn("No one is on that leaderboard yet!")
+		a.IRC.Say("No one is on that leaderboard yet!")
 		return
 	}
 
@@ -284,7 +284,7 @@ func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, 
 			msg += ", "
 		}
 	}
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
@@ -298,11 +298,11 @@ func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 		lat, lng, err = vid.Location()
 	}
 	if err != nil {
-		sayFn("I couldn't figure out current GPS coords, sorry!")
+		a.IRC.Say("I couldn't figure out current GPS coords, sorry!")
 	} else {
 		realDate := helpers.ActualDate(vid.DateFilmed, lat, lng)
 		fmtTime := realDate.Format("3:04pm MST")
-		sayFn(fmt.Sprintf("This moment was %s", fmtTime))
+		a.IRC.Say(fmt.Sprintf("This moment was %s", fmtTime))
 	}
 }
 
@@ -317,11 +317,11 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 		lat, lng, err = vid.Location()
 	}
 	if err != nil {
-		sayFn("I couldn't figure out current GPS coords, sorry!")
+		a.IRC.Say("I couldn't figure out current GPS coords, sorry!")
 	} else {
 		realDate := helpers.ActualDate(vid.DateFilmed, lat, lng)
 		fmtDate := realDate.Format("Monday January 2, 2006")
-		sayFn(fmt.Sprintf("This moment was %s", fmtDate))
+		a.IRC.Say(fmt.Sprintf("This moment was %s", fmtDate))
 	}
 }
 
@@ -332,7 +332,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 
 	if len(params) == 0 {
 		msg = "Try and guess what state we're in! For example: !guess CA"
-		sayFn(msg)
+		a.IRC.Say(msg)
 		return
 	}
 
@@ -341,7 +341,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 		prettyDur := durafmt.ParseShort(user.GuessCooldownRemaining())
 		msg = "I recently told you the answer! Try again in %s."
 		msg = fmt.Sprintf(msg, prettyDur)
-		sayFn(msg)
+		a.IRC.Say(msg)
 		return
 	}
 
@@ -356,7 +356,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		sayFn("I couldn't figure out current GPS coords, using next closest...")
+		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next()
 	}
 
@@ -372,7 +372,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	} else {
 		msg = "Try again! EarthDay"
 	}
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
@@ -399,14 +399,14 @@ func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) 
 	// Followup tracked: wire !report to a real notification surface
 	// (Discord webhook / push) so Dana actually sees it.
 	terrors.Log(fmt.Errorf("viewer report from %s: %s", user.Username, message), "!report")
-	sayFn("Thank you, I will look into this ASAP!")
+	a.IRC.Say("Thank you, I will look into this ASAP!")
 }
 
 func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !bonusmiles")
 	bonus := user.BonusMiles()
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
@@ -423,16 +423,16 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 		msg = fmt.Sprintf("%s, lat: %f, lng: %f", msg, lat, lng)
 	}
 	log.Println(msg)
-	sayFn(msg)
+	a.IRC.Say(msg)
 }
 
 func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	log.Println(user.Username, "ran !shutdown")
 	if !c.UserIsAdmin(user.Username) {
-		sayFn("Nice try bucko")
+		a.IRC.Say("Nice try bucko")
 		return
 	}
-	sayFn("Shutting down...")
+	a.IRC.Say("Shutting down...")
 	log.Printf("currently playing: %s", a.CurrentVideo())
 	background.StopCron()
 	a.Sessions.Shutdown(ctx)
@@ -455,13 +455,13 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 
 	// don't do anything if empty
 	if len(params) == 0 {
-		sayFn("What do you want to say?")
+		a.IRC.Say("What do you want to say?")
 		return
 	}
 
 	// if the arg was "hide", hide the text from view
 	if len(params) == 1 && strings.ToLower(params[0]) == "hide" {
-		sayFn("Got it! Hiding the message.")
+		a.IRC.Say("Got it! Hiding the message.")
 		a.Onscreens.HideMiddleText()
 		return
 	}

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -113,6 +113,94 @@ func TestKilometresCmd_SaysViaIRC(t *testing.T) {
 	}
 }
 
+func TestHelloCmd_GreetsNewViewer_ViaIRC(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	lastHelloTime = time.Time{} // clear rate limiter
+
+	app.helloCmd(context.Background(), newTestUser("newviewer"), nil)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one greeting via IRC, got %d: %v", len(rec.Says), rec.Says)
+	}
+	// a fresh user with 0 miles gets the newcomer hint appended
+	if !strings.Contains(rec.Says[0], "Tripbot") {
+		t.Errorf("expected newcomer hint in greeting via IRC, got %q", rec.Says[0])
+	}
+}
+
+func TestDateCmd_SaysViaIRC(t *testing.T) {
+	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	rec := &recordingIRC{}
+	app.IRC = rec
+
+	app.dateCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one Say() call, got %d: %v", len(rec.Says), rec.Says)
+	}
+	if !strings.HasPrefix(rec.Says[0], "This moment was") {
+		t.Errorf("unexpected date message via IRC: %q", rec.Says[0])
+	}
+	if !strings.Contains(rec.Says[0], "2019") {
+		t.Errorf("expected year 2019 in IRC output, got %q", rec.Says[0])
+	}
+}
+
+func TestTimeCmd_SaysViaIRC(t *testing.T) {
+	date := time.Date(2019, 6, 15, 18, 30, 0, 0, time.UTC)
+	vid := newTestVideo("Colorado", 39.5, -105.0, date)
+	app := newTestApp(vid)
+	rec := &recordingIRC{}
+	app.IRC = rec
+
+	app.timeCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one Say() call, got %d: %v", len(rec.Says), rec.Says)
+	}
+	if !strings.HasPrefix(rec.Says[0], "This moment was") {
+		t.Errorf("unexpected time message via IRC: %q", rec.Says[0])
+	}
+}
+
+func TestReportCmd_AcksViaIRC(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+
+	app.reportCmd(context.Background(), newTestUser("viewer1"), []string{"the", "bot", "is", "broken"})
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one ack via IRC, got %d: %v", len(rec.Says), rec.Says)
+	}
+	if !strings.Contains(rec.Says[0], "Thank you") {
+		t.Errorf("expected ack message via IRC, got %q", rec.Says[0])
+	}
+}
+
+func TestBonusMilesCmd_SaysViaIRC(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+
+	// BonusMiles is computed from user state; a zero user yields a stable string.
+	app.bonusMilesCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("expected exactly one Say() call, got %d: %v", len(rec.Says), rec.Says)
+	}
+	if !strings.Contains(rec.Says[0], "viewer1") {
+		t.Errorf("expected username in bonusmiles output via IRC, got %q", rec.Says[0])
+	}
+	if !strings.Contains(rec.Says[0], "bonus miles") {
+		t.Errorf("expected 'bonus miles' phrasing in IRC output, got %q", rec.Says[0])
+	}
+}
+
 // --- App.Sessions seam ---
 //
 // These tests exercise the new App.Sessions injection point. Pick a command

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -42,21 +42,21 @@ func (a *App) timewarpCmd(ctx context.Context, user *users.User, _ []string) {
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
-		Say("Sorry, timewarp isn't available right now")
+		a.IRC.Say("Sorry, timewarp isn't available right now")
 		return
 	}
 
 	// rate-limit the number of times this can run
 	if !c.UserIsAdmin(user.Username) {
 		if time.Now().Sub(lastTimewarpTime) < 20*time.Second {
-			Say("Not yet; enjoy the moment!")
+			a.IRC.Say("Not yet; enjoy the moment!")
 			return
 		}
 	}
 
 	// only say this if the caller is not me
 	if !c.UserIsAdmin(user.Username) {
-		Say("Here we go...!")
+		a.IRC.Say("Here we go...!")
 	}
 
 	// do the timewarp
@@ -69,21 +69,21 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
-		Say("Sorry, jump isn't available right now")
+		a.IRC.Say("Sorry, jump isn't available right now")
 		return
 	}
 
 	// rate-limit the number of times this can run
 	if !c.UserIsAdmin(user.Username) {
 		if time.Now().Sub(lastTimewarpTime) < 20*time.Second {
-			Say("Not yet; enjoy the moment!")
+			a.IRC.Say("Not yet; enjoy the moment!")
 			return
 		}
 	}
 
 	// exit if the user gave no args or too many
 	if len(params) == 0 || len(params) > 2 {
-		Say("Usage: !jump [state]")
+		a.IRC.Say("Usage: !jump [state]")
 		return
 	}
 
@@ -96,23 +96,23 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// check to see if we even have footage for this state
 	if _, ok := err.(*terrors.NoFootageForStateError); ok {
 		msg := fmt.Sprintf("No footage for %s... yet! ;)", titlecaseState)
-		Say(msg)
+		a.IRC.Say(msg)
 		return
 	}
 	// check to see if there was an error finding a candidate video
 	if err != nil {
 		terrors.Log(err, "error from finding random video for state")
-		Say("Usage: !jump [state]")
+		a.IRC.Say("Usage: !jump [state]")
 		return
 	}
 	// tell VLC to play it
 	err = a.VLC.PlayFileInPlaylist(randomVid.File())
 	if err != nil {
 		terrors.Log(err, "error from VLC client")
-		Say("Usage: !jump [state]")
+		a.IRC.Say("Usage: !jump [state]")
 		return
 	}
-	Say(fmt.Sprintf("Jumping to %s...!", titlecaseState))
+	a.IRC.Say(fmt.Sprintf("Jumping to %s...!", titlecaseState))
 	// update the currently-playing video
 	a.Video.GetCurrentlyPlaying()
 	// show the flag for the state
@@ -128,14 +128,14 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
-		Say("Sorry, skip isn't available right now")
+		a.IRC.Say("Sorry, skip isn't available right now")
 		return
 	}
 
 	// rate-limit the number of times this can run
 	if !c.UserIsAdmin(user.Username) {
 		if time.Now().Sub(lastTimewarpTime) < 20*time.Second {
-			Say("Not yet; enjoy the moment!")
+			a.IRC.Say("Not yet; enjoy the moment!")
 			return
 		}
 	}
@@ -150,7 +150,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 		n, err = strconv.Atoi(params[0])
 		// if conversion fails or they give too many args
 		if err != nil || len(params) > 1 {
-			Say("Usage: !skip [num]")
+			a.IRC.Say("Usage: !skip [num]")
 			return
 		}
 	}
@@ -173,14 +173,14 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
-		Say("Sorry, back isn't available right now")
+		a.IRC.Say("Sorry, back isn't available right now")
 		return
 	}
 
 	// rate-limit the number of times this can run
 	if !c.UserIsAdmin(user.Username) {
 		if time.Now().Sub(lastTimewarpTime) < 20*time.Second {
-			Say("Not yet; enjoy the moment!")
+			a.IRC.Say("Not yet; enjoy the moment!")
 			return
 		}
 	}
@@ -195,7 +195,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 		n, err = strconv.Atoi(params[0])
 		// if conversion fails or they give too many args
 		if err != nil || len(params) > 1 {
-			Say("Usage: !back [num]")
+			a.IRC.Say("Usage: !back [num]")
 			return
 		}
 	}

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -13,7 +13,6 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
-	"github.com/adanalife/tripbot/pkg/video"
 )
 
 // lastTimewarpTime is used to rate-limit users so they can't
@@ -92,7 +91,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// sanitize the input
 	state = helpers.RemoveNonLetters(state)
 	titlecaseState := helpers.TitlecaseState(state)
-	randomVid, err := video.FindRandomByState(state)
+	randomVid, err := a.Video.FindRandomByState(state)
 	// check to see if we even have footage for this state
 	if _, ok := err.(*terrors.NoFootageForStateError); ok {
 		msg := fmt.Sprintf("No footage for %s... yet! ;)", titlecaseState)

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -2,9 +2,11 @@ package chatbot
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -146,5 +148,122 @@ func TestGuessCmd_CorrectGuess_RefreshesVideoAfterTimewarp(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
+	}
+}
+
+// --- jumpCmd ---
+//
+// jumpCmd was previously untestable because it called the package-level
+// video.FindRandomByState directly (DB-backed). With Video.FindRandomByState
+// on the injectable Video interface, we can stage results and exercise all
+// three branches: success, no-footage-for-state, and bad input.
+
+func TestJumpCmd_AdminPlaysRandomFromState(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recOverlay := &recordingOnscreens{}
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{
+		// staged result returned from FindRandomByState; .File() renders as
+		// "<Slug>.MP4" — that's what gets passed to VLC.PlayFileInPlaylist.
+		RandomVid: video.Video{Slug: "2019_0615_183000_001", State: "California"},
+	}
+	recIRC := &recordingIRC{}
+	app.Onscreens = recOverlay
+	app.VLC = recVLC
+	app.Video = recVideo
+	app.IRC = recIRC
+
+	runAsAdmin(t, func() {
+		app.jumpCmd(context.Background(), newTestUser(adminUser), []string{"california"})
+	})
+
+	// Video: FindRandomByState("california") then GetCurrentlyPlaying() after VLC handoff.
+	wantVideo := []string{`FindRandomByState("california")`, "GetCurrentlyPlaying()"}
+	if len(recVideo.Calls) != len(wantVideo) {
+		t.Fatalf("expected %d Video calls, got %d: %v", len(wantVideo), len(recVideo.Calls), recVideo.Calls)
+	}
+	for i, want := range wantVideo {
+		if recVideo.Calls[i] != want {
+			t.Errorf("Video call %d: want %q, got %q", i, want, recVideo.Calls[i])
+		}
+	}
+
+	// VLC: PlayFileInPlaylist called with the staged video's filename.
+	wantVLC := `PlayFileInPlaylist("2019_0615_183000_001.MP4")`
+	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != wantVLC {
+		t.Errorf("expected one %s VLC call, got %v", wantVLC, recVLC.Calls)
+	}
+
+	// Onscreens: ShowFlag for the state's flag overlay.
+	if len(recOverlay.Calls) != 1 || !strings.HasPrefix(recOverlay.Calls[0], "ShowFlag(") {
+		t.Errorf("expected one ShowFlag overlay call, got %v", recOverlay.Calls)
+	}
+
+	// IRC: a "Jumping to California...!" message.
+	if len(recIRC.Says) != 1 || !strings.Contains(recIRC.Says[0], "Jumping to California") {
+		t.Errorf("expected single 'Jumping to California' message, got %v", recIRC.Says)
+	}
+}
+
+func TestJumpCmd_NoFootageForState(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recOverlay := &recordingOnscreens{}
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{
+		RandomErr: &terrors.NoFootageForStateError{Msg: "no matches found"},
+	}
+	recIRC := &recordingIRC{}
+	app.Onscreens = recOverlay
+	app.VLC = recVLC
+	app.Video = recVideo
+	app.IRC = recIRC
+
+	runAsAdmin(t, func() {
+		app.jumpCmd(context.Background(), newTestUser(adminUser), []string{"wyoming"})
+	})
+
+	// FindRandomByState was called; no GetCurrentlyPlaying refresh after.
+	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != `FindRandomByState("wyoming")` {
+		t.Errorf("expected single FindRandomByState(\"wyoming\"), got %v", recVideo.Calls)
+	}
+
+	// No VLC handoff, no flag overlay.
+	if len(recVLC.Calls) != 0 {
+		t.Errorf("expected no VLC calls on no-footage path, got %v", recVLC.Calls)
+	}
+	if len(recOverlay.Calls) != 0 {
+		t.Errorf("expected no overlay calls on no-footage path, got %v", recOverlay.Calls)
+	}
+
+	// IRC: the "No footage for X... yet!" message (titlecased).
+	if len(recIRC.Says) != 1 || !strings.Contains(recIRC.Says[0], "No footage for Wyoming") {
+		t.Errorf("expected single 'No footage for Wyoming' message, got %v", recIRC.Says)
+	}
+}
+
+func TestJumpCmd_RejectsBadInput(t *testing.T) {
+	app := newTestApp(video.Video{})
+	recVLC := &recordingVLC{}
+	recVideo := &recordingVideo{}
+	recIRC := &recordingIRC{}
+	app.VLC = recVLC
+	app.Video = recVideo
+	app.IRC = recIRC
+
+	runAsAdmin(t, func() {
+		app.jumpCmd(context.Background(), newTestUser(adminUser), nil)
+	})
+
+	// No state lookup, no playback.
+	if len(recVideo.Calls) != 0 {
+		t.Errorf("expected no Video calls on bad input, got %v", recVideo.Calls)
+	}
+	if len(recVLC.Calls) != 0 {
+		t.Errorf("expected no VLC calls on bad input, got %v", recVLC.Calls)
+	}
+
+	// IRC: usage message.
+	if len(recIRC.Says) != 1 || !strings.Contains(recIRC.Says[0], "Usage: !jump") {
+		t.Errorf("expected usage message via IRC, got %v", recIRC.Says)
 	}
 }

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -17,6 +17,9 @@ type Video interface {
 	// playing (an HTTP call to vlc-server in production), updates the
 	// package-level state, and returns the resulting Video.
 	GetCurrentlyPlaying() video.Video
+	// FindRandomByState returns a random video filmed in the given US state.
+	// Returns *terrors.NoFootageForStateError when no rows match.
+	FindRandomByState(state string) (video.Video, error)
 }
 
 // realVideo delegates to pkg/video.
@@ -29,4 +32,7 @@ func (realVideo) GetCurrentlyPlaying() video.Video {
 	// grows ctx-aware methods.
 	video.GetCurrentlyPlaying(context.Background())
 	return video.CurrentlyPlaying
+}
+func (realVideo) FindRandomByState(state string) (video.Video, error) {
+	return video.FindRandomByState(state)
 }

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -1,6 +1,8 @@
 package chatbot
 
 import (
+	"fmt"
+
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -10,14 +12,20 @@ type noopVideo struct{}
 
 func (noopVideo) Current() video.Video             { return video.Video{} }
 func (noopVideo) GetCurrentlyPlaying() video.Video { return video.Video{} }
+func (noopVideo) FindRandomByState(_ string) (video.Video, error) {
+	return video.Video{}, nil
+}
 
 // recordingVideo captures every call made to it so tests can assert that the
 // chatbot driver asked for the current video (or refreshed it). Vid is
-// returned from both methods; leave it zero-valued unless a test cares.
-// All call records are appended in order to Calls.
+// returned from Current/GetCurrentlyPlaying; RandomVid and RandomErr stage
+// what FindRandomByState returns. Leave fields zero-valued unless a test
+// cares. All call records are appended in order to Calls.
 type recordingVideo struct {
-	Calls []string
-	Vid   video.Video
+	Calls     []string
+	Vid       video.Video
+	RandomVid video.Video
+	RandomErr error
 }
 
 func (r *recordingVideo) Current() video.Video {
@@ -27,4 +35,8 @@ func (r *recordingVideo) Current() video.Video {
 func (r *recordingVideo) GetCurrentlyPlaying() video.Video {
 	r.Calls = append(r.Calls, "GetCurrentlyPlaying()")
 	return r.Vid
+}
+func (r *recordingVideo) FindRandomByState(state string) (video.Video, error) {
+	r.Calls = append(r.Calls, fmt.Sprintf("FindRandomByState(%q)", state))
+	return r.RandomVid, r.RandomErr
 }


### PR DESCRIPTION
Wraps up Phase A of the App-injection pattern: every `(a *App) ...Cmd` method body in `pkg/chatbot/commands.go` and `pkg/chatbot/playback.go` now flows through the App's interface fields. Drains the work explicitly deferred from the prior phase-A PRs ([#526](https://github.com/adanalife/tripbot/pull/526), [#536](https://github.com/adanalife/tripbot/pull/536), [#543](https://github.com/adanalife/tripbot/pull/543), [#544](https://github.com/adanalife/tripbot/pull/544), [#549](https://github.com/adanalife/tripbot/pull/549)).

## Two atomic commits

### 1. Migrate remaining sayFn/Say callsites to a.IRC.Say

Drains [#544](https://github.com/adanalife/tripbot/pull/544)'s deferred IRC-migration work (which scoped to 9 of ~34 callsites to keep the seam-introduction PR small):

- **commands.go:** 25 `sayFn(...)` callsites migrated to `a.IRC.Say(...)`
- **playback.go:** 16 `Say(...)` callsites migrated to `a.IRC.Say(...)`

`grep -nE 'sayFn\(|(^|[^.])Say\(' pkg/chatbot/commands.go pkg/chatbot/playback.go` → zero matches after this commit.

**Out of scope (still on global Say/sayFn — by design):**
- `handlers.go` free-function dispatchers (`PrivateMessage`, `UserJoin`, `UserPart`) — not App methods; conversion deferred to phase C registry refactor
- `chatbot.go` free functions (`AnnounceNewFollower`, `AnnounceSubscriber`, `Chatter`)
- `registry.go` pure-data registration

The `noopIRC.Say` → `sayFn` delegation introduced in [#544](https://github.com/adanalife/tripbot/pull/544) stays in place so the existing `captureSay`-based tests keep capturing migrated-command output without needing to migrate every test in this PR. `recordingIRC` migration of those legacy tests is follow-up.

5 new `recordingIRC`-based tests added on a sample of migrated commands: `helloCmd`, `dateCmd`, `timeCmd`, `reportCmd`, `bonusMilesCmd`.

### 2. Extend Video with FindRandomByState; add jumpCmd tests

Closes the load-bearing reason `jumpCmd` tests were skipped in [#543](https://github.com/adanalife/tripbot/pull/543): the command called `video.FindRandomByState(state)` directly, with no injection seam to stage the lookup result.

- `Video` interface gains `FindRandomByState(state) (video.Video, error)`
- `realVideo` delegates to the package function
- `recordingVideo` adds `RandomVid` + `RandomErr` fields to stage what the lookup returns
- `(a *App) jumpCmd` now calls `a.Video.FindRandomByState(state)` (last direct package-level `video.*` call in `playback.go` is gone)

3 new tests in `playback_test.go`:
- `TestJumpCmd_AdminPlaysRandomFromState` — full chain: Video staged → VLC.PlayFileInPlaylist → Onscreens.ShowFlag → Video.GetCurrentlyPlaying
- `TestJumpCmd_NoFootageForState` — `recordingVideo` returns `*terrors.NoFootageForStateError`; asserts the user-facing message and no playback side effects
- `TestJumpCmd_RejectsBadInput` — usage message + no `FindRandomByState` call

## Verification

- `task test` passes, pkg/chatbot included
- Diff scope is `pkg/chatbot/` only — `handlers.go` and `registry.go` not touched