### PR TITLE
refactor: migrate stdlib log to slog (rest of repo)

### DIFF
--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"runtime"
@@ -32,7 +33,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 
@@ -99,9 +99,8 @@ func main() {
 		_ = srv.Shutdown(ctx)
 	}()
 
-	log.Println(aurora.Cyan("Opening browser for Twitch sign-in..."))
-	log.Println("Visit:")
-	log.Println(aurora.Blue(authURL).Underline())
+	slog.Info("opening browser for Twitch sign-in")
+	slog.Info("visit URL", "url", authURL)
 	// Skip browser open in headless environments (e.g. the k8s Job).
 	if os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != "" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		helpers.OpenInBrowser(authURL)
@@ -112,7 +111,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("bootstrap failed: %v", err)
 		}
-		log.Println(aurora.Green("bootstrap successful — refresh token persisted to oauth_tokens"))
+		slog.Info("bootstrap successful, refresh token persisted to oauth_tokens")
 	case <-time.After(flowTimeout):
 		log.Fatalf("timed out after %s waiting for Twitch callback", flowTimeout)
 	}

--- a/cmd/backfill-miles/backfill-miles.go
+++ b/cmd/backfill-miles/backfill-miles.go
@@ -33,6 +33,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"math"
 	"os"
 
@@ -112,7 +113,7 @@ func main() {
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			log.Printf("close db: %v", err)
+			slog.Warn("close db", "err", err)
 		}
 	}()
 	if err := db.Ping(); err != nil {
@@ -125,7 +126,7 @@ func main() {
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
-			log.Printf("close rows: %v", err)
+			slog.Warn("close rows", "err", err)
 		}
 	}()
 
@@ -177,7 +178,7 @@ func main() {
 
 		if *apply && willUpdate {
 			if _, err := db.Exec(updateMilesSQL, r.computed, r.id); err != nil {
-				log.Printf("ERROR updating %s (id=%d): %v", r.username, r.id, err)
+				slog.Error("updating user miles failed", "username", r.username, "id", r.id, "err", err)
 			} else {
 				updateCount++
 			}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -28,7 +28,6 @@ import (
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-co-op/gocron/v2"
-	"github.com/logrusorgru/aurora/v3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -58,7 +57,7 @@ var telemetryShutdown telemetry.ShutdownFunc
 
 // main performs the various steps to get the bot running
 func main() {
-	log.Println(aurora.Cyan(fmt.Sprintf("tripbot version %s", version)))
+	slog.Info("tripbot starting", "version", version)
 	createRandomSeed()
 	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
 	// to trigger a graceful shutdown so in-flight requests aren't cut.
@@ -103,7 +102,7 @@ func initializeTelemetry() {
 	shutdown, err := telemetry.Init(context.Background(), "tripbot", version)
 	if err != nil {
 		// telemetry init failure shouldn't crash the bot — log and continue.
-		log.Println(aurora.Yellow(fmt.Sprintf("telemetry init: %v", err)))
+		slog.Warn("telemetry init failed", "err", err)
 	}
 	telemetryShutdown = shutdown
 }
@@ -153,8 +152,8 @@ func startOBSPolling() {
 func loadTwitchToken() {
 	if err := mytwitch.LoadFromDB(); err != nil {
 		if errors.Is(err, mytwitch.ErrNoToken) {
-			log.Printf("refusing to start: no oauth_tokens row for %q — tripbot will not run without a Twitch IRC connection", c.Conf.BotUsername)
-			log.Fatal("to fix: run `task tripbot:auth:bootstrap` from the infra directory")
+			slog.Error("refusing to start: no oauth_tokens row for bot", "bot_username", c.Conf.BotUsername, "fix", "task tripbot:auth:bootstrap")
+			os.Exit(1)
 		}
 		terrors.Fatal(err, "failed to load Twitch token from DB")
 	}
@@ -189,13 +188,12 @@ func updateWebhookSubscriptions() {
 // connectToTwitch joins Twitch chat and starts listening
 func connectToTwitch() {
 	client.Join(c.Conf.ChannelName)
-	log.Println("Joined channel", c.Conf.ChannelName)
-	log.Printf("URL: %s", aurora.Blue(fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName)).Underline())
+	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
 	// actually connect to Twitch
 	// wrapped in a loop in case twitch goes down
 	for {
-		log.Println(aurora.Magenta("Initializing connection to Twitch"))
+		slog.Info("initializing connection to Twitch")
 		err := client.Connect()
 		if err != nil {
 			terrors.Log(err, "unable to connect to twitch")
@@ -220,11 +218,11 @@ func gracefulShutdown() {
 	// wait for signal
 	<-ctrlC
 
-	log.Println(aurora.Red("caught CTRL-C"))
+	slog.Warn("caught CTRL-C, shutting down")
 	// anything below this probably won't be executed
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
-	log.Printf("Last played video: %s", aurora.Yellow(video.CurrentlyPlaying.File()))
+	slog.Info("last played video", "file", video.CurrentlyPlaying.File())
 	users.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {
@@ -235,7 +233,7 @@ func gracefulShutdown() {
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		if err := telemetryShutdown(flushCtx); err != nil {
-			log.Printf("telemetry shutdown: %v", err)
+			slog.Error("telemetry shutdown failed", "err", err)
 		}
 		cancel()
 	}

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -18,7 +18,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	vlcServer "github.com/adanalife/tripbot/pkg/vlc-server"
 	"github.com/getsentry/sentry-go"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 // version is overridable at build time via -ldflags "-X main.version=...".
@@ -27,7 +26,7 @@ var version = "dev"
 var telemetryShutdown telemetry.ShutdownFunc
 
 func main() {
-	log.Println(aurora.Cyan(fmt.Sprintf("vlc-server version %s", version)))
+	slog.Info("vlc-server starting", "version", version)
 
 	// we don't yet support libvlc on darwin
 	if helpers.RunningOnDarwin() {
@@ -86,7 +85,7 @@ func createOnscreens() {
 func initializeTelemetry() {
 	shutdown, err := telemetry.Init(context.Background(), "vlc-server", version)
 	if err != nil {
-		log.Println(aurora.Yellow(fmt.Sprintf("telemetry init: %v", err)))
+		slog.Warn("telemetry init failed", "err", err)
 	}
 	telemetryShutdown = shutdown
 }
@@ -115,7 +114,7 @@ func gracefulShutdown() {
 	// wait for signal
 	<-ctrlC
 
-	log.Println(aurora.Red("caught CTRL-C"))
+	slog.Warn("caught CTRL-C, shutting down")
 	// anything below this probably won't be executed
 	vlcServer.Shutdown()
 	//TODO: stop cron here
@@ -123,7 +122,7 @@ func gracefulShutdown() {
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		if err := telemetryShutdown(flushCtx); err != nil {
-			log.Printf("telemetry shutdown: %v", err)
+			slog.Error("telemetry shutdown failed", "err", err)
 		}
 		cancel()
 	}

--- a/pkg/background/cron.go
+++ b/pkg/background/cron.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"log"
+	"log/slog"
 
 	"github.com/go-co-op/gocron/v2"
 )
@@ -9,7 +10,7 @@ import (
 var Scheduler gocron.Scheduler
 
 func StartCron() {
-	log.Println("Starting cron")
+	slog.Info("starting cron")
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		log.Fatalf("error creating gocron scheduler: %v", err)
@@ -23,11 +24,11 @@ func StartCron() {
 // completion. Cron jobs here are short idempotent ticks that retry on the
 // next interval, so losing an in-flight execution is fine.
 func StopCron() {
-	log.Println("Stopping cron")
+	slog.Info("stopping cron")
 	if Scheduler == nil {
 		return
 	}
 	if err := Scheduler.Shutdown(); err != nil {
-		log.Printf("error shutting down gocron scheduler: %v", err)
+		slog.Error("error shutting down gocron scheduler", "err", err)
 	}
 }

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -3,7 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/rand"
 	"time"
 
@@ -133,7 +133,7 @@ func Whisper(username, msg string) {
 	//TODO: include whispers in log
 	// include the message in the log
 	// mylog.ChatMsg(c.Conf.BotUsername, msg)
-	log.Println("sending whisper to", username, ":", msg)
+	slog.Info("sending whisper", "to", username, "msg", msg)
 	// say the message to chat
 	client.Say(c.Conf.BotUsername, fmt.Sprintf("/w %s %s", username, msg))
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -3,7 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"math/rand"
 	"os"
@@ -36,13 +36,13 @@ const guessScoreboard = "guess_state_total"
 //TODO: incorrect guess scoreboard?
 
 func (a *App) helpCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !help")
+	slog.InfoContext(ctx, "ran !help", "username", user.Username)
 	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
 	a.IRC.Say(msg)
 }
 
 func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
-	log.Println(user.Username, "said hello")
+	slog.InfoContext(ctx, "user said hello", "username", user.Username)
 
 	// check if it was just a one-word hello
 	if len(params) > 0 {
@@ -71,12 +71,12 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 }
 
 func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !flag")
+	slog.InfoContext(ctx, "ran !flag", "username", user.Username)
 	a.Onscreens.ShowFlag(10 * time.Second)
 }
 
 func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !version")
+	slog.InfoContext(ctx, "ran !version", "username", user.Username)
 
 	if helpers.RunningOnWindows() {
 		a.IRC.Say("Sorry, I can't answer that right now")
@@ -100,14 +100,14 @@ func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !uptime")
+	slog.InfoContext(ctx, "ran !uptime", "username", user.Username)
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
 	a.IRC.Say(msg)
 }
 
 func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
-	log.Println(user.Username, "ran !miles")
+	slog.InfoContext(ctx, "ran !miles", "username", user.Username)
 	var username string
 	var lifetimeMiles, monthlyMiles float32
 
@@ -155,7 +155,7 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 }
 
 func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !kilometres")
+	slog.InfoContext(ctx, "ran !kilometres", "username", user.Username)
 	km := user.CurrentMiles() * 1.609344
 	msg := "@%s has %.2f kilometres."
 	msg = fmt.Sprintf(msg, user.Username, km)
@@ -163,7 +163,7 @@ func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !sunset")
+	slog.InfoContext(ctx, "ran !sunset", "username", user.Username)
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		sayFn("I couldn't figure out current GPS coords, using next closest...")
@@ -174,7 +174,7 @@ func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !location (or similar)")
+	slog.InfoContext(ctx, "ran !location (or similar)", "username", user.Username)
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		sayFn("I couldn't figure out current GPS coords, using next closest...")
@@ -198,7 +198,7 @@ func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !leaderboard")
+	slog.InfoContext(ctx, "ran !leaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
 	size := 10
@@ -223,7 +223,7 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 }
 
 func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !totalleaderboard")
+	slog.InfoContext(ctx, "ran !totalleaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
 	size := 10
@@ -248,7 +248,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 }
 
 func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !guessleaderboard")
+	slog.InfoContext(ctx, "ran !guessleaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
 	size := 10
@@ -288,7 +288,7 @@ func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, 
 }
 
 func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !time")
+	slog.InfoContext(ctx, "ran !time", "username", user.Username)
 	var err error
 	var lat, lng float64
 	vid := a.CurrentVideo()
@@ -307,7 +307,7 @@ func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !date")
+	slog.InfoContext(ctx, "ran !date", "username", user.Username)
 	var err error
 	var lat, lng float64
 	vid := a.CurrentVideo()
@@ -327,7 +327,7 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 
 //TODO: refactor to use golang '...' syntax
 func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
-	log.Println(user.Username, "ran !guess")
+	slog.InfoContext(ctx, "ran !guess", "username", user.Username)
 	var msg string
 
 	if len(params) == 0 {
@@ -376,7 +376,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 }
 
 func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !state")
+	slog.InfoContext(ctx, "ran !state", "username", user.Username)
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
@@ -393,7 +393,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 //TODO: maybe there could be a !cancel command or something
 //TODO: use fancy golang ... syntax?
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
-	log.Println(user.Username, "ran !report")
+	slog.InfoContext(ctx, "ran !report", "username", user.Username)
 	message := strings.Join(params, " ")
 	// Route the report through Sentry so it lands somewhere visible.
 	// Followup tracked: wire !report to a real notification surface
@@ -403,14 +403,14 @@ func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) 
 }
 
 func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !bonusmiles")
+	slog.InfoContext(ctx, "ran !bonusmiles", "username", user.Username)
 	bonus := user.BonusMiles()
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
 	sayFn(msg)
 }
 
 func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !secretinfo")
+	slog.InfoContext(ctx, "ran !secretinfo", "username", user.Username)
 	if !c.UserIsAdmin(user.Username) {
 		return
 	}
@@ -422,23 +422,23 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 	} else {
 		msg = fmt.Sprintf("%s, lat: %f, lng: %f", msg, lat, lng)
 	}
-	log.Println(msg)
+	slog.InfoContext(ctx, "secretinfo output", "msg", msg)
 	sayFn(msg)
 }
 
 func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !shutdown")
+	slog.InfoContext(ctx, "ran !shutdown", "username", user.Username)
 	if !c.UserIsAdmin(user.Username) {
 		sayFn("Nice try bucko")
 		return
 	}
 	sayFn("Shutting down...")
-	log.Printf("currently playing: %s", a.CurrentVideo())
+	slog.InfoContext(ctx, "shutdown: currently playing", "video", a.CurrentVideo())
 	background.StopCron()
 	a.Sessions.Shutdown(ctx)
 	err := database.Connection().Close()
 	if err != nil {
-		log.Println(err)
+		slog.ErrorContext(ctx, "DB close failed during shutdown", "err", err)
 	}
 	sentry.Flush(time.Second * 5)
 	os.Exit(0)
@@ -447,7 +447,7 @@ func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 //TODO: this will always be lower case, find out why
 // middleCmd sets the text at the bottom-middle of the stream
 func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) {
-	log.Println(user.Username, "ran !middle")
+	slog.InfoContext(ctx, "ran !middle", "username", user.Username)
 	// don't let strangers run this
 	if !c.UserIsAdmin(user.Username) {
 		return
@@ -469,8 +469,7 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 	// use the params as the text
 	text := strings.Join(params, " ")
 
-	// just to help debug
-	log.Printf("setting middle text to: %s", text)
+	slog.InfoContext(ctx, "setting middle text", "text", text)
 
 	a.Onscreens.ShowMiddleText(text)
 }

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -3,7 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -186,10 +186,9 @@ func UserPart(partMessage twitch.UserPartMessage) {
 // }
 
 // if the message comes from me, then post the message to chat.
-// log.Println above already flows to OTel via the slog redirect, and an
-// admin whisper that triggers Say() is logged again as a chat line.
+// An admin whisper that triggers Say() is logged again as a chat line.
 func GetWhisper(message twitch.WhisperMessage) {
-	log.Println("whisper from", message.User.Name, ":", message.Message)
+	slog.Info("whisper received", "from", message.User.Name, "msg", message.Message)
 	if c.UserIsAdmin(message.User.Name) {
 		Say(message.Message)
 	}

--- a/pkg/chatbot/irc.go
+++ b/pkg/chatbot/irc.go
@@ -2,7 +2,7 @@ package chatbot
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -34,7 +34,7 @@ func (realIRC) Say(msg string) {
 
 func (realIRC) Whisper(username, msg string) {
 	//TODO: include whispers in log
-	log.Println("sending whisper to", username, ":", msg)
+	slog.Info("sending whisper", "to", username, "msg", msg)
 	// go-twitch-irc v4 removed the Whisper() send method; replicate the
 	// v2 behavior by sending the raw IRC /w command via PRIVMSG on the
 	// bot's own channel.

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -3,7 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +38,7 @@ func (a *App) timewarp() {
 }
 
 func (a *App) timewarpCmd(ctx context.Context, user *users.User, _ []string) {
-	log.Println(user.Username, "ran !timewarp")
+	slog.InfoContext(ctx, "ran !timewarp", "username", user.Username)
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
@@ -65,7 +65,7 @@ func (a *App) timewarpCmd(ctx context.Context, user *users.User, _ []string) {
 
 func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
-	log.Println(user.Username, "ran !jump")
+	slog.InfoContext(ctx, "ran !jump", "username", user.Username)
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
@@ -124,7 +124,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	var n int
-	log.Println(user.Username, "ran !skip")
+	slog.InfoContext(ctx, "ran !skip", "username", user.Username)
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {
@@ -169,7 +169,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 	var err error
 	var n int
-	log.Println(user.Username, "ran !back")
+	slog.InfoContext(ctx, "ran !back", "username", user.Username)
 
 	// exit early if we're on OS X
 	if helpers.RunningOnDarwin() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"log/slog"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -45,8 +46,7 @@ func SetEnvironment() {
 	// env values come from envconfig instead — so the missing-file error is
 	// expected and noise. Only surface it for local-dev workflows.
 	if err != nil && (env == "development" || env == "testing") {
-		log.Println("Error loading .env file:", err)
-		log.Println("Continuing anyway...")
+		slog.Warn("error loading .env file, continuing anyway", "err", err, "env", env)
 	}
 
 	// Also load the docker env file as a base layer; docker-compose layers

--- a/pkg/config/tripbot/config.go
+++ b/pkg/config/tripbot/config.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"log"
+	"log/slog"
 
 	"github.com/adanalife/tripbot/pkg/config"
 	"github.com/kelseyhightower/envconfig"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 var Conf *TripbotConfig
@@ -30,6 +30,6 @@ func init() {
 
 	// give helpful reminders when things are disabled
 	if Conf.DisableTwitchWebhooks {
-		log.Println(aurora.Yellow("Disabling Twitch webhooks"))
+		slog.Warn("Twitch webhooks disabled")
 	}
 }

--- a/pkg/config/vlc-server/config.go
+++ b/pkg/config/vlc-server/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"log/slog"
 	"os"
 
 	"github.com/adanalife/tripbot/pkg/config"
@@ -37,7 +38,7 @@ func init() {
 		_, err := os.Stat(d)
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Println("Creating directory", d)
+				slog.Info("creating directory", "dir", d)
 				err = os.MkdirAll(d, 0755)
 				if err != nil {
 					log.Fatalf("Error creating directory %s: %s", d, err)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -3,11 +3,11 @@ package errors
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/adanalife/tripbot/pkg/config"
 	"github.com/getsentry/sentry-go"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 var conf config.Config
@@ -47,7 +47,7 @@ func Log(e error, msg string) {
 		})
 		sentry.CaptureException(e)
 	}
-	log.Printf("%s: %s", aurora.Red(msg), e)
+	slog.Error(msg, "err", e)
 }
 
 func Fatal(e error, msg string) {
@@ -62,5 +62,6 @@ func Fatal(e error, msg string) {
 		})
 		sentry.CaptureException(e)
 	}
-	log.Fatalf("%s: %s", aurora.Red(msg), e)
+	slog.Error(msg, "err", e)
+	os.Exit(1)
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -10,7 +10,6 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/google/uuid"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 type Event struct {
@@ -23,7 +22,7 @@ type Event struct {
 
 func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
-		log.Printf("Not logging in %s because we're in read-only mode", aurora.Magenta(user))
+		slog.InfoContext(ctx, "skipping login event: read-only mode", "user", user)
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
@@ -35,7 +34,7 @@ func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 
 func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
-		log.Printf("Not logging out %s because we're in read-only mode", aurora.Magenta(user))
+		slog.InfoContext(ctx, "skipping logout event: read-only mode", "user", user)
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,7 +20,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hako/durafmt"
 	"github.com/kelvins/geocoder"
-	"github.com/logrusorgru/aurora/v3"
 	"github.com/nathan-osman/go-sunrise"
 	"github.com/skratchdot/open-golang/open"
 )
@@ -186,10 +185,10 @@ func sunriseSunset(utcDate time.Time, lat, long float64) (time.Time, time.Time) 
 
 //TODO: text the admin if it errors opening browser?
 func OpenInBrowser(url string) {
-	log.Println("opening url")
+	slog.Info("opening url in browser", "url", url)
 	err := open.Run(url)
 	if err != nil {
-		log.Println(aurora.Red("error opening browser"), err)
+		slog.Error("error opening browser", "err", err)
 	}
 }
 

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -3,7 +3,7 @@ package obs
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -43,17 +43,17 @@ func PollStreamingActive(ctx context.Context, interval time.Duration) {
 func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 	client, err := goobs.New(addr, goobs.WithPassword(passwd))
 	if err != nil {
-		log.Printf("obs: websocket connect to %s failed: %v", addr, err)
+		slog.ErrorContext(ctx, "obs websocket connect failed", "addr", addr, "err", err)
 		instrumentation.OBSStreaming.Set(false)
 		return
 	}
 	defer func() {
 		if err := client.Disconnect(); err != nil {
-			log.Printf("obs: disconnect: %v", err)
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
 		}
 	}()
 
-	log.Printf("obs: connected to websocket at %s", addr)
+	slog.InfoContext(ctx, "obs websocket connected", "addr", addr)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -65,7 +65,7 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 		case <-ticker.C:
 			resp, err := client.Stream.GetStreamStatus()
 			if err != nil {
-				log.Printf("obs: GetStreamStatus error: %v", err)
+				slog.ErrorContext(ctx, "obs GetStreamStatus error", "err", err)
 				instrumentation.OBSStreaming.Set(false)
 				return // trigger reconnect
 			}
@@ -83,7 +83,7 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 			if err != nil {
 				// Non-fatal — keep the connection alive; stream-side
 				// gauges already published this tick.
-				log.Printf("obs: GetStats error: %v", err)
+				slog.WarnContext(ctx, "obs GetStats error", "err", err)
 				continue
 			}
 			instrumentation.OBSStats.Update(instrumentation.OBSStatsSnapshot{

--- a/pkg/onscreens-server/flag.go
+++ b/pkg/onscreens-server/flag.go
@@ -1,14 +1,14 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
 var FlagImage *Onscreen
 
 func InitFlagImage() {
-	log.Println("Creating flag image onscreen")
+	slog.Info("creating onscreen", "kind", "flag")
 	FlagImage = New()
 }
 

--- a/pkg/onscreens-server/gps.go
+++ b/pkg/onscreens-server/gps.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -10,7 +10,7 @@ var GPSImage *Onscreen
 var gpsDuration = time.Duration(150 * time.Second)
 
 func InitGPSImage() {
-	log.Println("Creating GPS image onscreen")
+	slog.Info("creating onscreen", "kind", "gps")
 	GPSImage = New()
 }
 

--- a/pkg/onscreens-server/leaderboard.go
+++ b/pkg/onscreens-server/leaderboard.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -10,7 +10,7 @@ var leaderboardDuration = time.Duration(20 * time.Second)
 var Leaderboard *Onscreen
 
 func InitLeaderboard() {
-	log.Println("Creating leaderboard onscreen")
+	slog.Info("creating onscreen", "kind", "leaderboard")
 	Leaderboard = New()
 }
 

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 	"math/rand"
 	"time"
 )
@@ -27,7 +27,7 @@ var possibleLeftMessages = []string{
 }
 
 func InitLeftRotator() {
-	log.Println("Creating left rotator onscreen")
+	slog.Info("creating onscreen", "kind", "left-rotator")
 	LeftRotator = New()
 	// Show a first message synchronously so the OBS browser source has
 	// content to render the moment it polls — otherwise there's a brief

--- a/pkg/onscreens-server/middle-text.go
+++ b/pkg/onscreens-server/middle-text.go
@@ -1,13 +1,13 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 )
 
 var MiddleText *Onscreen
 
 func InitMiddleText() {
-	log.Println("Creating middle text onscreen")
+	slog.Info("creating onscreen", "kind", "middle-text")
 	MiddleText = New()
 	// this is a permanent onscreen
 	MiddleText.DontExpire = true

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 	"math/rand"
 	"time"
 )
@@ -20,7 +20,7 @@ var possibleRightMessages = []string{
 }
 
 func InitRightRotator() {
-	log.Println("Creating right rotator onscreen")
+	slog.Info("creating onscreen", "kind", "right-rotator")
 	RightRotator = New()
 	// Show a first message synchronously so the OBS browser source has
 	// content to render the moment it polls — otherwise there's a brief

--- a/pkg/onscreens-server/timewarp.go
+++ b/pkg/onscreens-server/timewarp.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -10,7 +10,7 @@ var Timewarp *Onscreen
 var timewarpDuration = time.Duration(2 * time.Second)
 
 func InitTimewarp() {
-	log.Println("Creating timewarp onscreen")
+	slog.Info("creating onscreen", "kind", "timewarp")
 	Timewarp = New()
 }
 

--- a/pkg/scoreboards/scoreboards.go
+++ b/pkg/scoreboards/scoreboards.go
@@ -3,7 +3,7 @@ package scoreboards
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -61,7 +61,7 @@ func findOrCreateScoreboard(ctx context.Context, name string) (Scoreboard, error
 // createScoreboard() will actually create the DB record
 func createScoreboard(ctx context.Context, name string) (Scoreboard, error) {
 	if c.Conf.Verbose {
-		log.Println("creating scoreboard", name)
+		slog.InfoContext(ctx, "creating scoreboard", "name", name)
 	}
 	scoreboard := Scoreboard{Name: name}
 	result := database.GormDB().WithContext(ctx).Create(&scoreboard)

--- a/pkg/scoreboards/scores.go
+++ b/pkg/scoreboards/scores.go
@@ -3,7 +3,7 @@ package scoreboards
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -93,7 +93,7 @@ func findScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) 
 
 // createScore() will actually create the DB record
 func createScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
-	log.Printf("creating score user_id:%d, scoreboard_id:%d", userID, scoreboardID)
+	slog.InfoContext(ctx, "creating score", "user_id", userID, "scoreboard_id", scoreboardID)
 	score := Score{UserID: userID, ScoreboardID: scoreboardID}
 	result := database.GormDB().WithContext(ctx).Create(&score)
 	return score, result.Error
@@ -102,7 +102,7 @@ func createScore(ctx context.Context, userID, scoreboardID uint16) (Score, error
 // save() will take the given score and store it in the DB
 func (s Score) save(ctx context.Context) error {
 	if c.Conf.Verbose {
-		log.Println("saving score", s)
+		slog.InfoContext(ctx, "saving score", "user_id", s.UserID, "scoreboard_id", s.ScoreboardID, "value", s.Value)
 	}
 	err := database.GormDB().WithContext(ctx).Model(&s).Update("value", s.Value).Error
 	if err != nil {

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 
@@ -14,7 +14,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
-	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 
@@ -74,7 +73,8 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 
 // twitch issues a request here when creating a new webhook subscription
 func webhooksTwitchHandler(w http.ResponseWriter, r *http.Request) {
-	log.Println("got webhook challenge request at", r.URL.Path)
+	ctx := r.Context()
+	slog.InfoContext(ctx, "received webhook challenge request", "path", r.URL.Path)
 	// exit early if we've disabled webhooks
 	if c.Conf.DisableTwitchWebhooks {
 		http.Error(w, "501 not implemented", http.StatusNotImplemented)
@@ -84,11 +84,11 @@ func webhooksTwitchHandler(w http.ResponseWriter, r *http.Request) {
 	challenge, ok := r.URL.Query()["hub.challenge"]
 	if !ok || len(challenge[0]) < 1 {
 		terrors.Log(nil, "something went wrong with the challenge")
-		log.Printf("%#v", r.URL.Query())
+		slog.WarnContext(ctx, "webhook challenge missing hub.challenge", "query", fmt.Sprintf("%#v", r.URL.Query()))
 		http.Error(w, "404 not found", http.StatusNotFound)
 		return
 	}
-	log.Println("returning challenge")
+	slog.InfoContext(ctx, "returning webhook challenge")
 	fmt.Fprint(w, string(challenge[0]))
 }
 
@@ -110,7 +110,7 @@ func webhooksTwitchUsersFollowsHandler(w http.ResponseWriter, r *http.Request) {
 
 	for _, follower := range resp.Data.Follows {
 		username := follower.FromName
-		log.Println("got webhook for new follower:", username)
+		slog.InfoContext(r.Context(), "received webhook: new follower", "username", username)
 		users.LoginIfNecessary(r.Context(), username)
 		// announce new follower in chat
 		chatbot.AnnounceNewFollower(username)
@@ -136,7 +136,7 @@ func webhooksTwitchSubscriptionsEventsHandler(w http.ResponseWriter, r *http.Req
 
 	for _, event := range resp.Data.Events {
 		username := event.Subscription.UserName
-		log.Println("got webhook for new sub:", username)
+		slog.InfoContext(r.Context(), "received webhook: new sub", "username", username)
 		users.LoginIfNecessary(r.Context(), username)
 		// announce new sub in chat
 		chatbot.AnnounceSubscriber(event.Subscription)
@@ -172,7 +172,7 @@ func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Println(aurora.Cyan("successfully received token from twitch!"))
+	slog.InfoContext(r.Context(), "received token from twitch via auth callback")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprint(w, authSuccessHTML)
 }
@@ -218,13 +218,13 @@ func catchAllHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		http.Error(w, "404 not found", http.StatusNotFound)
-		log.Println("someone tried hitting", r.URL.Path)
+		slog.InfoContext(r.Context(), "404 GET", "path", r.URL.Path)
 		return
 
 	case "POST":
 		// someone tried to make a post and we dont know what to do with it
 		http.Error(w, "404 not found", http.StatusNotFound)
-		log.Println("someone tried posting to", r.URL.Path)
+		slog.InfoContext(r.Context(), "404 POST", "path", r.URL.Path)
 		return
 	// someone tried a PUT or a DELETE or something
 	default:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -37,7 +37,7 @@ const shutdownTimeout = 15 * time.Second
 // waits up to shutdownTimeout for in-flight requests to complete before
 // returning.
 func Start(ctx context.Context) {
-	log.Println("Starting web server on port", c.Conf.TripbotServerPort)
+	slog.InfoContext(ctx, "starting web server", "port", c.Conf.TripbotServerPort)
 
 	r := mux.NewRouter()
 
@@ -125,7 +125,7 @@ func Start(ctx context.Context) {
 			terrors.Fatal(err, "couldn't start server")
 		}
 	case <-ctx.Done():
-		log.Println("shutting down web server")
+		slog.InfoContext(ctx, "shutting down web server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {

--- a/pkg/server/twitch.go
+++ b/pkg/server/twitch.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	"log/slog"
 	"net/http"
 
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -29,7 +29,7 @@ type Event struct {
 }
 
 func decodeFollowWebhookResponse(r *http.Request) (*helix.UsersFollowsResponse, error) {
-	log.Println("decoding user webhook")
+	slog.InfoContext(r.Context(), "decoding user webhook")
 	// resp := &helix.Response{}
 
 	resp := &helix.UsersFollowsResponse{}
@@ -61,7 +61,7 @@ func decodeFollowWebhookResponse(r *http.Request) (*helix.UsersFollowsResponse, 
 }
 
 func decodeSubscriptionWebhookResponse(r *http.Request) (*SubscriptionWebhook, error) {
-	log.Println("decoding subscription webhook")
+	slog.InfoContext(r.Context(), "decoding subscription webhook")
 
 	// we use a custom struct because the 3rd party lib doesn't support webhooks yet
 	resp := &SubscriptionWebhook{}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -47,7 +47,7 @@ var noopShutdown ShutdownFunc = func(context.Context) error { return nil }
 // returns a non-nil ShutdownFunc — safe to defer unconditionally.
 func Init(ctx context.Context, serviceName, serviceVersion string) (ShutdownFunc, error) {
 	if disabled() {
-		log.Println("[telemetry] OTLP exporters disabled; only Prometheus /metrics will be populated")
+		slog.Info("telemetry: OTLP exporters disabled, only Prometheus /metrics will be populated")
 		if err := initPromOnlyMeter(ctx, serviceName, serviceVersion); err != nil {
 			return noopShutdown, fmt.Errorf("prom-only meter: %w", err)
 		}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
-	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -299,5 +299,5 @@ func RefreshUserAccessToken(_ context.Context) {
 	tokenMu.Unlock()
 	client.SetUserAccessToken(rotated.AccessToken)
 
-	log.Println(aurora.Cyan("successfully refreshed user access token"))
+	slog.Info("refreshed user access token")
 }

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -3,7 +3,7 @@ package twitch
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -78,9 +78,9 @@ func GetSubscribers(_ context.Context) {
 	instrumentation.TwitchAudience.SetSubscribers(int64(len(subscribers)))
 
 	if len(subscribers) > 0 {
-		log.Println("subscribers:", strings.Join(subscribers, ", "))
+		slog.Info("subscribers", "count", len(subscribers), "names", strings.Join(subscribers, ", "))
 	} else {
-		log.Println(c.Conf.ChannelName, "has no subscribers :(")
+		slog.Info("no subscribers", "channel", c.Conf.ChannelName)
 	}
 }
 
@@ -101,7 +101,7 @@ func GetFollowerCount(_ context.Context) {
 		return
 	}
 	instrumentation.TwitchAudience.SetFollowers(int64(resp.Data.Total))
-	log.Printf("%s has %d followers", c.Conf.ChannelName, resp.Data.Total)
+	slog.Info("follower count", "channel", c.Conf.ChannelName, "total", resp.Data.Total)
 }
 
 // UserIsSubscriber returns true if the user subscribes to the channel

--- a/pkg/twitch/webhooks.go
+++ b/pkg/twitch/webhooks.go
@@ -2,12 +2,11 @@ package twitch
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/logrusorgru/aurora/v3"
 	"github.com/nicklaw5/helix/v2"
 )
 
@@ -64,6 +63,6 @@ func getWebookSubscriptions() {
 			spew.Dump(resp.Data.WebhookSubscriptions)
 		}
 	} else {
-		log.Println(aurora.Red("no webhooks found"))
+		slog.Warn("no webhooks found")
 	}
 }

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -3,8 +3,7 @@ package users
 import (
 	"context"
 	"errors"
-	"fmt"
-	"log"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -19,7 +18,6 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/twitch"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 //TODO: consider moving this whole thing elsewhere (to background perhaps?)
@@ -98,13 +96,12 @@ func login(ctx context.Context, username string) *User {
 
 	// raise an error if a user is supposed to be a bot
 	if c.UserIsIgnored(username) && !user.IsBot {
-		log.Println(aurora.Red(username), errors.New("user should be bot"))
+		slog.WarnContext(ctx, "user should be marked as bot", "username", username, "err", errors.New("user should be bot"))
 	}
 
 	// just a silly message to confirm subscriber feature is working
 	if mytwitch.UserIsSubscriber(username) {
-		msg := fmt.Sprintf("subscriber %s logged in!", username)
-		log.Println(aurora.Magenta(msg))
+		slog.InfoContext(ctx, "subscriber logged in", "username", username)
 	}
 
 	// add them to the session
@@ -125,12 +122,13 @@ func (u User) logout(ctx context.Context) {
 	// print logout message if they're human
 	if !u.IsBot {
 		loggedInDur := time.Now().Sub(u.LoggedIn)
-		prettyDur := durafmt.ParseShort(loggedInDur)
-		dur := fmt.Sprintf("(%s)", aurora.Green(prettyDur))
-		miles := fmt.Sprintf("(%1.2fmi)", aurora.Yellow(sessionMiles))
-		monthlyMiles := fmt.Sprintf("(%1.2fmi this month)", aurora.Yellow(u.CurrentMonthlyMiles(ctx)))
-		guessScore := fmt.Sprintf("(%1.0f guesses)", aurora.Cyan(u.GetScore(ctx, scoreboards.CurrentGuessScoreboard())))
-		log.Println("logging out", u, dur, miles, monthlyMiles, guessScore)
+		slog.InfoContext(ctx, "logging out user",
+			"user", u.String(),
+			"duration", durafmt.ParseShort(loggedInDur).String(),
+			"session_miles", sessionMiles,
+			"monthly_miles", u.CurrentMonthlyMiles(ctx),
+			"guess_score", u.GetScore(ctx, scoreboards.CurrentGuessScoreboard()),
+		)
 	}
 
 	// update miles
@@ -162,7 +160,7 @@ func isLoggedIn(username string) bool {
 // ShutDown loops through all of the logged-in users and logs them out
 func Shutdown(ctx context.Context) {
 	if c.Conf.Verbose {
-		log.Println("these were the logged-in users")
+		slog.InfoContext(ctx, "logged-in users at shutdown")
 		spew.Dump(LoggedIn)
 	}
 	for _, user := range LoggedIn {
@@ -172,7 +170,7 @@ func Shutdown(ctx context.Context) {
 
 // GiveEveryoneMiles gives all logged-in users miles
 func GiveEveryoneMiles(gift float32) {
-	log.Println(aurora.Green("giving all logged-in users gift miles"))
+	slog.Info("giving all logged-in users gift miles", "gift", gift)
 	for _, user := range LoggedIn {
 		user.Miles += gift
 	}
@@ -242,11 +240,10 @@ func PrintCurrentSession(_ context.Context) {
 	usernames := sortedUsernameList()
 	coloredUsernames := colorizeUsernames(usernames)
 
-	log.Println("there are",
-		twitch.ChatterCount(), "users in chat,",
-		aurora.Cyan(countHumans()), "humans, and",
-		aurora.Gray(15, countBots()), "bots",
+	slog.Info("session snapshot",
+		"chatters", twitch.ChatterCount(),
+		"humans", countHumans(),
+		"bots", countBots(),
+		"logged_in", strings.Join(coloredUsernames, ", "),
 	)
-
-	log.Printf("Currently logged in: %s", strings.Join(coloredUsernames, ", "))
 }

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -3,7 +3,7 @@ package users
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"time"
 
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -58,7 +58,7 @@ func (u User) sessionMiles() float32 {
 	if u.IsSubscriber() {
 		bonusMiles := u.BonusMiles()
 		if c.Conf.Verbose {
-			log.Println(u.String(), "will get", aurora.Green(bonusMiles), "bonus miles")
+			slog.Info("subscriber will get bonus miles", "username", u.Username, "bonus_miles", bonusMiles)
 		}
 		sessionMiles += bonusMiles
 	}
@@ -85,7 +85,7 @@ func (u User) CurrentMonthlyMiles(ctx context.Context) float32 {
 // User.save() will take the given user and store it in the DB
 func (u User) save(ctx context.Context) {
 	if c.Conf.Verbose {
-		log.Println("saving user", u)
+		slog.InfoContext(ctx, "saving user", "username", u.Username)
 	}
 	err := database.GormDB().WithContext(ctx).Model(&u).Updates(map[string]any{
 		"last_seen":  u.LastSeen,
@@ -121,7 +121,7 @@ func (u User) String() string {
 // FindOrCreate will try to find the user in the DB, otherwise it will create a new user
 func FindOrCreate(ctx context.Context, username string) User {
 	if c.Conf.Verbose {
-		log.Printf("FindOrCreate(%s)", username)
+		slog.InfoContext(ctx, "FindOrCreate", "username", username)
 	}
 	user := Find(ctx, username)
 	if user.ID != 0 {
@@ -157,7 +157,7 @@ func (u *User) HasCommandAvailable() bool {
 	// check if they ran a command in the last 24 hrs
 	now := time.Now()
 	if now.Sub(u.lastCmd) > 24*time.Hour {
-		log.Println("letting", u, "run a command")
+		slog.Info("letting user run a command", "username", u.Username)
 		// update their lastCmd time
 		u.lastCmd = now
 		return true
@@ -186,7 +186,7 @@ func (u *User) HasGuessCommandAvailable(lastTimewarpTime time.Time) bool {
 
 	// check if they ran a location command recently
 	if u.GuessCooldownRemaining() <= 0 {
-		log.Println("letting", u, "run guess command")
+		slog.Info("letting user run guess command", "username", u.Username)
 		return true
 	}
 	return false
@@ -199,7 +199,7 @@ func (u *User) SetLastLocationTime() {
 //TODO: maybe return an err here?
 // create() will actually create the DB record
 func create(ctx context.Context, username string) User {
-	log.Println("creating user", username)
+	slog.InfoContext(ctx, "creating user", "username", username)
 	// create a new row, using default vals and creating a single visit
 	newUser := User{Username: username, NumVisits: 1}
 	if err := database.GormDB().WithContext(ctx).Create(&newUser).Error; err != nil {

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -3,7 +3,7 @@ package video
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -13,7 +13,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 // CurrentlyPlaying is the video that is currently playing
@@ -54,9 +53,9 @@ func GetCurrentlyPlaying(_ context.Context) {
 			terrors.Log(err, fmt.Sprintf("unable to create Video from %s", curVid))
 		}
 
-		log.Printf("now playing %s - %s",
-			aurora.Yellow(CurrentlyPlaying.File()),
-			aurora.Green(helpers.StateToStateAbbrev(CurrentlyPlaying.State)),
+		slog.Info("now playing",
+			"file", CurrentlyPlaying.File(),
+			"state", helpers.StateToStateAbbrev(CurrentlyPlaying.State),
 		)
 
 		// show the no-GPS image
@@ -85,7 +84,7 @@ func figureOutCurrentVideo() string {
 	out, err := exec.Command(scriptPath).Output()
 	outString := strings.TrimSpace(string(out))
 	if err != nil {
-		log.Println(outString)
+		slog.Error("figureOutCurrentVideo script failed", "err", err, "output", outString)
 		return ""
 	}
 	return outString

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -3,7 +3,7 @@ package vlcServer
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"strconv"
@@ -258,7 +258,7 @@ func catchAllHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		http.Error(w, "404 not found", http.StatusNotFound)
-		log.Println("someone tried hitting", r.URL.Path)
+		slog.InfoContext(r.Context(), "404 GET", "path", r.URL.Path)
 		return
 
 	// someone tried a PUT or a DELETE or something

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -1,7 +1,7 @@
 package vlcServer
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -23,7 +23,7 @@ import (
 
 // Start starts the web server
 func Start() {
-	log.Println("Starting VLC web server on", c.Conf.VlcServerBindAddress)
+	slog.Info("starting VLC web server", "bind", c.Conf.VlcServerBindAddress)
 
 	r := mux.NewRouter()
 

--- a/pkg/vlc-server/stats.go
+++ b/pkg/vlc-server/stats.go
@@ -2,7 +2,7 @@ package vlcServer
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -76,6 +76,6 @@ func PollStats(ctx context.Context, interval time.Duration) {
 // StartStatsPoller is a tiny launcher wrapper so cmd/vlc-server can `go
 // vlcServer.StartStatsPoller(...)` without juggling its own goroutine.
 func StartStatsPoller(ctx context.Context, interval time.Duration) {
-	log.Printf("vlc-server: starting libvlc stats poller, interval=%s", interval)
+	slog.InfoContext(ctx, "starting libvlc stats poller", "interval", interval)
 	go PollStats(ctx, interval)
 }

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -2,7 +2,7 @@ package vlcServer
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -109,7 +109,7 @@ func InitPlayer() {
 //TODO: are there more things to close gracefully?
 func Shutdown() {
 	if helpers.RunningOnDarwin() {
-		log.Println("not stopping VLC cause we're on darwin")
+		slog.Info("not stopping VLC on darwin")
 		return
 	}
 	err := player.Stop()

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -49,7 +50,7 @@ func main() {
 	if videoFile != "" {
 		vid, err := video.LoadOrCreate(videoFile)
 		if err != nil {
-			log.Println("unable to create video:", err)
+			slog.Error("unable to create video", "err", err, "file", videoFile)
 		}
 		lat, lon, err := vid.Location()
 		if err != nil {
@@ -74,12 +75,12 @@ func main() {
 				// actually process the image
 				vid, err := video.LoadOrCreate(path)
 				if err != nil {
-					log.Println("unable to create video:", err)
+					slog.Error("unable to create video", "err", err, "path", path)
 					return nil
 				}
 				lat, lon, err := vid.Location()
 				if err != nil {
-					log.Printf("failed to process video: %v", err)
+					slog.Error("failed to process video", "err", err, "path", path)
 					return nil
 				}
 				url := helpers.GoogleMapsURL(lat, lon)
@@ -88,7 +89,7 @@ func main() {
 			})
 		// something went wrong walking the directory
 		if err != nil {
-			log.Println(err)
+			slog.Error("directory walk failed", "err", err)
 		}
 	}
 

--- a/script/make-map/make-map.go
+++ b/script/make-map/make-map.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/png"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +56,7 @@ func main() {
 
 			vid, err := video.LoadOrCreate(path)
 			if err != nil {
-				log.Println("unable to create video:", err)
+				slog.Error("unable to create video", "err", err, "path", path)
 				return nil
 			}
 
@@ -128,7 +129,7 @@ func main() {
 
 	// something went wrong walking the directory
 	if err != nil {
-		log.Println(err)
+		slog.Error("directory walk failed", "err", err)
 	}
 
 }
@@ -137,14 +138,14 @@ func main() {
 func saveImage(img image.Image, imgPath string) error {
 	f, err := os.Create(imgPath)
 	if err != nil {
-		log.Println(err)
+		slog.Error("could not create image file", "err", err, "path", imgPath)
 		return err
 	}
 	defer f.Close()
 
 	err = png.Encode(f, img)
 	if err != nil {
-		log.Println(err)
+		slog.Error("png encode failed", "err", err, "path", imgPath)
 	}
 	return err
 }


### PR DESCRIPTION
## Summary

Follow-up to [#545](https://github.com/adanalife/tripbot/pull/545/changes) — completes the stdlib `log` → `log/slog` migration across the rest of the repo. One atomic commit per package.

## Why

Stdlib `log` already flows through slog/otelslog via the `slogWriter` adapter in `pkg/telemetry/telemetry.go`, so logs reach Grafana either way. This PR upgrades fidelity at the call sites:

- `log.Println` / `log.Printf` → `slog.Info` / `slog.Warn` / `slog.Error` at the level the message warrants.
- Extract structured fields where format verbs map to named variables (`log.Printf(\"user %s joined\", u)` → `slog.Info(\"user joined\", \"username\", u)`).
- Drop `aurora.Red` / `aurora.Yellow` / `aurora.Green` wrappers — ANSI escapes don't belong in structured logs.
- Use `slog.InfoContext(ctx, ...)` opportunistically where ctx is already in scope (HTTP handlers, chatbot commands, cron jobs post-[#547](https://github.com/adanalife/tripbot/pull/547/changes)) so log lines get a clickable `trace_id` linking to Tempo.

## What's kept stdlib

- **`log.Fatal*`** stays as `log.Fatal*` — `os.Exit(1)` semantics that slog can't replicate cleanly, and slogWriter still routes the message to OTel before exit.
- **`pkg/errors/Fatal()`** converts to `slog.Error + os.Exit(1)` so the fatal record lands at `level=error` rather than `level=info` via slogWriter.
- **The `slogWriter` adapter itself** stays — third-party libraries still write to stdlib `log`.

## Out of scope (follow-up, captured in `vault/tripbot/TODO.md`)

Full ctx threading at sites where the function signature doesn't currently take ctx. This PR opportunistically uses `InfoContext` where ctx is already available, but doesn't force signature changes.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [ ] CI green
- [ ] After deploy: confirm in Grafana Loki that records carry structured attrs (`err`, `username`, etc.) and that errors land with `detected_level=error`