### PR TITLE
chore(config): soft-disable optional env vars, default ENV

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,12 @@ func SetEnvironment() {
 
 	envVar, ok := os.LookupEnv("ENV")
 	if !ok {
-		log.Fatalln("You must set ENV")
+		envVar = "development"
+		slog.Warn("ENV not set, defaulting to development")
+		// envconfig.Process reads from the process env; the defaulted
+		// value has to be visible to the required:"true" field on
+		// TripbotConfig.Environment / VlcServerConfig.Environment.
+		os.Setenv("ENV", envVar)
 	}
 
 	// standardize the ENV to the long name

--- a/pkg/config/tripbot/config.go
+++ b/pkg/config/tripbot/config.go
@@ -32,4 +32,7 @@ func init() {
 	if Conf.DisableTwitchWebhooks {
 		slog.Warn("Twitch webhooks disabled")
 	}
+	if Conf.GoogleMapsAPIKey == "" {
+		slog.Warn("GOOGLE_MAPS_API_KEY not set — geocoder + static-map features disabled")
+	}
 }

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -12,8 +12,11 @@ type TripbotConfig struct {
 	BotUsername string `required:"true" envconfig:"BOT_USERNAME"`
 	// ExternalURL is the where the bot's HTTP server can be reached
 	ExternalURL string `required:"true" envconfig:"EXTERNAL_URL"`
-	// GoogleMapsAPIKey is the API key with which we access Google Maps
-	GoogleMapsAPIKey string `required:"true" envconfig:"GOOGLE_MAPS_API_KEY"`
+	// GoogleMapsAPIKey is the API key with which we access Google Maps.
+	// Optional — when unset, geocoder + static-map calls are skipped and
+	// callers fall back gracefully (no city/state lookups, no generated
+	// maps). The bot continues to run.
+	GoogleMapsAPIKey string `envconfig:"GOOGLE_MAPS_API_KEY"`
 	// ReadOnly is used to prevent writing some things to the DB
 	ReadOnly bool `default:"false" envconfig:"READ_ONLY"`
 	// Verbose determines output verbosity

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -24,7 +24,15 @@ import (
 	"github.com/skratchdot/open-golang/open"
 )
 
+// ErrMapsDisabled is returned by City/StateFromCoords when no Google Maps
+// API key is configured. Callers can treat it as a soft-disable signal
+// (skip the lookup, fall back to an empty result) rather than a real error.
+var ErrMapsDisabled = errors.New("maps API disabled: no GOOGLE_MAPS_API_KEY set")
+
 func CityFromCoords(lat, lon float64) (string, error) {
+	if geocoder.ApiKey == "" {
+		return "", ErrMapsDisabled
+	}
 	location := geocoder.Location{Latitude: lat, Longitude: lon}
 
 	addresses, err := geocoder.GeocodingReverse(location)
@@ -41,6 +49,9 @@ func CityFromCoords(lat, lon float64) (string, error) {
 }
 
 func StateFromCoords(lat, lon float64) (string, error) {
+	if geocoder.ApiKey == "" {
+		return "", ErrMapsDisabled
+	}
 	location := geocoder.Location{Latitude: lat, Longitude: lon}
 
 	addresses, err := geocoder.GeocodingReverse(location)

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -107,7 +107,9 @@ func (v Video) save() error {
 	if !flagged {
 		// figure out which state we're in
 		state, err = helpers.StateFromCoords(lat, lng)
-		if err != nil {
+		// ErrMapsDisabled is the expected steady-state when no Maps key
+		// is configured; don't spam Sentry on every video import.
+		if err != nil && !errors.Is(err, helpers.ErrMapsDisabled) {
 			terrors.Log(err, "error geocoding coords")
 		}
 	}


### PR DESCRIPTION
## Summary

A conservative pass on env-var ergonomics for the Go apps:

- **`ENV` defaults to `development`** when unset. Local-dev runs no longer crash with `You must set ENV`. Cluster pods get the value from k8s manifests, so behaviour there is unchanged. The defaulted value is exported back via `os.Setenv` so envconfig's `required:"true"` check on `TripbotConfig.Environment` / `VlcServerConfig.Environment` still passes.
- **`GOOGLE_MAPS_API_KEY` is now optional.** When unset:
  - `helpers.CityFromCoords` / `StateFromCoords` short-circuit with a new `ErrMapsDisabled` sentinel — no failed HTTP request, no Sentry noise.
  - The video-import path (`pkg/video.LoadOrCreate`) treats `ErrMapsDisabled` as expected steady-state.
  - `!location` still emits the Google Maps URL (built locally without an API call); the address part is blank. Degraded but functional.
  - Boot prints a yellow `GOOGLE_MAPS_API_KEY not set — geocoder + static-map features disabled` warn next to the existing webhook-disabled reminder.

## What's intentionally not changed

Per scope discussion, this PR is conservative — it doesn't touch the bigger asks:

- `pkg/twitch.init()` still hard-fatals on missing `TWITCH_CLIENT_ID/_SECRET`. Could soft-disable for a "no Twitch" local-dev mode in a follow-up.
- `pkg/database.init()` still hard-fatals on missing `DATABASE_USER/_DB/_HOST`. Moving to deferred-fatal-at-first-connection is a follow-up.
- `cmd/backfill-miles` still duplicates `os.Getenv("DATABASE_*")` — routing it through `pkg/database` would force it to inherit tripbot's full required-var init chain. Worth a small `pkg/database/dsn.go` extraction later.
- `EXTERNAL_URL` stays required (used by OAuth redirect + EventSub callbacks).

## Already in good shape (kept as the pattern)

- `pkg/telemetry` — empty endpoint / `OTEL_SDK_DISABLED=true` → Prom-only meter.
- `pkg/obs` — empty `OBS_WEBSOCKET_ADDR` / `_PASSWD` → in-cluster defaults.
- `pkg/errors` (Sentry) — empty DSN → SDK no-ops, errors still log.

## Test plan

- [ ] `mise exec -- go build ./...` clean ✓ (verified locally with libvlc CGO flags)
- [ ] CI green
- [ ] Local: run `bin/devenv` without setting `GOOGLE_MAPS_API_KEY` and confirm tripbot starts, prints the disabled-warn, and `!location` returns a bare maps URL
- [ ] Local: unset `ENV` and confirm boot logs `ENV not set, defaulting to development` instead of fatalling