### PR TITLE
obs: hourly browser-source refresh from entrypoint to cap CEF leak

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -38,12 +38,21 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
          vainfo \
          fonts-dejavu-core \
          ttf-mscorefonts-installer \
+         python3 \
+         python3-venv \
     && rm -rf /var/lib/apt/lists/*
+
+# obsws-python (in a venv to stay clear of PEP 668 system-managed python)
+# powers the hourly browser-source refresh that the entrypoint kicks off
+# as a workaround for CEF's per-frame memory leak.
+RUN python3 -m venv /opt/obs/venv \
+    && /opt/obs/venv/bin/pip install --no-cache-dir obsws-python
 
 COPY infra/docker/obs/config/ /opt/obs/config/
 COPY infra/docker/obs/entrypoint.sh /opt/obs/entrypoint.sh
 COPY infra/docker/obs/healthcheck.sh /opt/obs/healthcheck.sh
-RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh
+COPY bin/obs-browser-refresh /opt/obs/bin/obs-browser-refresh
+RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh /opt/obs/bin/obs-browser-refresh
 
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -49,7 +49,15 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
       # CEF runtime deps (chromium needs these even headless) \
       libnss3 libgbm1 libatk1.0-0t64 libatk-bridge2.0-0t64 libatspi2.0-0t64 \
       libcups2t64 libxdamage1 libxkbcommon0 libxkbfile1 libexpat1 libpango-1.0-0 \
+      # obsws-python venv for the entrypoint's hourly browser-source refresh \
+      python3 python3-venv \
     && rm -rf /var/lib/apt/lists/*
+
+# obsws-python (in a venv to stay clear of PEP 668 system-managed python)
+# powers the hourly browser-source refresh that the entrypoint kicks off
+# as a workaround for CEF's per-frame memory leak.
+RUN python3 -m venv /opt/obs/venv \
+    && /opt/obs/venv/bin/pip install --no-cache-dir obsws-python
 
 # Copy the compiled OBS install tree from the pre-baked base image. cmake
 # --install laid the tree out under /opt/obs-install (mapped to /usr/local on
@@ -67,7 +75,8 @@ RUN find /usr/local -name chrome-sandbox -exec chmod 4755 {} +
 COPY infra/docker/obs/config/ /opt/obs/config/
 COPY infra/docker/obs/entrypoint.sh /opt/obs/entrypoint.sh
 COPY infra/docker/obs/healthcheck.sh /opt/obs/healthcheck.sh
-RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh
+COPY bin/obs-browser-refresh /opt/obs/bin/obs-browser-refresh
+RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh /opt/obs/bin/obs-browser-refresh
 
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -75,4 +75,17 @@ sleep 1
 
 x11vnc -display "$DISPLAY" -forever -shared -rfbport 5900 -passwd "${VNC_PASSWD:-123456}" &
 
+# Hourly refresh of every browser source via the local obs-websocket port,
+# working around the CEF per-frame memory leak that otherwise OOMs OBS at
+# the 3Gi pod limit overnight. PR #555 capped browser-source render rate
+# to slow the bleed; this loop drops accumulated render state on a fixed
+# cycle so RSS stays bounded across multi-day uptimes.
+(
+  while sleep 3600; do
+    OBS_WEBSOCKET_HOST=localhost OBS_WEBSOCKET_PORT=4455 \
+      /opt/obs/venv/bin/python /opt/obs/bin/obs-browser-refresh \
+      || echo "[browser-refresh] failed (will retry next cycle)" >&2
+  done
+) &
+
 exec obs "${obs_args[@]}"

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -83,7 +83,7 @@ x11vnc -display "$DISPLAY" -forever -shared -rfbport 5900 -passwd "${VNC_PASSWD:
 (
   while sleep 3600; do
     OBS_WEBSOCKET_HOST=localhost OBS_WEBSOCKET_PORT=4455 \
-      /opt/obs/venv/bin/python /opt/obs/bin/obs-browser-refresh \
+      timeout 60 /opt/obs/venv/bin/python /opt/obs/bin/obs-browser-refresh \
       || echo "[browser-refresh] failed (will retry next cycle)" >&2
   done
 ) &


### PR DESCRIPTION
## Summary

- Pairs with #555 — that PR slowed the CEF per-frame leak from ~10 MB/min to ~0.3 MB/min by dropping render rate to 2 fps; this one *caps* it by reloading every browser source once an hour so accumulated render state is dropped on a fixed cycle.
- Runs `bin/obs-browser-refresh` (already used via `task obs:browser:refresh` from workstations) as a background loop in `entrypoint.sh`, talking to the local obs-websocket on `localhost:4455`. Survives independently of tripbot.
- Adds python3 + a venv with `obsws-python` to both `Dockerfile` and `Dockerfile.arm64` (~50 MB image growth). venv avoids Ubuntu 24.04's PEP 668 externally-managed-python error.

## Why entrypoint vs. alternatives

| Option | Why not |
|---|---|
| Goroutine in tripbot | Couples tripbot to OBS hygiene; if tripbot is down OBS keeps leaking |
| k8s CronJob | Cross-pod websocket auth + Secret plumbing for a 5-line workaround |
| Sidecar | Most moving parts for the same outcome |

Entrypoint loop colocates the workaround with the leaking process; refresh fails-soft (logs and continues on next cycle).

## Test plan

- [ ] Build new OBS image (both arches), redeploy stage
- [ ] `kubectl logs -f deploy/obs | grep -i refresh` shows `Refreshed: <name>` lines on the hour, all 7 browser sources
- [ ] Grafana OBS memory panel shows hourly sawtooth instead of monotonic climb
- [ ] Run 24h+ without OOM
- [ ] Spot-check the visible flicker on stream when refresh fires — should be sub-second and not jarring; if it's too noticeable we'll stagger refreshes