### PR TITLE
obs: shutdown CEF on conditionally-shown browser sources when hidden

### DIFF
--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -455,7 +455,7 @@
         "fps_custom": true,
         "fps": 2,
         "reroute_audio": false,
-        "shutdown": false,
+        "shutdown": true,
         "restart_when_active": false,
         "css": ""
       },
@@ -587,7 +587,7 @@
         "fps_custom": true,
         "fps": 2,
         "reroute_audio": false,
-        "shutdown": false,
+        "shutdown": true,
         "restart_when_active": false,
         "css": ""
       },
@@ -620,7 +620,7 @@
         "fps_custom": true,
         "fps": 2,
         "reroute_audio": false,
-        "shutdown": false,
+        "shutdown": true,
         "restart_when_active": false,
         "css": ""
       },


### PR DESCRIPTION
## Summary
- Flips `"shutdown": true` on three conditionally-shown OBS browser sources (Flag, Middle Text, Timewarp) in `infra/docker/obs/config/Tripbot.json.tmpl`. CEF now unloads the child process when these sources go hidden, freeing ~150-250 MB each. Always-shown sources (leaderboard, both rotators, GPS) keep `"shutdown": false` to avoid sub-second cold-start delays when they're constantly visible.
- Easy-win complement to #555 (FPS cap) and #556 (hourly refresh). Smaller-scope than the text_ft2_source migration TODO.

## Test plan
- [x] JSON template still parses / structure intact
- [ ] Verify on stage: trigger a Middle Text overlay via chat, hide, observe RSS drop on the OBS pod — `kubectl top pod obs-<hash>` before vs after
- [ ] Cold-start latency on re-show is sub-second / acceptable