### PR TITLE
vlc-server: graceful HTTP shutdown via signal-derived context

### DIFF
--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -42,6 +42,13 @@ func main() {
 	// initialize the onscreen elements
 	createOnscreens()
 
+	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
+	// to trigger a graceful shutdown so in-flight requests aren't cut.
+	// listenForShutdown's gracefulShutdown goroutine handles the rest of
+	// the app cleanup off the same signals.
+	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	// await graceful shutdown signal
 	listenForShutdown()
 
@@ -61,7 +68,7 @@ func main() {
 
 	// start the webserver
 	vlcServer.SetVersion(version)
-	vlcServer.Start()
+	vlcServer.Start(shutdownCtx)
 
 	// listen for termination signals and gracefully shutdown
 	defer vlcServer.Shutdown()

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -1,6 +1,8 @@
 package vlcServer
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -21,9 +23,18 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Start starts the web server
-func Start() {
-	slog.Info("starting VLC web server", "bind", c.Conf.VlcServerBindAddress)
+// shutdownTimeout is how long Shutdown waits for in-flight requests to
+// finish before forcing connections closed. 15s is the typical sweet spot:
+// long enough that healthy requests complete, short enough that a stuck
+// handler doesn't block process exit indefinitely.
+const shutdownTimeout = 15 * time.Second
+
+// Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
+// via signal.NotifyContext) the server stops accepting new connections and
+// waits up to shutdownTimeout for in-flight requests to complete before
+// returning.
+func Start(ctx context.Context) {
+	slog.InfoContext(ctx, "starting VLC web server", "bind", c.Conf.VlcServerBindAddress)
 
 	r := mux.NewRouter()
 
@@ -110,9 +121,29 @@ func Start() {
 		Handler:        otelhttp.NewHandler(app, c.Conf.ServerType),
 	}
 
-	//TODO: add graceful shutdown
-	if err := srv.ListenAndServe(); err != nil {
-		terrors.Fatal(err, "couldn't start server")
+	// Run ListenAndServe in a goroutine so we can block on ctx.Done() and
+	// trigger a graceful shutdown when a signal arrives. ErrServerClosed is
+	// the expected return after Shutdown is called and is not an error.
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			terrors.Fatal(err, "couldn't start server")
+		}
+	case <-ctx.Done():
+		slog.InfoContext(ctx, "shutting down VLC web server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			terrors.Log(err, "error during VLC web server shutdown")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Mirrors #440's graceful HTTP shutdown shape on `pkg/vlc-server/server.go`. SIGTERM now waits for in-flight `/onscreens/*`, `/health/*`, `/state.json` requests to finish via `srv.Shutdown(ctx)` with a 15s timeout, instead of cutting the connection.
- `cmd/vlc-server` derives the context from `signal.NotifyContext` on SIGINT/SIGTERM and threads it into `vlcServer.Start`. The existing `gracefulShutdown` goroutine continues to handle the rest of the app cleanup off the same signals.
- Resolves the `//TODO: add graceful shutdown` comment #440 left as the follow-up.

## Test plan
- [x] `go test ./pkg/vlc-server/...` builds locally (CGO + libvlc); local run hits unrelated `/opt/data` env requirement
- [ ] Verify on stage: `kubectl rollout restart deployment/vlc-server -n tripbot` should drain cleanly without cutting active onscreens requests