### PR TITLE
chatbot: ungate !report command

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -170,7 +170,7 @@ func (a *App) buildRegistry() []Command {
 			Trigger:        "!report",
 			Aliases:        []string{"no audio", "no sound", "no music", "frozen"},
 			Handler:        a.reportCmd,
-			RequiresFollow: true,
+			RequiresFollow: false,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Flips `RequiresFollow` from true to false on the `!report` Command entry in `pkg/chatbot/registry.go`. First-time viewers and lurkers can now use `!report` without first following the channel, which is the right policy for a report-a-problem command.

## Test plan
- [x] `go test ./pkg/chatbot/...` passes locally (pre-existing playback-test failures on develop are unrelated to this change)
- [ ] Smoke: non-follower can run `!report <message>` in staging