### PR TITLE
refactor(obs): move OBS-websocket polling from tripbot to vlc-server

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -18,7 +18,6 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
-	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
@@ -73,7 +72,6 @@ func main() {
 	findInitialVideo()
 	users.InitLeaderboard(context.Background())
 	startCron()
-	startOBSPolling()
 	loadTwitchToken()   // must precede chatbot.Initialize — provides the IRC token
 	setUpTwitchClient() // required for the below
 	updateSubscribers()
@@ -138,12 +136,6 @@ func startCron() {
 	// start cron and attach cronjobs
 	background.StartCron()
 	scheduleBackgroundJobs()
-}
-
-// startOBSPolling starts the background goroutine that polls OBS WebSocket
-// for streaming state and updates the obs_streaming_active gauge.
-func startOBSPolling() {
-	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 }
 
 // loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -14,6 +14,7 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/obs"
 	onscreensServer "github.com/adanalife/tripbot/pkg/onscreens-server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	vlcServer "github.com/adanalife/tripbot/pkg/vlc-server"
@@ -58,6 +59,9 @@ func main() {
 	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
 	// surface them as OTel gauges. No-op when telemetry is disabled.
 	vlcServer.StartStatsPoller(context.Background(), 5*time.Second)
+
+	// poll the OBS WebSocket for streaming state + render/output stats.
+	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 
 	// start the webserver
 	vlcServer.SetVersion(version)

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -26,22 +26,6 @@ var (
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
-	obsStreamingGauge = mustGauge("obs_streaming_active", "1 if OBS is actively streaming, 0 otherwise")
-
-	obsActiveFPS              = mustFloat64Gauge("obs_active_fps", "Current FPS being rendered by OBS")
-	obsAverageFrameRenderMS   = mustFloat64Gauge("obs_average_frame_render_time_ms", "Average time in milliseconds OBS spends rendering a frame")
-	obsCPUUsage               = mustFloat64Gauge("obs_cpu_usage_percent", "Current OBS CPU usage (percent)")
-	obsMemoryUsage            = mustFloat64Gauge("obs_memory_usage_mb", "Current OBS memory usage in MB")
-	obsRenderSkippedFrames    = mustFloat64Gauge("obs_render_skipped_frames", "Render-thread skipped frames since OBS started")
-	obsRenderTotalFrames      = mustFloat64Gauge("obs_render_total_frames", "Render-thread total frames since OBS started")
-	obsOutputSkippedFrames    = mustFloat64Gauge("obs_output_skipped_frames", "Output-thread skipped frames since OBS started")
-	obsOutputTotalFrames      = mustFloat64Gauge("obs_output_total_frames", "Output-thread total frames since OBS started")
-	obsStreamOutputBytes      = mustFloat64Gauge("obs_stream_output_bytes", "Bytes sent by the stream output (cumulative since stream start)")
-	obsStreamOutputDurationMS = mustFloat64Gauge("obs_stream_output_duration_ms", "Current stream output duration in milliseconds")
-	obsStreamCongestion       = mustFloat64Gauge("obs_stream_output_congestion", "Stream output congestion (0..1)")
-	obsStreamReconnecting     = mustGauge("obs_stream_output_reconnecting", "1 if the stream output is currently reconnecting, 0 otherwise")
-	obsStreamSkippedFrames    = mustFloat64Gauge("obs_stream_output_skipped_frames", "Stream-output skipped frames since stream start")
-	obsStreamTotalFrames      = mustFloat64Gauge("obs_stream_output_total_frames", "Stream-output total frames since stream start")
 )
 
 // ChatMessages exposes the chat-message counter through a tiny stable API
@@ -73,52 +57,6 @@ var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followe
 // TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
 // like "GetUsers"; statusCode is the HTTP status reported by Twitch.
 var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
-
-// OBSStreaming exposes the streaming-active gauge.
-var OBSStreaming = obsStreamingIface{g: obsStreamingGauge}
-
-// OBSStatsSnapshot bundles OBS performance + stream-output stats so the
-// poller can publish in a single call without coupling instrumentation to
-// goobs types.
-type OBSStatsSnapshot struct {
-	ActiveFPS              float64
-	AverageFrameRenderTime float64 // ms
-	CPUUsage               float64 // percent
-	MemoryUsage            float64 // MB
-	RenderSkippedFrames    float64
-	RenderTotalFrames      float64
-	OutputSkippedFrames    float64
-	OutputTotalFrames      float64
-}
-
-// OBSStreamSnapshot is the stream-output side (only meaningful while
-// streaming, but always safe to publish — fields are zero when idle).
-type OBSStreamSnapshot struct {
-	OutputBytes       float64
-	OutputDurationMS  float64
-	OutputCongestion  float64
-	Reconnecting      bool
-	SkippedFrames     float64
-	TotalFrames       float64
-}
-
-// OBSStats exposes the OBS performance + stream-output gauges.
-var OBSStats = obsStatsIface{
-	activeFPS:           obsActiveFPS,
-	averageFrameRender:  obsAverageFrameRenderMS,
-	cpuUsage:            obsCPUUsage,
-	memoryUsage:         obsMemoryUsage,
-	renderSkippedFrames: obsRenderSkippedFrames,
-	renderTotalFrames:   obsRenderTotalFrames,
-	outputSkippedFrames: obsOutputSkippedFrames,
-	outputTotalFrames:   obsOutputTotalFrames,
-	streamBytes:         obsStreamOutputBytes,
-	streamDuration:      obsStreamOutputDurationMS,
-	streamCongestion:    obsStreamCongestion,
-	streamReconnecting:  obsStreamReconnecting,
-	streamSkipped:       obsStreamSkippedFrames,
-	streamTotal:         obsStreamTotalFrames,
-}
 
 type chatCounterIface struct{ counter metric.Int64Counter }
 
@@ -170,59 +108,6 @@ func (h twitchHelixErrorsIface) Inc(endpoint string, statusCode int) {
 		attribute.String("endpoint", endpoint),
 		attribute.Int("status_code", statusCode),
 	))
-}
-
-type obsStreamingIface struct{ g metric.Int64Gauge }
-
-func (o obsStreamingIface) Set(active bool) {
-	v := int64(0)
-	if active {
-		v = 1
-	}
-	o.g.Record(context.Background(), v)
-}
-
-type obsStatsIface struct {
-	activeFPS           metric.Float64Gauge
-	averageFrameRender  metric.Float64Gauge
-	cpuUsage            metric.Float64Gauge
-	memoryUsage         metric.Float64Gauge
-	renderSkippedFrames metric.Float64Gauge
-	renderTotalFrames   metric.Float64Gauge
-	outputSkippedFrames metric.Float64Gauge
-	outputTotalFrames   metric.Float64Gauge
-	streamBytes         metric.Float64Gauge
-	streamDuration      metric.Float64Gauge
-	streamCongestion    metric.Float64Gauge
-	streamReconnecting  metric.Int64Gauge
-	streamSkipped       metric.Float64Gauge
-	streamTotal         metric.Float64Gauge
-}
-
-func (o obsStatsIface) Update(s OBSStatsSnapshot) {
-	ctx := context.Background()
-	o.activeFPS.Record(ctx, s.ActiveFPS)
-	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime)
-	o.cpuUsage.Record(ctx, s.CPUUsage)
-	o.memoryUsage.Record(ctx, s.MemoryUsage)
-	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames)
-	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames)
-	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames)
-	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames)
-}
-
-func (o obsStatsIface) UpdateStream(s OBSStreamSnapshot) {
-	ctx := context.Background()
-	o.streamBytes.Record(ctx, s.OutputBytes)
-	o.streamDuration.Record(ctx, s.OutputDurationMS)
-	o.streamCongestion.Record(ctx, s.OutputCongestion)
-	v := int64(0)
-	if s.Reconnecting {
-		v = 1
-	}
-	o.streamReconnecting.Record(ctx, v)
-	o.streamSkipped.Record(ctx, s.SkippedFrames)
-	o.streamTotal.Record(ctx, s.TotalFrames)
 }
 
 func mustCounter(name, desc string) metric.Int64Counter {

--- a/pkg/instrumentation/vlc_server.go
+++ b/pkg/instrumentation/vlc_server.go
@@ -7,14 +7,30 @@ import (
 )
 
 var (
-	vlcInputBitRate        = mustFloat64Gauge("vlc_player_input_bitrate", "libvlc input bitrate (libvlc-native units, ~bytes/µs)")
-	vlcDemuxBitRate        = mustFloat64Gauge("vlc_player_demux_bitrate", "libvlc demux bitrate (libvlc-native units, ~bytes/µs)")
-	vlcDisplayedFPS        = mustFloat64Gauge("vlc_player_displayed_fps", "Derived frames-per-second: delta of displayed pictures over the poll interval")
-	vlcDecodedVideo        = mustFloat64Gauge("vlc_player_decoded_video_frames", "Total decoded video blocks since the current Media started (resets on media change)")
-	vlcDisplayedPictures   = mustFloat64Gauge("vlc_player_displayed_pictures", "Total displayed frames since the current Media started (resets on media change)")
-	vlcLostPictures        = mustFloat64Gauge("vlc_player_lost_pictures", "Total lost (dropped) frames since the current Media started (resets on media change)")
-	vlcDemuxCorrupted      = mustFloat64Gauge("vlc_player_demux_corrupted", "Demux corruptions discarded since the current Media started")
-	vlcDemuxDiscontinuity  = mustFloat64Gauge("vlc_player_demux_discontinuity", "Demux discontinuities dropped since the current Media started")
+	vlcInputBitRate       = mustFloat64Gauge("vlc_player_input_bitrate", "libvlc input bitrate (libvlc-native units, ~bytes/µs)")
+	vlcDemuxBitRate       = mustFloat64Gauge("vlc_player_demux_bitrate", "libvlc demux bitrate (libvlc-native units, ~bytes/µs)")
+	vlcDisplayedFPS       = mustFloat64Gauge("vlc_player_displayed_fps", "Derived frames-per-second: delta of displayed pictures over the poll interval")
+	vlcDecodedVideo       = mustFloat64Gauge("vlc_player_decoded_video_frames", "Total decoded video blocks since the current Media started (resets on media change)")
+	vlcDisplayedPictures  = mustFloat64Gauge("vlc_player_displayed_pictures", "Total displayed frames since the current Media started (resets on media change)")
+	vlcLostPictures       = mustFloat64Gauge("vlc_player_lost_pictures", "Total lost (dropped) frames since the current Media started (resets on media change)")
+	vlcDemuxCorrupted     = mustFloat64Gauge("vlc_player_demux_corrupted", "Demux corruptions discarded since the current Media started")
+	vlcDemuxDiscontinuity = mustFloat64Gauge("vlc_player_demux_discontinuity", "Demux discontinuities dropped since the current Media started")
+
+	obsStreamingGauge         = mustGauge("obs_streaming_active", "1 if OBS is actively streaming, 0 otherwise")
+	obsActiveFPS              = mustFloat64Gauge("obs_active_fps", "Current FPS being rendered by OBS")
+	obsAverageFrameRenderMS   = mustFloat64Gauge("obs_average_frame_render_time_ms", "Average time in milliseconds OBS spends rendering a frame")
+	obsCPUUsage               = mustFloat64Gauge("obs_cpu_usage_percent", "Current OBS CPU usage (percent)")
+	obsMemoryUsage            = mustFloat64Gauge("obs_memory_usage_mb", "Current OBS memory usage in MB")
+	obsRenderSkippedFrames    = mustFloat64Gauge("obs_render_skipped_frames", "Render-thread skipped frames since OBS started")
+	obsRenderTotalFrames      = mustFloat64Gauge("obs_render_total_frames", "Render-thread total frames since OBS started")
+	obsOutputSkippedFrames    = mustFloat64Gauge("obs_output_skipped_frames", "Output-thread skipped frames since OBS started")
+	obsOutputTotalFrames      = mustFloat64Gauge("obs_output_total_frames", "Output-thread total frames since OBS started")
+	obsStreamOutputBytes      = mustFloat64Gauge("obs_stream_output_bytes", "Bytes sent by the stream output (cumulative since stream start)")
+	obsStreamOutputDurationMS = mustFloat64Gauge("obs_stream_output_duration_ms", "Current stream output duration in milliseconds")
+	obsStreamCongestion       = mustFloat64Gauge("obs_stream_output_congestion", "Stream output congestion (0..1)")
+	obsStreamReconnecting     = mustGauge("obs_stream_output_reconnecting", "1 if the stream output is currently reconnecting, 0 otherwise")
+	obsStreamSkippedFrames    = mustFloat64Gauge("obs_stream_output_skipped_frames", "Stream-output skipped frames since stream start")
+	obsStreamTotalFrames      = mustFloat64Gauge("obs_stream_output_total_frames", "Stream-output total frames since stream start")
 )
 
 // VLCPlayerStatsSnapshot is the shape vlc-server hands to instrumentation
@@ -64,4 +80,103 @@ func (v vlcPlayerStatsIface) Update(s VLCPlayerStatsSnapshot) {
 	v.lostPictures.Record(ctx, s.LostPictures)
 	v.demuxCorrupted.Record(ctx, s.DemuxCorrupted)
 	v.demuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity)
+}
+
+// OBSStreaming exposes the streaming-active gauge.
+var OBSStreaming = obsStreamingIface{g: obsStreamingGauge}
+
+// OBSStatsSnapshot bundles OBS performance + stream-output stats so the
+// poller can publish in a single call without coupling instrumentation to
+// goobs types.
+type OBSStatsSnapshot struct {
+	ActiveFPS              float64
+	AverageFrameRenderTime float64 // ms
+	CPUUsage               float64 // percent
+	MemoryUsage            float64 // MB
+	RenderSkippedFrames    float64
+	RenderTotalFrames      float64
+	OutputSkippedFrames    float64
+	OutputTotalFrames      float64
+}
+
+// OBSStreamSnapshot is the stream-output side (only meaningful while
+// streaming, but always safe to publish — fields are zero when idle).
+type OBSStreamSnapshot struct {
+	OutputBytes      float64
+	OutputDurationMS float64
+	OutputCongestion float64
+	Reconnecting     bool
+	SkippedFrames    float64
+	TotalFrames      float64
+}
+
+// OBSStats exposes the OBS performance + stream-output gauges.
+var OBSStats = obsStatsIface{
+	activeFPS:           obsActiveFPS,
+	averageFrameRender:  obsAverageFrameRenderMS,
+	cpuUsage:            obsCPUUsage,
+	memoryUsage:         obsMemoryUsage,
+	renderSkippedFrames: obsRenderSkippedFrames,
+	renderTotalFrames:   obsRenderTotalFrames,
+	outputSkippedFrames: obsOutputSkippedFrames,
+	outputTotalFrames:   obsOutputTotalFrames,
+	streamBytes:         obsStreamOutputBytes,
+	streamDuration:      obsStreamOutputDurationMS,
+	streamCongestion:    obsStreamCongestion,
+	streamReconnecting:  obsStreamReconnecting,
+	streamSkipped:       obsStreamSkippedFrames,
+	streamTotal:         obsStreamTotalFrames,
+}
+
+type obsStreamingIface struct{ g metric.Int64Gauge }
+
+func (o obsStreamingIface) Set(active bool) {
+	v := int64(0)
+	if active {
+		v = 1
+	}
+	o.g.Record(context.Background(), v)
+}
+
+type obsStatsIface struct {
+	activeFPS           metric.Float64Gauge
+	averageFrameRender  metric.Float64Gauge
+	cpuUsage            metric.Float64Gauge
+	memoryUsage         metric.Float64Gauge
+	renderSkippedFrames metric.Float64Gauge
+	renderTotalFrames   metric.Float64Gauge
+	outputSkippedFrames metric.Float64Gauge
+	outputTotalFrames   metric.Float64Gauge
+	streamBytes         metric.Float64Gauge
+	streamDuration      metric.Float64Gauge
+	streamCongestion    metric.Float64Gauge
+	streamReconnecting  metric.Int64Gauge
+	streamSkipped       metric.Float64Gauge
+	streamTotal         metric.Float64Gauge
+}
+
+func (o obsStatsIface) Update(s OBSStatsSnapshot) {
+	ctx := context.Background()
+	o.activeFPS.Record(ctx, s.ActiveFPS)
+	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime)
+	o.cpuUsage.Record(ctx, s.CPUUsage)
+	o.memoryUsage.Record(ctx, s.MemoryUsage)
+	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames)
+	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames)
+	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames)
+	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames)
+}
+
+func (o obsStatsIface) UpdateStream(s OBSStreamSnapshot) {
+	ctx := context.Background()
+	o.streamBytes.Record(ctx, s.OutputBytes)
+	o.streamDuration.Record(ctx, s.OutputDurationMS)
+	o.streamCongestion.Record(ctx, s.OutputCongestion)
+	v := int64(0)
+	if s.Reconnecting {
+		v = 1
+	}
+	o.streamReconnecting.Record(ctx, v)
+	o.streamSkipped.Record(ctx, s.SkippedFrames)
+	o.streamTotal.Record(ctx, s.TotalFrames)
 }


### PR DESCRIPTION
## Summary

Moves the OBS WebSocket polling goroutine (`PollStreamingActive`) out of the tripbot cmd and into vlc-server. Tripbot is a chat/scoreboard service — it doesn't otherwise need to know OBS exists. vlc-server already lives on OBS's data plane (dashcam RTSP, onscreens HTTP) and is the natural home for OBS-facing integration.

This is the polling half of the vlc-server / onscreens-server boundary cleanup. Pairs with the future `text_ft2_source` push migration which will share the same goobs connection — keeps OBS-facing code in one place so the eventual onscreens-out-of-vlc-server split stays cheap.

- `cmd/tripbot/tripbot.go` — drop `pkg/obs` import, remove `startOBSPolling()` and its call.
- `cmd/vlc-server/vlc-server.go` — add the polling goroutine next to the existing libvlc stats poller.
- `pkg/instrumentation/{tripbot,vlc_server}.go` — relocate the `obs_*` gauges and `OBSStreaming` / `OBSStats` interfaces into `vlc_server.go` to make ownership obvious. Same package, no callsite changes.

## Telemetry impact

The `obs_*` metrics keep their names but their `service.name` resource attribute flips from `tripbot` to `vlc-server`. Three Grafana alerts in `infra/terraform/stage-1/grafana-alerts.tf` filter on `service_name=\"tripbot\"` for `obs_stream_output_*` — updated in sibling PR [infra#483](https://github.com/adanalife/infra/pull/483/changes).

## Test plan

- [ ] CI green
- [ ] Deploy to stage; confirm `obs_streaming_active{service_name=\"vlc-server\"}` shows up in Grafana within ~1 min
- [ ] Confirm `obs_streaming_active{service_name=\"tripbot\"}` stops reporting (no orphan series)
- [ ] Apply [infra#483](https://github.com/adanalife/infra/pull/483/changes) so the stream_health alerts match the new label