### PR TITLE
taskfile: add vlc-server:{vet,build}:macos targets

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -108,3 +108,30 @@ tasks:
       OBS_WEBSOCKET_PASSWD: '{{.OBS_WEBSOCKET_PASSWD | default "adanalife"}}'
     cmds:
       - uv run --with obsws-python bin/obs-browser-refresh
+
+  # vlc-server native macOS build — links against the libvlc bundled
+  # inside VLC.app. Saves recreating the CGO incantation from memory.
+  # See vault/tripbot/vlc-server/gotchas.md for the full story; key bits:
+  #   * rpath is required for `go test` / `go run`, not just `go build` —
+  #     otherwise `dyld: Library not loaded: @rpath/libvlc.dylib`.
+  #   * Do NOT add `-lvlc` to LDFLAGS — libvlc-go's own #cgo LDFLAGS
+  #     directive already does it; duplicating triggers a linker warning.
+  #   * `-Wno-error=incompatible-function-pointer-types` mutes a
+  #     libvlc-go/v3 vs Apple-clang fatal that's harmless at runtime.
+
+  vlc-server:vet:macos:
+    desc: Run `go vet` on vlc-server against VLC.app's libvlc headers (no link)
+    platforms: [darwin]
+    env:
+      CGO_CFLAGS: -I/Applications/VLC.app/Contents/MacOS/include
+    cmds:
+      - mise exec -- go vet ./pkg/vlc-server/...
+
+  vlc-server:build:macos:
+    desc: Build vlc-server natively on macOS against VLC.app's libvlc
+    platforms: [darwin]
+    env:
+      CGO_CFLAGS: -I/Applications/VLC.app/Contents/MacOS/include
+      CGO_LDFLAGS: -L/Applications/VLC.app/Contents/MacOS/lib -Wl,-rpath,/Applications/VLC.app/Contents/MacOS/lib -Wno-error=incompatible-function-pointer-types
+    cmds:
+      - mise exec -- go build -o bin/vlc-server ./cmd/vlc-server


### PR DESCRIPTION
## Summary

Codifies the libvlc CGO incantation for macOS dev so it doesn't have to be recreated from memory each time. Two new targets, both `platforms: [darwin]` so they don't fire on Linux CI:

- **\`vlc-server:vet:macos\`** — \`go vet\` against VLC.app's libvlc headers. No link, no rpath needed. Cheap "did my edits to \`pkg/vlc-server\` compile cleanly" check.
- **\`vlc-server:build:macos\`** — full build linked against \`libvlc.dylib\` bundled inside VLC.app, producing \`bin/vlc-server\`.

## Key flags

| Flag | Why |
|---|---|
| \`-I/Applications/VLC.app/Contents/MacOS/include\` | Where VLC.app keeps \`vlc/vlc.h\` |
| \`-L/Applications/VLC.app/Contents/MacOS/lib\` | Where the dylibs live |
| \`-Wl,-rpath,/Applications/VLC.app/Contents/MacOS/lib\` | Required for \`go test\` / \`go run\` (and any binary launch) — without it the binary aborts with \`dyld: Library not loaded: @rpath/libvlc.dylib\` |
| \`-Wno-error=incompatible-function-pointer-types\` | Mutes a libvlc-go/v3 vs Apple-clang fatal that's harmless at runtime |

\`mise exec --\` so the pinned Go toolchain (1.26.3 per \`.tool-versions\`) resolves in task's non-interactive subshell.

## Out of scope

\`vlc-server:run:macos\` deferred. Requires env-var defaults that belong in \`pkg/config\` — separate TODO ("Audit env-var requirements at startup"). Build + vet ship now; run lands once config defaults are reasonable.

## Test plan

- [x] \`task vlc-server:vet:macos\` — clean
- [x] \`task vlc-server:build:macos\` — produces a 26 MB Mach-O arm64 at \`bin/vlc-server\`
- [x] \`./bin/vlc-server --help\` exits with "You must set ENV" (rpath wiring works at runtime; no \`dyld\` load error)
- [x] \`otool -l\` confirms \`LC_RPATH = /Applications/VLC.app/Contents/MacOS/lib\`