### PR TITLE
refactor: thread ctx into more slog calls (follow-up to #552)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -99,10 +99,11 @@ func listenForShutdown() {
 // logs). No-ops cleanly if OTEL_SDK_DISABLED is set or no OTLP endpoint
 // is configured — see pkg/telemetry.
 func initializeTelemetry() {
-	shutdown, err := telemetry.Init(context.Background(), "tripbot", version)
+	ctx := context.Background()
+	shutdown, err := telemetry.Init(ctx, "tripbot", version)
 	if err != nil {
 		// telemetry init failure shouldn't crash the bot — log and continue.
-		slog.Warn("telemetry init failed", "err", err)
+		slog.WarnContext(ctx, "telemetry init failed", "err", err)
 	}
 	telemetryShutdown = shutdown
 }
@@ -233,7 +234,7 @@ func gracefulShutdown() {
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		if err := telemetryShutdown(flushCtx); err != nil {
-			slog.Error("telemetry shutdown failed", "err", err)
+			slog.ErrorContext(flushCtx, "telemetry shutdown failed", "err", err)
 		}
 		cancel()
 	}

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -83,9 +83,10 @@ func createOnscreens() {
 // logs). No-ops cleanly if OTEL_SDK_DISABLED is set or no OTLP endpoint
 // is configured — see pkg/telemetry.
 func initializeTelemetry() {
-	shutdown, err := telemetry.Init(context.Background(), "vlc-server", version)
+	ctx := context.Background()
+	shutdown, err := telemetry.Init(ctx, "vlc-server", version)
 	if err != nil {
-		slog.Warn("telemetry init failed", "err", err)
+		slog.WarnContext(ctx, "telemetry init failed", "err", err)
 	}
 	telemetryShutdown = shutdown
 }
@@ -122,7 +123,7 @@ func gracefulShutdown() {
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		if err := telemetryShutdown(flushCtx); err != nil {
-			slog.Error("telemetry shutdown failed", "err", err)
+			slog.ErrorContext(flushCtx, "telemetry shutdown failed", "err", err)
 		}
 		cancel()
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -47,7 +47,7 @@ var noopShutdown ShutdownFunc = func(context.Context) error { return nil }
 // returns a non-nil ShutdownFunc — safe to defer unconditionally.
 func Init(ctx context.Context, serviceName, serviceVersion string) (ShutdownFunc, error) {
 	if disabled() {
-		slog.Info("telemetry: OTLP exporters disabled, only Prometheus /metrics will be populated")
+		slog.InfoContext(ctx, "telemetry: OTLP exporters disabled, only Prometheus /metrics will be populated")
 		if err := initPromOnlyMeter(ctx, serviceName, serviceVersion); err != nil {
 			return noopShutdown, fmt.Errorf("prom-only meter: %w", err)
 		}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -223,7 +223,7 @@ func GenerateUserAccessToken(code string) error {
 //
 // TODO: helix client surface should move behind an interface so this
 // function can be unit-tested without a real Twitch round-trip.
-func RefreshUserAccessToken(_ context.Context) {
+func RefreshUserAccessToken(ctx context.Context) {
 	botUser := c.Conf.BotUsername
 
 	acquired, release, err := oauthtokens.TryRefreshLock("twitch", botUser)
@@ -299,5 +299,5 @@ func RefreshUserAccessToken(_ context.Context) {
 	tokenMu.Unlock()
 	client.SetUserAccessToken(rotated.AccessToken)
 
-	slog.Info("refreshed user access token")
+	slog.InfoContext(ctx, "refreshed user access token")
 }

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -44,11 +44,10 @@ func getChannelID(username string) string {
 }
 
 // GetSubscribers pulls down the most recent list of subscribers.
-// ctx is forward-compat plumbing — the helix client doesn't accept ctx
-// yet, so the Helix HTTP call isn't currently linked under the parent
-// cron span. Threading it now lets future ctx-aware helix wrappers nest
-// automatically.
-func GetSubscribers(_ context.Context) {
+// ctx is forward-compat plumbing for nesting helix HTTP under the parent
+// cron span; the helix client doesn't accept ctx yet, but the log lines
+// get a trace_id link via slog.InfoContext.
+func GetSubscribers(ctx context.Context) {
 	//TODO: should we do this elsewhere as well?
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
@@ -78,15 +77,15 @@ func GetSubscribers(_ context.Context) {
 	instrumentation.TwitchAudience.SetSubscribers(int64(len(subscribers)))
 
 	if len(subscribers) > 0 {
-		slog.Info("subscribers", "count", len(subscribers), "names", strings.Join(subscribers, ", "))
+		slog.InfoContext(ctx, "subscribers", "count", len(subscribers), "names", strings.Join(subscribers, ", "))
 	} else {
-		slog.Info("no subscribers", "channel", c.Conf.ChannelName)
+		slog.InfoContext(ctx, "no subscribers", "channel", c.Conf.ChannelName)
 	}
 }
 
 // GetFollowerCount fetches the current total follower count for the
 // channel. ctx is forward-compat plumbing (see GetSubscribers).
-func GetFollowerCount(_ context.Context) {
+func GetFollowerCount(ctx context.Context) {
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
 	}
@@ -101,7 +100,7 @@ func GetFollowerCount(_ context.Context) {
 		return
 	}
 	instrumentation.TwitchAudience.SetFollowers(int64(resp.Data.Total))
-	slog.Info("follower count", "channel", c.Conf.ChannelName, "total", resp.Data.Total)
+	slog.InfoContext(ctx, "follower count", "channel", c.Conf.ChannelName, "total", resp.Data.Total)
 }
 
 // UserIsSubscriber returns true if the user subscribes to the channel

--- a/pkg/twitch/webhooks.go
+++ b/pkg/twitch/webhooks.go
@@ -21,19 +21,19 @@ var subsTopic = []string{
 
 // UpdateWebhookSubscriptions will create new webhook subscriptions.
 // ctx is forward-compat plumbing (see GetSubscribers).
-func UpdateWebhookSubscriptions(_ context.Context) {
+func UpdateWebhookSubscriptions(ctx context.Context) {
 	if c.Conf.DisableTwitchWebhooks {
 		return
 	}
-	subscribeToWebhook(followsTopic)
+	subscribeToWebhook(ctx, followsTopic)
 	// since the staging account isn't an affiliate, don't bother
 	if c.Conf.IsProduction() {
-		subscribeToWebhook(subsTopic)
+		subscribeToWebhook(ctx, subsTopic)
 	}
-	getWebookSubscriptions()
+	getWebookSubscriptions(ctx)
 }
 
-func subscribeToWebhook(pair []string) {
+func subscribeToWebhook(_ context.Context, pair []string) {
 	topic := pair[0]
 	endpoint := pair[1]
 
@@ -50,7 +50,7 @@ func subscribeToWebhook(pair []string) {
 	}
 }
 
-func getWebookSubscriptions() {
+func getWebookSubscriptions(ctx context.Context) {
 	// talk to twitch and see what the current webhooks are
 	//TODO: this doesn't seem to work, like at all
 	resp, err := currentTwitchClient.GetWebhookSubscriptions(&helix.WebhookSubscriptionsParams{})
@@ -63,6 +63,6 @@ func getWebookSubscriptions() {
 			spew.Dump(resp.Data.WebhookSubscriptions)
 		}
 	} else {
-		slog.Warn("no webhooks found")
+		slog.WarnContext(ctx, "no webhooks found")
 	}
 }

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -234,13 +234,13 @@ func countBots() int {
 }
 
 // PrintCurrentSession simply prints info about the current session.
-// ctx is forward-compat plumbing — twitch.ChatterCount doesn't take ctx
-// yet, so the parameter is currently unused.
-func PrintCurrentSession(_ context.Context) {
+// ctx links the snapshot log line to the parent cron-tick span;
+// twitch.ChatterCount doesn't take ctx yet.
+func PrintCurrentSession(ctx context.Context) {
 	usernames := sortedUsernameList()
 	coloredUsernames := colorizeUsernames(usernames)
 
-	slog.Info("session snapshot",
+	slog.InfoContext(ctx, "session snapshot",
 		"chatters", twitch.ChatterCount(),
 		"humans", countHumans(),
 		"bots", countBots(),

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -29,7 +29,7 @@ var timeStarted time.Time
 // trace spans for cron.video.GetCurrentlyPlaying ticks will nest the
 // underlying VLC poll and GPS-image toggles as children.
 //TODO: consider making this return a video struct
-func GetCurrentlyPlaying(_ context.Context) {
+func GetCurrentlyPlaying(ctx context.Context) {
 	var err error
 
 	// save the video we used last time
@@ -37,7 +37,7 @@ func GetCurrentlyPlaying(_ context.Context) {
 
 	// figure out what's currently playing
 	if helpers.RunningOnDarwin() {
-		curVid = figureOutCurrentVideo()
+		curVid = figureOutCurrentVideo(ctx)
 	} else {
 		curVid = vlcClient.CurrentlyPlaying()
 	}
@@ -53,7 +53,7 @@ func GetCurrentlyPlaying(_ context.Context) {
 			terrors.Log(err, fmt.Sprintf("unable to create Video from %s", curVid))
 		}
 
-		slog.Info("now playing",
+		slog.InfoContext(ctx, "now playing",
 			"file", CurrentlyPlaying.File(),
 			"state", helpers.StateToStateAbbrev(CurrentlyPlaying.State),
 		)
@@ -74,7 +74,7 @@ func CurrentProgress() time.Duration {
 	return time.Since(timeStarted)
 }
 
-func figureOutCurrentVideo() string {
+func figureOutCurrentVideo(ctx context.Context) string {
 	if helpers.RunningOnWindows() {
 		terrors.Log(nil, "can't run script on windows")
 		return ""
@@ -84,7 +84,7 @@ func figureOutCurrentVideo() string {
 	out, err := exec.Command(scriptPath).Output()
 	outString := strings.TrimSpace(string(out))
 	if err != nil {
-		slog.Error("figureOutCurrentVideo script failed", "err", err, "output", outString)
+		slog.ErrorContext(ctx, "figureOutCurrentVideo script failed", "err", err, "output", outString)
 		return ""
 	}
 	return outString


### PR DESCRIPTION
## Summary

Follow-up to [#552](https://github.com/adanalife/tripbot/pull/552/changes) — opportunistic conversion of `slog.Info/Warn/Error` to `slog.*Context` at sites where ctx is already in scope after the trace-ctx threading in [#535](https://github.com/adanalife/tripbot/pull/535/changes) and [#547](https://github.com/adanalife/tripbot/pull/547/changes).

Each log line that switches to `*Context` now carries a clickable `trace_id` linking the Loki record to its Tempo span.

## What changed (one commit per package)

- **twitch** — `GetSubscribers`, `GetFollowerCount`, `RefreshUserAccessToken` rename `_ context.Context` → `ctx`; thread ctx into the internal `subscribeToWebhook` / `getWebookSubscriptions` helpers (one ctx-having caller). 5 sites.
- **users/session** — `PrintCurrentSession`'s session-snapshot log. 1 site.
- **video** — `GetCurrentlyPlaying` + the darwin-only `figureOutCurrentVideo` helper. 2 sites.
- **telemetry** — the OTLP-disabled info log inside `Init(ctx, …)`. 1 site.
- **cmd/tripbot** + **cmd/vlc-server** — telemetry init warn (ctx hoisted out of inline `context.Background()`) and the shutdown-failed error (uses the in-scope `flushCtx`). 4 sites total.

## What's still on the TODO

Bigger threading work is parked: the `chatUser` interface (`HasCommandAvailable` / `HasGuessCommandAvailable`), `User.CurrentMiles` / `sessionMiles` (multi-caller, including non-ctx leaderboard code), `Whisper` interface (post-#544/#551 IRC seam), and `terrors.Log/Fatal` (would need a ctx variant). All called out in the "Thread ctx through log call sites" vault item.

## Test plan

- [x] `mise exec -- go build ./...` clean
- [ ] CI green
- [ ] After deploy: confirm in Grafana Loki that records from the touched call sites (subscriber updates, video transitions, session snapshots, telemetry warnings) carry `trace_id` linking to their Tempo span