### PR TITLE
http: name HTTP spans after the route template

### DIFF
--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -133,9 +133,11 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
-// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
-// surface the underlying mux route template to the otelhttp middleware, so
-// each registration declares it.
+// (via otelhttp.Labeler) and traces (via the active span), and overrides
+// the span name with the route template so spans group by route in Tempo
+// instead of all collapsing under the operation name passed to
+// otelhttp.NewHandler. Negroni doesn't surface the underlying mux route
+// template to the otelhttp middleware, so each registration declares it.
 func tagged(route string, h http.HandlerFunc) http.Handler {
 	attr := semconv.HTTPRoute(route)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -143,7 +145,9 @@ func tagged(route string, h http.HandlerFunc) http.Handler {
 		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
 			labeler.Add(attr)
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attr)
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attr)
+		span.SetName(route)
 		h(w, req)
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -128,9 +128,11 @@ func Start(ctx context.Context) {
 }
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
-// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
-// surface the underlying mux route template to the otelhttp middleware, so
-// each registration declares it.
+// (via otelhttp.Labeler) and traces (via the active span), and overrides
+// the span name with the route template so spans group by route in Tempo
+// instead of all collapsing under the operation name passed to
+// otelhttp.NewHandler. Negroni doesn't surface the underlying mux route
+// template to the otelhttp middleware, so each registration declares it.
 func tagged(route string, h http.HandlerFunc) http.Handler {
 	attr := semconv.HTTPRoute(route)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -138,7 +140,9 @@ func tagged(route string, h http.HandlerFunc) http.Handler {
 		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
 			labeler.Add(attr)
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attr)
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attr)
+		span.SetName(route)
 		h(w, req)
 	})
 }

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -137,9 +137,11 @@ func Start(ctx context.Context) {
 }
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
-// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
-// surface the underlying mux route template to the otelhttp middleware, so
-// each registration declares it.
+// (via otelhttp.Labeler) and traces (via the active span), and overrides
+// the span name with the route template so spans group by route in Tempo
+// instead of all collapsing under the operation name passed to
+// otelhttp.NewHandler. Negroni doesn't surface the underlying mux route
+// template to the otelhttp middleware, so each registration declares it.
 func tagged(route string, h http.HandlerFunc) http.Handler {
 	attr := semconv.HTTPRoute(route)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -147,7 +149,9 @@ func tagged(route string, h http.HandlerFunc) http.Handler {
 		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
 			labeler.Add(attr)
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attr)
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attr)
+		span.SetName(route)
 		h(w, req)
 	})
 }


### PR DESCRIPTION
## Summary

Closes the vault TODO: \`otelhttp.WithRouteTag\` per route registration. Spans now group by route in Tempo instead of all collapsing under the operation name.

## What changed

Each binary's \`tagged()\` helper (pkg/server, pkg/vlc-server, pkg/onscreens-server) gets one new line: \`span.SetName(route)\`. The http.route attribute was already being set — the missing piece was overriding the default span name.

Before: every HTTP span in Tempo is named \`"vlc-server"\` (or \`"tripbot"\` / \`"onscreens-server"\`) regardless of route. Tempo's operation list shows one entry per binary.

After: spans are named \`/vlc/play/{video}\`, \`/onscreens/middle/{action}\`, \`/auth/callback\`, etc. Tempo's operation list shows one entry per route, with latency percentiles per route.

## Why this and not otelhttp.WithRouteTag

\`otelhttp.WithRouteTag\` was removed in otelhttp v0.49+ (we're on v0.68). The equivalent today is what \`tagged()\` already does (set http.route attribute), plus calling \`span.SetName\`. Span renaming via WithSpanNameFormatter doesn't work cleanly with gorilla/mux because the formatter fires before the route is matched.

## Test plan

- [x] \`mise exec -- go build ./...\` clean
- [ ] CI green
- [ ] After deploy: verify in Tempo that HTTP spans now have route-template names per service