### PR TITLE
http clients: thread ctx for cross-process trace propagation

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -71,7 +71,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !flag", "username", user.Username)
-	a.Onscreens.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 }
 
 func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
@@ -208,7 +208,7 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 	leaderboard = leaderboard[:size]
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard("Monthly Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, "Monthly Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d miles this month: ", size)
@@ -233,7 +233,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 	leaderboard := lifetime[:size]
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard("Total Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, "Total Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d lifetime miles: ", size)
@@ -273,7 +273,7 @@ func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, 
 	}
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard("Correct Guesses This Month", intLeaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d correct guesses this month: ", size)
@@ -362,7 +362,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
 		msg = fmt.Sprintf("@%s got it! We're in %s", user.Username, vid.State)
 		// show the flag for the state
-		a.Onscreens.ShowFlag(10 * time.Second)
+		a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 		// increase their guess score
 		user.AddToScore(ctx, guessScoreboard, 1.0)
 		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
@@ -383,7 +383,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state
-	a.Onscreens.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
 	a.IRC.Say(msg)
@@ -461,7 +461,7 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 	// if the arg was "hide", hide the text from view
 	if len(params) == 1 && strings.ToLower(params[0]) == "hide" {
 		a.IRC.Say("Got it! Hiding the message.")
-		a.Onscreens.HideMiddleText()
+		a.Onscreens.HideMiddleText(ctx)
 		return
 	}
 
@@ -470,5 +470,5 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 
 	slog.InfoContext(ctx, "setting middle text", "text", text)
 
-	a.Onscreens.ShowMiddleText(text)
+	a.Onscreens.ShowMiddleText(ctx, text)
 }

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"time"
 
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
@@ -10,20 +11,28 @@ import (
 // commands depend on. Tests inject a fake; production uses the package-backed
 // realOnscreens adapter wired in defaultApp.
 type Onscreens interface {
-	ShowFlag(dur time.Duration) error
-	ShowLeaderboard(title string, leaderboard [][]string) error
-	HideMiddleText() error
-	ShowMiddleText(msg string) error
-	ShowTimewarp() error
+	ShowFlag(ctx context.Context, dur time.Duration) error
+	ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error
+	HideMiddleText(ctx context.Context) error
+	ShowMiddleText(ctx context.Context, msg string) error
+	ShowTimewarp(ctx context.Context) error
 }
 
 // realOnscreens delegates to pkg/onscreens-client.
 type realOnscreens struct{}
 
-func (realOnscreens) ShowFlag(dur time.Duration) error { return onscreensClient.ShowFlag(dur) }
-func (realOnscreens) ShowLeaderboard(title string, lb [][]string) error {
-	return onscreensClient.ShowLeaderboard(title, lb)
+func (realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
+	return onscreensClient.ShowFlag(ctx, dur)
 }
-func (realOnscreens) HideMiddleText() error          { return onscreensClient.HideMiddleText() }
-func (realOnscreens) ShowMiddleText(msg string) error { return onscreensClient.ShowMiddleText(msg) }
-func (realOnscreens) ShowTimewarp() error            { return onscreensClient.ShowTimewarp() }
+func (realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][]string) error {
+	return onscreensClient.ShowLeaderboard(ctx, title, lb)
+}
+func (realOnscreens) HideMiddleText(ctx context.Context) error {
+	return onscreensClient.HideMiddleText(ctx)
+}
+func (realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
+	return onscreensClient.ShowMiddleText(ctx, msg)
+}
+func (realOnscreens) ShowTimewarp(ctx context.Context) error {
+	return onscreensClient.ShowTimewarp(ctx)
+}

--- a/pkg/chatbot/onscreens_test.go
+++ b/pkg/chatbot/onscreens_test.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -9,11 +10,11 @@ import (
 // overlay surface — it just swallows every call.
 type noopOnscreens struct{}
 
-func (noopOnscreens) ShowFlag(_ time.Duration) error                      { return nil }
-func (noopOnscreens) ShowLeaderboard(_ string, _ [][]string) error        { return nil }
-func (noopOnscreens) HideMiddleText() error                               { return nil }
-func (noopOnscreens) ShowMiddleText(_ string) error                       { return nil }
-func (noopOnscreens) ShowTimewarp() error                                 { return nil }
+func (noopOnscreens) ShowFlag(_ context.Context, _ time.Duration) error                      { return nil }
+func (noopOnscreens) ShowLeaderboard(_ context.Context, _ string, _ [][]string) error        { return nil }
+func (noopOnscreens) HideMiddleText(_ context.Context) error                                 { return nil }
+func (noopOnscreens) ShowMiddleText(_ context.Context, _ string) error                       { return nil }
+func (noopOnscreens) ShowTimewarp(_ context.Context) error                                   { return nil }
 
 // recordingOnscreens captures every call made to it so tests can assert
 // the chatbot invoked the expected overlay method with the expected args.
@@ -22,23 +23,23 @@ type recordingOnscreens struct {
 	Calls []string
 }
 
-func (r *recordingOnscreens) ShowFlag(dur time.Duration) error {
+func (r *recordingOnscreens) ShowFlag(_ context.Context, dur time.Duration) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowFlag(%s)", dur))
 	return nil
 }
-func (r *recordingOnscreens) ShowLeaderboard(title string, lb [][]string) error {
+func (r *recordingOnscreens) ShowLeaderboard(_ context.Context, title string, lb [][]string) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowLeaderboard(%q, %d rows)", title, len(lb)))
 	return nil
 }
-func (r *recordingOnscreens) HideMiddleText() error {
+func (r *recordingOnscreens) HideMiddleText(_ context.Context) error {
 	r.Calls = append(r.Calls, "HideMiddleText()")
 	return nil
 }
-func (r *recordingOnscreens) ShowMiddleText(msg string) error {
+func (r *recordingOnscreens) ShowMiddleText(_ context.Context, msg string) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowMiddleText(%q)", msg))
 	return nil
 }
-func (r *recordingOnscreens) ShowTimewarp() error {
+func (r *recordingOnscreens) ShowTimewarp(_ context.Context) error {
 	r.Calls = append(r.Calls, "ShowTimewarp()")
 	return nil
 }

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -23,10 +23,10 @@ var lastTimewarpTime time.Time
 // timewarp jumps the playhead to a random video in the loop
 func (a *App) timewarp(ctx context.Context) {
 	// show timewarp onscreen
-	a.Onscreens.ShowTimewarp()
+	a.Onscreens.ShowTimewarp(ctx)
 
 	// shuffle to a new video
-	err := a.VLC.PlayRandom()
+	err := a.VLC.PlayRandom(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
@@ -105,7 +105,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 		return
 	}
 	// tell VLC to play it
-	err = a.VLC.PlayFileInPlaylist(randomVid.File())
+	err = a.VLC.PlayFileInPlaylist(ctx, randomVid.File())
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 		a.IRC.Say("Usage: !jump [state]")
@@ -115,7 +115,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// update the currently-playing video
 	a.Video.GetCurrentlyPlaying()
 	// show the flag for the state
-	a.Onscreens.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -155,7 +155,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 	}
 
 	// skip to a new video
-	err = a.VLC.Skip(n)
+	err = a.VLC.Skip(ctx, n)
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
@@ -200,7 +200,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 	}
 
 	// back to an old video
-	err = a.VLC.Back(n)
+	err = a.VLC.Back(ctx, n)
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -1,6 +1,8 @@
 package chatbot
 
 import (
+	"context"
+
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
@@ -9,16 +11,20 @@ import (
 // package-backed realVLC adapter wired in defaultApp. Mirrors the Onscreens
 // injection pattern.
 type VLC interface {
-	PlayRandom() error
-	PlayFileInPlaylist(filename string) error
-	Skip(n int) error
-	Back(n int) error
+	PlayRandom(ctx context.Context) error
+	PlayFileInPlaylist(ctx context.Context, filename string) error
+	Skip(ctx context.Context, n int) error
+	Back(ctx context.Context, n int) error
 }
 
 // realVLC delegates to pkg/vlc-client.
 type realVLC struct{}
 
-func (realVLC) PlayRandom() error                     { return vlcClient.PlayRandom() }
-func (realVLC) PlayFileInPlaylist(filename string) error { return vlcClient.PlayFileInPlaylist(filename) }
-func (realVLC) Skip(n int) error                      { return vlcClient.Skip(n) }
-func (realVLC) Back(n int) error                      { return vlcClient.Back(n) }
+func (realVLC) PlayRandom(ctx context.Context) error {
+	return vlcClient.PlayRandom(ctx)
+}
+func (realVLC) PlayFileInPlaylist(ctx context.Context, filename string) error {
+	return vlcClient.PlayFileInPlaylist(ctx, filename)
+}
+func (realVLC) Skip(ctx context.Context, n int) error { return vlcClient.Skip(ctx, n) }
+func (realVLC) Back(ctx context.Context, n int) error { return vlcClient.Back(ctx, n) }

--- a/pkg/chatbot/vlc_test.go
+++ b/pkg/chatbot/vlc_test.go
@@ -1,15 +1,18 @@
 package chatbot
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // noopVLC satisfies VLC for tests that don't care about playback transitions
 // — it just swallows every call.
 type noopVLC struct{}
 
-func (noopVLC) PlayRandom() error                     { return nil }
-func (noopVLC) PlayFileInPlaylist(_ string) error     { return nil }
-func (noopVLC) Skip(_ int) error                      { return nil }
-func (noopVLC) Back(_ int) error                      { return nil }
+func (noopVLC) PlayRandom(_ context.Context) error                       { return nil }
+func (noopVLC) PlayFileInPlaylist(_ context.Context, _ string) error     { return nil }
+func (noopVLC) Skip(_ context.Context, _ int) error                      { return nil }
+func (noopVLC) Back(_ context.Context, _ int) error                      { return nil }
 
 // recordingVLC captures every call made to it so tests can assert that
 // the chatbot drove playback as expected. All call records are appended
@@ -18,19 +21,19 @@ type recordingVLC struct {
 	Calls []string
 }
 
-func (r *recordingVLC) PlayRandom() error {
+func (r *recordingVLC) PlayRandom(_ context.Context) error {
 	r.Calls = append(r.Calls, "PlayRandom()")
 	return nil
 }
-func (r *recordingVLC) PlayFileInPlaylist(filename string) error {
+func (r *recordingVLC) PlayFileInPlaylist(_ context.Context, filename string) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("PlayFileInPlaylist(%q)", filename))
 	return nil
 }
-func (r *recordingVLC) Skip(n int) error {
+func (r *recordingVLC) Skip(_ context.Context, n int) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("Skip(%d)", n))
 	return nil
 }
-func (r *recordingVLC) Back(n int) error {
+func (r *recordingVLC) Back(_ context.Context, n int) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("Back(%d)", n))
 	return nil
 }

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -1,10 +1,10 @@
 package onscreensClient
 
 import (
-	"log/slog"
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -19,38 +19,39 @@ import (
 var onscreensServerURL = "http://" + c.Conf.OnscreensServerHost
 
 // httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans. See pkg/vlc-client for the same pattern.
+// so outbound calls produce spans and propagate W3C tracecontext headers.
+// See pkg/vlc-client for the same pattern.
 var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
-func HideMiddleText() error {
-	_, err := getUrl(onscreensServerURL + "/onscreens/middle/hide")
+func HideMiddleText(ctx context.Context) error {
+	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/middle/hide")
 	if err != nil {
-		slog.Error("error showing leaderboard onscreen", "err", err)
+		slog.ErrorContext(ctx, "error hiding middle onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
-func ShowMiddleText(msg string) error {
+func ShowMiddleText(ctx context.Context, msg string) error {
 	url := onscreensServerURL + "/onscreens/middle/show"
 	url = fmt.Sprintf("%s?msg=%s", url, helpers.Base64Encode(msg))
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error showing middle onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing middle onscreen", "err", err)
 		return err
 	}
 	return err
 }
 
-func ShowLeaderboard(title string, leaderboard [][]string) error {
+func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
 	content := users.LeaderboardContent(title, leaderboard)
 
 	url := onscreensServerURL + "/onscreens/leaderboard/show"
 	url = fmt.Sprintf("%s?content=%s", url, helpers.Base64Encode(content))
 
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error showing leaderboard onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing leaderboard onscreen", "err", err)
 		return err
 	}
 	return nil
@@ -74,67 +75,71 @@ func ShowGuessLeaderboard(ctx context.Context) {
 	}
 
 	// display leaderboard on screen
-	ShowLeaderboard("Correct Guesses This Month", intLeaderboard)
+	ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 }
 
-func ShowTimewarp() error {
-	_, err := getUrl(onscreensServerURL + "/onscreens/timewarp/show")
+func ShowTimewarp(ctx context.Context) error {
+	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/timewarp/show")
 	if err != nil {
-		slog.Error("error showing timewarp onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing timewarp onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
-func ShowFlag(dur time.Duration) error {
+func ShowFlag(ctx context.Context, dur time.Duration) error {
 	//TODO: bring this back
 	// url := onscreensServerURL + "/onscreens/flag/show"
 	// url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	// _, err := getUrl(url)
+	// _, err := getUrl(ctx, url)
 	// if err != nil {
-	// 	slog.Error("error showing flag onscreen", "err", err)
+	// 	slog.ErrorContext(ctx, "error showing flag onscreen", "err", err)
 	// 	return err
 	// }
 	return nil
 }
 
-func ShowGPSImage(dur time.Duration) error {
+func ShowGPSImage(ctx context.Context, dur time.Duration) error {
 	url := onscreensServerURL + "/onscreens/gps/show"
 	url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error showing gps onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing gps onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
-func HideGPSImage() error {
-	_, err := getUrl(onscreensServerURL + "/onscreens/gps/hide")
+func HideGPSImage(ctx context.Context) error {
+	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/gps/hide")
 	if err != nil {
-		slog.Error("error hiding gps onscreen", "err", err)
+		slog.ErrorContext(ctx, "error hiding gps onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
 //TODO: move this to a common location
-func getUrl(url string) (string, error) {
-	response, err := httpClient.Get(url)
+func getUrl(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.Error("error connecting to VLC server", "err", err)
+		slog.ErrorContext(ctx, "error building request to onscreens server", "err", err)
 		return "", err
-	} else {
-		defer response.Body.Close()
-		contents, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			slog.Error("error reading response from VLC server", "err", err)
-			return "", err
-		}
-		// make note of non-200 status codes
-		if response.StatusCode != 200 {
-			slog.Error(fmt.Sprintf("non-200 response from server (%d)", response.StatusCode))
-		}
-		return string(contents), nil
 	}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "error connecting to onscreens server", "err", err)
+		return "", err
+	}
+	defer response.Body.Close()
+	contents, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "error reading response from onscreens server", "err", err)
+		return "", err
+	}
+	// make note of non-200 status codes
+	if response.StatusCode != 200 {
+		slog.ErrorContext(ctx, "non-200 response from server", "status", response.StatusCode)
+	}
+	return string(contents), nil
 }

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -37,7 +37,7 @@ func GetCurrentlyPlaying(ctx context.Context) {
 	if helpers.RunningOnDarwin() {
 		curVid = figureOutCurrentVideo(ctx)
 	} else {
-		curVid = vlcClient.CurrentlyPlaying()
+		curVid = vlcClient.CurrentlyPlaying(ctx)
 	}
 
 	// if the currently-playing video has changed
@@ -59,9 +59,9 @@ func GetCurrentlyPlaying(ctx context.Context) {
 		// show the no-GPS image
 		if CurrentlyPlaying.Flagged {
 			//TODO: kinda cludgy that we hardcode 60s here
-			onscreensClient.ShowGPSImage(60 * time.Second)
+			onscreensClient.ShowGPSImage(ctx, 60 * time.Second)
 		} else {
-			onscreensClient.HideGPSImage()
+			onscreensClient.HideGPSImage(ctx)
 		}
 	}
 }

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -1,9 +1,10 @@
 package vlcClient
 
 import (
-	"log/slog"
+	"context"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/http"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -14,81 +15,86 @@ import (
 var vlcServerURL = "http://" + c.Conf.VlcServerHost
 
 // httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans. Most callers here are cron/IRC-driven
-// (no inbound HTTP context), so traceparent propagation is best-effort
-// until ctx-threaded variants of these helpers exist.
+// so outbound calls produce spans and propagate W3C tracecontext headers.
+// Callers must pass ctx so the propagation has an active span to attach to —
+// passing context.Background() will still send the request, just without a
+// parent span linking it to the caller's trace.
 var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
 // CurrentlyPlaying finds the currently-playing video path
-func CurrentlyPlaying() string {
-	response, err := getUrl(vlcServerURL + "/vlc/current")
+func CurrentlyPlaying(ctx context.Context) string {
+	response, err := getUrl(ctx, vlcServerURL+"/vlc/current")
 	if err != nil {
-		slog.Error("unable to determine current video", "err", err)
+		slog.ErrorContext(ctx, "unable to determine current video", "err", err)
 		return ""
 	}
 	return response
 }
 
 // PlayRandom plays a random file from the playlist
-func PlayRandom() error {
-	_, err := getUrl(vlcServerURL + "/vlc/random")
+func PlayRandom(ctx context.Context) error {
+	_, err := getUrl(ctx, vlcServerURL+"/vlc/random")
 	if err != nil {
-		slog.Error("error playing random video", "err", err)
+		slog.ErrorContext(ctx, "error playing random video", "err", err)
 		return err
 	}
 	return nil
 }
 
 // PlayFileInPlaylist plays a given file
-func PlayFileInPlaylist(filename string) error {
+func PlayFileInPlaylist(ctx context.Context, filename string) error {
 	url := vlcServerURL + "/vlc/play/" + filename
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error playing file", "err", err)
+		slog.ErrorContext(ctx, "error playing file", "err", err)
 		return err
 	}
 	return nil
 }
 
-func Skip(n int) error {
+func Skip(ctx context.Context, n int) error {
 	url := vlcServerURL + "/vlc/skip"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error skipping video", "err", err)
+		slog.ErrorContext(ctx, "error skipping video", "err", err)
 		return err
 	}
 	return nil
 }
 
-func Back(n int) error {
+func Back(ctx context.Context, n int) error {
 	url := vlcServerURL + "/vlc/back"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error going back to a video", "err", err)
+		slog.ErrorContext(ctx, "error going back to a video", "err", err)
 		return err
 	}
 	return nil
 }
 
 //TODO: move this to a common location
-func getUrl(url string) (string, error) {
-	response, err := httpClient.Get(url)
+func getUrl(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.Error("error connecting to VLC server", "err", err)
+		slog.ErrorContext(ctx, "error building request to VLC server", "err", err)
 		return "", err
-	} else {
-		defer response.Body.Close()
-		contents, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			slog.Error("error reading response from VLC server", "err", err)
-			return "", err
-		}
-		return string(contents), nil
 	}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "error connecting to VLC server", "err", err)
+		return "", err
+	}
+	defer response.Body.Close()
+	contents, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "error reading response from VLC server", "err", err)
+		return "", err
+	}
+	return string(contents), nil
 }


### PR DESCRIPTION
## Summary

Closes the cross-process gap in the trace story. Today a chatbot command's \`chat.command\` span ends at the HTTP boundary — when chatbot calls \`a.VLC.PlayRandom()\`, the vlc-server handler starts a fresh root span. The trace fragments.

After this PR: one trace per chat command, end-to-end across \`Twitch IRC → tripbot → vlc-server → libvlc\` (and the same for onscreens-server overlay calls). W3C tracecontext rides the wire via otelhttp.NewTransport (already wired) + the new ctx-aware request construction.

## What changed

- **\`pkg/vlc-client\`** — every public func (\`CurrentlyPlaying\`, \`PlayRandom\`, \`PlayFileInPlaylist\`, \`Skip\`, \`Back\`) + internal \`getUrl\` take \`context.Context\`. \`httpClient.Get(url)\` → \`http.NewRequestWithContext + httpClient.Do\` so the otel transport sees the parent span.
- **\`pkg/onscreens-client\`** — same shape across \`HideMiddleText\`, \`ShowMiddleText\`, \`ShowLeaderboard\`, \`ShowTimewarp\`, \`ShowFlag\`, \`ShowGPSImage\`, \`HideGPSImage\`, \`getUrl\`.
- **\`pkg/chatbot.VLC\` + \`pkg/chatbot.Onscreens\` interfaces** — methods grow ctx. \`realVLC\` / \`realOnscreens\` adapters forward; \`noopVLC\` / \`noopOnscreens\` / \`recordingVLC\` / \`recordingOnscreens\` test fakes swallow with \`_\`.
- **Callsites** — \`pkg/chatbot/playback.go\` (8 \`a.VLC.*\` calls), \`pkg/chatbot/commands.go\` (9 \`a.Onscreens.*\` calls), \`pkg/video/video.go\` (3 client calls). All already had ctx in scope from prior trace-threading work.

## Trade-off

\`pkg/chatbot\` tests that asserted on call ordering still work — the recordingX fakes record the same call strings (ctx isn't included in the record). No test rewrites needed.

## Test plan

- [x] \`mise exec -- go build ./...\` clean
- [x] \`mise exec -- go vet ./...\` clean (one pre-existing signal.Notify warning unrelated)
- [ ] CI green
- [ ] After deploy: pick a \`!timewarp\` in Tempo and verify the trace shows \`chat.command\` → \`HTTP GET /vlc/random\` → (vlc-server) \`/vlc/random\` as parent/child spans in a single trace