### PR TITLE
video: thread ctx through pkg/video/db.go

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -125,7 +125,7 @@ func startHttpServer(ctx context.Context) {
 func findInitialVideo() {
 	video.GetCurrentlyPlaying(context.Background())
 	v := video.CurrentlyPlaying
-	_, err := video.LoadOrCreate(v.String())
+	_, err := video.LoadOrCreate(context.Background(), v.String())
 	if err != nil {
 		slog.Error("error loading initial video, is there a video playing?", "err", err)
 	}

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -166,7 +166,7 @@ func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 	lat, lng, _ := vid.Location()
 	a.IRC.Say(helpers.SunsetStr(vid.DateFilmed, lat, lng))
@@ -179,7 +179,7 @@ func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		//TODO: write something like vid.FindClosest() that
 		// chooses whether or not to use Next() vs Prev()
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 	// extract the coordinates
 	lat, lng, err := vid.Location()
@@ -292,7 +292,7 @@ func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 	var lat, lng float64
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		lat, lng, err = vid.Next().Location()
+		lat, lng, err = vid.Next(ctx).Location()
 	} else {
 		lat, lng, err = vid.Location()
 	}
@@ -311,7 +311,7 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	var lat, lng float64
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		lat, lng, err = vid.Next().Location()
+		lat, lng, err = vid.Next(ctx).Location()
 	} else {
 		lat, lng, err = vid.Location()
 	}
@@ -356,7 +356,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
@@ -379,7 +379,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -31,7 +31,7 @@ func (a *App) timewarp(ctx context.Context) {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -91,7 +91,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// sanitize the input
 	state = helpers.RemoveNonLetters(state)
 	titlecaseState := helpers.TitlecaseState(state)
-	randomVid, err := a.Video.FindRandomByState(state)
+	randomVid, err := a.Video.FindRandomByState(ctx, state)
 	// check to see if we even have footage for this state
 	if _, ok := err.(*terrors.NoFootageForStateError); ok {
 		msg := fmt.Sprintf("No footage for %s... yet! ;)", titlecaseState)
@@ -113,7 +113,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	}
 	a.IRC.Say(fmt.Sprintf("Jumping to %s...!", titlecaseState))
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// show the flag for the state
 	a.Onscreens.ShowFlag(10 * time.Second)
 	// update our record of last time it ran
@@ -160,7 +160,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -205,7 +205,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -16,23 +16,20 @@ type Video interface {
 	// GetCurrentlyPlaying refreshes pkg/video's notion of what's currently
 	// playing (an HTTP call to vlc-server in production), updates the
 	// package-level state, and returns the resulting Video.
-	GetCurrentlyPlaying() video.Video
+	GetCurrentlyPlaying(ctx context.Context) video.Video
 	// FindRandomByState returns a random video filmed in the given US state.
 	// Returns *terrors.NoFootageForStateError when no rows match.
-	FindRandomByState(state string) (video.Video, error)
+	FindRandomByState(ctx context.Context, state string) (video.Video, error)
 }
 
 // realVideo delegates to pkg/video.
 type realVideo struct{}
 
 func (realVideo) Current() video.Video { return video.CurrentlyPlaying }
-func (realVideo) GetCurrentlyPlaying() video.Video {
-	// chat-command callers don't currently propagate ctx through the
-	// chatbot.Video interface — Background is fine until that interface
-	// grows ctx-aware methods.
-	video.GetCurrentlyPlaying(context.Background())
+func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
+	video.GetCurrentlyPlaying(ctx)
 	return video.CurrentlyPlaying
 }
-func (realVideo) FindRandomByState(state string) (video.Video, error) {
-	return video.FindRandomByState(state)
+func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
+	return video.FindRandomByState(ctx, state)
 }

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/adanalife/tripbot/pkg/video"
@@ -10,9 +11,9 @@ import (
 // playing video — it just returns the zero value for every call.
 type noopVideo struct{}
 
-func (noopVideo) Current() video.Video             { return video.Video{} }
-func (noopVideo) GetCurrentlyPlaying() video.Video { return video.Video{} }
-func (noopVideo) FindRandomByState(_ string) (video.Video, error) {
+func (noopVideo) Current() video.Video                           { return video.Video{} }
+func (noopVideo) GetCurrentlyPlaying(_ context.Context) video.Video { return video.Video{} }
+func (noopVideo) FindRandomByState(_ context.Context, _ string) (video.Video, error) {
 	return video.Video{}, nil
 }
 
@@ -32,11 +33,11 @@ func (r *recordingVideo) Current() video.Video {
 	r.Calls = append(r.Calls, "Current()")
 	return r.Vid
 }
-func (r *recordingVideo) GetCurrentlyPlaying() video.Video {
+func (r *recordingVideo) GetCurrentlyPlaying(_ context.Context) video.Video {
 	r.Calls = append(r.Calls, "GetCurrentlyPlaying()")
 	return r.Vid
 }
-func (r *recordingVideo) FindRandomByState(state string) (video.Video, error) {
+func (r *recordingVideo) FindRandomByState(_ context.Context, state string) (video.Video, error) {
 	r.Calls = append(r.Calls, fmt.Sprintf("FindRandomByState(%q)", state))
 	return r.RandomVid, r.RandomErr
 }

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -1,9 +1,10 @@
 package video
 
 import (
-	"log/slog"
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -16,22 +17,22 @@ import (
 
 // LoadOrCreate() will look up the video in the DB,
 // or add it to the DB if it's not there yet
-func LoadOrCreate(path string) (Video, error) {
+func LoadOrCreate(ctx context.Context, path string) (Video, error) {
 	slug := slug(path)
 
-	vid, err := load(slug)
+	vid, err := load(ctx, slug)
 	if err != nil {
 		// create a new video
-		vid, err = create(slug)
+		vid, err = create(ctx, slug)
 	}
 
 	return vid, err
 }
 
 // load() fetches a Video from the DB
-func load(slug string) (Video, error) {
+func load(ctx context.Context, slug string) (Video, error) {
 	var vid Video
-	result := database.GormDB().Where("slug = ?", slug).First(&vid)
+	result := database.GormDB().WithContext(ctx).Where("slug = ?", slug).First(&vid)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return Video{}, errors.New("no matches found")
 	}
@@ -39,9 +40,9 @@ func load(slug string) (Video, error) {
 }
 
 //TODO: combine this with load()?
-func loadById(id int64) (Video, error) {
+func loadById(ctx context.Context, id int64) (Video, error) {
 	var vid Video
-	result := database.GormDB().First(&vid, id)
+	result := database.GormDB().WithContext(ctx).First(&vid, id)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return Video{}, errors.New("no matches found")
 	}
@@ -52,7 +53,7 @@ func loadById(id int64) (Video, error) {
 //TODO: this is kinda weird, we create an empty Video
 // and then we save it to the DB... maybe we could just
 // save right to the DB? It would take some refactoring.
-func create(file string) (Video, error) {
+func create(ctx context.Context, file string) (Video, error) {
 	var newVid Video
 	var blankDate time.Time
 
@@ -78,21 +79,21 @@ func create(file string) (Video, error) {
 	}
 
 	// store the video in the DB
-	err = newVid.save()
+	err = newVid.save(ctx)
 	if err != nil {
-		slog.Error("error saving to DB", "err", err)
+		slog.ErrorContext(ctx, "error saving to DB", "err", err)
 	}
 
 	// now fetch it from the DB
 	//TODO: this is an extra DB call, do we care?
-	dbVid, err := load(slug)
+	dbVid, err := load(ctx, slug)
 
 	return dbVid, err
 }
 
 // save() will store the video in the DB
 //TODO: I think this can be achieved much easier, c.p. user save
-func (v Video) save() error {
+func (v Video) save(ctx context.Context) error {
 	var err error
 	flagged := v.Flagged
 	lat := v.Lat
@@ -101,7 +102,7 @@ func (v Video) save() error {
 
 	if lat == 0 || lng == 0 {
 		//TODO: this is where we used to run ocrCoords()
-		slog.Error("OCRing coords skipped!")
+		slog.ErrorContext(ctx, "OCRing coords skipped!")
 		flagged = true
 	}
 
@@ -111,7 +112,7 @@ func (v Video) save() error {
 		// ErrMapsDisabled is the expected steady-state when no Maps key
 		// is configured; don't spam Sentry on every video import.
 		if err != nil && !errors.Is(err, helpers.ErrMapsDisabled) {
-			slog.Error("error geocoding coords", "err", err)
+			slog.ErrorContext(ctx, "error geocoding coords", "err", err)
 		}
 	}
 
@@ -126,16 +127,16 @@ func (v Video) save() error {
 		State:       state,
 		DateCreated: v.DateCreated,
 	}
-	return database.GormDB().Create(&insert).Error
+	return database.GormDB().WithContext(ctx).Create(&insert).Error
 }
 
 // Next() finds the next unflagged video
 //TODO: should this be NextUnflagged?
 //TODO: handle errors in here?
-func (v Video) Next() Video {
+func (v Video) Next(ctx context.Context) Video {
 	vid := v
 	for { // ever
-		vid, _ = loadById(vid.NextVid.Int64)
+		vid, _ = loadById(ctx, vid.NextVid.Int64)
 		// use the first unflagged video we find
 		if !vid.Flagged {
 			break
@@ -144,8 +145,8 @@ func (v Video) Next() Video {
 	return vid
 }
 
-func (v Video) SetNextVid(nextVid Video) error {
-	return database.GormDB().Model(&v).Update("next_vid", nextVid.ID).Error
+func (v Video) SetNextVid(ctx context.Context, nextVid Video) error {
+	return database.GormDB().WithContext(ctx).Model(&v).Update("next_vid", nextVid.ID).Error
 }
 
 func validate(dashStr string) error {
@@ -166,7 +167,7 @@ func validate(dashStr string) error {
 	return nil
 }
 
-func FindRandomByState(state string) (Video, error) {
+func FindRandomByState(ctx context.Context, state string) (Video, error) {
 	var vid Video
 
 	// convert to long form
@@ -180,12 +181,12 @@ func FindRandomByState(state string) (Video, error) {
 	state = helpers.TitlecaseState(state)
 
 	//TODO: ORDER BY random() will eventually get too slow
-	result := database.GormDB().Where("state = ?", state).Order("random()").Limit(1).First(&vid)
+	result := database.GormDB().WithContext(ctx).Where("state = ?", state).Order("random()").Limit(1).First(&vid)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return vid, &terrors.NoFootageForStateError{Msg: "no matches found"}
 	}
 	if result.Error != nil {
-		slog.Error("error fetching vid from DB", "err", result.Error)
+		slog.ErrorContext(ctx, "error fetching vid from DB", "err", result.Error)
 		return vid, result.Error
 	}
 	return vid, nil

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -46,7 +46,7 @@ func GetCurrentlyPlaying(ctx context.Context) {
 		timeStarted = time.Now()
 
 		// share the Video with the system
-		CurrentlyPlaying, err = LoadOrCreate(curVid)
+		CurrentlyPlaying, err = LoadOrCreate(ctx, curVid)
 		if err != nil {
 			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", curVid)
 		}

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -48,7 +48,7 @@ func main() {
 
 	// a file was passed in via the CLI
 	if videoFile != "" {
-		vid, err := video.LoadOrCreate(videoFile)
+		vid, err := video.LoadOrCreate(context.Background(), videoFile)
 		if err != nil {
 			slog.Error("unable to create video", "err", err, "file", videoFile)
 		}
@@ -73,7 +73,7 @@ func main() {
 				}
 
 				// actually process the image
-				vid, err := video.LoadOrCreate(path)
+				vid, err := video.LoadOrCreate(context.Background(), path)
 				if err != nil {
 					slog.Error("unable to create video", "err", err, "path", path)
 					return nil

--- a/script/make-map/make-map.go
+++ b/script/make-map/make-map.go
@@ -54,7 +54,7 @@ func main() {
 				return nil
 			}
 
-			vid, err := video.LoadOrCreate(path)
+			vid, err := video.LoadOrCreate(context.Background(), path)
 			if err != nil {
 				slog.Error("unable to create video", "err", err, "path", path)
 				return nil


### PR DESCRIPTION
## Summary

Closes the last big ctx-threading gap. \`pkg/video/db.go\` predated the trace-ctx work and was the largest cluster of ctx-less DB queries. After this PR, every video DB op (\`LoadOrCreate\`, \`load\`, \`loadById\`, \`create\`, \`save\`, \`Next\`, \`SetNextVid\`, \`FindRandomByState\`) takes ctx and uses GORM's \`.WithContext(ctx)\` so otelsql produces SQL spans as children of the parent.

## What changed

- **\`pkg/video/db.go\`** — every func grows ctx; queries pick up \`.WithContext(ctx)\`. Two \`slog.Error\` → \`slog.ErrorContext\`.
- **\`pkg/video/video.go\`** — \`GetCurrentlyPlaying\`'s call to \`LoadOrCreate\` passes ctx through.
- **\`pkg/chatbot.Video\` interface** — \`GetCurrentlyPlaying\` and \`FindRandomByState\` get ctx; \`Current()\` stays as-is (pure read of package state). \`realVideo.GetCurrentlyPlaying\` drops its inline \`context.Background()\` — the workaround comment is no longer accurate.
- **\`pkg/chatbot/video_test.go\`** — \`noopVideo\` and \`recordingVideo\` fakes take ctx (swallow with \`_\`).
- **Callsites** — \`pkg/chatbot/playback.go\` + \`pkg/chatbot/commands.go\` pass ctx into \`a.Video.*\` and \`vid.Next()\` (6 sites). All already have ctx from prior threading.
- **Startup / CLI sites** — \`cmd/tripbot/tripbot.go\`'s \`findInitialVideo\` + \`script/collect-gps\` + \`script/make-map\` pass \`context.Background()\` (no live span there).

## Test plan

- [x] \`mise exec -- go build ./...\` clean
- [x] \`mise exec -- go vet ./...\` clean (pre-existing signal.Notify warning unrelated)
- [ ] CI green
- [ ] After deploy: spot-check Tempo that a \`!miles\` trace shows the video DB queries as SQL spans under the chat.command span