### PR TITLE
sentry: drop counter + breadcrumb noise filter

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/config"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/getsentry/sentry-go"
 	sentryotel "github.com/getsentry/sentry-go/otel"
 )
@@ -65,7 +66,10 @@ func Initialize(c config.Config, version string) {
 // has the complete record; Sentry receives a deduplicated sample.
 func throttle(c config.Config) func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 	if c == nil || (!c.IsProduction() && !c.IsStaging()) {
-		return func(*sentry.Event, *sentry.EventHint) *sentry.Event { return nil }
+		return func(*sentry.Event, *sentry.EventHint) *sentry.Event {
+			instrumentation.SentryEventsDropped.Inc("disabled")
+			return nil
+		}
 	}
 	var (
 		mu          sync.Mutex
@@ -82,6 +86,7 @@ func throttle(c config.Config) func(event *sentry.Event, hint *sentry.EventHint)
 			windowCount = 0
 		}
 		if windowCount >= hourlyCap {
+			instrumentation.SentryEventsDropped.Inc("cap")
 			return nil
 		}
 		// event.Message is the slog record's Message field when sent via
@@ -89,6 +94,7 @@ func throttle(c config.Config) func(event *sentry.Event, hint *sentry.EventHint)
 		// collapse to one event per cooldown window.
 		fp := event.Message
 		if t, ok := lastSent[fp]; ok && now.Sub(t) < fingerprintCooldown {
+			instrumentation.SentryEventsDropped.Inc("cooldown")
 			return nil
 		}
 		lastSent[fp] = now

--- a/pkg/instrumentation/sentry.go
+++ b/pkg/instrumentation/sentry.go
@@ -1,0 +1,26 @@
+package instrumentation
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// sentryEventsDropped counts events the pkg/errors BeforeSend throttle
+// suppressed before they reached Sentry. Labeled by reason so Grafana
+// can show cooldown-vs-cap separately.
+var sentryEventsDropped = mustCounter(
+	"sentry_events_dropped_total",
+	"Sentry events dropped by the BeforeSend throttle, labeled by reason (cooldown|cap|disabled)",
+)
+
+// SentryEventsDropped exposes the drop counter; call SentryEventsDropped.Inc(reason)
+// from inside BeforeSend when an event is being suppressed.
+var SentryEventsDropped = sentryDroppedIface{counter: sentryEventsDropped}
+
+type sentryDroppedIface struct{ counter metric.Int64Counter }
+
+func (s sentryDroppedIface) Inc(reason string) {
+	s.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("reason", reason)))
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -243,13 +243,36 @@ func (m multiHandler) WithGroup(name string) slog.Handler {
 // the Sentry event arrives with the preceding log trail attached.
 // Error+ is skipped — samber/slog-sentry already turns those into
 // full Sentry events with their own captured attribute set.
+//
+// Sentry caps breadcrumbs at 100 per scope; high-volume routine logs
+// (per-command "ran !X", per-cron-tick "session snapshot", etc.) would
+// quickly evict the recent, useful records before an error fires. The
+// noisy-prefix list below names the messages we know fire on every
+// command or every minute via cron; they stay in Loki but skip the
+// breadcrumb pipeline.
 type breadcrumbHandler struct{}
+
+// breadcrumbSkipPrefixes lists slog message prefixes that fire frequently
+// enough to drown out other context if all routed to Sentry breadcrumbs.
+var breadcrumbSkipPrefixes = []string{
+	"ran !",            // every chat command (chatbot/commands.go + playback.go)
+	"now playing",      // per video transition via cron.video.GetCurrentlyPlaying
+	"session snapshot", // every 5min via cron.users.PrintCurrentSession
+	"subscribers",      // every 5min via cron.twitch.GetSubscribers
+	"no subscribers",   // ditto
+	"follower count",   // every 5min via cron.twitch.GetFollowerCount
+}
 
 func (breadcrumbHandler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= slog.LevelInfo && level < slog.LevelError
 }
 
 func (breadcrumbHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, p := range breadcrumbSkipPrefixes {
+		if strings.HasPrefix(r.Message, p) {
+			return nil
+		}
+	}
 	hub := sentry.CurrentHub()
 	if fromCtx := sentry.GetHubFromContext(ctx); fromCtx != nil {
 		hub = fromCtx


### PR DESCRIPTION
## Summary

Two small follow-ups to [#573](https://github.com/adanalife/tripbot/pull/573/changes):

1. **Drop counter** — make the BeforeSend throttle visible in Prom. \`sentry_events_dropped_total{reason=cooldown|cap|disabled}\` so Grafana can show what's being suppressed without checking Sentry.

2. **Breadcrumb noise filter** — Sentry caps breadcrumbs at 100 per scope. Without filtering, "ran !X" (every command), "now playing" (per video change), and the cron-tick logs ("session snapshot", "subscribers", "follower count") evict useful records before an error fires. Filtered messages still go to Loki.

## What changed

- \`pkg/instrumentation/sentry.go\` (new) — \`SentryEventsDropped\` counter via the existing meter pattern.
- \`pkg/errors/errors.go\` — three \`Inc("disabled"|"cap"|"cooldown")\` calls in the BeforeSend hook.
- \`pkg/telemetry/telemetry.go\` — \`breadcrumbSkipPrefixes\` list + early-return in \`breadcrumbHandler.Handle\` for routine high-volume logs.

## Open question / tradeoff

The skip-prefix list is conservative — only the most clearly-routine messages. If the breadcrumb trail still feels noisy after deploy, extend the list. Going the other direction (allowlist) is more invasive but cleaner long-term; deferring until we have observational data.

## Test plan

- [x] \`mise exec -- go build ./...\` clean
- [ ] CI green
- [ ] After deploy: confirm \`sentry_events_dropped_total\` populates in Prom; confirm a Sentry event no longer has "ran !X" cluttering its breadcrumbs