### PR TITLE
slog: canonicalize attribute keys per new ADR

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -130,7 +130,7 @@ func Whisper(username, msg string) {
 	//TODO: include whispers in log
 	// include the message in the log
 	// mylog.ChatMsg(c.Conf.BotUsername, msg)
-	slog.Info("sending whisper", "to", username, "msg", msg)
+	slog.Info("sending whisper", "to", username, "text", msg)
 	// say the message to chat
 	client.Say(c.Conf.BotUsername, fmt.Sprintf("/w %s %s", username, msg))
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -421,7 +421,7 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 	} else {
 		msg = fmt.Sprintf("%s, lat: %f, lng: %f", msg, lat, lng)
 	}
-	slog.InfoContext(ctx, "secretinfo output", "msg", msg)
+	slog.InfoContext(ctx, "secretinfo output", "text", msg)
 	a.IRC.Say(msg)
 }
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -187,7 +187,7 @@ func UserPart(partMessage twitch.UserPartMessage) {
 // if the message comes from me, then post the message to chat.
 // An admin whisper that triggers Say() is logged again as a chat line.
 func GetWhisper(message twitch.WhisperMessage) {
-	slog.Info("whisper received", "from", message.User.Name, "msg", message.Message)
+	slog.Info("whisper received", "from", message.User.Name, "text", message.Message)
 	if c.UserIsAdmin(message.User.Name) {
 		Say(message.Message)
 	}

--- a/pkg/chatbot/irc.go
+++ b/pkg/chatbot/irc.go
@@ -34,7 +34,7 @@ func (realIRC) Say(msg string) {
 
 func (realIRC) Whisper(username, msg string) {
 	//TODO: include whispers in log
-	slog.Info("sending whisper", "to", username, "msg", msg)
+	slog.Info("sending whisper", "to", username, "text", msg)
 	// go-twitch-irc v4 removed the Whisper() send method; replicate the
 	// v2 behavior by sending the raw IRC /w command via PRIVMSG on the
 	// bot's own channel.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -22,7 +22,7 @@ type Event struct {
 
 func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping login event: read-only mode", "user", user)
+		slog.InfoContext(ctx, "skipping login event: read-only mode", "username", user)
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
@@ -34,7 +34,7 @@ func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 
 func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping logout event: read-only mode", "user", user)
+		slog.InfoContext(ctx, "skipping logout event: read-only mode", "username", user)
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {


### PR DESCRIPTION
## Summary

Closes the convention-pass follow-up from the logging series. Picks canonical keys for slog attributes and sweeps the two consistency drifts the audit found.

ADR landed in vault: \`vault/decisions/slog-attribute-keys.md\` — canonical keys (\`username\`, \`user_id\`, \`command\`, \`text\`, \`file\`, etc.), forbidden patterns (\`msg\` attr collides with slog record's \`msg=\` field), and the special-cased Sentry keys (\`user\` as Group, \`err\` for exception extraction).

## What changed

- **2 sites**: \`pkg/events/events.go\` — \`"user"\` → \`"username"\`. Two skipping-event Info logs in the read-only-mode short-circuits.
- **4 sites**: \`pkg/chatbot/{chatbot,irc,handlers,commands}.go\` — \`"msg"\` → \`"text"\` for chat-message bodies. The whisper sites (chatbot.go + irc.go) are dead code today (see the Whisper TODO) but inconsistent with everything else; updating now keeps the surface coherent.

Audit numbers before the sweep:

| key | count | action |
|---|---|---|
| \`username\` | 33 | canonical, no change |
| \`user\` | 2 | rename → \`username\` |
| \`msg\` | 4 | rename → \`text\` |
| \`err\` | 110 | canonical, no change |

## Test plan

- [x] \`mise exec -- go build ./...\` clean
- [ ] CI green