### PR TITLE
Release v2.9.2: develop → master

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -125,7 +125,7 @@ func startHttpServer(ctx context.Context) {
 func findInitialVideo() {
 	video.GetCurrentlyPlaying(context.Background())
 	v := video.CurrentlyPlaying
-	_, err := video.LoadOrCreate(v.String())
+	_, err := video.LoadOrCreate(context.Background(), v.String())
 	if err != nil {
 		slog.Error("error loading initial video, is there a video playing?", "err", err)
 	}

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -130,7 +130,7 @@ func Whisper(username, msg string) {
 	//TODO: include whispers in log
 	// include the message in the log
 	// mylog.ChatMsg(c.Conf.BotUsername, msg)
-	slog.Info("sending whisper", "to", username, "msg", msg)
+	slog.Info("sending whisper", "to", username, "text", msg)
 	// say the message to chat
 	client.Say(c.Conf.BotUsername, fmt.Sprintf("/w %s %s", username, msg))
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -71,7 +71,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !flag", "username", user.Username)
-	a.Onscreens.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 }
 
 func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
@@ -208,7 +208,7 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 	leaderboard = leaderboard[:size]
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard("Monthly Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, "Monthly Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d miles this month: ", size)
@@ -233,7 +233,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 	leaderboard := lifetime[:size]
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard("Total Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, "Total Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d lifetime miles: ", size)
@@ -273,7 +273,7 @@ func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, 
 	}
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard("Correct Guesses This Month", intLeaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d correct guesses this month: ", size)
@@ -362,7 +362,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
 		msg = fmt.Sprintf("@%s got it! We're in %s", user.Username, vid.State)
 		// show the flag for the state
-		a.Onscreens.ShowFlag(10 * time.Second)
+		a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 		// increase their guess score
 		user.AddToScore(ctx, guessScoreboard, 1.0)
 		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
@@ -383,7 +383,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state
-	a.Onscreens.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
 	a.IRC.Say(msg)
@@ -461,7 +461,7 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 	// if the arg was "hide", hide the text from view
 	if len(params) == 1 && strings.ToLower(params[0]) == "hide" {
 		a.IRC.Say("Got it! Hiding the message.")
-		a.Onscreens.HideMiddleText()
+		a.Onscreens.HideMiddleText(ctx)
 		return
 	}
 
@@ -470,5 +470,5 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 
 	slog.InfoContext(ctx, "setting middle text", "text", text)
 
-	a.Onscreens.ShowMiddleText(text)
+	a.Onscreens.ShowMiddleText(ctx, text)
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -166,7 +166,7 @@ func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 	lat, lng, _ := vid.Location()
 	a.IRC.Say(helpers.SunsetStr(vid.DateFilmed, lat, lng))
@@ -179,7 +179,7 @@ func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		//TODO: write something like vid.FindClosest() that
 		// chooses whether or not to use Next() vs Prev()
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 	// extract the coordinates
 	lat, lng, err := vid.Location()
@@ -292,7 +292,7 @@ func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 	var lat, lng float64
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		lat, lng, err = vid.Next().Location()
+		lat, lng, err = vid.Next(ctx).Location()
 	} else {
 		lat, lng, err = vid.Location()
 	}
@@ -311,7 +311,7 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	var lat, lng float64
 	vid := a.CurrentVideo()
 	if vid.Flagged {
-		lat, lng, err = vid.Next().Location()
+		lat, lng, err = vid.Next(ctx).Location()
 	} else {
 		lat, lng, err = vid.Location()
 	}
@@ -356,7 +356,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
@@ -379,7 +379,7 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.CurrentVideo()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next()
+		vid = vid.Next(ctx)
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -421,7 +421,7 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 	} else {
 		msg = fmt.Sprintf("%s, lat: %f, lng: %f", msg, lat, lng)
 	}
-	slog.InfoContext(ctx, "secretinfo output", "msg", msg)
+	slog.InfoContext(ctx, "secretinfo output", "text", msg)
 	a.IRC.Say(msg)
 }
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -187,7 +187,7 @@ func UserPart(partMessage twitch.UserPartMessage) {
 // if the message comes from me, then post the message to chat.
 // An admin whisper that triggers Say() is logged again as a chat line.
 func GetWhisper(message twitch.WhisperMessage) {
-	slog.Info("whisper received", "from", message.User.Name, "msg", message.Message)
+	slog.Info("whisper received", "from", message.User.Name, "text", message.Message)
 	if c.UserIsAdmin(message.User.Name) {
 		Say(message.Message)
 	}

--- a/pkg/chatbot/irc.go
+++ b/pkg/chatbot/irc.go
@@ -34,7 +34,7 @@ func (realIRC) Say(msg string) {
 
 func (realIRC) Whisper(username, msg string) {
 	//TODO: include whispers in log
-	slog.Info("sending whisper", "to", username, "msg", msg)
+	slog.Info("sending whisper", "to", username, "text", msg)
 	// go-twitch-irc v4 removed the Whisper() send method; replicate the
 	// v2 behavior by sending the raw IRC /w command via PRIVMSG on the
 	// bot's own channel.

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"time"
 
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
@@ -10,20 +11,28 @@ import (
 // commands depend on. Tests inject a fake; production uses the package-backed
 // realOnscreens adapter wired in defaultApp.
 type Onscreens interface {
-	ShowFlag(dur time.Duration) error
-	ShowLeaderboard(title string, leaderboard [][]string) error
-	HideMiddleText() error
-	ShowMiddleText(msg string) error
-	ShowTimewarp() error
+	ShowFlag(ctx context.Context, dur time.Duration) error
+	ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error
+	HideMiddleText(ctx context.Context) error
+	ShowMiddleText(ctx context.Context, msg string) error
+	ShowTimewarp(ctx context.Context) error
 }
 
 // realOnscreens delegates to pkg/onscreens-client.
 type realOnscreens struct{}
 
-func (realOnscreens) ShowFlag(dur time.Duration) error { return onscreensClient.ShowFlag(dur) }
-func (realOnscreens) ShowLeaderboard(title string, lb [][]string) error {
-	return onscreensClient.ShowLeaderboard(title, lb)
+func (realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
+	return onscreensClient.ShowFlag(ctx, dur)
 }
-func (realOnscreens) HideMiddleText() error          { return onscreensClient.HideMiddleText() }
-func (realOnscreens) ShowMiddleText(msg string) error { return onscreensClient.ShowMiddleText(msg) }
-func (realOnscreens) ShowTimewarp() error            { return onscreensClient.ShowTimewarp() }
+func (realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][]string) error {
+	return onscreensClient.ShowLeaderboard(ctx, title, lb)
+}
+func (realOnscreens) HideMiddleText(ctx context.Context) error {
+	return onscreensClient.HideMiddleText(ctx)
+}
+func (realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
+	return onscreensClient.ShowMiddleText(ctx, msg)
+}
+func (realOnscreens) ShowTimewarp(ctx context.Context) error {
+	return onscreensClient.ShowTimewarp(ctx)
+}

--- a/pkg/chatbot/onscreens_test.go
+++ b/pkg/chatbot/onscreens_test.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -9,11 +10,11 @@ import (
 // overlay surface — it just swallows every call.
 type noopOnscreens struct{}
 
-func (noopOnscreens) ShowFlag(_ time.Duration) error                      { return nil }
-func (noopOnscreens) ShowLeaderboard(_ string, _ [][]string) error        { return nil }
-func (noopOnscreens) HideMiddleText() error                               { return nil }
-func (noopOnscreens) ShowMiddleText(_ string) error                       { return nil }
-func (noopOnscreens) ShowTimewarp() error                                 { return nil }
+func (noopOnscreens) ShowFlag(_ context.Context, _ time.Duration) error                      { return nil }
+func (noopOnscreens) ShowLeaderboard(_ context.Context, _ string, _ [][]string) error        { return nil }
+func (noopOnscreens) HideMiddleText(_ context.Context) error                                 { return nil }
+func (noopOnscreens) ShowMiddleText(_ context.Context, _ string) error                       { return nil }
+func (noopOnscreens) ShowTimewarp(_ context.Context) error                                   { return nil }
 
 // recordingOnscreens captures every call made to it so tests can assert
 // the chatbot invoked the expected overlay method with the expected args.
@@ -22,23 +23,23 @@ type recordingOnscreens struct {
 	Calls []string
 }
 
-func (r *recordingOnscreens) ShowFlag(dur time.Duration) error {
+func (r *recordingOnscreens) ShowFlag(_ context.Context, dur time.Duration) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowFlag(%s)", dur))
 	return nil
 }
-func (r *recordingOnscreens) ShowLeaderboard(title string, lb [][]string) error {
+func (r *recordingOnscreens) ShowLeaderboard(_ context.Context, title string, lb [][]string) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowLeaderboard(%q, %d rows)", title, len(lb)))
 	return nil
 }
-func (r *recordingOnscreens) HideMiddleText() error {
+func (r *recordingOnscreens) HideMiddleText(_ context.Context) error {
 	r.Calls = append(r.Calls, "HideMiddleText()")
 	return nil
 }
-func (r *recordingOnscreens) ShowMiddleText(msg string) error {
+func (r *recordingOnscreens) ShowMiddleText(_ context.Context, msg string) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowMiddleText(%q)", msg))
 	return nil
 }
-func (r *recordingOnscreens) ShowTimewarp() error {
+func (r *recordingOnscreens) ShowTimewarp(_ context.Context) error {
 	r.Calls = append(r.Calls, "ShowTimewarp()")
 	return nil
 }

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -23,10 +23,10 @@ var lastTimewarpTime time.Time
 // timewarp jumps the playhead to a random video in the loop
 func (a *App) timewarp(ctx context.Context) {
 	// show timewarp onscreen
-	a.Onscreens.ShowTimewarp()
+	a.Onscreens.ShowTimewarp(ctx)
 
 	// shuffle to a new video
-	err := a.VLC.PlayRandom()
+	err := a.VLC.PlayRandom(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
@@ -105,7 +105,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 		return
 	}
 	// tell VLC to play it
-	err = a.VLC.PlayFileInPlaylist(randomVid.File())
+	err = a.VLC.PlayFileInPlaylist(ctx, randomVid.File())
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 		a.IRC.Say("Usage: !jump [state]")
@@ -115,7 +115,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// update the currently-playing video
 	a.Video.GetCurrentlyPlaying()
 	// show the flag for the state
-	a.Onscreens.ShowFlag(10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -155,7 +155,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 	}
 
 	// skip to a new video
-	err = a.VLC.Skip(n)
+	err = a.VLC.Skip(ctx, n)
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
@@ -200,7 +200,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 	}
 
 	// back to an old video
-	err = a.VLC.Back(n)
+	err = a.VLC.Back(ctx, n)
 	if err != nil {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -31,7 +31,7 @@ func (a *App) timewarp(ctx context.Context) {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -91,7 +91,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// sanitize the input
 	state = helpers.RemoveNonLetters(state)
 	titlecaseState := helpers.TitlecaseState(state)
-	randomVid, err := a.Video.FindRandomByState(state)
+	randomVid, err := a.Video.FindRandomByState(ctx, state)
 	// check to see if we even have footage for this state
 	if _, ok := err.(*terrors.NoFootageForStateError); ok {
 		msg := fmt.Sprintf("No footage for %s... yet! ;)", titlecaseState)
@@ -113,7 +113,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	}
 	a.IRC.Say(fmt.Sprintf("Jumping to %s...!", titlecaseState))
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// show the flag for the state
 	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
 	// update our record of last time it ran
@@ -160,7 +160,7 @@ func (a *App) skipCmd(ctx context.Context, user *users.User, params []string) {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }
@@ -205,7 +205,7 @@ func (a *App) backCmd(ctx context.Context, user *users.User, params []string) {
 		slog.ErrorContext(ctx, "error from VLC client", "err", err)
 	}
 	// update the currently-playing video
-	a.Video.GetCurrentlyPlaying()
+	a.Video.GetCurrentlyPlaying(ctx)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -16,23 +16,20 @@ type Video interface {
 	// GetCurrentlyPlaying refreshes pkg/video's notion of what's currently
 	// playing (an HTTP call to vlc-server in production), updates the
 	// package-level state, and returns the resulting Video.
-	GetCurrentlyPlaying() video.Video
+	GetCurrentlyPlaying(ctx context.Context) video.Video
 	// FindRandomByState returns a random video filmed in the given US state.
 	// Returns *terrors.NoFootageForStateError when no rows match.
-	FindRandomByState(state string) (video.Video, error)
+	FindRandomByState(ctx context.Context, state string) (video.Video, error)
 }
 
 // realVideo delegates to pkg/video.
 type realVideo struct{}
 
 func (realVideo) Current() video.Video { return video.CurrentlyPlaying }
-func (realVideo) GetCurrentlyPlaying() video.Video {
-	// chat-command callers don't currently propagate ctx through the
-	// chatbot.Video interface — Background is fine until that interface
-	// grows ctx-aware methods.
-	video.GetCurrentlyPlaying(context.Background())
+func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
+	video.GetCurrentlyPlaying(ctx)
 	return video.CurrentlyPlaying
 }
-func (realVideo) FindRandomByState(state string) (video.Video, error) {
-	return video.FindRandomByState(state)
+func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
+	return video.FindRandomByState(ctx, state)
 }

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/adanalife/tripbot/pkg/video"
@@ -10,9 +11,9 @@ import (
 // playing video — it just returns the zero value for every call.
 type noopVideo struct{}
 
-func (noopVideo) Current() video.Video             { return video.Video{} }
-func (noopVideo) GetCurrentlyPlaying() video.Video { return video.Video{} }
-func (noopVideo) FindRandomByState(_ string) (video.Video, error) {
+func (noopVideo) Current() video.Video                           { return video.Video{} }
+func (noopVideo) GetCurrentlyPlaying(_ context.Context) video.Video { return video.Video{} }
+func (noopVideo) FindRandomByState(_ context.Context, _ string) (video.Video, error) {
 	return video.Video{}, nil
 }
 
@@ -32,11 +33,11 @@ func (r *recordingVideo) Current() video.Video {
 	r.Calls = append(r.Calls, "Current()")
 	return r.Vid
 }
-func (r *recordingVideo) GetCurrentlyPlaying() video.Video {
+func (r *recordingVideo) GetCurrentlyPlaying(_ context.Context) video.Video {
 	r.Calls = append(r.Calls, "GetCurrentlyPlaying()")
 	return r.Vid
 }
-func (r *recordingVideo) FindRandomByState(state string) (video.Video, error) {
+func (r *recordingVideo) FindRandomByState(_ context.Context, state string) (video.Video, error) {
 	r.Calls = append(r.Calls, fmt.Sprintf("FindRandomByState(%q)", state))
 	return r.RandomVid, r.RandomErr
 }

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -1,6 +1,8 @@
 package chatbot
 
 import (
+	"context"
+
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
@@ -9,16 +11,20 @@ import (
 // package-backed realVLC adapter wired in defaultApp. Mirrors the Onscreens
 // injection pattern.
 type VLC interface {
-	PlayRandom() error
-	PlayFileInPlaylist(filename string) error
-	Skip(n int) error
-	Back(n int) error
+	PlayRandom(ctx context.Context) error
+	PlayFileInPlaylist(ctx context.Context, filename string) error
+	Skip(ctx context.Context, n int) error
+	Back(ctx context.Context, n int) error
 }
 
 // realVLC delegates to pkg/vlc-client.
 type realVLC struct{}
 
-func (realVLC) PlayRandom() error                     { return vlcClient.PlayRandom() }
-func (realVLC) PlayFileInPlaylist(filename string) error { return vlcClient.PlayFileInPlaylist(filename) }
-func (realVLC) Skip(n int) error                      { return vlcClient.Skip(n) }
-func (realVLC) Back(n int) error                      { return vlcClient.Back(n) }
+func (realVLC) PlayRandom(ctx context.Context) error {
+	return vlcClient.PlayRandom(ctx)
+}
+func (realVLC) PlayFileInPlaylist(ctx context.Context, filename string) error {
+	return vlcClient.PlayFileInPlaylist(ctx, filename)
+}
+func (realVLC) Skip(ctx context.Context, n int) error { return vlcClient.Skip(ctx, n) }
+func (realVLC) Back(ctx context.Context, n int) error { return vlcClient.Back(ctx, n) }

--- a/pkg/chatbot/vlc_test.go
+++ b/pkg/chatbot/vlc_test.go
@@ -1,15 +1,18 @@
 package chatbot
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // noopVLC satisfies VLC for tests that don't care about playback transitions
 // — it just swallows every call.
 type noopVLC struct{}
 
-func (noopVLC) PlayRandom() error                     { return nil }
-func (noopVLC) PlayFileInPlaylist(_ string) error     { return nil }
-func (noopVLC) Skip(_ int) error                      { return nil }
-func (noopVLC) Back(_ int) error                      { return nil }
+func (noopVLC) PlayRandom(_ context.Context) error                       { return nil }
+func (noopVLC) PlayFileInPlaylist(_ context.Context, _ string) error     { return nil }
+func (noopVLC) Skip(_ context.Context, _ int) error                      { return nil }
+func (noopVLC) Back(_ context.Context, _ int) error                      { return nil }
 
 // recordingVLC captures every call made to it so tests can assert that
 // the chatbot drove playback as expected. All call records are appended
@@ -18,19 +21,19 @@ type recordingVLC struct {
 	Calls []string
 }
 
-func (r *recordingVLC) PlayRandom() error {
+func (r *recordingVLC) PlayRandom(_ context.Context) error {
 	r.Calls = append(r.Calls, "PlayRandom()")
 	return nil
 }
-func (r *recordingVLC) PlayFileInPlaylist(filename string) error {
+func (r *recordingVLC) PlayFileInPlaylist(_ context.Context, filename string) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("PlayFileInPlaylist(%q)", filename))
 	return nil
 }
-func (r *recordingVLC) Skip(n int) error {
+func (r *recordingVLC) Skip(_ context.Context, n int) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("Skip(%d)", n))
 	return nil
 }
-func (r *recordingVLC) Back(n int) error {
+func (r *recordingVLC) Back(_ context.Context, n int) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("Back(%d)", n))
 	return nil
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/config"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/getsentry/sentry-go"
 	sentryotel "github.com/getsentry/sentry-go/otel"
 )
@@ -65,7 +66,10 @@ func Initialize(c config.Config, version string) {
 // has the complete record; Sentry receives a deduplicated sample.
 func throttle(c config.Config) func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 	if c == nil || (!c.IsProduction() && !c.IsStaging()) {
-		return func(*sentry.Event, *sentry.EventHint) *sentry.Event { return nil }
+		return func(*sentry.Event, *sentry.EventHint) *sentry.Event {
+			instrumentation.SentryEventsDropped.Inc("disabled")
+			return nil
+		}
 	}
 	var (
 		mu          sync.Mutex
@@ -82,6 +86,7 @@ func throttle(c config.Config) func(event *sentry.Event, hint *sentry.EventHint)
 			windowCount = 0
 		}
 		if windowCount >= hourlyCap {
+			instrumentation.SentryEventsDropped.Inc("cap")
 			return nil
 		}
 		// event.Message is the slog record's Message field when sent via
@@ -89,6 +94,7 @@ func throttle(c config.Config) func(event *sentry.Event, hint *sentry.EventHint)
 		// collapse to one event per cooldown window.
 		fp := event.Message
 		if t, ok := lastSent[fp]; ok && now.Sub(t) < fingerprintCooldown {
+			instrumentation.SentryEventsDropped.Inc("cooldown")
 			return nil
 		}
 		lastSent[fp] = now

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -22,7 +22,7 @@ type Event struct {
 
 func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping login event: read-only mode", "user", user)
+		slog.InfoContext(ctx, "skipping login event: read-only mode", "username", user)
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "login", SessionID: sessionID}).Error; err != nil {
@@ -34,7 +34,7 @@ func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 
 func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping logout event: read-only mode", "user", user)
+		slog.InfoContext(ctx, "skipping logout event: read-only mode", "username", user)
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Event: "logout", SessionID: sessionID}).Error; err != nil {

--- a/pkg/instrumentation/sentry.go
+++ b/pkg/instrumentation/sentry.go
@@ -1,0 +1,26 @@
+package instrumentation
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// sentryEventsDropped counts events the pkg/errors BeforeSend throttle
+// suppressed before they reached Sentry. Labeled by reason so Grafana
+// can show cooldown-vs-cap separately.
+var sentryEventsDropped = mustCounter(
+	"sentry_events_dropped_total",
+	"Sentry events dropped by the BeforeSend throttle, labeled by reason (cooldown|cap|disabled)",
+)
+
+// SentryEventsDropped exposes the drop counter; call SentryEventsDropped.Inc(reason)
+// from inside BeforeSend when an event is being suppressed.
+var SentryEventsDropped = sentryDroppedIface{counter: sentryEventsDropped}
+
+type sentryDroppedIface struct{ counter metric.Int64Counter }
+
+func (s sentryDroppedIface) Inc(reason string) {
+	s.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("reason", reason)))
+}

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -1,10 +1,10 @@
 package onscreensClient
 
 import (
-	"log/slog"
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -19,38 +19,39 @@ import (
 var onscreensServerURL = "http://" + c.Conf.OnscreensServerHost
 
 // httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans. See pkg/vlc-client for the same pattern.
+// so outbound calls produce spans and propagate W3C tracecontext headers.
+// See pkg/vlc-client for the same pattern.
 var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
-func HideMiddleText() error {
-	_, err := getUrl(onscreensServerURL + "/onscreens/middle/hide")
+func HideMiddleText(ctx context.Context) error {
+	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/middle/hide")
 	if err != nil {
-		slog.Error("error showing leaderboard onscreen", "err", err)
+		slog.ErrorContext(ctx, "error hiding middle onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
-func ShowMiddleText(msg string) error {
+func ShowMiddleText(ctx context.Context, msg string) error {
 	url := onscreensServerURL + "/onscreens/middle/show"
 	url = fmt.Sprintf("%s?msg=%s", url, helpers.Base64Encode(msg))
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error showing middle onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing middle onscreen", "err", err)
 		return err
 	}
 	return err
 }
 
-func ShowLeaderboard(title string, leaderboard [][]string) error {
+func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
 	content := users.LeaderboardContent(title, leaderboard)
 
 	url := onscreensServerURL + "/onscreens/leaderboard/show"
 	url = fmt.Sprintf("%s?content=%s", url, helpers.Base64Encode(content))
 
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error showing leaderboard onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing leaderboard onscreen", "err", err)
 		return err
 	}
 	return nil
@@ -74,67 +75,71 @@ func ShowGuessLeaderboard(ctx context.Context) {
 	}
 
 	// display leaderboard on screen
-	ShowLeaderboard("Correct Guesses This Month", intLeaderboard)
+	ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 }
 
-func ShowTimewarp() error {
-	_, err := getUrl(onscreensServerURL + "/onscreens/timewarp/show")
+func ShowTimewarp(ctx context.Context) error {
+	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/timewarp/show")
 	if err != nil {
-		slog.Error("error showing timewarp onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing timewarp onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
-func ShowFlag(dur time.Duration) error {
+func ShowFlag(ctx context.Context, dur time.Duration) error {
 	//TODO: bring this back
 	// url := onscreensServerURL + "/onscreens/flag/show"
 	// url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	// _, err := getUrl(url)
+	// _, err := getUrl(ctx, url)
 	// if err != nil {
-	// 	slog.Error("error showing flag onscreen", "err", err)
+	// 	slog.ErrorContext(ctx, "error showing flag onscreen", "err", err)
 	// 	return err
 	// }
 	return nil
 }
 
-func ShowGPSImage(dur time.Duration) error {
+func ShowGPSImage(ctx context.Context, dur time.Duration) error {
 	url := onscreensServerURL + "/onscreens/gps/show"
 	url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error showing gps onscreen", "err", err)
+		slog.ErrorContext(ctx, "error showing gps onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
-func HideGPSImage() error {
-	_, err := getUrl(onscreensServerURL + "/onscreens/gps/hide")
+func HideGPSImage(ctx context.Context) error {
+	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/gps/hide")
 	if err != nil {
-		slog.Error("error hiding gps onscreen", "err", err)
+		slog.ErrorContext(ctx, "error hiding gps onscreen", "err", err)
 		return err
 	}
 	return nil
 }
 
 //TODO: move this to a common location
-func getUrl(url string) (string, error) {
-	response, err := httpClient.Get(url)
+func getUrl(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.Error("error connecting to VLC server", "err", err)
+		slog.ErrorContext(ctx, "error building request to onscreens server", "err", err)
 		return "", err
-	} else {
-		defer response.Body.Close()
-		contents, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			slog.Error("error reading response from VLC server", "err", err)
-			return "", err
-		}
-		// make note of non-200 status codes
-		if response.StatusCode != 200 {
-			slog.Error(fmt.Sprintf("non-200 response from server (%d)", response.StatusCode))
-		}
-		return string(contents), nil
 	}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "error connecting to onscreens server", "err", err)
+		return "", err
+	}
+	defer response.Body.Close()
+	contents, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "error reading response from onscreens server", "err", err)
+		return "", err
+	}
+	// make note of non-200 status codes
+	if response.StatusCode != 200 {
+		slog.ErrorContext(ctx, "non-200 response from server", "status", response.StatusCode)
+	}
+	return string(contents), nil
 }

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -133,9 +133,11 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
-// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
-// surface the underlying mux route template to the otelhttp middleware, so
-// each registration declares it.
+// (via otelhttp.Labeler) and traces (via the active span), and overrides
+// the span name with the route template so spans group by route in Tempo
+// instead of all collapsing under the operation name passed to
+// otelhttp.NewHandler. Negroni doesn't surface the underlying mux route
+// template to the otelhttp middleware, so each registration declares it.
 func tagged(route string, h http.HandlerFunc) http.Handler {
 	attr := semconv.HTTPRoute(route)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -143,7 +145,9 @@ func tagged(route string, h http.HandlerFunc) http.Handler {
 		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
 			labeler.Add(attr)
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attr)
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attr)
+		span.SetName(route)
 		h(w, req)
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -128,9 +128,11 @@ func Start(ctx context.Context) {
 }
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
-// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
-// surface the underlying mux route template to the otelhttp middleware, so
-// each registration declares it.
+// (via otelhttp.Labeler) and traces (via the active span), and overrides
+// the span name with the route template so spans group by route in Tempo
+// instead of all collapsing under the operation name passed to
+// otelhttp.NewHandler. Negroni doesn't surface the underlying mux route
+// template to the otelhttp middleware, so each registration declares it.
 func tagged(route string, h http.HandlerFunc) http.Handler {
 	attr := semconv.HTTPRoute(route)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -138,7 +140,9 @@ func tagged(route string, h http.HandlerFunc) http.Handler {
 		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
 			labeler.Add(attr)
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attr)
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attr)
+		span.SetName(route)
 		h(w, req)
 	})
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -243,13 +243,36 @@ func (m multiHandler) WithGroup(name string) slog.Handler {
 // the Sentry event arrives with the preceding log trail attached.
 // Error+ is skipped — samber/slog-sentry already turns those into
 // full Sentry events with their own captured attribute set.
+//
+// Sentry caps breadcrumbs at 100 per scope; high-volume routine logs
+// (per-command "ran !X", per-cron-tick "session snapshot", etc.) would
+// quickly evict the recent, useful records before an error fires. The
+// noisy-prefix list below names the messages we know fire on every
+// command or every minute via cron; they stay in Loki but skip the
+// breadcrumb pipeline.
 type breadcrumbHandler struct{}
+
+// breadcrumbSkipPrefixes lists slog message prefixes that fire frequently
+// enough to drown out other context if all routed to Sentry breadcrumbs.
+var breadcrumbSkipPrefixes = []string{
+	"ran !",            // every chat command (chatbot/commands.go + playback.go)
+	"now playing",      // per video transition via cron.video.GetCurrentlyPlaying
+	"session snapshot", // every 5min via cron.users.PrintCurrentSession
+	"subscribers",      // every 5min via cron.twitch.GetSubscribers
+	"no subscribers",   // ditto
+	"follower count",   // every 5min via cron.twitch.GetFollowerCount
+}
 
 func (breadcrumbHandler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= slog.LevelInfo && level < slog.LevelError
 }
 
 func (breadcrumbHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, p := range breadcrumbSkipPrefixes {
+		if strings.HasPrefix(r.Message, p) {
+			return nil
+		}
+	}
 	hub := sentry.CurrentHub()
 	if fromCtx := sentry.GetHubFromContext(ctx); fromCtx != nil {
 		hub = fromCtx

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -1,9 +1,10 @@
 package video
 
 import (
-	"log/slog"
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -16,22 +17,22 @@ import (
 
 // LoadOrCreate() will look up the video in the DB,
 // or add it to the DB if it's not there yet
-func LoadOrCreate(path string) (Video, error) {
+func LoadOrCreate(ctx context.Context, path string) (Video, error) {
 	slug := slug(path)
 
-	vid, err := load(slug)
+	vid, err := load(ctx, slug)
 	if err != nil {
 		// create a new video
-		vid, err = create(slug)
+		vid, err = create(ctx, slug)
 	}
 
 	return vid, err
 }
 
 // load() fetches a Video from the DB
-func load(slug string) (Video, error) {
+func load(ctx context.Context, slug string) (Video, error) {
 	var vid Video
-	result := database.GormDB().Where("slug = ?", slug).First(&vid)
+	result := database.GormDB().WithContext(ctx).Where("slug = ?", slug).First(&vid)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return Video{}, errors.New("no matches found")
 	}
@@ -39,9 +40,9 @@ func load(slug string) (Video, error) {
 }
 
 //TODO: combine this with load()?
-func loadById(id int64) (Video, error) {
+func loadById(ctx context.Context, id int64) (Video, error) {
 	var vid Video
-	result := database.GormDB().First(&vid, id)
+	result := database.GormDB().WithContext(ctx).First(&vid, id)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return Video{}, errors.New("no matches found")
 	}
@@ -52,7 +53,7 @@ func loadById(id int64) (Video, error) {
 //TODO: this is kinda weird, we create an empty Video
 // and then we save it to the DB... maybe we could just
 // save right to the DB? It would take some refactoring.
-func create(file string) (Video, error) {
+func create(ctx context.Context, file string) (Video, error) {
 	var newVid Video
 	var blankDate time.Time
 
@@ -78,21 +79,21 @@ func create(file string) (Video, error) {
 	}
 
 	// store the video in the DB
-	err = newVid.save()
+	err = newVid.save(ctx)
 	if err != nil {
-		slog.Error("error saving to DB", "err", err)
+		slog.ErrorContext(ctx, "error saving to DB", "err", err)
 	}
 
 	// now fetch it from the DB
 	//TODO: this is an extra DB call, do we care?
-	dbVid, err := load(slug)
+	dbVid, err := load(ctx, slug)
 
 	return dbVid, err
 }
 
 // save() will store the video in the DB
 //TODO: I think this can be achieved much easier, c.p. user save
-func (v Video) save() error {
+func (v Video) save(ctx context.Context) error {
 	var err error
 	flagged := v.Flagged
 	lat := v.Lat
@@ -101,7 +102,7 @@ func (v Video) save() error {
 
 	if lat == 0 || lng == 0 {
 		//TODO: this is where we used to run ocrCoords()
-		slog.Error("OCRing coords skipped!")
+		slog.ErrorContext(ctx, "OCRing coords skipped!")
 		flagged = true
 	}
 
@@ -111,7 +112,7 @@ func (v Video) save() error {
 		// ErrMapsDisabled is the expected steady-state when no Maps key
 		// is configured; don't spam Sentry on every video import.
 		if err != nil && !errors.Is(err, helpers.ErrMapsDisabled) {
-			slog.Error("error geocoding coords", "err", err)
+			slog.ErrorContext(ctx, "error geocoding coords", "err", err)
 		}
 	}
 
@@ -126,16 +127,16 @@ func (v Video) save() error {
 		State:       state,
 		DateCreated: v.DateCreated,
 	}
-	return database.GormDB().Create(&insert).Error
+	return database.GormDB().WithContext(ctx).Create(&insert).Error
 }
 
 // Next() finds the next unflagged video
 //TODO: should this be NextUnflagged?
 //TODO: handle errors in here?
-func (v Video) Next() Video {
+func (v Video) Next(ctx context.Context) Video {
 	vid := v
 	for { // ever
-		vid, _ = loadById(vid.NextVid.Int64)
+		vid, _ = loadById(ctx, vid.NextVid.Int64)
 		// use the first unflagged video we find
 		if !vid.Flagged {
 			break
@@ -144,8 +145,8 @@ func (v Video) Next() Video {
 	return vid
 }
 
-func (v Video) SetNextVid(nextVid Video) error {
-	return database.GormDB().Model(&v).Update("next_vid", nextVid.ID).Error
+func (v Video) SetNextVid(ctx context.Context, nextVid Video) error {
+	return database.GormDB().WithContext(ctx).Model(&v).Update("next_vid", nextVid.ID).Error
 }
 
 func validate(dashStr string) error {
@@ -166,7 +167,7 @@ func validate(dashStr string) error {
 	return nil
 }
 
-func FindRandomByState(state string) (Video, error) {
+func FindRandomByState(ctx context.Context, state string) (Video, error) {
 	var vid Video
 
 	// convert to long form
@@ -180,12 +181,12 @@ func FindRandomByState(state string) (Video, error) {
 	state = helpers.TitlecaseState(state)
 
 	//TODO: ORDER BY random() will eventually get too slow
-	result := database.GormDB().Where("state = ?", state).Order("random()").Limit(1).First(&vid)
+	result := database.GormDB().WithContext(ctx).Where("state = ?", state).Order("random()").Limit(1).First(&vid)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return vid, &terrors.NoFootageForStateError{Msg: "no matches found"}
 	}
 	if result.Error != nil {
-		slog.Error("error fetching vid from DB", "err", result.Error)
+		slog.ErrorContext(ctx, "error fetching vid from DB", "err", result.Error)
 		return vid, result.Error
 	}
 	return vid, nil

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -46,7 +46,7 @@ func GetCurrentlyPlaying(ctx context.Context) {
 		timeStarted = time.Now()
 
 		// share the Video with the system
-		CurrentlyPlaying, err = LoadOrCreate(curVid)
+		CurrentlyPlaying, err = LoadOrCreate(ctx, curVid)
 		if err != nil {
 			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", curVid)
 		}

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -37,7 +37,7 @@ func GetCurrentlyPlaying(ctx context.Context) {
 	if helpers.RunningOnDarwin() {
 		curVid = figureOutCurrentVideo(ctx)
 	} else {
-		curVid = vlcClient.CurrentlyPlaying()
+		curVid = vlcClient.CurrentlyPlaying(ctx)
 	}
 
 	// if the currently-playing video has changed
@@ -59,9 +59,9 @@ func GetCurrentlyPlaying(ctx context.Context) {
 		// show the no-GPS image
 		if CurrentlyPlaying.Flagged {
 			//TODO: kinda cludgy that we hardcode 60s here
-			onscreensClient.ShowGPSImage(60 * time.Second)
+			onscreensClient.ShowGPSImage(ctx, 60 * time.Second)
 		} else {
-			onscreensClient.HideGPSImage()
+			onscreensClient.HideGPSImage(ctx)
 		}
 	}
 }

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -1,9 +1,10 @@
 package vlcClient
 
 import (
-	"log/slog"
+	"context"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/http"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -14,81 +15,86 @@ import (
 var vlcServerURL = "http://" + c.Conf.VlcServerHost
 
 // httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans. Most callers here are cron/IRC-driven
-// (no inbound HTTP context), so traceparent propagation is best-effort
-// until ctx-threaded variants of these helpers exist.
+// so outbound calls produce spans and propagate W3C tracecontext headers.
+// Callers must pass ctx so the propagation has an active span to attach to —
+// passing context.Background() will still send the request, just without a
+// parent span linking it to the caller's trace.
 var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
 // CurrentlyPlaying finds the currently-playing video path
-func CurrentlyPlaying() string {
-	response, err := getUrl(vlcServerURL + "/vlc/current")
+func CurrentlyPlaying(ctx context.Context) string {
+	response, err := getUrl(ctx, vlcServerURL+"/vlc/current")
 	if err != nil {
-		slog.Error("unable to determine current video", "err", err)
+		slog.ErrorContext(ctx, "unable to determine current video", "err", err)
 		return ""
 	}
 	return response
 }
 
 // PlayRandom plays a random file from the playlist
-func PlayRandom() error {
-	_, err := getUrl(vlcServerURL + "/vlc/random")
+func PlayRandom(ctx context.Context) error {
+	_, err := getUrl(ctx, vlcServerURL+"/vlc/random")
 	if err != nil {
-		slog.Error("error playing random video", "err", err)
+		slog.ErrorContext(ctx, "error playing random video", "err", err)
 		return err
 	}
 	return nil
 }
 
 // PlayFileInPlaylist plays a given file
-func PlayFileInPlaylist(filename string) error {
+func PlayFileInPlaylist(ctx context.Context, filename string) error {
 	url := vlcServerURL + "/vlc/play/" + filename
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error playing file", "err", err)
+		slog.ErrorContext(ctx, "error playing file", "err", err)
 		return err
 	}
 	return nil
 }
 
-func Skip(n int) error {
+func Skip(ctx context.Context, n int) error {
 	url := vlcServerURL + "/vlc/skip"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error skipping video", "err", err)
+		slog.ErrorContext(ctx, "error skipping video", "err", err)
 		return err
 	}
 	return nil
 }
 
-func Back(n int) error {
+func Back(ctx context.Context, n int) error {
 	url := vlcServerURL + "/vlc/back"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(url)
+	_, err := getUrl(ctx, url)
 	if err != nil {
-		slog.Error("error going back to a video", "err", err)
+		slog.ErrorContext(ctx, "error going back to a video", "err", err)
 		return err
 	}
 	return nil
 }
 
 //TODO: move this to a common location
-func getUrl(url string) (string, error) {
-	response, err := httpClient.Get(url)
+func getUrl(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.Error("error connecting to VLC server", "err", err)
+		slog.ErrorContext(ctx, "error building request to VLC server", "err", err)
 		return "", err
-	} else {
-		defer response.Body.Close()
-		contents, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			slog.Error("error reading response from VLC server", "err", err)
-			return "", err
-		}
-		return string(contents), nil
 	}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "error connecting to VLC server", "err", err)
+		return "", err
+	}
+	defer response.Body.Close()
+	contents, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "error reading response from VLC server", "err", err)
+		return "", err
+	}
+	return string(contents), nil
 }

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -137,9 +137,11 @@ func Start(ctx context.Context) {
 }
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
-// (via otelhttp.Labeler) and traces (via the active span). Negroni doesn't
-// surface the underlying mux route template to the otelhttp middleware, so
-// each registration declares it.
+// (via otelhttp.Labeler) and traces (via the active span), and overrides
+// the span name with the route template so spans group by route in Tempo
+// instead of all collapsing under the operation name passed to
+// otelhttp.NewHandler. Negroni doesn't surface the underlying mux route
+// template to the otelhttp middleware, so each registration declares it.
 func tagged(route string, h http.HandlerFunc) http.Handler {
 	attr := semconv.HTTPRoute(route)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -147,7 +149,9 @@ func tagged(route string, h http.HandlerFunc) http.Handler {
 		if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
 			labeler.Add(attr)
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attr)
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attr)
+		span.SetName(route)
 		h(w, req)
 	})
 }

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -48,7 +48,7 @@ func main() {
 
 	// a file was passed in via the CLI
 	if videoFile != "" {
-		vid, err := video.LoadOrCreate(videoFile)
+		vid, err := video.LoadOrCreate(context.Background(), videoFile)
 		if err != nil {
 			slog.Error("unable to create video", "err", err, "file", videoFile)
 		}
@@ -73,7 +73,7 @@ func main() {
 				}
 
 				// actually process the image
-				vid, err := video.LoadOrCreate(path)
+				vid, err := video.LoadOrCreate(context.Background(), path)
 				if err != nil {
 					slog.Error("unable to create video", "err", err, "path", path)
 					return nil

--- a/script/make-map/make-map.go
+++ b/script/make-map/make-map.go
@@ -54,7 +54,7 @@ func main() {
 				return nil
 			}
 
-			vid, err := video.LoadOrCreate(path)
+			vid, err := video.LoadOrCreate(context.Background(), path)
 			if err != nil {
 				slog.Error("unable to create video", "err", err, "path", path)
 				return nil


### PR DESCRIPTION
Patch release. Logging-improvements series: end-to-end trace continuity across the chatbot → vlc-server → onscreens-server boundary, HTTP spans group by route template instead of collapsing under per-binary names, ctx threaded through the last big DB layer (\`pkg/video/db.go\`), and Sentry gets a Prom-visible drop counter + breadcrumb noise filter. New ADR documents canonical slog attribute keys.

Pairs with [adanalife/infra#488](https://github.com/adanalife/infra/pull/488) which surfaces \`sentry_events_dropped_total\` in Grafana.

## What's shipping

- [#575](https://github.com/adanalife/tripbot/pull/575/changes) — HTTP spans named by route template
- [#576](https://github.com/adanalife/tripbot/pull/576/changes) — cross-process trace propagation via HTTP clients
- [#577](https://github.com/adanalife/tripbot/pull/577/changes) — ctx threaded through pkg/video/db.go
- [#578](https://github.com/adanalife/tripbot/pull/578/changes) — Sentry drop counter + breadcrumb filter
- [#579](https://github.com/adanalife/tripbot/pull/579/changes) — slog attribute key canonicalization