### PR TITLE
fix(chatbot): point !discord at the non-expiring invite

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -71,7 +71,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!discord",
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Join us on Discord: https://discord.gg/Bk9EuGdMX")
+				sayFn("Join us on Discord: https://discord.gg/hKvNgZrk52")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

The `!discord` command (added in #527) pointed at `https://discord.gg/Bk9EuGdMX`, a standard server invite that expires every ~30 days. Swap to `https://discord.gg/hKvNgZrk52`, a non-expiring invite — keeps the chat command working without periodic rotation.

Matches the `/discord` short-URL just added on the website side in [adanalife/website#222](https://github.com/adanalife/website/pull/222), so the same invite is reachable via `!discord` in chat and `dana.lol/discord` on the web.

## Test plan

- [ ] After merge + deploy, in Twitch chat: `!discord` → bot replies with `Join us on Discord: https://discord.gg/hKvNgZrk52`
- [ ] Click the link, confirm it lands on the server invite page (not "this invite has expired")