### PR TITLE
fix: smooth inter-clip transitions in the dashcam stream

### DIFF
--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -299,9 +299,9 @@
       "settings": {
         "input": "${DASHCAM_RTSP_URL}",
         "is_local_file": false,
-        "reconnect_delay_sec": 10,
+        "reconnect_delay_sec": 1,
         "restart_on_activate": false,
-        "buffering_mb": 2,
+        "buffering_mb": 8,
         "hw_decode": false,
         "clear_on_media_end": false,
         "close_when_inactive": false

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -16,8 +16,13 @@ type VlcServerConfig struct {
 	RunDir string `default:"/opt/data/run" envconfig:"RUN_DIR"`
 
 	// VlcFileCaching is the libvlc --file-caching value in milliseconds.
-	// Defaults to today's hardcoded value; tune per-host without recompiling.
-	VlcFileCaching int `default:"1111" envconfig:"VLC_FILE_CACHING"`
+	// Tune per-host without recompiling. Lower = faster between-clip
+	// startup (smaller frame gap that OBS's ffmpeg_source has to ride
+	// out before disconnect/reconnect kicks in); higher = more headroom
+	// for bursty disk/NFS read latency. 300ms is a working baseline for
+	// local-NFS-backed playback; the prior 1111 was unscientific tuning
+	// from years ago that left a >1s frame gap on each clip transition.
+	VlcFileCaching int `default:"300" envconfig:"VLC_FILE_CACHING"`
 	// VlcAvcodecHw is the libvlc --avcodec-hw value (Linux-only). One of
 	// none, vdpau_avcodec, cuda. Only applied on Linux hosts; ignored on
 	// Windows/Darwin (matches today's platform-specific flag layering).


### PR DESCRIPTION
## Summary

Two complementary tweaks to make the dashcam stream survive its own playlist transitions without flashing.

**Problem.** Watching the prod-1 stream, there's a brief flash with no video between clips. The OBS pod logs the smoking gun:

> warning: [Media Source 'Dashcam']: Disconnected. Reconnecting...

OBS's `ffmpeg_source` is consuming `rtsp://vlc-server:8554/dashcam`. Between clips, VLC's libvlc `--file-caching=1111ms` creates a ~1s frame gap while the next Media's decoder warms up. OBS's small `buffering_mb=2` drains in that window → source marks itself disconnected → `reconnect_delay_sec=10` stretches the visible black to as much as 10s.

**Two-sided fix.** Each commit is independently meaningful, intentionally split per the atomic-commits ADR.

| Commit | Side | Change |
|---|---|---|
| obs: ride out inter-clip frame gaps | OBS | `buffering_mb` 2→8, `reconnect_delay_sec` 10→1 in `Tripbot.json.tmpl` |
| vlc-server: drop VLC_FILE_CACHING default | VLC | `pkg/config/vlc-server/type.go` default 1111ms→300ms |

## Why these specific values

- `buffering_mb=8`: enough to absorb a sub-second frame gap at 1080p60 H264 at any reasonable bitrate.
- `reconnect_delay_sec=1`: if a disconnect *does* still fire (e.g. an unusually long clip warmup), recovery is ~1s not 10s.
- `VLC_FILE_CACHING=300`: working baseline for local-NFS-backed playback on adanalife-minipc (Synology over 2.5GbE). The old 1111 was unscientific tuning from years back. The value is env-tunable per host if a slower backing store needs more headroom.

## Out of scope

- The continuous H.264 decoder errors throughout the stream (`concealing N DC/AC/MV errors`) — that's RTP-over-UDP packet loss inside the cluster, a different problem.
- Pre-transcoding the corpus to a uniform spec — the proper long-term fix (existing TODO).
- Adding `transcode{...}` to VLC's sout chain — the heavier-hammer fallback if these two tweaks don't fully kill the flash.

## Test plan

- [ ] CI passes (Go build, vlc/obs container builds).
- [ ] Release PR `develop → master` cuts a new version → multi-arch images pushed.
- [ ] `kubectl rollout restart deploy/obs deploy/vlc-server` on adanalife-minipc.
- [ ] Watch `twitch.tv/adanalife_staging` through several clip transitions — no flash, no "Disconnected. Reconnecting..." in `kubectl logs deploy/obs`.
- [ ] Verify VLC playback still feels smooth (300ms file cache hasn't introduced stutter on NFS reads).