### PR TITLE
negroni: log /health/live + /health/ready at debug to cut probe spam

### DIFF
--- a/pkg/httpmw/slog_logger.go
+++ b/pkg/httpmw/slog_logger.go
@@ -1,0 +1,55 @@
+// Package httpmw holds HTTP middleware shared across tripbot's web servers
+// (tripbot, vlc-server, onscreens-server).
+package httpmw
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/urfave/negroni/v3"
+)
+
+// healthPaths are logged at Debug instead of Info so kubelet's liveness
+// and readiness probes don't dominate the default log stream. Other
+// frequent paths (e.g. /metrics) stay at Info — add them here if they
+// become noisy.
+var healthPaths = map[string]bool{
+	"/health/live":  true,
+	"/health/ready": true,
+}
+
+// SlogLogger is a negroni-compatible middleware that emits one slog
+// record per HTTP request. It replaces negroni.Logger so request logs
+// flow through the project's slog handlers (console + OTel + Sentry)
+// and structured fields land cleanly in Loki.
+type SlogLogger struct{}
+
+// NewSlogLogger constructs a SlogLogger.
+func NewSlogLogger() *SlogLogger { return &SlogLogger{} }
+
+// ServeHTTP implements negroni.Handler.
+func (l *SlogLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
+	next(rw, r)
+
+	status := 0
+	size := 0
+	if res, ok := rw.(negroni.ResponseWriter); ok {
+		status = res.Status()
+		size = res.Size()
+	}
+
+	level := slog.LevelInfo
+	if healthPaths[r.URL.Path] {
+		level = slog.LevelDebug
+	}
+	slog.LogAttrs(r.Context(), level, "http request",
+		slog.String("method", r.Method),
+		slog.String("path", r.URL.Path),
+		slog.Int("status", status),
+		slog.Int("bytes", size),
+		slog.Duration("duration", time.Since(start)),
+		slog.String("remote", r.RemoteAddr),
+	)
+}

--- a/pkg/httpmw/slog_logger_test.go
+++ b/pkg/httpmw/slog_logger_test.go
@@ -1,0 +1,57 @@
+package httpmw
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/urfave/negroni/v3"
+)
+
+func TestSlogLoggerLevelByPath(t *testing.T) {
+	cases := []struct {
+		path     string
+		wantLvl  string
+		notLevel string
+	}{
+		{path: "/health/live", wantLvl: "DEBUG", notLevel: "INFO"},
+		{path: "/health/ready", wantLvl: "DEBUG", notLevel: "INFO"},
+		{path: "/anything-else", wantLvl: "INFO", notLevel: "DEBUG"},
+		{path: "/health/", wantLvl: "INFO", notLevel: "DEBUG"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			n := negroni.New(NewSlogLogger())
+			n.UseHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil).WithContext(context.Background())
+			rec := httptest.NewRecorder()
+			n.ServeHTTP(rec, req)
+
+			out := buf.String()
+			if !strings.Contains(out, "level="+tc.wantLvl) {
+				t.Fatalf("want level=%s in log line, got %q", tc.wantLvl, out)
+			}
+			if strings.Contains(out, "level="+tc.notLevel) {
+				t.Fatalf("did not want level=%s in log line, got %q", tc.notLevel, out)
+			}
+			if !strings.Contains(out, "path="+tc.path) {
+				t.Fatalf("want path=%s in log line, got %q", tc.path, out)
+			}
+			if !strings.Contains(out, "status=200") {
+				t.Fatalf("want status=200 in log line, got %q", out)
+			}
+		})
+	}
+}

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -9,6 +9,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -73,7 +74,10 @@ func Start() {
 		helpers.PrintAllRoutes(r)
 	}
 
-	app := negroni.Classic()
+	// negroni.New + explicit middleware so we can swap negroni's stdlib
+	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
+	// middleware from negroni.Classic is dropped (no public/ directory).
+	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
 
 	metricsMw := middleware.New(middleware.Config{
 		Recorder: metrics.NewRecorder(metrics.Config{}),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -67,9 +68,10 @@ func Start(ctx context.Context) {
 		helpers.PrintAllRoutes(r)
 	}
 
-	// negroni classic adds panic recovery, logger, and static file middlewares
-	// c.p. https://github.com/urfave/negroni
-	app := negroni.Classic()
+	// negroni.New + explicit middleware so we can swap negroni's stdlib
+	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
+	// middleware from negroni.Classic is dropped (no public/ directory).
+	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -10,6 +10,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -75,10 +76,11 @@ func Start(ctx context.Context) {
 		helpers.PrintAllRoutes(r)
 	}
 
-	// negroni classic adds panic recovery, logger, and static file middlewares
-	// c.p. https://github.com/urfave/negroni
+	// negroni.New + explicit middleware so we can swap negroni's stdlib
+	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
+	// middleware from negroni.Classic is dropped (no public/ directory).
 	//TODO: consider adding HTMLPanicFormatter
-	app := negroni.Classic()
+	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{


### PR DESCRIPTION
## Summary

- New `pkg/httpmw.SlogLogger` middleware emits one structured slog record per HTTP request (method/path/status/bytes/duration/remote), routed through the project's existing slog handlers (console + OTel + Sentry).
- `/health/live` and `/health/ready` log at `slog.LevelDebug` instead of Info so kubelet probe polling stops dominating the default log stream. Everything else stays at Info.
- All three web servers (`tripbot`, `vlc-server`, `onscreens-server`) swap `negroni.Classic()` for `negroni.New(NewRecovery(), httpmw.NewSlogLogger())`. The static-file middleware from `Classic` is dropped — no `public/` directory in any of the three.

## Test plan

- [ ] `go test ./pkg/httpmw/...` — covers Debug-vs-Info level selection by path
- [ ] Hit `/health/live` and `/health/ready` on a running server, confirm the entries appear at `level=DEBUG` (not in default console output) and at `detected_level=debug` in Loki
- [ ] Hit a normal route (e.g. `/version`), confirm it still logs at `level=INFO`
- [ ] Trigger a panic in a handler, confirm `negroni.NewRecovery` still catches it