### PR TITLE
feat: VAAPI hardware accel for OBS encode + VLC decode

### DIFF
--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -302,7 +302,7 @@
         "reconnect_delay_sec": 10,
         "restart_on_activate": false,
         "buffering_mb": 2,
-        "hw_decode": false,
+        "hw_decode": true,
         "clear_on_media_end": false,
         "close_when_inactive": false
       },

--- a/infra/docker/obs/config/basic.ini.tmpl
+++ b/infra/docker/obs/config/basic.ini.tmpl
@@ -10,7 +10,7 @@ ScaleType=lanczos
 [Output]
 Mode=Simple
 [SimpleOutput]
-StreamEncoder=x264
+StreamEncoder=${OBS_STREAM_ENCODER}
 VBitrate=${OBS_VIDEO_BITRATE}
 ABitrate=${OBS_AUDIO_BITRATE}
 Preset=${OBS_ENCODER_PRESET}

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -33,6 +33,14 @@ case "${OBS_QUALITY_PRESET:-high}" in
     ;;
 esac
 
+# Stream encoder selection. Default x264 (software) keeps stage-1 /
+# local dev / Mac k3d working without /dev/dri exposed. Override via
+# OBS_STREAM_ENCODER=ffmpeg_vaapi (k8s configmap in prod-1) to use
+# the host's Intel iGPU for hardware H.264 encode, dropping x264's
+# 15-25% P-core cost at 1080p60.
+export OBS_STREAM_ENCODER="${OBS_STREAM_ENCODER:-x264}"
+echo "OBS stream encoder: ${OBS_STREAM_ENCODER}"
+
 # OBS 32 split the legacy global.ini in two: app-level settings stayed in
 # global.ini (BrowserHWAccel etc.) and user-preference settings moved to
 # user.ini. Seed both so OBS sees a complete config and never prompts about

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:24.04
 
+# libva2 / libva-drm2 / mesa-va-drivers / vainfo are the userspace
+# VA-API plumbing libvlc needs to discover and use /dev/dri/renderD128
+# when VLC_AVCODEC_HW is "any" or "vaapi". intel-media-va-driver-non-free
+# is the actual Intel-specific driver and is amd64-only on Ubuntu
+# multiverse, so installed conditionally.
+ARG TARGETARCH
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -8,16 +14,22 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     curl \
     git \
     grc \
+    libva-drm2 \
+    libva2 \
     libvlc-dev \
+    mesa-va-drivers \
     net-tools \
     pkg-config \
     supervisor \
     syslog-ng \
+    vainfo \
     vim \
     vlc-plugin-base \
+  && if [ "$TARGETARCH" = "amd64" ]; then \
+       apt-get install -y --no-install-recommends intel-media-va-driver-non-free; \
+     fi \
   && rm -rf /var/lib/apt/lists/*
 
-ARG TARGETARCH
 RUN curl -fsSL https://go.dev/dl/go1.26.3.linux-${TARGETARCH}.tar.gz \
   | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:/go/bin:${PATH}"

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -19,9 +19,16 @@ type VlcServerConfig struct {
 	// Defaults to today's hardcoded value; tune per-host without recompiling.
 	VlcFileCaching int `default:"1111" envconfig:"VLC_FILE_CACHING"`
 	// VlcAvcodecHw is the libvlc --avcodec-hw value (Linux-only). One of
-	// none, vdpau_avcodec, cuda. Only applied on Linux hosts; ignored on
-	// Windows/Darwin (matches today's platform-specific flag layering).
-	VlcAvcodecHw string `default:"vdpau_avcodec" envconfig:"VLC_AVCODEC_HW"`
+	// any, none, vaapi, vdpau_avcodec, cuda. "any" lets libvlc pick the
+	// best available backend based on the host hardware: VAAPI on Intel
+	// iGPUs (the prod-1 minipc path, /dev/dri/renderD128 exposed via
+	// hostPath mount), VDPAU on NVIDIA hosts, none if no acceleration
+	// is reachable. The prior "vdpau_avcodec" default was NVIDIA-specific
+	// and silently fell back to software decode on Intel — undocumented
+	// performance loss on every adanalife host. Only applied on Linux
+	// hosts; ignored on Windows/Darwin (matches today's platform-specific
+	// flag layering).
+	VlcAvcodecHw string `default:"any" envconfig:"VLC_AVCODEC_HW"`
 	// VlcVout is the libvlc --vout value (Linux-only). Defaults to dummy
 	// (headless container, no X server). For local-display modes on
 	// Linux, set VLC_VOUT=x11. Only applied on Linux hosts; ignored on


### PR DESCRIPTION
## Summary

Turn on Intel VAAPI hardware accel for the dashcam pipeline on adanalife-minipc (i9-13900H Iris Xe). Three atomic commits — one per concern. None of them activate VAAPI alone; together with the paired infra PR ([#498](https://github.com/adanalife/infra/pull/498/changes)) they shift the encode + both decode paths to the iGPU.

## Commits

| Commit | Scope |
|---|---|
| obs: route StreamEncoder via OBS_STREAM_ENCODER + flip hw_decode | OBS image — entrypoint exports `OBS_STREAM_ENCODER` (default `x264`), `basic.ini.tmpl` templates the value, `Tripbot.json.tmpl` Dashcam source flips `hw_decode: true` |
| vlc: install VA-API userspace + intel-media driver (amd64) | VLC `Dockerfile` adds `libva2 libva-drm2 mesa-va-drivers vainfo` for both arches; `intel-media-va-driver-non-free` only on amd64 (multiverse package, arm64 doesn't ship it) |
| vlc-server: VLC_AVCODEC_HW default vdpau_avcodec -> any | `pkg/config/vlc-server/type.go` — the prior default was NVIDIA-only and silently fell back to software on Intel. `any` lets libvlc pick per-host |

## Why now

The MS-01's i9-13900H integrated Iris Xe has full QSV / VAAPI for H.264 / H.265 / AV1 encode + decode. We've been ignoring it: software x264 encode (~15-25% of a P-core at 1080p60) and software H.264 decode of every dashcam clip. The 2026-05-19 Talos upgrade added the `i915-ucode` extension so `/dev/dri/renderD128` now exists on the node; the paired infra PR plumbs it through to the workload pods via the **Intel GPU device plugin** (standard K8s extended-resource pattern — no hostPath, no PSS escalation).

Wins on the i9-13900H at 1080p60:
- OBS encoder x264 -> VAAPI: ~15-25% of a P-core freed
- OBS source decode software -> hw: ~5-10% saved
- VLC playback decode software -> VAAPI: ~5-10% saved

## Compatibility

- **stage-1 / local k3d:** `OBS_STREAM_ENCODER` defaults to `x264`, no `gpu.intel.com/i915` resource request, VLC's `any` finds nothing usable and falls back to software. No regression on the dev laptop.
- **prod-1:** `k8s/apps/obs/overlays/prod-1` overrides to `OBS_STREAM_ENCODER=ffmpeg_vaapi` (in [#498](https://github.com/adanalife/infra/pull/498/changes)); both pods request `gpu.intel.com/i915: 1`; libvlc picks `vaapi` based on what's reachable.
- **Multi-arch:** arm64 builds skip `intel-media-va-driver-non-free`; the userspace plumbing still installs.

## Sibling PR

- Infra: [adanalife/infra#498](https://github.com/adanalife/infra/pull/498/changes) — installs the Intel GPU device plugin + Intel XPU Manager (Prometheus scrape + Grafana dashboard) on prod-1, switches the OBS + vlc-server overlays to request `gpu.intel.com/i915` as a standard extended resource. Land in either order; both no-ops alone, together they activate VAAPI.

## Test plan

- [ ] CI green on this PR (VLC + OBS image builds across amd64 + arm64).
- [ ] Sibling infra #498 merged + `task k8s:prod:platform:up` re-run; intel-gpu-plugin + intel-xpumanager DaemonSets reach Ready in kube-system.
- [ ] This PR merges to develop. Release PR `develop -> master` cuts a new version, multi-arch images published.
- [ ] `kubectl rollout restart deploy/obs deploy/vlc-server` on adanalife-minipc.
- [ ] `kubectl exec deploy/obs -- vainfo 2>&1 | head` reports Intel iHD driver.
- [ ] `kubectl logs deploy/obs | grep -i vaapi` shows the encoder initializing.
- [ ] OBS pod CPU drops noticeably (`kubectl top pod`).
- [ ] Grafana → Intel XPU Manager Exporter dashboard shows non-zero engine utilization on the Video / Video Enhance engines while OBS is streaming.
- [ ] `twitch.tv/adanalife_staging` still streaming smoothly at the same visual quality.