### PR TITLE
ops metrics: cron runs/panics, http panics, helix rate-limit headroom

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -29,20 +30,37 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"runtime/debug"
 )
 
 var cronTracer = otel.Tracer("github.com/adanalife/tripbot/cmd/tripbot/cron")
 
 // tracedJob wraps a cron callback in a span so each tick shows up as its
-// own trace. The scheduler's job ctx is the span's parent and is threaded
-// into fn, so DB queries (otelsql) and outbound HTTP (otelhttp) nest under
-// cron.<name> in Tempo as children of the cron tick.
+// own trace, records run-count / duration / last-run-timestamp metrics
+// per job, and recovers panics so a single failing job doesn't kill the
+// scheduler goroutine. The scheduler's job ctx is the span's parent and
+// is threaded into fn, so DB queries (otelsql) and outbound HTTP
+// (otelhttp) nest under cron.<name> in Tempo as children of the cron tick.
 func tracedJob(name string, fn func(context.Context)) func(context.Context) {
 	return func(ctx context.Context) {
+		start := time.Now()
 		ctx, span := cronTracer.Start(ctx, "cron."+name,
 			trace.WithAttributes(attribute.String("cron.job", name)))
 		defer span.End()
+		defer func() {
+			if r := recover(); r != nil {
+				slog.ErrorContext(ctx, "cron panic recovered",
+					"job", name,
+					"err", fmt.Sprintf("%v", r),
+					"stack", string(debug.Stack()),
+				)
+				instrumentation.Cron.Panic(name)
+				span.SetStatus(codes.Error, fmt.Sprintf("panic: %v", r))
+			}
+			instrumentation.Cron.Observe(name, time.Since(start).Seconds(), time.Now().Unix())
+		}()
 		fn(ctx)
 	}
 }

--- a/pkg/httpmw/recovery.go
+++ b/pkg/httpmw/recovery.go
@@ -1,0 +1,47 @@
+package httpmw
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+)
+
+// Recovery is a negroni-compatible middleware that catches panics in the
+// request goroutine, logs the stack via slog, calls an optional OnPanic
+// hook (typically to bump a metrics counter), then writes a 500 response.
+//
+// It replaces negroni.Recovery so panic events flow through the project's
+// slog handler chain (console + OTel + Sentry breadcrumbs/events) and can
+// be alerted on via a metrics counter.
+type Recovery struct {
+	// OnPanic is called with the recovered value before the 500 is
+	// written. Typical use is to increment a counter like
+	// instrumentation.HTTPPanics.Inc(serviceName).
+	OnPanic func(r any)
+}
+
+// NewRecovery constructs a Recovery middleware.
+func NewRecovery(onPanic func(r any)) *Recovery {
+	return &Recovery{OnPanic: onPanic}
+}
+
+// ServeHTTP implements negroni.Handler.
+func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer func() {
+		if err := recover(); err != nil {
+			stack := debug.Stack()
+			slog.ErrorContext(r.Context(), "panic recovered",
+				"err", fmt.Sprintf("%v", err),
+				"method", r.Method,
+				"path", r.URL.Path,
+				"stack", string(stack),
+			)
+			if rec.OnPanic != nil {
+				rec.OnPanic(err)
+			}
+			http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+	}()
+	next(rw, r)
+}

--- a/pkg/httpmw/recovery_test.go
+++ b/pkg/httpmw/recovery_test.go
@@ -1,0 +1,68 @@
+package httpmw
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/urfave/negroni/v3"
+)
+
+func TestRecoveryCatchesPanic(t *testing.T) {
+	var called bool
+	var recovered any
+	rec := NewRecovery(func(r any) {
+		called = true
+		recovered = r
+	})
+
+	n := negroni.New(rec)
+	n.UseHandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	})
+
+	w := httptest.NewRecorder()
+	n.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	if !called {
+		t.Fatal("OnPanic was not invoked")
+	}
+	if got, ok := recovered.(string); !ok || got != "kaboom" {
+		t.Fatalf("OnPanic got %v, want \"kaboom\"", recovered)
+	}
+}
+
+func TestRecoveryPassThrough(t *testing.T) {
+	rec := NewRecovery(func(any) { t.Fatal("OnPanic should not fire when there's no panic") })
+
+	n := negroni.New(rec)
+	n.UseHandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	n.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestRecoveryNilCallback(t *testing.T) {
+	rec := NewRecovery(nil)
+
+	n := negroni.New(rec)
+	n.UseHandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	})
+
+	w := httptest.NewRecorder()
+	n.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (nil OnPanic should still recover)", w.Code)
+	}
+}

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -26,6 +26,20 @@ var (
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
+
+	twitchHelixRateRemaining = mustGauge("twitch_helix_rate_limit_remaining", "Last-seen Ratelimit-Remaining header from Twitch Helix responses (per app-access bearer)")
+	twitchHelixRateLimit     = mustGauge("twitch_helix_rate_limit_total", "Last-seen Ratelimit-Limit header from Twitch Helix responses (per app-access bearer)")
+
+	cronRuns     = mustCounter("tripbot_cron_runs_total", "Total cron job invocations, labeled by job")
+	cronPanics   = mustCounter("tripbot_cron_panics_total", "Cron job panics recovered, labeled by job")
+	cronLastRun  = mustGauge("tripbot_cron_last_run_timestamp_seconds", "Unix timestamp of the most recent completion of each cron job, labeled by job")
+	cronDuration = mustHistogram(
+		"tripbot_cron_duration_seconds",
+		"Cron job duration in seconds, labeled by job",
+		0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60,
+	)
+
+	httpPanics = mustCounter("tripbot_http_panics_total", "HTTP handler panics recovered, labeled by service")
 )
 
 // ChatMessages exposes the chat-message counter through a tiny stable API
@@ -57,6 +71,22 @@ var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followe
 // TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
 // like "GetUsers"; statusCode is the HTTP status reported by Twitch.
 var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
+
+// TwitchHelixRateLimit exposes the per-bearer Helix rate-budget gauges.
+// SetRemaining + SetLimit are called by the response-recording transport
+// on every Helix call so dashboards / alerts can see headroom without
+// waiting for a 429.
+var TwitchHelixRateLimit = twitchHelixRateLimitIface{remaining: twitchHelixRateRemaining, limit: twitchHelixRateLimit}
+
+// Cron exposes cron job metrics. Observe(job, seconds) is called on every
+// completion (success or recovered panic); Panic(job) is additionally
+// called when a recover() fires. Together they enable "stalled cron" and
+// "panicking cron" alerts.
+var Cron = cronIface{runs: cronRuns, panics: cronPanics, lastRun: cronLastRun, duration: cronDuration}
+
+// HTTPPanics exposes the HTTP-handler panic counter. Increment from a
+// recovery middleware that catches panics in the request goroutine.
+var HTTPPanics = httpPanicsIface{counter: httpPanics}
 
 type chatCounterIface struct{ counter metric.Int64Counter }
 
@@ -108,6 +138,50 @@ func (h twitchHelixErrorsIface) Inc(endpoint string, statusCode int) {
 		attribute.String("endpoint", endpoint),
 		attribute.Int("status_code", statusCode),
 	))
+}
+
+type twitchHelixRateLimitIface struct {
+	remaining metric.Int64Gauge
+	limit     metric.Int64Gauge
+}
+
+func (r twitchHelixRateLimitIface) SetRemaining(n int64) {
+	r.remaining.Record(context.Background(), n)
+}
+
+func (r twitchHelixRateLimitIface) SetLimit(n int64) {
+	r.limit.Record(context.Background(), n)
+}
+
+type cronIface struct {
+	runs     metric.Int64Counter
+	panics   metric.Int64Counter
+	lastRun  metric.Int64Gauge
+	duration metric.Float64Histogram
+}
+
+// Observe records a completed cron run: bumps the run counter, records the
+// duration, and updates the last-run timestamp. Call on every completion,
+// including when a panic was recovered, so "no successful run in 3× interval"
+// alerts still see activity from a panicking job.
+func (c cronIface) Observe(job string, seconds float64, now int64) {
+	attr := metric.WithAttributes(attribute.String("job", job))
+	c.runs.Add(context.Background(), 1, attr)
+	c.duration.Record(context.Background(), seconds, attr)
+	c.lastRun.Record(context.Background(), now, attr)
+}
+
+// Panic records a cron panic. Call from a recover() handler before Observe.
+func (c cronIface) Panic(job string) {
+	c.panics.Add(context.Background(), 1, metric.WithAttributes(attribute.String("job", job)))
+}
+
+type httpPanicsIface struct{ counter metric.Int64Counter }
+
+// Inc records one recovered HTTP-handler panic, labeled by service
+// (typically c.Conf.ServerType: "tripbot" / "vlc_server" / "onscreens_server").
+func (h httpPanicsIface) Inc(service string) {
+	h.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("service", service)))
 }
 
 func mustCounter(name, desc string) metric.Int64Counter {

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -10,6 +10,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -77,7 +78,10 @@ func Start() {
 	// negroni.New + explicit middleware so we can swap negroni's stdlib
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
-	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
+	app := negroni.New(
+		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
+		httpmw.NewSlogLogger(),
+	)
 
 	metricsMw := middleware.New(middleware.Config{
 		Recorder: metrics.NewRecorder(metrics.Config{}),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -71,7 +72,10 @@ func Start(ctx context.Context) {
 	// negroni.New + explicit middleware so we can swap negroni's stdlib
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
-	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
+	app := negroni.New(
+		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
+		httpmw.NewSlogLogger(),
+	)
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -24,7 +24,11 @@ import (
 // no trail in Tempo; with it, each helix.GetUsers / GetSubscriptions / etc.
 // shows up as a span. Pairs with the otelhttp transports already used by
 // pkg/vlc-client and pkg/onscreens-client.
-var helixHTTPClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+//
+// The rateLimitRecorder wraps the otelhttp transport so every Helix
+// response also updates the twitch_helix_rate_limit_* gauges — dashboards
+// can see remaining headroom without waiting for a 429.
+var helixHTTPClient = &http.Client{Transport: rateLimitRecorder{next: otelhttp.NewTransport(http.DefaultTransport)}}
 
 // Scopes is the OAuth scope set requested for the bot account. Single source
 // of truth — referenced by Client() (App Access Token request),

--- a/pkg/twitch/helix_ratelimit.go
+++ b/pkg/twitch/helix_ratelimit.go
@@ -1,0 +1,33 @@
+package twitch
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+)
+
+// rateLimitRecorder is a RoundTripper that reads Twitch Helix's
+// Ratelimit-* response headers and surfaces them as OTel gauges, so
+// dashboards / alerts can see remaining headroom without waiting for
+// 429s. Helix returns these headers on every response; the per-bearer
+// quota is shared across all calls from the same App Access Token.
+type rateLimitRecorder struct{ next http.RoundTripper }
+
+func (rt rateLimitRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.next.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if v := resp.Header.Get("Ratelimit-Remaining"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			instrumentation.TwitchHelixRateLimit.SetRemaining(int64(n))
+		}
+	}
+	if v := resp.Header.Get("Ratelimit-Limit"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			instrumentation.TwitchHelixRateLimit.SetLimit(int64(n))
+		}
+	}
+	return resp, err
+}

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -11,6 +11,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -80,7 +81,10 @@ func Start(ctx context.Context) {
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
 	//TODO: consider adding HTMLPanicFormatter
-	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
+	app := negroni.New(
+		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
+		httpmw.NewSlogLogger(),
+	)
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{


### PR DESCRIPTION
## Summary

Three production-pre-launch observability additions that turn currently-invisible failure modes into alertable metrics.

**Cron metrics** (\`cmd/tripbot/tripbot.go\` \`tracedJob\`)
- \`tripbot_cron_runs_total{job}\` — every completion
- \`tripbot_cron_duration_seconds{job}\` — histogram per run
- \`tripbot_cron_last_run_timestamp_seconds{job}\` — Unix seconds of last completion
- \`tripbot_cron_panics_total{job}\` — recovered panics
- \`tracedJob\` now also \`recover()\`s panics so a single failing job doesn't kill the scheduler goroutine

**HTTP panic counter** (\`pkg/httpmw.Recovery\` across all three servers)
- \`tripbot_http_panics_total{service}\` — labels: \`tripbot\` / \`vlc_server\` / \`onscreens_server\`
- Replaces \`negroni.NewRecovery\` so panic stacks flow through slog (and from there to Loki + Sentry breadcrumbs) and can be alerted

**Twitch Helix rate-budget gauge** (\`pkg/twitch.rateLimitRecorder\`)
- \`twitch_helix_rate_limit_remaining\` / \`_total\` — read from \`Ratelimit-*\` response headers on every Helix call
- Lets dashboards see headroom before a 429 fires

## Test plan

- [ ] \`go test ./pkg/httpmw/...\` — recovery middleware unit tests
- [ ] Trigger a panic in a handler and confirm: 500 response, \`tripbot_http_panics_total\` incremented, stack visible in Loki
- [ ] On a running tripbot, hit a Helix-dependent command and confirm \`twitch_helix_rate_limit_remaining\` is populated
- [ ] Let a cron job tick and confirm \`tripbot_cron_runs_total{job=...}\` increments and \`tripbot_cron_last_run_timestamp_seconds\` is updated

## Pairs with

- #585 (real /health/ready) — both are part of the pre-launch observability fill-out
- Vault TODOs in \`vault/infra/TODO.md\` for the actual alert rules + notification policy