### PR TITLE
Release v2.9.3: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.9.3] — 2026-05-19
+
+Patch release. Wires up a meaningful production-side observability surface: cron jobs now emit run-count / duration / last-run-timestamp metrics and recover panics so a single failing job doesn't kill the scheduler goroutine; HTTP handlers count panics per service so a flapping endpoint becomes alertable instead of just log-shaped; the Helix client surfaces its `Ratelimit-*` response headers as gauges so the per-bearer 800-req/min quota is visible before a 429 fires. Kubelet liveness/readiness probes drop to `slog.LevelDebug` to keep the default Info stream usable. VAAPI hardware acceleration lands on both the OBS encode path and the VLC decode path. Inter-clip transitions in the dashcam stream get smoothed. The `!discord` chatbot command stops handing out invites that expire.
+
+### Observability
+
+- **Cron run counts, duration, last-run timestamps, and panic recovery.** `cmd/tripbot/tripbot.go`'s `tracedJob` wrapper now records `tripbot_cron_runs_total{job}`, `tripbot_cron_duration_seconds{job}` (histogram), and `tripbot_cron_last_run_timestamp_seconds{job}` on every completion — enabling alerts like "no successful run in 3× interval" without changing the (no-return-value) cron callback signature. A `defer recover()` also catches panics, logs the stack via slog, increments `tripbot_cron_panics_total{job}`, and marks the span as Error. Previously a panicking job would crash the scheduler goroutine and silently stop running thereafter. ([#586])
+- **`tripbot_http_panics_total{service}` counter via a slog-native recovery middleware.** Replaces `negroni.NewRecovery` with `pkg/httpmw.Recovery` across all three web servers (tripbot, vlc-server, onscreens-server). Recovers panics, logs the stack via slog (so it reaches OTel/Loki and Sentry breadcrumbs/events via the existing handler chain), increments the counter, then writes a 500. `sentrynegroni` continues to capture panics on its inner defer before the outer recovery handles cleanup. ([#586])
+- **`twitch_helix_rate_limit_remaining` / `_total` gauges.** Wraps the `otelhttp` transport with a `rateLimitRecorder` that reads `Ratelimit-Remaining` and `Ratelimit-Limit` off every Helix response. The 800-req/min per-bearer quota is shared across all calls from the bot's App Access Token, so a single gauge is the right shape — dashboards / alerts see headroom before 429s land. ([#586])
+- **`/health/live` and `/health/ready` log at `slog.LevelDebug`.** Adds `pkg/httpmw.SlogLogger`, an slog-native request logger emitting one structured record per HTTP request (method/path/status/bytes/duration/remote) that replaces `negroni.Logger`'s stdlib log output across all three servers. Health-check probes log at Debug instead of Info so kubelet's frequent liveness/readiness polling stops dominating the default log stream; everything else stays at Info. ([#583])
+
+### Streaming
+
+- **VAAPI hardware acceleration on OBS encode + VLC decode.** OBS now uses `libva` for H.264 encoding (offloading from the CPU); VLC defaults `VLC_AVCODEC_HW` from `vdpau_avcodec` to `any` so libvlc picks VAAPI when the Intel `i915` device is reachable. The matching K8s wiring (Intel device plugin, `gpu.intel.com/i915` resource request on both pods) lives in [adanalife/infra#499](https://github.com/adanalife/infra/pull/499). ([#584])
+- **Smooth inter-clip transitions in the dashcam stream.** Reduces the visible cut between dashcam clips so the loop reads as a continuous drive rather than a slideshow of segments. ([#582])
+
+### Chatbot
+
+- **`!discord` points at the non-expiring invite.** Previously the chat command handed out invites with TTL, so the link in the chat scrollback would silently 404 after a while. ([#581])
+
+[#581]: https://github.com/adanalife/tripbot/pull/581
+[#582]: https://github.com/adanalife/tripbot/pull/582
+[#583]: https://github.com/adanalife/tripbot/pull/583
+[#584]: https://github.com/adanalife/tripbot/pull/584
+[#586]: https://github.com/adanalife/tripbot/pull/586
+
 ## [v2.9.1] — 2026-05-18
 
 Patch release. Unifies the error-capture pipeline on `slog` so direct `slog.Error` calls (telemetry init, OBS adapter, etc.) reach Sentry alongside the existing `terrors.Log` sites, with a per-fingerprint cooldown + hourly cap to stay under the free tier. Threads `ctx` through a few more chatbot/users helpers so the per-command gating decisions and miles-math log lines carry `trace_id` linking back to their `chat.command` span. Retires the dead Twitch Helix Webhooks code path — the upstream API was deprecated by Twitch in 2021 and the receive/subscribe surface has been gated off via `DISABLE_TWITCH_WEBHOOKS=true` since the platform cutover; the only behavior actually lost is the live new-follower / new-sub chat shout, queued for re-introduction via EventSub. Pairs with [adanalife/infra#485](https://github.com/adanalife/infra/pull/485) (drops the `DISABLE_TWITCH_WEBHOOKS` env var from the kustomizations).

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -29,20 +30,37 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"runtime/debug"
 )
 
 var cronTracer = otel.Tracer("github.com/adanalife/tripbot/cmd/tripbot/cron")
 
 // tracedJob wraps a cron callback in a span so each tick shows up as its
-// own trace. The scheduler's job ctx is the span's parent and is threaded
-// into fn, so DB queries (otelsql) and outbound HTTP (otelhttp) nest under
-// cron.<name> in Tempo as children of the cron tick.
+// own trace, records run-count / duration / last-run-timestamp metrics
+// per job, and recovers panics so a single failing job doesn't kill the
+// scheduler goroutine. The scheduler's job ctx is the span's parent and
+// is threaded into fn, so DB queries (otelsql) and outbound HTTP
+// (otelhttp) nest under cron.<name> in Tempo as children of the cron tick.
 func tracedJob(name string, fn func(context.Context)) func(context.Context) {
 	return func(ctx context.Context) {
+		start := time.Now()
 		ctx, span := cronTracer.Start(ctx, "cron."+name,
 			trace.WithAttributes(attribute.String("cron.job", name)))
 		defer span.End()
+		defer func() {
+			if r := recover(); r != nil {
+				slog.ErrorContext(ctx, "cron panic recovered",
+					"job", name,
+					"err", fmt.Sprintf("%v", r),
+					"stack", string(debug.Stack()),
+				)
+				instrumentation.Cron.Panic(name)
+				span.SetStatus(codes.Error, fmt.Sprintf("panic: %v", r))
+			}
+			instrumentation.Cron.Observe(name, time.Since(start).Seconds(), time.Now().Unix())
+		}()
 		fn(ctx)
 	}
 }

--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -299,9 +299,9 @@
       "settings": {
         "input": "${DASHCAM_RTSP_URL}",
         "is_local_file": false,
-        "reconnect_delay_sec": 10,
+        "reconnect_delay_sec": 1,
         "restart_on_activate": false,
-        "buffering_mb": 2,
+        "buffering_mb": 8,
         "hw_decode": true,
         "clear_on_media_end": false,
         "close_when_inactive": false

--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -302,7 +302,7 @@
         "reconnect_delay_sec": 10,
         "restart_on_activate": false,
         "buffering_mb": 2,
-        "hw_decode": false,
+        "hw_decode": true,
         "clear_on_media_end": false,
         "close_when_inactive": false
       },

--- a/infra/docker/obs/config/basic.ini.tmpl
+++ b/infra/docker/obs/config/basic.ini.tmpl
@@ -10,7 +10,7 @@ ScaleType=lanczos
 [Output]
 Mode=Simple
 [SimpleOutput]
-StreamEncoder=x264
+StreamEncoder=${OBS_STREAM_ENCODER}
 VBitrate=${OBS_VIDEO_BITRATE}
 ABitrate=${OBS_AUDIO_BITRATE}
 Preset=${OBS_ENCODER_PRESET}

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -33,6 +33,14 @@ case "${OBS_QUALITY_PRESET:-high}" in
     ;;
 esac
 
+# Stream encoder selection. Default x264 (software) keeps stage-1 /
+# local dev / Mac k3d working without /dev/dri exposed. Override via
+# OBS_STREAM_ENCODER=ffmpeg_vaapi (k8s configmap in prod-1) to use
+# the host's Intel iGPU for hardware H.264 encode, dropping x264's
+# 15-25% P-core cost at 1080p60.
+export OBS_STREAM_ENCODER="${OBS_STREAM_ENCODER:-x264}"
+echo "OBS stream encoder: ${OBS_STREAM_ENCODER}"
+
 # OBS 32 split the legacy global.ini in two: app-level settings stayed in
 # global.ini (BrowserHWAccel etc.) and user-preference settings moved to
 # user.ini. Seed both so OBS sees a complete config and never prompts about

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:24.04
 
+# libva2 / libva-drm2 / mesa-va-drivers / vainfo are the userspace
+# VA-API plumbing libvlc needs to discover and use /dev/dri/renderD128
+# when VLC_AVCODEC_HW is "any" or "vaapi". intel-media-va-driver-non-free
+# is the actual Intel-specific driver and is amd64-only on Ubuntu
+# multiverse, so installed conditionally.
+ARG TARGETARCH
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -8,16 +14,22 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     curl \
     git \
     grc \
+    libva-drm2 \
+    libva2 \
     libvlc-dev \
+    mesa-va-drivers \
     net-tools \
     pkg-config \
     supervisor \
     syslog-ng \
+    vainfo \
     vim \
     vlc-plugin-base \
+  && if [ "$TARGETARCH" = "amd64" ]; then \
+       apt-get install -y --no-install-recommends intel-media-va-driver-non-free; \
+     fi \
   && rm -rf /var/lib/apt/lists/*
 
-ARG TARGETARCH
 RUN curl -fsSL https://go.dev/dl/go1.26.3.linux-${TARGETARCH}.tar.gz \
   | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:/go/bin:${PATH}"

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -71,7 +71,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!discord",
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Join us on Discord: https://discord.gg/Bk9EuGdMX")
+				sayFn("Join us on Discord: https://discord.gg/hKvNgZrk52")
 			},
 		},
 		{

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -16,8 +16,13 @@ type VlcServerConfig struct {
 	RunDir string `default:"/opt/data/run" envconfig:"RUN_DIR"`
 
 	// VlcFileCaching is the libvlc --file-caching value in milliseconds.
-	// Defaults to today's hardcoded value; tune per-host without recompiling.
-	VlcFileCaching int `default:"1111" envconfig:"VLC_FILE_CACHING"`
+	// Tune per-host without recompiling. Lower = faster between-clip
+	// startup (smaller frame gap that OBS's ffmpeg_source has to ride
+	// out before disconnect/reconnect kicks in); higher = more headroom
+	// for bursty disk/NFS read latency. 300ms is a working baseline for
+	// local-NFS-backed playback; the prior 1111 was unscientific tuning
+	// from years ago that left a >1s frame gap on each clip transition.
+	VlcFileCaching int `default:"300" envconfig:"VLC_FILE_CACHING"`
 	// VlcAvcodecHw is the libvlc --avcodec-hw value (Linux-only). One of
 	// any, none, vaapi, vdpau_avcodec, cuda. "any" lets libvlc pick the
 	// best available backend based on the host hardware: VAAPI on Intel

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -19,9 +19,16 @@ type VlcServerConfig struct {
 	// Defaults to today's hardcoded value; tune per-host without recompiling.
 	VlcFileCaching int `default:"1111" envconfig:"VLC_FILE_CACHING"`
 	// VlcAvcodecHw is the libvlc --avcodec-hw value (Linux-only). One of
-	// none, vdpau_avcodec, cuda. Only applied on Linux hosts; ignored on
-	// Windows/Darwin (matches today's platform-specific flag layering).
-	VlcAvcodecHw string `default:"vdpau_avcodec" envconfig:"VLC_AVCODEC_HW"`
+	// any, none, vaapi, vdpau_avcodec, cuda. "any" lets libvlc pick the
+	// best available backend based on the host hardware: VAAPI on Intel
+	// iGPUs (the prod-1 minipc path, /dev/dri/renderD128 exposed via
+	// hostPath mount), VDPAU on NVIDIA hosts, none if no acceleration
+	// is reachable. The prior "vdpau_avcodec" default was NVIDIA-specific
+	// and silently fell back to software decode on Intel — undocumented
+	// performance loss on every adanalife host. Only applied on Linux
+	// hosts; ignored on Windows/Darwin (matches today's platform-specific
+	// flag layering).
+	VlcAvcodecHw string `default:"any" envconfig:"VLC_AVCODEC_HW"`
 	// VlcVout is the libvlc --vout value (Linux-only). Defaults to dummy
 	// (headless container, no X server). For local-display modes on
 	// Linux, set VLC_VOUT=x11. Only applied on Linux hosts; ignored on

--- a/pkg/httpmw/recovery.go
+++ b/pkg/httpmw/recovery.go
@@ -1,0 +1,47 @@
+package httpmw
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+)
+
+// Recovery is a negroni-compatible middleware that catches panics in the
+// request goroutine, logs the stack via slog, calls an optional OnPanic
+// hook (typically to bump a metrics counter), then writes a 500 response.
+//
+// It replaces negroni.Recovery so panic events flow through the project's
+// slog handler chain (console + OTel + Sentry breadcrumbs/events) and can
+// be alerted on via a metrics counter.
+type Recovery struct {
+	// OnPanic is called with the recovered value before the 500 is
+	// written. Typical use is to increment a counter like
+	// instrumentation.HTTPPanics.Inc(serviceName).
+	OnPanic func(r any)
+}
+
+// NewRecovery constructs a Recovery middleware.
+func NewRecovery(onPanic func(r any)) *Recovery {
+	return &Recovery{OnPanic: onPanic}
+}
+
+// ServeHTTP implements negroni.Handler.
+func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer func() {
+		if err := recover(); err != nil {
+			stack := debug.Stack()
+			slog.ErrorContext(r.Context(), "panic recovered",
+				"err", fmt.Sprintf("%v", err),
+				"method", r.Method,
+				"path", r.URL.Path,
+				"stack", string(stack),
+			)
+			if rec.OnPanic != nil {
+				rec.OnPanic(err)
+			}
+			http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+	}()
+	next(rw, r)
+}

--- a/pkg/httpmw/recovery_test.go
+++ b/pkg/httpmw/recovery_test.go
@@ -1,0 +1,68 @@
+package httpmw
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/urfave/negroni/v3"
+)
+
+func TestRecoveryCatchesPanic(t *testing.T) {
+	var called bool
+	var recovered any
+	rec := NewRecovery(func(r any) {
+		called = true
+		recovered = r
+	})
+
+	n := negroni.New(rec)
+	n.UseHandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	})
+
+	w := httptest.NewRecorder()
+	n.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	if !called {
+		t.Fatal("OnPanic was not invoked")
+	}
+	if got, ok := recovered.(string); !ok || got != "kaboom" {
+		t.Fatalf("OnPanic got %v, want \"kaboom\"", recovered)
+	}
+}
+
+func TestRecoveryPassThrough(t *testing.T) {
+	rec := NewRecovery(func(any) { t.Fatal("OnPanic should not fire when there's no panic") })
+
+	n := negroni.New(rec)
+	n.UseHandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	n.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestRecoveryNilCallback(t *testing.T) {
+	rec := NewRecovery(nil)
+
+	n := negroni.New(rec)
+	n.UseHandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	})
+
+	w := httptest.NewRecorder()
+	n.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (nil OnPanic should still recover)", w.Code)
+	}
+}

--- a/pkg/httpmw/slog_logger.go
+++ b/pkg/httpmw/slog_logger.go
@@ -1,0 +1,55 @@
+// Package httpmw holds HTTP middleware shared across tripbot's web servers
+// (tripbot, vlc-server, onscreens-server).
+package httpmw
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/urfave/negroni/v3"
+)
+
+// healthPaths are logged at Debug instead of Info so kubelet's liveness
+// and readiness probes don't dominate the default log stream. Other
+// frequent paths (e.g. /metrics) stay at Info — add them here if they
+// become noisy.
+var healthPaths = map[string]bool{
+	"/health/live":  true,
+	"/health/ready": true,
+}
+
+// SlogLogger is a negroni-compatible middleware that emits one slog
+// record per HTTP request. It replaces negroni.Logger so request logs
+// flow through the project's slog handlers (console + OTel + Sentry)
+// and structured fields land cleanly in Loki.
+type SlogLogger struct{}
+
+// NewSlogLogger constructs a SlogLogger.
+func NewSlogLogger() *SlogLogger { return &SlogLogger{} }
+
+// ServeHTTP implements negroni.Handler.
+func (l *SlogLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
+	next(rw, r)
+
+	status := 0
+	size := 0
+	if res, ok := rw.(negroni.ResponseWriter); ok {
+		status = res.Status()
+		size = res.Size()
+	}
+
+	level := slog.LevelInfo
+	if healthPaths[r.URL.Path] {
+		level = slog.LevelDebug
+	}
+	slog.LogAttrs(r.Context(), level, "http request",
+		slog.String("method", r.Method),
+		slog.String("path", r.URL.Path),
+		slog.Int("status", status),
+		slog.Int("bytes", size),
+		slog.Duration("duration", time.Since(start)),
+		slog.String("remote", r.RemoteAddr),
+	)
+}

--- a/pkg/httpmw/slog_logger_test.go
+++ b/pkg/httpmw/slog_logger_test.go
@@ -1,0 +1,57 @@
+package httpmw
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/urfave/negroni/v3"
+)
+
+func TestSlogLoggerLevelByPath(t *testing.T) {
+	cases := []struct {
+		path     string
+		wantLvl  string
+		notLevel string
+	}{
+		{path: "/health/live", wantLvl: "DEBUG", notLevel: "INFO"},
+		{path: "/health/ready", wantLvl: "DEBUG", notLevel: "INFO"},
+		{path: "/anything-else", wantLvl: "INFO", notLevel: "DEBUG"},
+		{path: "/health/", wantLvl: "INFO", notLevel: "DEBUG"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			n := negroni.New(NewSlogLogger())
+			n.UseHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil).WithContext(context.Background())
+			rec := httptest.NewRecorder()
+			n.ServeHTTP(rec, req)
+
+			out := buf.String()
+			if !strings.Contains(out, "level="+tc.wantLvl) {
+				t.Fatalf("want level=%s in log line, got %q", tc.wantLvl, out)
+			}
+			if strings.Contains(out, "level="+tc.notLevel) {
+				t.Fatalf("did not want level=%s in log line, got %q", tc.notLevel, out)
+			}
+			if !strings.Contains(out, "path="+tc.path) {
+				t.Fatalf("want path=%s in log line, got %q", tc.path, out)
+			}
+			if !strings.Contains(out, "status=200") {
+				t.Fatalf("want status=200 in log line, got %q", out)
+			}
+		})
+	}
+}

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -26,6 +26,20 @@ var (
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
+
+	twitchHelixRateRemaining = mustGauge("twitch_helix_rate_limit_remaining", "Last-seen Ratelimit-Remaining header from Twitch Helix responses (per app-access bearer)")
+	twitchHelixRateLimit     = mustGauge("twitch_helix_rate_limit_total", "Last-seen Ratelimit-Limit header from Twitch Helix responses (per app-access bearer)")
+
+	cronRuns     = mustCounter("tripbot_cron_runs_total", "Total cron job invocations, labeled by job")
+	cronPanics   = mustCounter("tripbot_cron_panics_total", "Cron job panics recovered, labeled by job")
+	cronLastRun  = mustGauge("tripbot_cron_last_run_timestamp_seconds", "Unix timestamp of the most recent completion of each cron job, labeled by job")
+	cronDuration = mustHistogram(
+		"tripbot_cron_duration_seconds",
+		"Cron job duration in seconds, labeled by job",
+		0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60,
+	)
+
+	httpPanics = mustCounter("tripbot_http_panics_total", "HTTP handler panics recovered, labeled by service")
 )
 
 // ChatMessages exposes the chat-message counter through a tiny stable API
@@ -57,6 +71,22 @@ var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followe
 // TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
 // like "GetUsers"; statusCode is the HTTP status reported by Twitch.
 var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
+
+// TwitchHelixRateLimit exposes the per-bearer Helix rate-budget gauges.
+// SetRemaining + SetLimit are called by the response-recording transport
+// on every Helix call so dashboards / alerts can see headroom without
+// waiting for a 429.
+var TwitchHelixRateLimit = twitchHelixRateLimitIface{remaining: twitchHelixRateRemaining, limit: twitchHelixRateLimit}
+
+// Cron exposes cron job metrics. Observe(job, seconds) is called on every
+// completion (success or recovered panic); Panic(job) is additionally
+// called when a recover() fires. Together they enable "stalled cron" and
+// "panicking cron" alerts.
+var Cron = cronIface{runs: cronRuns, panics: cronPanics, lastRun: cronLastRun, duration: cronDuration}
+
+// HTTPPanics exposes the HTTP-handler panic counter. Increment from a
+// recovery middleware that catches panics in the request goroutine.
+var HTTPPanics = httpPanicsIface{counter: httpPanics}
 
 type chatCounterIface struct{ counter metric.Int64Counter }
 
@@ -108,6 +138,50 @@ func (h twitchHelixErrorsIface) Inc(endpoint string, statusCode int) {
 		attribute.String("endpoint", endpoint),
 		attribute.Int("status_code", statusCode),
 	))
+}
+
+type twitchHelixRateLimitIface struct {
+	remaining metric.Int64Gauge
+	limit     metric.Int64Gauge
+}
+
+func (r twitchHelixRateLimitIface) SetRemaining(n int64) {
+	r.remaining.Record(context.Background(), n)
+}
+
+func (r twitchHelixRateLimitIface) SetLimit(n int64) {
+	r.limit.Record(context.Background(), n)
+}
+
+type cronIface struct {
+	runs     metric.Int64Counter
+	panics   metric.Int64Counter
+	lastRun  metric.Int64Gauge
+	duration metric.Float64Histogram
+}
+
+// Observe records a completed cron run: bumps the run counter, records the
+// duration, and updates the last-run timestamp. Call on every completion,
+// including when a panic was recovered, so "no successful run in 3× interval"
+// alerts still see activity from a panicking job.
+func (c cronIface) Observe(job string, seconds float64, now int64) {
+	attr := metric.WithAttributes(attribute.String("job", job))
+	c.runs.Add(context.Background(), 1, attr)
+	c.duration.Record(context.Background(), seconds, attr)
+	c.lastRun.Record(context.Background(), now, attr)
+}
+
+// Panic records a cron panic. Call from a recover() handler before Observe.
+func (c cronIface) Panic(job string) {
+	c.panics.Add(context.Background(), 1, metric.WithAttributes(attribute.String("job", job)))
+}
+
+type httpPanicsIface struct{ counter metric.Int64Counter }
+
+// Inc records one recovered HTTP-handler panic, labeled by service
+// (typically c.Conf.ServerType: "tripbot" / "vlc_server" / "onscreens_server").
+func (h httpPanicsIface) Inc(service string) {
+	h.counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("service", service)))
 }
 
 func mustCounter(name, desc string) metric.Int64Counter {

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -10,6 +10,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -77,7 +78,10 @@ func Start() {
 	// negroni.New + explicit middleware so we can swap negroni's stdlib
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
-	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
+	app := negroni.New(
+		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
+		httpmw.NewSlogLogger(),
+	)
 
 	metricsMw := middleware.New(middleware.Config{
 		Recorder: metrics.NewRecorder(metrics.Config{}),

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -9,6 +9,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -73,7 +74,10 @@ func Start() {
 		helpers.PrintAllRoutes(r)
 	}
 
-	app := negroni.Classic()
+	// negroni.New + explicit middleware so we can swap negroni's stdlib
+	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
+	// middleware from negroni.Classic is dropped (no public/ directory).
+	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
 
 	metricsMw := middleware.New(middleware.Config{
 		Recorder: metrics.NewRecorder(metrics.Config{}),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -71,7 +72,10 @@ func Start(ctx context.Context) {
 	// negroni.New + explicit middleware so we can swap negroni's stdlib
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
-	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
+	app := negroni.New(
+		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
+		httpmw.NewSlogLogger(),
+	)
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -67,9 +68,10 @@ func Start(ctx context.Context) {
 		helpers.PrintAllRoutes(r)
 	}
 
-	// negroni classic adds panic recovery, logger, and static file middlewares
-	// c.p. https://github.com/urfave/negroni
-	app := negroni.Classic()
+	// negroni.New + explicit middleware so we can swap negroni's stdlib
+	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
+	// middleware from negroni.Classic is dropped (no public/ directory).
+	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -24,7 +24,11 @@ import (
 // no trail in Tempo; with it, each helix.GetUsers / GetSubscriptions / etc.
 // shows up as a span. Pairs with the otelhttp transports already used by
 // pkg/vlc-client and pkg/onscreens-client.
-var helixHTTPClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+//
+// The rateLimitRecorder wraps the otelhttp transport so every Helix
+// response also updates the twitch_helix_rate_limit_* gauges — dashboards
+// can see remaining headroom without waiting for a 429.
+var helixHTTPClient = &http.Client{Transport: rateLimitRecorder{next: otelhttp.NewTransport(http.DefaultTransport)}}
 
 // Scopes is the OAuth scope set requested for the bot account. Single source
 // of truth — referenced by Client() (App Access Token request),

--- a/pkg/twitch/helix_ratelimit.go
+++ b/pkg/twitch/helix_ratelimit.go
@@ -1,0 +1,33 @@
+package twitch
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+)
+
+// rateLimitRecorder is a RoundTripper that reads Twitch Helix's
+// Ratelimit-* response headers and surfaces them as OTel gauges, so
+// dashboards / alerts can see remaining headroom without waiting for
+// 429s. Helix returns these headers on every response; the per-bearer
+// quota is shared across all calls from the same App Access Token.
+type rateLimitRecorder struct{ next http.RoundTripper }
+
+func (rt rateLimitRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.next.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if v := resp.Header.Get("Ratelimit-Remaining"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			instrumentation.TwitchHelixRateLimit.SetRemaining(int64(n))
+		}
+	}
+	if v := resp.Header.Get("Ratelimit-Limit"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			instrumentation.TwitchHelixRateLimit.SetLimit(int64(n))
+		}
+	}
+	return resp, err
+}

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -10,6 +10,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -75,10 +76,11 @@ func Start(ctx context.Context) {
 		helpers.PrintAllRoutes(r)
 	}
 
-	// negroni classic adds panic recovery, logger, and static file middlewares
-	// c.p. https://github.com/urfave/negroni
+	// negroni.New + explicit middleware so we can swap negroni's stdlib
+	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
+	// middleware from negroni.Classic is dropped (no public/ directory).
 	//TODO: consider adding HTMLPanicFormatter
-	app := negroni.Classic()
+	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -11,6 +11,7 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -80,7 +81,10 @@ func Start(ctx context.Context) {
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
 	//TODO: consider adding HTMLPanicFormatter
-	app := negroni.New(negroni.NewRecovery(), httpmw.NewSlogLogger())
+	app := negroni.New(
+		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
+		httpmw.NewSlogLogger(),
+	)
 
 	// attach http-metrics (prometheus) middleware
 	metricsMw := middleware.New(middleware.Config{


### PR DESCRIPTION
Patch release rolling up the 5 PRs merged to develop since v2.9.2.

## Highlights

**Production-side observability surface** — cron jobs now emit run-count / duration / last-run-timestamp metrics and recover panics (so a single failing job no longer kills the scheduler goroutine); HTTP handlers count panics per service; the Helix client surfaces its `Ratelimit-*` response headers as gauges so the 800-req/min quota is visible before a 429 fires. ([#586])

**Kubelet probe log spam fix** — `/health/live` + `/health/ready` log at `slog.LevelDebug` via a new slog-native request-logger middleware that also routes structured fields to Loki. ([#583])

**VAAPI hardware acceleration** — OBS H.264 encoding + VLC decoding now offload to the Intel iGPU; pairs with [adanalife/infra#499](https://github.com/adanalife/infra/pull/499) (Intel device plugin + `gpu.intel.com/i915` requests). ([#584])

**Smooth inter-clip transitions** in the dashcam stream. ([#582])

**`!discord` link no longer expires.** ([#581])

## Out of scope (deferred)

- `release/v2.9.2` shipped without a CHANGELOG entry — backfill is its own follow-up.
- Real `/health/ready` semantics, Pyroscope continuous profiling, and the matching infra-side bits (SENTRY_ENVIRONMENT per overlay, Go-runtime alerts, dashboard panels) are open in separate PRs — they ride the next release.

## Test plan

- [ ] Pre-merge: CI green on this PR (`gh pr checks <N>`)
- [ ] Merge with **Create a merge commit** (not squash) per [merge-strategy-by-target-branch](../vault/decisions/merge-strategy-by-target-branch.md). Default bump = patch; no `#minor` / `#major` keyword needed.
- [ ] `auto-tag.yml` produces `v2.9.3`
- [ ] `release.yml` ships multi-arch images for tripbot / vlc / obs
- [ ] Stage-1 smoke per `vault/tripbot/release-checklist.md`