### PR TITLE
refactor(vlc-server): construct via New(), drop package globals

### DIFF
--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -25,6 +25,10 @@ var version = "dev"
 
 var telemetryShutdown telemetry.ShutdownFunc
 
+// srv is the running vlc-server, captured in main so gracefulShutdown can
+// reach it from its signal-handler goroutine.
+var srv *vlcServer.Server
+
 func main() {
 	slog.Info("vlc-server starting", "version", version)
 
@@ -55,23 +59,26 @@ func main() {
 	// set up error logging
 	initializeErrorLogger()
 
-	// start VLC
-	vlcServer.InitPlayer()
-	vlcServer.PlayRandom() // play a random video
+	// start VLC + load media; surfaces libvlc init errors instead of
+	// fatalling-during-init from inside the package.
+	var err error
+	srv, err = vlcServer.New(vlcServer.Config{Version: version})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Shutdown()
+
+	srv.PlayRandom() // play a random video
 
 	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
 	// surface them as OTel gauges. No-op when telemetry is disabled.
-	vlcServer.StartStatsPoller(context.Background(), 5*time.Second)
+	srv.StartStatsPoller(context.Background(), 5*time.Second)
 
 	// poll the OBS WebSocket for streaming state + render/output stats.
 	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 
 	// start the webserver
-	vlcServer.SetVersion(version)
-	vlcServer.Start(shutdownCtx)
-
-	// listen for termination signals and gracefully shutdown
-	defer vlcServer.Shutdown()
+	srv.Start(shutdownCtx)
 }
 
 // initializeTelemetry brings up OpenTelemetry providers (traces, metrics,
@@ -112,7 +119,9 @@ func gracefulShutdown() {
 
 	slog.Warn("caught CTRL-C, shutting down")
 	// anything below this probably won't be executed
-	vlcServer.Shutdown()
+	if srv != nil {
+		srv.Shutdown()
+	}
 	//TODO: stop cron here
 	sentry.Flush(time.Second * 5)
 	if telemetryShutdown != nil {

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -12,40 +12,33 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// versionTag is set by main via SetVersion; overridden at build time
-// through `-ldflags "-X main.version=..."`.
-var versionTag = "dev"
-
-// SetVersion lets cmd/vlc-server inject its build-time version string
-// before the HTTP server starts.
-func SetVersion(v string) {
-	if v != "" {
-		versionTag = v
-	}
-}
-
 // healthcheck URL, for tools to verify the stream is alive
-func healthHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "OK")
 }
 
-// versionHandler returns build metadata as JSON. The tag comes from the
-// build-time ldflag; sha + built_at are read from the binary's embedded
-// VCS info (Go's automatic -buildvcs).
-func versionHandler(w http.ResponseWriter, r *http.Request) {
+// versionHandler returns build metadata as JSON. The tag comes from
+// Server.Version (injected via Config at construction time); sha +
+// built_at are read from the binary's embedded VCS info (Go's automatic
+// -buildvcs).
+func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
+	tag := s.Version
+	if tag == "" {
+		tag = "dev"
+	}
 	resp := struct {
 		Tag     string `json:"tag"`
 		Sha     string `json:"sha"`
 		BuiltAt string `json:"built_at"`
-	}{Tag: versionTag}
+	}{Tag: tag}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, s := range info.Settings {
-			switch s.Key {
+		for _, st := range info.Settings {
+			switch st.Key {
 			case "vcs.revision":
-				resp.Sha = s.Value
+				resp.Sha = st.Value
 			case "vcs.time":
-				resp.BuiltAt = s.Value
+				resp.BuiltAt = st.Value
 			}
 		}
 	}
@@ -56,28 +49,28 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {
 	// return the currently-playing file
-	fmt.Fprint(w, currentlyPlaying())
+	fmt.Fprint(w, s.currentlyPlaying())
 }
 
-func vlcPlayHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) vlcPlayHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	spew.Dump(vars)
 
 	videoFile := vars["video"]
 
 	spew.Dump(videoFile)
-	playVideoFile(videoFile)
+	s.playVideoFile(videoFile)
 
 	//TODO: better response
 	fmt.Fprintf(w, "OK")
 }
 
-func vlcBackHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) vlcBackHandler(w http.ResponseWriter, r *http.Request) {
 	num, ok := r.URL.Query()["n"]
 	if !ok || len(num) > 1 {
-		back(1)
+		s.back(1)
 		return
 	}
 	i, err := strconv.Atoi(num[0])
@@ -87,17 +80,17 @@ func vlcBackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	back(i)
+	s.back(i)
 
 	//TODO: better response
 	fmt.Fprintf(w, "OK")
 
 }
 
-func vlcSkipHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) vlcSkipHandler(w http.ResponseWriter, r *http.Request) {
 	num, ok := r.URL.Query()["n"]
 	if !ok || len(num) > 1 {
-		skip(1)
+		s.skip(1)
 		return
 	}
 	i, err := strconv.Atoi(num[0])
@@ -107,29 +100,29 @@ func vlcSkipHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skip(i)
+	s.skip(i)
 
 	//TODO: better response
 	fmt.Fprintf(w, "OK")
 }
 
-func vlcRandomHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) vlcRandomHandler(w http.ResponseWriter, r *http.Request) {
 	// play a random file
-	err := PlayRandom()
+	err := s.PlayRandom()
 	if err != nil {
 		http.Error(w, "error playing random", http.StatusInternalServerError)
 	}
 	fmt.Fprintf(w, "OK")
 }
 
-func faviconHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) faviconHandler(w http.ResponseWriter, r *http.Request) {
 	//	// return a favicon if anyone asks for one
 	//} else if r.URL.Path == "/favicon.ico" {
 	http.ServeFile(w, r, "assets/favicon.ico")
 }
 
 //TODO: use more StatusExpectationFailed instead of http.StatusUnprocessableEntity
-func catchAllHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) catchAllHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		http.Error(w, "404 not found", http.StatusNotFound)

--- a/pkg/vlc-server/handlers_test.go
+++ b/pkg/vlc-server/handlers_test.go
@@ -8,14 +8,12 @@ import (
 )
 
 func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
-	saved := versionTag
-	defer func() { versionTag = saved }()
-	SetVersion("v9.9.9-test")
+	s := &Server{Version: "v9.9.9-test"}
 
 	req := httptest.NewRequest(http.MethodGet, "/version", nil)
 	rec := httptest.NewRecorder()
 
-	versionHandler(rec, req)
+	s.versionHandler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -41,10 +39,11 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 // input before reaching libvlc, so we never touch the real player.
 
 func TestVlcSkipHandlerInvalidIntReturns422(t *testing.T) {
+	s := &Server{}
 	req := httptest.NewRequest(http.MethodGet, "/vlc/skip?n=notanumber", nil)
 	rec := httptest.NewRecorder()
 
-	vlcSkipHandler(rec, req)
+	s.vlcSkipHandler(rec, req)
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusUnprocessableEntity)
@@ -52,10 +51,11 @@ func TestVlcSkipHandlerInvalidIntReturns422(t *testing.T) {
 }
 
 func TestVlcBackHandlerInvalidIntReturns422(t *testing.T) {
+	s := &Server{}
 	req := httptest.NewRequest(http.MethodGet, "/vlc/back?n=notanumber", nil)
 	rec := httptest.NewRecorder()
 
-	vlcBackHandler(rec, req)
+	s.vlcBackHandler(rec, req)
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusUnprocessableEntity)
@@ -63,10 +63,11 @@ func TestVlcBackHandlerInvalidIntReturns422(t *testing.T) {
 }
 
 func TestCatchAllHandlerNonGet(t *testing.T) {
+	s := &Server{}
 	req := httptest.NewRequest(http.MethodPost, "/anything", nil)
 	rec := httptest.NewRecorder()
 
-	catchAllHandler(rec, req)
+	s.catchAllHandler(rec, req)
 
 	body := rec.Body.String()
 	if body == "" {
@@ -75,10 +76,11 @@ func TestCatchAllHandlerNonGet(t *testing.T) {
 }
 
 func TestCatchAllHandlerGet404(t *testing.T) {
+	s := &Server{}
 	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
 	rec := httptest.NewRecorder()
 
-	catchAllHandler(rec, req)
+	s.catchAllHandler(rec, req)
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -1,26 +1,25 @@
 package vlcServer
 
 import (
-	"log/slog"
 	"errors"
+	"log/slog"
 	"math/rand"
 	"path/filepath"
-
 )
 
 //TODO: should we handle the case where index is outside range?
 // or just explicitly pass in what we get here?
-func playAtIndex(index int) error {
+func (s *Server) playAtIndex(index int) error {
 	// start playing the media
-	return playlist.PlayAtIndex(uint(index))
+	return s.Playlist.PlayAtIndex(uint(index))
 }
 
 // playVideoFile plays a video file in the playlist
-func playVideoFile(vidStr string) error {
+func (s *Server) playVideoFile(vidStr string) error {
 	// extract just the filename
 	videoFile := filepath.Base(vidStr)
-	index := getIndex(videoFile)
-	return playAtIndex(index)
+	index := s.getIndex(videoFile)
+	return s.playAtIndex(index)
 }
 
 // nextIndex computes a wrapped playlist position. Pure function so it can
@@ -37,18 +36,18 @@ func nextIndex(current, offset, length int) int {
 }
 
 // skip plays the video n items forward in the playlist,
-func skip(n int) error {
-	return playAtIndex(nextIndex(currentIndex(), n, len(videoFiles)))
+func (s *Server) skip(n int) error {
+	return s.playAtIndex(nextIndex(s.currentIndex(), n, len(s.VideoFiles)))
 }
 
 // back plays the video n items backward in the playlist,
-func back(n int) error {
-	return playAtIndex(nextIndex(currentIndex(), -n, len(videoFiles)))
+func (s *Server) back(n int) error {
+	return s.playAtIndex(nextIndex(s.currentIndex(), -n, len(s.VideoFiles)))
 }
 
 // PlayRandom plays a random file from the playlist
-func PlayRandom() error {
-	count, err := mediaList.Count()
+func (s *Server) PlayRandom() error {
+	count, err := s.MediaList.Count()
 	if err != nil {
 		slog.Error("error counting media in VLC media list", "err", err)
 	}
@@ -62,11 +61,11 @@ func PlayRandom() error {
 	random := rand.Intn(count)
 
 	// start playing the media
-	return playAtIndex(random)
+	return s.playAtIndex(random)
 }
 
-func getIndex(vidStr string) int {
-	for i, file := range videoFiles {
+func (s *Server) getIndex(vidStr string) int {
+	for i, file := range s.VideoFiles {
 		if file == vidStr {
 			return i
 		}
@@ -74,8 +73,8 @@ func getIndex(vidStr string) int {
 	return -1
 }
 
-func currentIndex() int {
+func (s *Server) currentIndex() int {
 	// extract just the filename
-	videoFile := filepath.Base(currentlyPlaying())
-	return getIndex(videoFile)
+	videoFile := filepath.Base(s.currentlyPlaying())
+	return s.getIndex(videoFile)
 }

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	libvlc "github.com/adrg/libvlc-go/v3"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -31,11 +32,42 @@ import (
 // handler doesn't block process exit indefinitely.
 const shutdownTimeout = 15 * time.Second
 
+// Config is the construction-time configuration passed to New. It carries
+// only the runtime knobs the binary needs to inject at startup; everything
+// else flows in via the package-level c.Conf read from env.
+type Config struct {
+	// Version is the build-time version string, surfaced via /version.
+	Version string
+}
+
+// Server is the vlc-server runtime: libvlc handles plus the embedded HTTP
+// server. Constructed via New so libvlc init failures surface as errors
+// instead of fatal-during-init side effects.
+type Server struct {
+	Version    string
+	Player     *libvlc.Player
+	Playlist   *libvlc.ListPlayer
+	MediaList  *libvlc.MediaList
+	VideoFiles []string
+
+	http *http.Server
+}
+
+// New constructs a Server, initializing libvlc and loading media off disk.
+// Returns an error if libvlc init or media loading fails.
+func New(cfg Config) (*Server, error) {
+	s := &Server{Version: cfg.Version}
+	if err := s.initPlayer(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 // Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
 // via signal.NotifyContext) the server stops accepting new connections and
 // waits up to shutdownTimeout for in-flight requests to complete before
 // returning.
-func Start(ctx context.Context) {
+func (s *Server) Start(ctx context.Context) {
 	slog.InfoContext(ctx, "starting VLC web server", "bind", c.Conf.VlcServerBindAddress)
 
 	r := mux.NewRouter()
@@ -43,22 +75,22 @@ func Start(ctx context.Context) {
 	// healthcheck endpoints
 	//TODO: handle HEAD requests here too
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.Handle("/", tagged("/health/", healthHandler))
-	hp.Handle("/live", tagged("/health/live", healthHandler))
-	hp.Handle("/ready", tagged("/health/ready", healthHandler))
+	hp.Handle("/", tagged("/health/", s.healthHandler))
+	hp.Handle("/live", tagged("/health/live", s.healthHandler))
+	hp.Handle("/ready", tagged("/health/ready", s.healthHandler))
 
 	// version endpoint — returns build metadata as JSON
-	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")
+	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")
 
 	// vlc endpoints
 	vlc := r.PathPrefix("/vlc").Methods("GET").Subrouter()
-	vlc.Handle("/current", tagged("/vlc/current", vlcCurrentHandler))
-	vlc.Handle("/play/{video}", tagged("/vlc/play/{video}", vlcPlayHandler))
-	vlc.Handle("/random", tagged("/vlc/random", vlcRandomHandler))
-	vlc.Handle("/back", tagged("/vlc/back", vlcBackHandler))
-	vlc.Handle("/back/{n}", tagged("/vlc/back/{n}", vlcBackHandler))
-	vlc.Handle("/skip", tagged("/vlc/skip", vlcSkipHandler))
-	vlc.Handle("/skip/{n}", tagged("/vlc/skip/{n}", vlcSkipHandler))
+	vlc.Handle("/current", tagged("/vlc/current", s.vlcCurrentHandler))
+	vlc.Handle("/play/{video}", tagged("/vlc/play/{video}", s.vlcPlayHandler))
+	vlc.Handle("/random", tagged("/vlc/random", s.vlcRandomHandler))
+	vlc.Handle("/back", tagged("/vlc/back", s.vlcBackHandler))
+	vlc.Handle("/back/{n}", tagged("/vlc/back/{n}", s.vlcBackHandler))
+	vlc.Handle("/skip", tagged("/vlc/skip", s.vlcSkipHandler))
+	vlc.Handle("/skip/{n}", tagged("/vlc/skip/{n}", s.vlcSkipHandler))
 
 	// onscreen endpoints now live in cmd/onscreens-server (separate binary,
 	// separate port). vlc-server no longer serves /onscreens/* — clients
@@ -68,10 +100,10 @@ func Start(ctx context.Context) {
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
 	// static assets
-	r.Handle("/favicon.ico", tagged("/favicon.ico", faviconHandler)).Methods("GET")
+	r.Handle("/favicon.ico", tagged("/favicon.ico", s.faviconHandler)).Methods("GET")
 
 	// catch everything else
-	r.Handle("/", tagged("/", catchAllHandler))
+	r.Handle("/", tagged("/", s.catchAllHandler))
 
 	if c.Conf.Verbose {
 		helpers.PrintAllRoutes(r)
@@ -106,7 +138,7 @@ func Start(ctx context.Context) {
 	// attaching routes to handler happens last
 	app.UseHandler(r)
 
-	srv := &http.Server{
+	s.http = &http.Server{
 		Addr: c.Conf.VlcServerBindAddress,
 		// Good practice to set timeouts to avoid Slowloris attacks.
 		WriteTimeout:   time.Second * 15,
@@ -121,7 +153,7 @@ func Start(ctx context.Context) {
 	// the expected return after Shutdown is called and is not an error.
 	serverErr := make(chan error, 1)
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErr <- err
 		}
 		close(serverErr)
@@ -136,7 +168,7 @@ func Start(ctx context.Context) {
 		slog.InfoContext(ctx, "shutting down VLC web server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
+		if err := s.http.Shutdown(shutdownCtx); err != nil {
 			slog.ErrorContext(shutdownCtx, "error during VLC web server shutdown", "err", err)
 		}
 	}

--- a/pkg/vlc-server/stats.go
+++ b/pkg/vlc-server/stats.go
@@ -8,14 +8,14 @@ import (
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 )
 
-// PollStats polls libvlc for playback statistics every interval and pushes
+// pollStats polls libvlc for playback statistics every interval and pushes
 // them through pkg/instrumentation. Intended to run as a long-lived
-// goroutine started after InitPlayer.
+// goroutine started after New.
 //
 // libvlc resets these counters when the current Media changes; we detect
 // that by watching for a negative delta in DisplayedPictures and skip the
 // FPS sample on that tick to avoid a phantom dip.
-func PollStats(ctx context.Context, interval time.Duration) {
+func (s *Server) pollStats(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -30,10 +30,10 @@ func PollStats(ctx context.Context, interval time.Duration) {
 		case <-ctx.Done():
 			return
 		case now := <-ticker.C:
-			if player == nil {
+			if s.Player == nil {
 				continue
 			}
-			media, err := player.Media()
+			media, err := s.Player.Media()
 			if err != nil || media == nil {
 				havePrev = false
 				continue
@@ -73,9 +73,9 @@ func PollStats(ctx context.Context, interval time.Duration) {
 	}
 }
 
-// StartStatsPoller is a tiny launcher wrapper so cmd/vlc-server can `go
-// vlcServer.StartStatsPoller(...)` without juggling its own goroutine.
-func StartStatsPoller(ctx context.Context, interval time.Duration) {
+// StartStatsPoller is a tiny launcher wrapper so cmd/vlc-server can
+// `srv.StartStatsPoller(...)` without juggling its own goroutine.
+func (s *Server) StartStatsPoller(ctx context.Context, interval time.Duration) {
 	slog.InfoContext(ctx, "starting libvlc stats poller", "interval", interval)
-	go PollStats(ctx, interval)
+	go s.pollStats(ctx, interval)
 }

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -13,15 +13,12 @@ import (
 	libvlc "github.com/adrg/libvlc-go/v3"
 )
 
-var player *libvlc.Player
-var playlist *libvlc.ListPlayer
-var mediaList *libvlc.MediaList
-var videoFiles []string
-
 //TODO: figure out if vdpau_avcodec can be better than none
 //TODO: there are a ton of potentially-useful avcodec flags
 
-// platform-invariant flags that never need per-host tuning
+// platform-invariant flags that never need per-host tuning.
+// Stays package-level: immutable build-time configuration; cgo init order
+// depends on these being package-scoped, not struct fields.
 var vlcStaticFlags = []string{
 	"--ignore-config", // ignore any config files that might get loaded
 	"--fullscreen",    // start fullscreened (only matters when VLC_OUTPUT renders a window; no-op headless)
@@ -97,39 +94,50 @@ var vlcVerboseFlags = []string{
 	"-vv", // be very verbose (used for debugging)
 }
 
-// InitPlayer creates a VLC player and sets up a playlist
-func InitPlayer() {
-	startVLC()
-	createPlayer()
-	setToLoop()
-	loadMedia()
+// initPlayer creates a VLC player and sets up a playlist. Order is
+// load-bearing: libvlc.Init must happen before any *libvlc* object can be
+// created, and the media list must be attached to the playlist before
+// media is added to it. Preserve this sequence verbatim.
+func (s *Server) initPlayer() error {
+	if err := startVLC(); err != nil {
+		return err
+	}
+	if err := s.createPlayer(); err != nil {
+		return err
+	}
+	if err := s.setToLoop(); err != nil {
+		return err
+	}
+	return s.loadMedia()
 }
 
-// Shutdown cleans up VLC as best it can
+// Shutdown cleans up VLC as best it can. The release order (player.Stop →
+// player.Release → libvlc.Release) is order-sensitive — releasing the
+// libvlc instance before the player segfaults. Preserve verbatim.
+//
 //TODO: are there more things to close gracefully?
-func Shutdown() {
+func (s *Server) Shutdown() {
 	if helpers.RunningOnDarwin() {
 		slog.Info("not stopping VLC on darwin")
 		return
 	}
-	err := player.Stop()
-	if err != nil {
-		slog.Error("error stopping player", "err", err)
+	if s.Player != nil {
+		if err := s.Player.Stop(); err != nil {
+			slog.Error("error stopping player", "err", err)
+		}
+		if err := s.Player.Release(); err != nil {
+			slog.Error("error releasing player", "err", err)
+		}
 	}
-	err = player.Release()
-	if err != nil {
-		slog.Error("error releasing player", "err", err)
-	}
-	err = libvlc.Release()
-	if err != nil {
+	if err := libvlc.Release(); err != nil {
 		slog.Error("error releasing libvlc", "err", err)
 	}
 }
 
 // currentlyPlaying finds the currently-playing video path
 // (it's pretty hacky right now)
-func currentlyPlaying() string {
-	cur, err := player.Media()
+func (s *Server) currentlyPlaying() string {
+	cur, err := s.Player.Media()
 	if err != nil {
 		slog.Error("error fetching currently-playing media", "err", err)
 	}
@@ -144,7 +152,7 @@ func currentlyPlaying() string {
 	return filepath.Base(path)
 }
 
-func startVLC() {
+func startVLC() error {
 	// build the base flag set from the static list + config-driven tuning
 	// values. Defaults in pkg/config/vlc-server reproduce what used to be
 	// hardcoded here, so unset env vars yield identical behavior.
@@ -185,53 +193,55 @@ func startVLC() {
 
 	// start up VLC with given command flags
 	if err := libvlc.Init(vlcCmdFlags...); err != nil {
-		terrors.Fatal(err, "error initializing VLC")
+		return fmt.Errorf("error initializing VLC: %w", err)
 	}
+	return nil
 }
 
-func createPlayer() {
-	var err error
-
+func (s *Server) createPlayer() error {
 	// create a new playlist-player
-	playlist, err = libvlc.NewListPlayer()
+	playlist, err := libvlc.NewListPlayer()
 	if err != nil {
-		terrors.Fatal(err, "error creating VLC playlist player")
+		return fmt.Errorf("error creating VLC playlist player: %w", err)
 	}
+	s.Playlist = playlist
 
 	// save the player so we can use it later
-	player, err = playlist.Player()
+	player, err := playlist.Player()
 	if err != nil {
-		terrors.Fatal(err, "error fetching VLC player")
+		return fmt.Errorf("error fetching VLC player: %w", err)
 	}
+	s.Player = player
 
 	// this will store all of our videos
-	mediaList, err = libvlc.NewMediaList()
+	mediaList, err := libvlc.NewMediaList()
 	if err != nil {
-		terrors.Fatal(err, "error creating VLC media list")
+		return fmt.Errorf("error creating VLC media list: %w", err)
 	}
+	s.MediaList = mediaList
 
 	// plug our medialist into the player
-	err = playlist.SetMediaList(mediaList)
-	if err != nil {
-		terrors.Fatal(err, "error setting VLC media list")
+	if err := playlist.SetMediaList(mediaList); err != nil {
+		return fmt.Errorf("error setting VLC media list: %w", err)
 	}
+	return nil
 }
 
-func setToLoop() {
+func (s *Server) setToLoop() error {
 	// set the player to loop forever
-	err := playlist.SetPlaybackMode(libvlc.Loop)
-	if err != nil {
-		terrors.Fatal(err, "error setting VLC playback mode")
+	if err := s.Playlist.SetPlaybackMode(libvlc.Loop); err != nil {
+		return fmt.Errorf("error setting VLC playback mode: %w", err)
 	}
+	return nil
 }
 
-func loadMedia() {
-	loadLocalMedia()
+func (s *Server) loadMedia() error {
+	return s.loadLocalMedia()
 }
 
 // loadLocalMedia walks the VideoDir and adds all videos to
 // the playlist.
-func loadLocalMedia() {
+func (s *Server) loadLocalMedia() error {
 	var filePaths []string
 	// add all files from the VideoDir to the medialist
 	err := filepath.Walk(c.Conf.VideoDir, func(path string, info os.FileInfo, err error) error {
@@ -247,24 +257,25 @@ func loadLocalMedia() {
 		filePaths = append(filePaths, path)
 		// add the video filename to videoFiles list
 		videoFile := filepath.Base(path)
-		videoFiles = append(videoFiles, videoFile)
+		s.VideoFiles = append(s.VideoFiles, videoFile)
 		return nil
 	})
 	if err != nil {
-		terrors.Fatal(err, "error walking VideoDir")
+		return fmt.Errorf("error walking VideoDir: %w", err)
 	}
 
 	// loop over the files and add their paths to VLC
 	for _, file := range filePaths {
 		media, err := libvlc.NewMediaFromPath(file)
 		if err != nil {
-			terrors.Fatal(err, "error creating media from path")
+			return fmt.Errorf("error creating media from path: %w", err)
 		}
 		if err := media.AddOptions(mediaOptions()...); err != nil {
-			terrors.Fatal(err, "error setting media options")
+			return fmt.Errorf("error setting media options: %w", err)
 		}
-		if err := mediaList.AddMedia(media); err != nil {
-			terrors.Fatal(err, "error adding files to VLC media list")
+		if err := s.MediaList.AddMedia(media); err != nil {
+			return fmt.Errorf("error adding files to VLC media list: %w", err)
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Converts `pkg/vlc-server` from package-level globals to a `*Server` struct constructed via `New(Config) (*Server, error)`. The libvlc handles (`Player`, `Playlist`, `MediaList`, `VideoFiles`) become struct fields; `PlayRandom`/`Shutdown`/`Start`/`StartStatsPoller` and the HTTP handlers become methods; `cmd/vlc-server/vlc-server.go` collapses its setup chain into one `New()` plus method calls.

## Why

The vlc-server binary has zero importers outside its own `main()` — `git grep \"vlc-server\\\"\" -- '*.go'` shows only `cmd/vlc-server/`, `pkg/vlc-server/server.go`, `pkg/vlc-server/vlc.go`, and `pkg/vlc-server/setup_test.go`. That means it can go directly to \"no globals, explicit construction\" final form in one PR. The chatbot in tripbot talks to vlc-server over HTTP, not via Go imports.

Immutable cgo flag arrays (`vlcStaticFlags`, `vlcCmdFlags`, etc.) stay package-level — they're build-time configuration, not state, and cgo init order depends on them being package-scoped.

The libvlc `Shutdown()` release order (`Player.Stop` → `Player.Release` → `libvlc.Release`) and the `initPlayer()` init order (`startVLC` → `createPlayer` → `setToLoop` → `loadMedia`) are preserved verbatim — both are order-sensitive and reordering segfaults.

## Test plan

- [ ] \`go build ./...\` clean (verified: macOS path, only pre-existing duplicate-rpath/-lvlc linker warnings).
- [ ] \`go vet ./pkg/vlc-server/...\` clean (verified via macOS path).
- [ ] \`go test ./pkg/vlc-server/...\` passes (verified in the testing devenv container).
- [ ] vlc-server binary starts cleanly against a real libvlc backend.
- [ ] In bin/devenv: video starts playing, \`!skip\` / \`!back\` / \`!timewarp\` from chat work end-to-end.
- [ ] \`Shutdown()\` ordering preserved — ctrl-c the process and confirm no libvlc segfaults.

Note: \`go vet ./...\` surfaces one pre-existing warning in \`cmd/vlc-server/vlc-server.go\` (\`misuse of unbuffered os.Signal channel\` in \`gracefulShutdown()\`) that exists on origin/develop and is not introduced by this PR.