### PR TITLE
refactor(onscreens-server): per-test Server, graceful shutdown ctx

### DIFF
--- a/cmd/onscreens-server/onscreens-server.go
+++ b/cmd/onscreens-server/onscreens-server.go
@@ -21,16 +21,34 @@ var version = "dev"
 
 var telemetryShutdown telemetry.ShutdownFunc
 
+// srv is the running onscreens-server, captured in main so
+// gracefulShutdown can reach it from its signal-handler goroutine.
+var srv *onscreensServer.Server
+
+// httpShutdownTimeout is how long gracefulShutdown waits for in-flight
+// requests to finish before forcing connections closed. 5s matches the
+// telemetry/sentry flush deadlines used below — the whole shutdown path
+// should complete in well under 15s so process supervisors don't SIGKILL
+// us mid-drain.
+const httpShutdownTimeout = 5 * time.Second
+
 func main() {
 	slog.Info("onscreens-server starting", "version", version)
 
 	// write the current pid to a pidfile
 	helpers.WritePidFile(c.Conf.OnscreensPidFile)
 
+	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
+	// to trigger a graceful shutdown so in-flight requests aren't cut.
+	// listenForShutdown's gracefulShutdown goroutine handles the rest of
+	// the app cleanup off the same signals.
+	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	// construct the server — runs all per-onscreen init (singletons +
 	// background loops) up front so the HTTP routes have everything to
 	// read by the time the listener accepts.
-	srv := onscreensServer.New(onscreensServer.Config{Version: version})
+	srv = onscreensServer.New(onscreensServer.Config{Version: version})
 
 	// await graceful shutdown signal
 	listenForShutdown()
@@ -41,8 +59,9 @@ func main() {
 	// set up error logging
 	initializeErrorLogger()
 
-	// start the webserver — blocks until ListenAndServe returns
-	if err := srv.Start(context.Background()); err != nil {
+	// start the webserver — blocks until ListenAndServe returns or the
+	// signal handler cancels shutdownCtx
+	if err := srv.Start(shutdownCtx); err != nil {
 		terrors.Fatal(err, "couldn't start server")
 	}
 }
@@ -68,7 +87,9 @@ func listenForShutdown() {
 	go gracefulShutdown()
 }
 
-// gracefulShutdown catches CTRL-C and cleans up
+// gracefulShutdown catches CTRL-C and cleans up. Drains the HTTP server
+// first (so in-flight onscreens-render requests don't get cut), then
+// flushes Sentry + telemetry exporters before exiting.
 func gracefulShutdown() {
 	ctrlC := make(chan os.Signal, 1)
 	signal.Notify(ctrlC,
@@ -81,6 +102,15 @@ func gracefulShutdown() {
 	<-ctrlC
 
 	slog.Warn("caught CTRL-C, shutting down")
+
+	if srv != nil {
+		httpCtx, cancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
+		if err := srv.Shutdown(httpCtx); err != nil {
+			slog.Error("error during onscreens-server HTTP shutdown", "err", err)
+		}
+		cancel()
+	}
+
 	sentry.Flush(time.Second * 5)
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/pkg/onscreens-server/handlers_test.go
+++ b/pkg/onscreens-server/handlers_test.go
@@ -12,7 +12,7 @@ import (
 // input before reaching the onscreen singletons.
 
 func TestOnscreensMiddleHandlerInvalidBase64Returns422(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/middle/show?msg=!!!not-base64!!!", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "show"})
@@ -26,7 +26,7 @@ func TestOnscreensMiddleHandlerInvalidBase64Returns422(t *testing.T) {
 }
 
 func TestOnscreensMiddleHandlerMissingMsgReturns417(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/middle/show", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "show"})
@@ -40,7 +40,7 @@ func TestOnscreensMiddleHandlerMissingMsgReturns417(t *testing.T) {
 }
 
 func TestOnscreensMiddleHandlerUnknownActionReturns417(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/middle/explode", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "explode"})
@@ -54,7 +54,7 @@ func TestOnscreensMiddleHandlerUnknownActionReturns417(t *testing.T) {
 }
 
 func TestOnscreensLeaderboardHandlerInvalidBase64Returns422(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/leaderboard/show?content=!!!", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "show"})
@@ -68,7 +68,7 @@ func TestOnscreensLeaderboardHandlerInvalidBase64Returns422(t *testing.T) {
 }
 
 func TestOnscreensFlagHandlerUnknownActionReturns417(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/flag/explode", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "explode"})

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -74,12 +74,16 @@ func New(cfg Config) *Server {
 }
 
 // Start brings up the HTTP listener serving all /onscreens/* routes plus
-// the standard /health, /version, /metrics surface. It blocks until the
-// listener returns; callers typically fatal on a non-nil error.
+// the standard /health, /version, /metrics surface. It blocks until either
+// ListenAndServe returns an error or ctx is canceled (typically by the
+// process-level signal handler in cmd/onscreens-server). Callers should
+// fatal on a non-nil error.
 //
-// ctx is currently only used to feed graceful-shutdown plumbing for
-// future use; the listener itself is shut down by the process-level
-// signal handler in cmd/onscreens-server.
+// When ctx is canceled Start returns nil; the caller is responsible for
+// invoking Shutdown with its own deadline so in-flight requests get a
+// chance to drain. The split keeps Start's return contract simple
+// (listener-error vs. clean-stop) and lets the signal handler control
+// the shutdown deadline.
 func (s *Server) Start(ctx context.Context) error {
 	slog.InfoContext(ctx, "starting onscreens-server web server", "bind", c.Conf.OnscreensServerBindAddress)
 
@@ -149,10 +153,38 @@ func (s *Server) Start(ctx context.Context) error {
 		Handler:        otelhttp.NewHandler(app, c.Conf.ServerType),
 	}
 
-	if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	// Run ListenAndServe in a goroutine so Start can block on ctx.Done()
+	// and return cleanly when the signal handler cancels the context. The
+	// caller calls Shutdown after Start returns to drain in-flight
+	// requests with its chosen deadline. ErrServerClosed is the expected
+	// return after Shutdown is called and is not surfaced as an error.
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	select {
+	case err := <-serverErr:
 		return err
+	case <-ctx.Done():
+		return nil
 	}
-	return nil
+}
+
+// Shutdown gracefully stops the HTTP listener, allowing in-flight
+// requests up to ctx's deadline to complete before closing connections.
+// Returns the error from http.Server.Shutdown so callers can log or act
+// on a timeout. Safe to call once Start has returned (or concurrently
+// while Start is blocked on ctx.Done()); calling on a zero-value Server
+// (Start never ran) is a no-op.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.http == nil {
+		return nil
+	}
+	return s.http.Shutdown(ctx)
 }
 
 // versionHandler returns build metadata as JSON. The tag comes from the

--- a/pkg/onscreens-server/setup_test.go
+++ b/pkg/onscreens-server/setup_test.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"sync"
+	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -14,20 +14,16 @@ func init() {
 	terrors.Initialize(*c.Conf, "test")
 }
 
-// testServer constructs a *Server once per test binary and reuses it
-// across tests. Constructing fresh per test would be cleaner but each
-// New() call spawns the seven background goroutines (rotator loops +
-// expiry sweepers); the current tests are read-only against handler
-// validation paths so the shared instance is fine and saves the
-// goroutine churn.
-var (
-	testServerOnce sync.Once
-	testServerInst *Server
-)
-
-func testServer() *Server {
-	testServerOnce.Do(func() {
-		testServerInst = New(Config{Version: "test"})
-	})
-	return testServerInst
+// newTestServer constructs a fresh *Server for the calling test, giving
+// each test real state isolation rather than the cross-test sharing the
+// old sync.Once helper provided.
+//
+// New() spawns the seven onscreens' background goroutines (rotator loops +
+// expiry sweepers). They have no stop hook today, so each test leaks its
+// goroutines for the duration of the test process. That's fine for state
+// isolation — every *Server has its own onscreen singletons, and the
+// leaked goroutines only touch the *Server that spawned them.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	return New(Config{Version: "test"})
 }


### PR DESCRIPTION
## Summary

Two follow-ups on top of #591 (the onscreens-server `*Server` refactor):

1. Tests construct a fresh `*Server` per test via a `newTestServer(t)` helper; the `sync.Once` shared-state helper is gone. Real state isolation between tests.
2. Shutdown ctx plumbed through `cmd/onscreens-server/onscreens-server.go` -> `(s *Server) Start(ctx)` -> `(s *Server) Shutdown(ctx)` -> `http.Server.Shutdown(ctx)`. `gracefulShutdown` now drains in-flight HTTP requests with a 5s timeout instead of `os.Exit(1)`-ing immediately.

Each item is its own atomic commit. Pattern matches vlc-server's #592 shutdown shape.

## Test plan

- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test ./pkg/onscreens-server/...` passes (per-test isolation verified)
- [ ] onscreens-server binary starts cleanly, all 7 onscreens render
- [ ] In bin/devenv: ctrl-c the process, confirm graceful shutdown (no log spam, OBS reconnects cleanly when onscreens-server comes back up)