### PR TITLE
refactor(clients): onscreens-client and vlc-client to *Client structs

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -11,8 +11,10 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/kelvins/geocoder"
 	"gorm.io/gorm"
@@ -65,8 +67,8 @@ func (a *App) db() *gorm.DB {
 var defaultApp = &App{
 	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
-	Onscreens: realOnscreens{},
-	VLC:       realVLC{},
+	Onscreens: realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost)},
+	VLC:       realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},
 	Video:     realVideo{},
 	IRC:       realIRC{},
 	Sessions:  realSessions{},

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Onscreens is the subset of the onscreens-client surface that chatbot
-// commands depend on. Tests inject a fake; production uses the package-backed
+// commands depend on. Tests inject a fake; production uses the
 // realOnscreens adapter wired in defaultApp.
 type Onscreens interface {
 	ShowFlag(ctx context.Context, dur time.Duration) error
@@ -18,21 +18,25 @@ type Onscreens interface {
 	ShowTimewarp(ctx context.Context) error
 }
 
-// realOnscreens delegates to pkg/onscreens-client.
-type realOnscreens struct{}
+// realOnscreens delegates to a constructed *onscreensClient.Client. The
+// concrete Client instance is owned by the App (wired up in defaultApp),
+// not read off a package-level global in pkg/onscreens-client.
+type realOnscreens struct {
+	c *onscreensClient.Client
+}
 
-func (realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
-	return onscreensClient.ShowFlag(ctx, dur)
+func (r realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
+	return r.c.ShowFlag(ctx, dur)
 }
-func (realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][]string) error {
-	return onscreensClient.ShowLeaderboard(ctx, title, lb)
+func (r realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][]string) error {
+	return r.c.ShowLeaderboard(ctx, title, lb)
 }
-func (realOnscreens) HideMiddleText(ctx context.Context) error {
-	return onscreensClient.HideMiddleText(ctx)
+func (r realOnscreens) HideMiddleText(ctx context.Context) error {
+	return r.c.HideMiddleText(ctx)
 }
-func (realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
-	return onscreensClient.ShowMiddleText(ctx, msg)
+func (r realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
+	return r.c.ShowMiddleText(ctx, msg)
 }
-func (realOnscreens) ShowTimewarp(ctx context.Context) error {
-	return onscreensClient.ShowTimewarp(ctx)
+func (r realOnscreens) ShowTimewarp(ctx context.Context) error {
+	return r.c.ShowTimewarp(ctx)
 }

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -8,8 +8,8 @@ import (
 
 // VLC is the subset of the vlc-client surface that chatbot commands depend
 // on (timewarp, jump, skip, back). Tests inject a fake; production uses the
-// package-backed realVLC adapter wired in defaultApp. Mirrors the Onscreens
-// injection pattern.
+// realVLC adapter wired in defaultApp. Mirrors the Onscreens injection
+// pattern.
 type VLC interface {
 	PlayRandom(ctx context.Context) error
 	PlayFileInPlaylist(ctx context.Context, filename string) error
@@ -17,14 +17,18 @@ type VLC interface {
 	Back(ctx context.Context, n int) error
 }
 
-// realVLC delegates to pkg/vlc-client.
-type realVLC struct{}
+// realVLC delegates to a constructed *vlcClient.Client. The concrete Client
+// instance is owned by the App (wired up in defaultApp), not read off a
+// package-level global in pkg/vlc-client.
+type realVLC struct {
+	c *vlcClient.Client
+}
 
-func (realVLC) PlayRandom(ctx context.Context) error {
-	return vlcClient.PlayRandom(ctx)
+func (r realVLC) PlayRandom(ctx context.Context) error {
+	return r.c.PlayRandom(ctx)
 }
-func (realVLC) PlayFileInPlaylist(ctx context.Context, filename string) error {
-	return vlcClient.PlayFileInPlaylist(ctx, filename)
+func (r realVLC) PlayFileInPlaylist(ctx context.Context, filename string) error {
+	return r.c.PlayFileInPlaylist(ctx, filename)
 }
-func (realVLC) Skip(ctx context.Context, n int) error { return vlcClient.Skip(ctx, n) }
-func (realVLC) Back(ctx context.Context, n int) error { return vlcClient.Back(ctx, n) }
+func (r realVLC) Skip(ctx context.Context, n int) error { return r.c.Skip(ctx, n) }
+func (r realVLC) Back(ctx context.Context, n int) error { return r.c.Back(ctx, n) }

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -16,15 +16,32 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-var onscreensServerURL = "http://" + c.Conf.OnscreensServerHost
+// Client talks to the onscreens-server HTTP API. Construct via New(host); the
+// package-level defaultClient is wired up at init for callers that still hit
+// the free-function shims below.
+type Client struct {
+	serverURL  string
+	httpClient *http.Client
+}
 
-// httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans and propagate W3C tracecontext headers.
-// See pkg/vlc-client for the same pattern.
-var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+// New returns a Client pointed at the given onscreens-server host. The HTTP
+// transport is OTel-instrumented so outbound calls produce spans and
+// propagate W3C tracecontext headers.
+func New(host string) *Client {
+	return &Client{
+		serverURL:  "http://" + host,
+		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+	}
+}
 
-func HideMiddleText(ctx context.Context) error {
-	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/middle/hide")
+// defaultClient is the package-level Client used by the free-function shims
+// below. It exists so callers that haven't been migrated yet (pkg/video,
+// cmd/tripbot's cron registration) keep working. New consumers should
+// construct their own *Client via New().
+var defaultClient = New(c.Conf.OnscreensServerHost)
+
+func (c *Client) HideMiddleText(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/onscreens/middle/hide")
 	if err != nil {
 		slog.ErrorContext(ctx, "error hiding middle onscreen", "err", err)
 		return err
@@ -32,10 +49,10 @@ func HideMiddleText(ctx context.Context) error {
 	return nil
 }
 
-func ShowMiddleText(ctx context.Context, msg string) error {
-	url := onscreensServerURL + "/onscreens/middle/show"
+func (c *Client) ShowMiddleText(ctx context.Context, msg string) error {
+	url := c.serverURL + "/onscreens/middle/show"
 	url = fmt.Sprintf("%s?msg=%s", url, helpers.Base64Encode(msg))
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing middle onscreen", "err", err)
 		return err
@@ -43,13 +60,13 @@ func ShowMiddleText(ctx context.Context, msg string) error {
 	return err
 }
 
-func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
+func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
 	content := users.LeaderboardContent(title, leaderboard)
 
-	url := onscreensServerURL + "/onscreens/leaderboard/show"
+	url := c.serverURL + "/onscreens/leaderboard/show"
 	url = fmt.Sprintf("%s?content=%s", url, helpers.Base64Encode(content))
 
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing leaderboard onscreen", "err", err)
 		return err
@@ -58,7 +75,7 @@ func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) 
 }
 
 //TODO: this is taken right from the !guessleaderboard command, DRY it?
-func ShowGuessLeaderboard(ctx context.Context) {
+func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
 	// select users to show in leaderboard
 	size := 10
 	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
@@ -75,11 +92,11 @@ func ShowGuessLeaderboard(ctx context.Context) {
 	}
 
 	// display leaderboard on screen
-	ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
+	c.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 }
 
-func ShowTimewarp(ctx context.Context) error {
-	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/timewarp/show")
+func (c *Client) ShowTimewarp(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/onscreens/timewarp/show")
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing timewarp onscreen", "err", err)
 		return err
@@ -87,11 +104,11 @@ func ShowTimewarp(ctx context.Context) error {
 	return nil
 }
 
-func ShowFlag(ctx context.Context, dur time.Duration) error {
+func (c *Client) ShowFlag(ctx context.Context, dur time.Duration) error {
 	//TODO: bring this back
-	// url := onscreensServerURL + "/onscreens/flag/show"
+	// url := c.serverURL + "/onscreens/flag/show"
 	// url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	// _, err := getUrl(ctx, url)
+	// _, err := c.get(ctx, url)
 	// if err != nil {
 	// 	slog.ErrorContext(ctx, "error showing flag onscreen", "err", err)
 	// 	return err
@@ -99,10 +116,10 @@ func ShowFlag(ctx context.Context, dur time.Duration) error {
 	return nil
 }
 
-func ShowGPSImage(ctx context.Context, dur time.Duration) error {
-	url := onscreensServerURL + "/onscreens/gps/show"
+func (c *Client) ShowGPSImage(ctx context.Context, dur time.Duration) error {
+	url := c.serverURL + "/onscreens/gps/show"
 	url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing gps onscreen", "err", err)
 		return err
@@ -110,8 +127,8 @@ func ShowGPSImage(ctx context.Context, dur time.Duration) error {
 	return nil
 }
 
-func HideGPSImage(ctx context.Context) error {
-	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/gps/hide")
+func (c *Client) HideGPSImage(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/onscreens/gps/hide")
 	if err != nil {
 		slog.ErrorContext(ctx, "error hiding gps onscreen", "err", err)
 		return err
@@ -120,13 +137,13 @@ func HideGPSImage(ctx context.Context) error {
 }
 
 //TODO: move this to a common location
-func getUrl(ctx context.Context, url string) (string, error) {
+func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		slog.ErrorContext(ctx, "error building request to onscreens server", "err", err)
 		return "", err
 	}
-	response, err := httpClient.Do(req)
+	response, err := c.httpClient.Do(req)
 	if err != nil {
 		slog.ErrorContext(ctx, "error connecting to onscreens server", "err", err)
 		return "", err
@@ -143,3 +160,19 @@ func getUrl(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
+
+// ---- package-level shims (transitional) ----
+// Each free function calls the corresponding method on defaultClient. These
+// preserve the existing public surface for unmigrated callers (pkg/video,
+// cmd/tripbot). New consumers should construct their own *Client via New().
+
+func HideMiddleText(ctx context.Context) error                { return defaultClient.HideMiddleText(ctx) }
+func ShowMiddleText(ctx context.Context, msg string) error    { return defaultClient.ShowMiddleText(ctx, msg) }
+func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
+	return defaultClient.ShowLeaderboard(ctx, title, leaderboard)
+}
+func ShowGuessLeaderboard(ctx context.Context)                  { defaultClient.ShowGuessLeaderboard(ctx) }
+func ShowTimewarp(ctx context.Context) error                    { return defaultClient.ShowTimewarp(ctx) }
+func ShowFlag(ctx context.Context, dur time.Duration) error     { return defaultClient.ShowFlag(ctx, dur) }
+func ShowGPSImage(ctx context.Context, dur time.Duration) error { return defaultClient.ShowGPSImage(ctx, dur) }
+func HideGPSImage(ctx context.Context) error                    { return defaultClient.HideGPSImage(ctx) }

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -11,19 +11,37 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-//TODO: eventually support HTTPS
-var vlcServerURL = "http://" + c.Conf.VlcServerHost
+// Client talks to the vlc-server HTTP API. Construct via New(host); the
+// package-level defaultClient is wired up at init for callers that still hit
+// the free-function shims below.
+type Client struct {
+	serverURL  string
+	httpClient *http.Client
+}
 
-// httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans and propagate W3C tracecontext headers.
-// Callers must pass ctx so the propagation has an active span to attach to —
-// passing context.Background() will still send the request, just without a
-// parent span linking it to the caller's trace.
-var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+// New returns a Client pointed at the given vlc-server host. The HTTP
+// transport is OTel-instrumented so outbound calls produce spans and
+// propagate W3C tracecontext headers. Callers must pass ctx so the
+// propagation has an active span to attach to — passing context.Background()
+// will still send the request, just without a parent span linking it to the
+// caller's trace.
+//
+//TODO: eventually support HTTPS
+func New(host string) *Client {
+	return &Client{
+		serverURL:  "http://" + host,
+		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+	}
+}
+
+// defaultClient is the package-level Client used by the free-function shims
+// below. It exists so callers that haven't been migrated yet (pkg/video)
+// keep working. New consumers should construct their own *Client via New().
+var defaultClient = New(c.Conf.VlcServerHost)
 
 // CurrentlyPlaying finds the currently-playing video path
-func CurrentlyPlaying(ctx context.Context) string {
-	response, err := getUrl(ctx, vlcServerURL+"/vlc/current")
+func (c *Client) CurrentlyPlaying(ctx context.Context) string {
+	response, err := c.get(ctx, c.serverURL+"/vlc/current")
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to determine current video", "err", err)
 		return ""
@@ -32,8 +50,8 @@ func CurrentlyPlaying(ctx context.Context) string {
 }
 
 // PlayRandom plays a random file from the playlist
-func PlayRandom(ctx context.Context) error {
-	_, err := getUrl(ctx, vlcServerURL+"/vlc/random")
+func (c *Client) PlayRandom(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/vlc/random")
 	if err != nil {
 		slog.ErrorContext(ctx, "error playing random video", "err", err)
 		return err
@@ -42,9 +60,9 @@ func PlayRandom(ctx context.Context) error {
 }
 
 // PlayFileInPlaylist plays a given file
-func PlayFileInPlaylist(ctx context.Context, filename string) error {
-	url := vlcServerURL + "/vlc/play/" + filename
-	_, err := getUrl(ctx, url)
+func (c *Client) PlayFileInPlaylist(ctx context.Context, filename string) error {
+	url := c.serverURL + "/vlc/play/" + filename
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error playing file", "err", err)
 		return err
@@ -52,12 +70,12 @@ func PlayFileInPlaylist(ctx context.Context, filename string) error {
 	return nil
 }
 
-func Skip(ctx context.Context, n int) error {
-	url := vlcServerURL + "/vlc/skip"
+func (c *Client) Skip(ctx context.Context, n int) error {
+	url := c.serverURL + "/vlc/skip"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error skipping video", "err", err)
 		return err
@@ -65,12 +83,12 @@ func Skip(ctx context.Context, n int) error {
 	return nil
 }
 
-func Back(ctx context.Context, n int) error {
-	url := vlcServerURL + "/vlc/back"
+func (c *Client) Back(ctx context.Context, n int) error {
+	url := c.serverURL + "/vlc/back"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error going back to a video", "err", err)
 		return err
@@ -79,13 +97,13 @@ func Back(ctx context.Context, n int) error {
 }
 
 //TODO: move this to a common location
-func getUrl(ctx context.Context, url string) (string, error) {
+func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		slog.ErrorContext(ctx, "error building request to VLC server", "err", err)
 		return "", err
 	}
-	response, err := httpClient.Do(req)
+	response, err := c.httpClient.Do(req)
 	if err != nil {
 		slog.ErrorContext(ctx, "error connecting to VLC server", "err", err)
 		return "", err
@@ -98,3 +116,16 @@ func getUrl(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
+
+// ---- package-level shims (transitional) ----
+// Each free function calls the corresponding method on defaultClient. These
+// preserve the existing public surface for unmigrated callers (pkg/video).
+// New consumers should construct their own *Client via New().
+
+func CurrentlyPlaying(ctx context.Context) string         { return defaultClient.CurrentlyPlaying(ctx) }
+func PlayRandom(ctx context.Context) error                { return defaultClient.PlayRandom(ctx) }
+func PlayFileInPlaylist(ctx context.Context, filename string) error {
+	return defaultClient.PlayFileInPlaylist(ctx, filename)
+}
+func Skip(ctx context.Context, n int) error { return defaultClient.Skip(ctx, n) }
+func Back(ctx context.Context, n int) error { return defaultClient.Back(ctx, n) }


### PR DESCRIPTION
## Summary

Converts `pkg/onscreens-client` and `pkg/vlc-client` from package-level globals (`onscreensServerURL` + `httpClient`, `vlcServerURL` + `httpClient`) to `*Client` structs constructed via `New(host) *Client`. Methods on `*Client` carry the per-instance state.

**This is a stepping-stone, not the final form.** Package-level free functions remain as thin shims calling a `var defaultClient = New(...)` so existing callers in `pkg/video` and `cmd/tripbot/tripbot.go` continue to work unchanged. A follow-up PR — when `pkg/video` gets its own globals refactor — will migrate those callers and delete the package-level shims and `defaultClient`.

Net effect: globals collapse from 2 per package (URL + httpClient) to 1 (`defaultClient` as a stand-in for the unmigrated callers). The chatbot's `realOnscreens` / `realVLC` adapters now hold a constructed `*Client`, wired up explicitly in `defaultApp` rather than calling package-level functions.

## What changes for callers

- `pkg/video/video.go` — unchanged. Still calls `onscreensClient.ShowGPSImage(...)`, etc. The shims preserve the signatures.
- `cmd/tripbot/tripbot.go:254` — unchanged. `onscreensClient.ShowGuessLeaderboard` still has the same `func(context.Context)` signature.
- `pkg/chatbot/onscreens.go` and `pkg/chatbot/vlc.go` — `realOnscreens` / `realVLC` now hold a `*Client`. The `Onscreens` and `VLC` interfaces are unchanged.
- `pkg/chatbot/chatbot.go` — `defaultApp` explicitly constructs the two `*Client` instances.

The chatbot tests using `noopOnscreens` / `recordingOnscreens` / `noopVLC` / `recordingVLC` fakes are unaffected — they implement the unchanged interfaces.

## Test plan

- [ ] \`go build ./...\` clean
- [ ] \`go vet ./...\` clean
- [ ] \`go test ./pkg/onscreens-client/... ./pkg/vlc-client/... ./pkg/chatbot/...\` passes
- [ ] In bin/devenv: \`!flag US\`, \`!middle hi\`, \`!leaderboard\`, \`!timewarp\`, \`!skip\`, \`!back\`, \`!goto X\` from chat all still work