### PR TITLE
refactor(video): introduce *Player, delete onscreens/vlc client shims

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -142,7 +142,7 @@ func startHttpServer(ctx context.Context) {
 // we want to run this early, otherwise it will be unset until the first cron job runs
 func findInitialVideo() {
 	video.GetCurrentlyPlaying(context.Background())
-	v := video.CurrentlyPlaying
+	v := video.CurrentlyPlaying()
 	_, err := video.LoadOrCreate(context.Background(), v.String())
 	if err != nil {
 		slog.Error("error loading initial video, is there a video playing?", "err", err)
@@ -226,7 +226,7 @@ func gracefulShutdown() {
 	// anything below this probably won't be executed
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
-	slog.Info("last played video", "file", video.CurrentlyPlaying.File())
+	slog.Info("last played video", "file", video.CurrentlyPlaying().File())
 	users.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -248,10 +248,11 @@ func gracefulShutdown() {
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
 func scheduleBackgroundJobs() {
+	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost)
 	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
 	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
-	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard)
+	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
 	addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
 	addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
 	addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -65,7 +65,7 @@ func (a *App) db() *gorm.DB {
 }
 
 var defaultApp = &App{
-	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
+	CurrentVideo: func() video.Video { return video.CurrentlyPlaying() },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
 	Onscreens: realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost)},
 	VLC:       realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -25,10 +25,10 @@ type Video interface {
 // realVideo delegates to pkg/video.
 type realVideo struct{}
 
-func (realVideo) Current() video.Video { return video.CurrentlyPlaying }
+func (realVideo) Current() video.Video { return video.CurrentlyPlaying() }
 func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
 	video.GetCurrentlyPlaying(ctx)
-	return video.CurrentlyPlaying
+	return video.CurrentlyPlaying()
 }
 func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
 	return video.FindRandomByState(ctx, state)

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -9,16 +9,13 @@ import (
 	"strings"
 	"time"
 
-	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/users"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// Client talks to the onscreens-server HTTP API. Construct via New(host); the
-// package-level defaultClient is wired up at init for callers that still hit
-// the free-function shims below.
+// Client talks to the onscreens-server HTTP API. Construct via New(host).
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
@@ -33,12 +30,6 @@ func New(host string) *Client {
 		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 	}
 }
-
-// defaultClient is the package-level Client used by the free-function shims
-// below. It exists so callers that haven't been migrated yet (pkg/video,
-// cmd/tripbot's cron registration) keep working. New consumers should
-// construct their own *Client via New().
-var defaultClient = New(c.Conf.OnscreensServerHost)
 
 func (c *Client) HideMiddleText(ctx context.Context) error {
 	_, err := c.get(ctx, c.serverURL+"/onscreens/middle/hide")
@@ -160,19 +151,3 @@ func (c *Client) get(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
-
-// ---- package-level shims (transitional) ----
-// Each free function calls the corresponding method on defaultClient. These
-// preserve the existing public surface for unmigrated callers (pkg/video,
-// cmd/tripbot). New consumers should construct their own *Client via New().
-
-func HideMiddleText(ctx context.Context) error                { return defaultClient.HideMiddleText(ctx) }
-func ShowMiddleText(ctx context.Context, msg string) error    { return defaultClient.ShowMiddleText(ctx, msg) }
-func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
-	return defaultClient.ShowLeaderboard(ctx, title, leaderboard)
-}
-func ShowGuessLeaderboard(ctx context.Context)                  { defaultClient.ShowGuessLeaderboard(ctx) }
-func ShowTimewarp(ctx context.Context) error                    { return defaultClient.ShowTimewarp(ctx) }
-func ShowFlag(ctx context.Context, dur time.Duration) error     { return defaultClient.ShowFlag(ctx, dur) }
-func ShowGPSImage(ctx context.Context, dur time.Duration) error { return defaultClient.ShowGPSImage(ctx, dur) }
-func HideGPSImage(ctx context.Context) error                    { return defaultClient.HideGPSImage(ctx) }

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -8,17 +8,37 @@ import (
 	"strings"
 	"time"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
-// CurrentlyPlaying is the video that is currently playing
-var CurrentlyPlaying Video
+// Player owns the state of "what's currently playing" and the clients that
+// drive the VLC playback + onscreens overlays. Construct via NewPlayer; the
+// package-level defaultPlayer is wired up at init for callers that still hit
+// the free-function shims below.
+type Player struct {
+	CurrentlyPlaying Video // exported because external callers used to read video.CurrentlyPlaying
+	curVid, preVid   string
+	timeStarted      time.Time
+	onscreens        *onscreensClient.Client
+	vlc              *vlcClient.Client
+}
 
-// these are used to keep track of the current video
-var curVid, preVid string
-var timeStarted time.Time
+// NewPlayer returns a Player with its own Onscreens + VLC clients.
+func NewPlayer(onscreens *onscreensClient.Client, vlc *vlcClient.Client) *Player {
+	return &Player{onscreens: onscreens, vlc: vlc}
+}
+
+// defaultPlayer is the package-level Player used by the free-function shims
+// below. Exists so callers that aren't constructor-injected (cmd/tripbot
+// bootstrap, script/collect-gps) keep working. New consumers should construct
+// their own *Player via NewPlayer().
+var defaultPlayer = NewPlayer(
+	onscreensClient.New(c.Conf.OnscreensServerHost),
+	vlcClient.New(c.Conf.VlcServerHost),
+)
 
 // GetCurrentlyPlaying will use lsof to figure out
 // which dashcam video is currently playing (seriously).
@@ -27,52 +47,55 @@ var timeStarted time.Time
 // trace spans for cron.video.GetCurrentlyPlaying ticks will nest the
 // underlying VLC poll and GPS-image toggles as children.
 //TODO: consider making this return a video struct
-func GetCurrentlyPlaying(ctx context.Context) {
+func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 	var err error
 
 	// save the video we used last time
-	preVid = curVid
+	p.preVid = p.curVid
 
 	// figure out what's currently playing
 	if helpers.RunningOnDarwin() {
-		curVid = figureOutCurrentVideo(ctx)
+		p.curVid = p.figureOutCurrentVideo(ctx)
 	} else {
-		curVid = vlcClient.CurrentlyPlaying(ctx)
+		p.curVid = p.vlc.CurrentlyPlaying(ctx)
 	}
 
 	// if the currently-playing video has changed
-	if curVid != preVid {
+	if p.curVid != p.preVid {
 		// reset the stopwatch
-		timeStarted = time.Now()
+		p.timeStarted = time.Now()
 
 		// share the Video with the system
-		CurrentlyPlaying, err = LoadOrCreate(ctx, curVid)
+		p.CurrentlyPlaying, err = LoadOrCreate(ctx, p.curVid)
 		if err != nil {
-			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", curVid)
+			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", p.curVid)
 		}
 
 		slog.InfoContext(ctx, "now playing",
-			"file", CurrentlyPlaying.File(),
-			"state", helpers.StateToStateAbbrev(CurrentlyPlaying.State),
+			"file", p.CurrentlyPlaying.File(),
+			"state", helpers.StateToStateAbbrev(p.CurrentlyPlaying.State),
 		)
 
 		// show the no-GPS image
-		if CurrentlyPlaying.Flagged {
+		if p.CurrentlyPlaying.Flagged {
 			//TODO: kinda cludgy that we hardcode 60s here
-			onscreensClient.ShowGPSImage(ctx, 60 * time.Second)
+			p.onscreens.ShowGPSImage(ctx, 60*time.Second)
 		} else {
-			onscreensClient.HideGPSImage(ctx)
+			p.onscreens.HideGPSImage(ctx)
 		}
 	}
 }
 
 // CurrentProgress represents how long the video has been playing
 // it will be useful eventually for choosing the exact right screenshot
-func CurrentProgress() time.Duration {
-	return time.Since(timeStarted)
+func (p *Player) CurrentProgress() time.Duration {
+	return time.Since(p.timeStarted)
 }
 
-func figureOutCurrentVideo(ctx context.Context) string {
+// Current returns the currently-playing video.
+func (p *Player) Current() Video { return p.CurrentlyPlaying }
+
+func (p *Player) figureOutCurrentVideo(ctx context.Context) string {
 	if helpers.RunningOnWindows() {
 		slog.ErrorContext(ctx, "can't run script on windows")
 		return ""
@@ -87,3 +110,12 @@ func figureOutCurrentVideo(ctx context.Context) string {
 	}
 	return outString
 }
+
+// ---- package-level shims (transitional) ----
+// Each free function calls the corresponding method on defaultPlayer. These
+// preserve the existing public surface for unmigrated callers. New consumers
+// should construct their own *Player via NewPlayer().
+
+func GetCurrentlyPlaying(ctx context.Context) { defaultPlayer.GetCurrentlyPlaying(ctx) }
+func CurrentProgress() time.Duration          { return defaultPlayer.CurrentProgress() }
+func CurrentlyPlaying() Video                 { return defaultPlayer.Current() }

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -7,13 +7,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// Client talks to the vlc-server HTTP API. Construct via New(host); the
-// package-level defaultClient is wired up at init for callers that still hit
-// the free-function shims below.
+// Client talks to the vlc-server HTTP API. Construct via New(host).
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
@@ -33,11 +30,6 @@ func New(host string) *Client {
 		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 	}
 }
-
-// defaultClient is the package-level Client used by the free-function shims
-// below. It exists so callers that haven't been migrated yet (pkg/video)
-// keep working. New consumers should construct their own *Client via New().
-var defaultClient = New(c.Conf.VlcServerHost)
 
 // CurrentlyPlaying finds the currently-playing video path
 func (c *Client) CurrentlyPlaying(ctx context.Context) string {
@@ -116,16 +108,3 @@ func (c *Client) get(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
-
-// ---- package-level shims (transitional) ----
-// Each free function calls the corresponding method on defaultClient. These
-// preserve the existing public surface for unmigrated callers (pkg/video).
-// New consumers should construct their own *Client via New().
-
-func CurrentlyPlaying(ctx context.Context) string         { return defaultClient.CurrentlyPlaying(ctx) }
-func PlayRandom(ctx context.Context) error                { return defaultClient.PlayRandom(ctx) }
-func PlayFileInPlaylist(ctx context.Context, filename string) error {
-	return defaultClient.PlayFileInPlaylist(ctx, filename)
-}
-func Skip(ctx context.Context, n int) error { return defaultClient.Skip(ctx, n) }
-func Back(ctx context.Context, n int) error { return defaultClient.Back(ctx, n) }

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -43,7 +43,7 @@ func main() {
 		}
 		// preload the currently-playing vid
 		video.GetCurrentlyPlaying(context.Background())
-		videoFile = video.CurrentlyPlaying.String()
+		videoFile = video.CurrentlyPlaying().String()
 	}
 
 	// a file was passed in via the CLI


### PR DESCRIPTION
## Summary

Refactors `pkg/video` from package-level globals to a `*Player` struct constructed via `NewPlayer(onscreens, vlc)`. The Player owns the previously package-scoped state (`curVid`, `preVid`, `timeStarted`, and `CurrentlyPlaying`) plus the two HTTP clients it talks to.

Migrates the last remaining caller of the onscreens-client free functions (`cmd/tripbot/tripbot.go:254`, the `ShowGuessLeaderboard` cron registration) to a constructed `*Client` method value.

Deletes the `defaultClient` package-level singletons and free-function shims from both `pkg/onscreens-client` and `pkg/vlc-client` — there are no callers left.

## What changes for external callers

- `video.CurrentlyPlaying` (var read) becomes `video.CurrentlyPlaying()` (func call). 6 sites: 2 in cmd/tripbot, 3 in pkg/chatbot, 1 in script/collect-gps.
- `video.GetCurrentlyPlaying(ctx)` and `video.CurrentProgress()` unchanged at the callsite — they're now thin shims around `defaultPlayer.X()`.
- `pkg/chatbot.Video` and `pkg/chatbot.Onscreens` interfaces unchanged — fakes don't need updates.

## State of globals after this PR

- `pkg/video`: 3 globals to 1 (`defaultPlayer`, a constructed singleton).
- `pkg/onscreens-client`: 1 global (`defaultClient`) to 0.
- `pkg/vlc-client`: 1 global (`defaultClient`) to 0.

## Test plan

- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go test ./pkg/video/... ./pkg/chatbot/... ./pkg/onscreens-client/... ./pkg/vlc-client/...` passes
- [ ] In bin/devenv: bot starts, video plays, `!miles`/`!flag US`/`!middle hi`/`!timewarp`/`!skip`/`!back` all work
- [ ] The 5-minute `ShowGuessLeaderboard` cron still fires (check OBS overlay or telemetry)