### PR TITLE
refactor(chatbot): drop CurrentVideo closure, route through Video.Current()

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -13,7 +13,6 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/adanalife/tripbot/pkg/video"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/kelvins/geocoder"
@@ -27,7 +26,6 @@ var Uptime time.Time
 // App holds injectable dependencies for the chatbot.
 // Tests instantiate it directly with fakes; production uses defaultApp.
 type App struct {
-	CurrentVideo func() video.Video
 	// DB is the GORM handle used by commands that need to read or write the
 	// database. nil in tests that don't exercise the DB; otherwise either the
 	// real database.GormDB() or a sqlmock-backed gorm.DB.
@@ -40,8 +38,6 @@ type App struct {
 	VLC VLC
 	// Video reads / refreshes the currently-playing dashcam video. Tests
 	// inject a no-op fake; production uses the realVideo adapter.
-	// CurrentVideo (above) is the older closure-based seam; both live on
-	// App for now and a follow-up will subsume CurrentVideo into Video.
 	Video Video
 	// IRC sends chat output (Say, Whisper). Tests inject a recordingIRC
 	// to assert on chat messages; production uses the realIRC adapter
@@ -65,7 +61,6 @@ func (a *App) db() *gorm.DB {
 }
 
 var defaultApp = &App{
-	CurrentVideo: func() video.Video { return video.CurrentlyPlaying() },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
 	Onscreens: realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost)},
 	VLC:       realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -163,7 +163,7 @@ func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 
 func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !sunset", "username", user.Username)
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next(ctx)
@@ -174,7 +174,7 @@ func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 
 func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !location (or similar)", "username", user.Username)
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		//TODO: write something like vid.FindClosest() that
@@ -290,7 +290,7 @@ func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !time", "username", user.Username)
 	var err error
 	var lat, lng float64
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	if vid.Flagged {
 		lat, lng, err = vid.Next(ctx).Location()
 	} else {
@@ -309,7 +309,7 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !date", "username", user.Username)
 	var err error
 	var lat, lng float64
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	if vid.Flagged {
 		lat, lng, err = vid.Next(ctx).Location()
 	} else {
@@ -353,7 +353,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 		guess = helpers.StateAbbrevToState(guess)
 	}
 
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next(ctx)
@@ -376,7 +376,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !state", "username", user.Username)
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	if vid.Flagged {
 		a.IRC.Say("I couldn't figure out current GPS coords, using next closest...")
 		vid = vid.Next(ctx)
@@ -413,7 +413,7 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 	if !c.UserIsAdmin(user.Username) {
 		return
 	}
-	vid := a.CurrentVideo()
+	vid := a.Video.Current()
 	msg := fmt.Sprintf("currently playing: %s, playtime: %s", vid, video.CurrentProgress())
 	lat, lng, err := vid.Location()
 	if err != nil {
@@ -432,7 +432,7 @@ func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 		return
 	}
 	a.IRC.Say("Shutting down...")
-	slog.InfoContext(ctx, "shutdown: currently playing", "video", a.CurrentVideo())
+	slog.InfoContext(ctx, "shutdown: currently playing", "video", a.Video.Current())
 	background.StopCron()
 	a.Sessions.Shutdown(ctx)
 	err := database.Connection().Close()

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -37,20 +37,19 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 	return video.Video{State: state, Lat: lat, Lng: lng, DateFilmed: date}
 }
 
-// newTestApp returns an App with CurrentVideo returning vid, plus no-op
-// Onscreens, VLC, Video, IRC, and Sessions fakes. For commands that
-// don't use CurrentVideo, pass a zero-value video.Video. To assert on
-// any of those surfaces, replace the corresponding field with a
-// recording fake (recordingOnscreens / recordingVLC / recordingVideo /
-// recordingIRC / recordingSessions).
+// newTestApp returns an App whose Video reports vid as the currently-playing
+// video, plus no-op Onscreens, VLC, IRC, and Sessions fakes. For commands
+// that don't read Video, pass a zero-value video.Video. To assert on any of
+// those surfaces, replace the corresponding field with a recording fake
+// (recordingOnscreens / recordingVLC / recordingVideo / recordingIRC /
+// recordingSessions).
 func newTestApp(vid video.Video) *App {
 	return &App{
-		CurrentVideo: func() video.Video { return vid },
-		Onscreens:    noopOnscreens{},
-		VLC:          noopVLC{},
-		Video:        noopVideo{},
-		IRC:          noopIRC{},
-		Sessions:     noopSessions{},
+		Onscreens: noopOnscreens{},
+		VLC:       noopVLC{},
+		Video:     &recordingVideo{Vid: vid},
+		IRC:       noopIRC{},
+		Sessions:  noopSessions{},
 	}
 }
 

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -146,7 +146,7 @@ func TestGuessCmd_CorrectGuess_RefreshesVideoAfterTimewarp(t *testing.T) {
 	mock := installMockDB(t)
 	vid := newTestVideo("Colorado", 39.5, -105.0, time.Now())
 	app := newTestApp(vid)
-	recVideo := &recordingVideo{}
+	recVideo := &recordingVideo{Vid: vid}
 	app.Video = recVideo
 
 	expectAddToScoreChain(mock)
@@ -157,8 +157,12 @@ func TestGuessCmd_CorrectGuess_RefreshesVideoAfterTimewarp(t *testing.T) {
 
 	app.guessCmd(context.Background(), newTestUser("viewer1"), []string{"Colorado"})
 
-	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
-		t.Errorf("expected timewarp to refresh Video via GetCurrentlyPlaying, got %v", recVideo.Calls)
+	// guessCmd first reads the current vid (Current), then the correct-guess
+	// path runs a.timewarp() which refreshes via GetCurrentlyPlaying.
+	wantCalls := []string{"Current()", "GetCurrentlyPlaying()"}
+	if len(recVideo.Calls) != len(wantCalls) ||
+		recVideo.Calls[0] != wantCalls[0] || recVideo.Calls[1] != wantCalls[1] {
+		t.Errorf("expected calls %v, got %v", wantCalls, recVideo.Calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)


### PR DESCRIPTION
## Summary

Deletes the `CurrentVideo func() video.Video` closure from `App` (and its wiring in `defaultApp`), migrating the eight `a.CurrentVideo()` callsites in `commands.go` to `a.Video.Current()`. The closure was a transitional seam introduced alongside the `Video` interface and slated for removal once `Video` covered the same surface — `Video.Current()` already does exactly what `CurrentVideo()` did.

Net: one fewer field on `App`, one fewer thing for test fixtures to wire up, and a single interface seam for "the currently-playing video" instead of two parallel ones.

## Notes on the test changes

`newTestApp(vid)` previously wired both a `CurrentVideo` closure that returned `vid` and a `noopVideo{}` for `Video`. With the closure gone, `newTestApp` now uses `&recordingVideo{Vid: vid}` for `Video` so `a.Video.Current()` returns the test's vid. The recording fake's `Calls` slice is appended-to on each call; tests that don't assert on `Calls` are unaffected.

One test (`TestGuessCmd_CorrectGuess_RefreshesVideoAfterTimewarp`) constructed a fresh `&recordingVideo{}` with a zero `Vid` and overwrote `app.Video` with it — this previously worked because `CurrentVideo` was a separate seam still pointing at the test's vid. Updated to carry the vid through (`&recordingVideo{Vid: vid}`) and to expect the new `Current()` call recording alongside the existing `GetCurrentlyPlaying()`.

## Test plan

- [ ] \`go build ./...\` clean
- [ ] \`go vet ./...\` clean
- [ ] \`go test ./pkg/chatbot/...\` passes
- [ ] In bin/devenv: \`!sunset\`, \`!location\`, \`!gps\`, \`!state\`, \`!secretinfo\`, \`!shutdown\` (the eight commands that used to call \`a.CurrentVideo()\`) all still respond correctly