### PR TITLE
Release v2.11.0: develop → master #minor

### DIFF
--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -73,16 +73,20 @@ jobs:
 
     - name: Wait for healthcheck
       run: |
+        # /health/live is the process-alive probe; /health/ready now
+        # consults libvlc player state, which won't reach a "running"
+        # status in CI because the container has no video files mounted
+        # (the smoke test only verifies the server started).
         for i in $(seq 1 30); do
-          if curl -sf "http://localhost:$VLC_PORT/health/ready"; then
+          if curl -sf "http://localhost:$VLC_PORT/health/live"; then
             echo ""
-            echo "VLC server is ready!"
+            echo "VLC server is alive!"
             exit 0
           fi
           echo "Waiting for VLC server... ($i/30)"
           sleep 2
         done
-        echo "VLC server failed to become ready"
+        echo "VLC server failed to come up"
         exit 1
 
     - name: Check VLC current video

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.11.0] — 2026-05-19
+
+Minor release. Finishes the no-globals refactor across the three remaining packages: `pkg/video` lifts into `*Player`, `pkg/onscreens-client` / `pkg/vlc-client` lift into `*Client`, and post-refactor polish lands on `vlc-server` / `onscreens-server` (real `Health()`, graceful shutdown ctx, per-test isolation). OBS's display stack swaps from Xvfb + fluxbox + x11vnc to Sway (headless Wayland) + wayvnc + Qt6 Wayland, supervised by supervisord — gets the 1080p60 composite off Mesa llvmpipe (~14 CPU cores) and onto the iGPU's render engine, and unblocks the `_tex` zero-copy variant of the VAAPI encoder. The `!version` chatbot command stops shelling out and reads `/etc/tripbot/version` directly.
+
+### Streaming
+
+- **OBS display stack on Sway headless + wayvnc.** Out: `xvfb x11vnc fluxbox dbus-x11 x11-utils`. In: `sway wayvnc xwayland qt6-wayland supervisor`. New `sway-headless.conf` (one virtual 1920x1200@60Hz output, fullscreen OBS, no decorations), per-service supervisord declarations (sway → wayvnc → obs → browser-refresh, with Wayland-socket-wait logic for the dependents), `entrypoint.sh` keeps the template-rendering responsibilities but `exec`s supervisord instead of launching Xvfb/fluxbox/x11vnc by hand. `healthcheck.sh` ports from `xprop` / `xdpyinfo` to `swaymsg get_tree`. Background: after v2.10.0's VAAPI work, prod-1 measurement showed OBS CPU only dropped 1579% → 1487%; thread breakdown revealed 19 `llvmpipe-*` threads at 65-82% CPU doing the composite in software because Xvfb has no DRI3 / GLX hardware path. `BrowserHWAccel=false` stays for the initial rollout. ([#597])
+
+### Internals
+
+- **`pkg/video`: `*Player` struct, `NewPlayer(onscreens, vlc)`.** Owns the previously package-scoped state (`curVid`, `preVid`, `timeStarted`, `CurrentlyPlaying`) plus its two HTTP clients. `video.CurrentlyPlaying` (var read) becomes `video.CurrentlyPlaying()` (func call) at 6 callsites. `GetCurrentlyPlaying(ctx)` and `CurrentProgress()` keep their existing shapes as thin shims around `defaultPlayer.X()`. ([#600])
+- **`pkg/onscreens-client` and `pkg/vlc-client`: `*Client` structs, `New(host) *Client`.** Globals collapse from 2 per package (URL + `httpClient`) to 1 (`defaultClient`) initially, then to 0 once #600 migrates the last callers. Chatbot's `realOnscreens` / `realVLC` adapters hold a constructed `*Client`, wired in `defaultApp`. ([#596], [#600])
+- **`pkg/vlc-server` post-refactor polish.** `New()` either returns a fully-constructed `*Server` or `(nil, err)` — never partial. `(s *Server) Health() error` reflects libvlc player state; `/health/ready` returns 503 with the error message when the player isn't running. Shutdown ctx plumbed into `Shutdown()` and `StartStatsPoller`; `main()`'s graceful-shutdown path drains in-flight HTTP requests with a 5s timeout. ([#594])
+- **`pkg/onscreens-server` post-refactor polish.** Tests construct a fresh `*Server` per test via `newTestServer(t)`; the `sync.Once` shared-state helper is gone. Shutdown ctx plumbed through `(s *Server) Start(ctx)` → `Shutdown(ctx)` → `http.Server.Shutdown(ctx)`; `gracefulShutdown` drains in-flight HTTP requests with a 5s timeout. ([#595])
+
+### Chatbot
+
+- **`!version` reads `/etc/tripbot/version` directly, drops the shell-out.** Ports `bin/current-version.sh` to native Go in `pkg/chatbot/versionCmd`. The version file is already baked at build time (per #419), so the per-invocation `git remote update` + `git describe` round-trip was wasted work. Falls back to `"dev"` (matching the ldflag default the `/version` HTTP handler uses) when the file is missing. ([#598])
+
+[#594]: https://github.com/adanalife/tripbot/pull/594
+[#595]: https://github.com/adanalife/tripbot/pull/595
+[#596]: https://github.com/adanalife/tripbot/pull/596
+[#597]: https://github.com/adanalife/tripbot/pull/597
+[#598]: https://github.com/adanalife/tripbot/pull/598
+[#600]: https://github.com/adanalife/tripbot/pull/600
+
 ## [v2.10.0] — 2026-05-19
 
 Minor release. Two `pkg/` binaries (onscreens-server, vlc-server) finish their no-globals refactor — each now constructs via `New(Config)` with explicit dependencies, eliminating package-level state and making both binaries unit-testable. OBS flips to Advanced Output mode for VAAPI encode (v2.9.3's VAAPI work shipped via Simple Output, which has no VAAPI branch in OBS 32's `StreamEncoder` switch — silent fallback to x264 under the hood). Test infrastructure: `.env.testing` was missing `ONSCREENS_SERVER_HOST` since #568, blocking 146 test functions across 7 packages in CI; restoring the var lifts coverage from FAIL (0%) to 59.7% in `pkg/chatbot`, 76.0% in `pkg/oauthtokens`, 41.1% in `pkg/server`, and meaningful coverage in `pkg/users`, `pkg/twitch`, `pkg/video`, `pkg/scoreboards`.

--- a/bin/current-version.sh
+++ b/bin/current-version.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Called by pkg/chatbot/commands.go (versionCmd): prints latest git tag for !version.
-
-git remote update >/dev/null 2>&1
-git describe --tags --abbrev=0 2>/dev/null

--- a/cmd/onscreens-server/onscreens-server.go
+++ b/cmd/onscreens-server/onscreens-server.go
@@ -21,16 +21,34 @@ var version = "dev"
 
 var telemetryShutdown telemetry.ShutdownFunc
 
+// srv is the running onscreens-server, captured in main so
+// gracefulShutdown can reach it from its signal-handler goroutine.
+var srv *onscreensServer.Server
+
+// httpShutdownTimeout is how long gracefulShutdown waits for in-flight
+// requests to finish before forcing connections closed. 5s matches the
+// telemetry/sentry flush deadlines used below — the whole shutdown path
+// should complete in well under 15s so process supervisors don't SIGKILL
+// us mid-drain.
+const httpShutdownTimeout = 5 * time.Second
+
 func main() {
 	slog.Info("onscreens-server starting", "version", version)
 
 	// write the current pid to a pidfile
 	helpers.WritePidFile(c.Conf.OnscreensPidFile)
 
+	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
+	// to trigger a graceful shutdown so in-flight requests aren't cut.
+	// listenForShutdown's gracefulShutdown goroutine handles the rest of
+	// the app cleanup off the same signals.
+	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	// construct the server — runs all per-onscreen init (singletons +
 	// background loops) up front so the HTTP routes have everything to
 	// read by the time the listener accepts.
-	srv := onscreensServer.New(onscreensServer.Config{Version: version})
+	srv = onscreensServer.New(onscreensServer.Config{Version: version})
 
 	// await graceful shutdown signal
 	listenForShutdown()
@@ -41,8 +59,9 @@ func main() {
 	// set up error logging
 	initializeErrorLogger()
 
-	// start the webserver — blocks until ListenAndServe returns
-	if err := srv.Start(context.Background()); err != nil {
+	// start the webserver — blocks until ListenAndServe returns or the
+	// signal handler cancels shutdownCtx
+	if err := srv.Start(shutdownCtx); err != nil {
 		terrors.Fatal(err, "couldn't start server")
 	}
 }
@@ -68,7 +87,9 @@ func listenForShutdown() {
 	go gracefulShutdown()
 }
 
-// gracefulShutdown catches CTRL-C and cleans up
+// gracefulShutdown catches CTRL-C and cleans up. Drains the HTTP server
+// first (so in-flight onscreens-render requests don't get cut), then
+// flushes Sentry + telemetry exporters before exiting.
 func gracefulShutdown() {
 	ctrlC := make(chan os.Signal, 1)
 	signal.Notify(ctrlC,
@@ -81,6 +102,15 @@ func gracefulShutdown() {
 	<-ctrlC
 
 	slog.Warn("caught CTRL-C, shutting down")
+
+	if srv != nil {
+		httpCtx, cancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
+		if err := srv.Shutdown(httpCtx); err != nil {
+			slog.Error("error during onscreens-server HTTP shutdown", "err", err)
+		}
+		cancel()
+	}
+
 	sentry.Flush(time.Second * 5)
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -142,7 +142,7 @@ func startHttpServer(ctx context.Context) {
 // we want to run this early, otherwise it will be unset until the first cron job runs
 func findInitialVideo() {
 	video.GetCurrentlyPlaying(context.Background())
-	v := video.CurrentlyPlaying
+	v := video.CurrentlyPlaying()
 	_, err := video.LoadOrCreate(context.Background(), v.String())
 	if err != nil {
 		slog.Error("error loading initial video, is there a video playing?", "err", err)
@@ -226,7 +226,7 @@ func gracefulShutdown() {
 	// anything below this probably won't be executed
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
-	slog.Info("last played video", "file", video.CurrentlyPlaying.File())
+	slog.Info("last played video", "file", video.CurrentlyPlaying().File())
 	users.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {
@@ -248,10 +248,11 @@ func gracefulShutdown() {
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
 func scheduleBackgroundJobs() {
+	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost)
 	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
 	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
-	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensClient.ShowGuessLeaderboard)
+	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
 	addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
 	addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
 	addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -66,13 +66,24 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer srv.Shutdown()
+	// On normal exit (Start returns when shutdownCtx is canceled), drain
+	// the HTTP server with a bounded ctx and release libvlc. The
+	// gracefulShutdown goroutine below also calls Shutdown for the
+	// os.Exit path — Shutdown tolerates being invoked twice (libvlc
+	// Release is a no-op when the instance is already released).
+	defer func() {
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(drainCtx)
+	}()
 
 	srv.PlayRandom() // play a random video
 
 	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
 	// surface them as OTel gauges. No-op when telemetry is disabled.
-	srv.StartStatsPoller(context.Background(), 5*time.Second)
+	// Tied to shutdownCtx so the poller goroutine exits cleanly on
+	// SIGINT/SIGTERM.
+	srv.StartStatsPoller(shutdownCtx, 5*time.Second)
 
 	// poll the OBS WebSocket for streaming state + render/output stats.
 	go obs.PollStreamingActive(context.Background(), 30*time.Second)
@@ -120,7 +131,9 @@ func gracefulShutdown() {
 	slog.Warn("caught CTRL-C, shutting down")
 	// anything below this probably won't be executed
 	if srv != nil {
-		srv.Shutdown()
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		srv.Shutdown(drainCtx)
+		cancel()
 	}
 	//TODO: stop cron here
 	sentry.Flush(time.Second * 5)

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -13,9 +13,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 #
 # intel-media-va-driver-non-free + vainfo enable hardware H.264/H.265
 # encode via VAAPI on Intel iGPU hosts (Gen 11+ Iris Xe / UHD 770).
-# Requires /dev/dri device passthrough at runtime; OBS scenes select
-# "FFmpeg VAAPI" as the output encoder. Software x264 is the fallback
-# when no iGPU is exposed.
+# OBS connects to the iGPU's render engine for OpenGL composite via the
+# sway Wayland compositor (WLR_BACKENDS=headless), so /dev/dri/card0 must
+# be mounted at runtime — provided by the Intel device plugin's
+# gpu.intel.com/i915 resource grant in the prod-1 overlay.
+#
+# Display stack: sway (headless Wayland compositor) + wayvnc (Wayland VNC
+# server) + qt6-wayland (Qt's Wayland QPA plugin for OBS's UI). Replaces
+# the previous Xvfb / fluxbox / x11vnc trio so OBS's OpenGL hits the iGPU
+# instead of falling back to Mesa llvmpipe (CPU rasterizer).
+#
+# supervisor manages the three (+ the browser-refresh loop) so each has
+# its own restart policy and dependency-on-Wayland-socket logic; matches
+# the VLC container's structure.
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
       | debconf-set-selections \
     && apt-get update \
@@ -24,15 +34,15 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
     && add-apt-repository -y ppa:obsproject/obs-studio \
     && apt-get install -y --no-install-recommends \
          obs-studio \
-         xvfb \
-         x11vnc \
-         fluxbox \
+         sway \
+         wayvnc \
+         xwayland \
+         qt6-wayland \
+         supervisor \
          feh \
          tini \
          gettext-base \
          procps \
-         x11-utils \
-         dbus-x11 \
          libgl1-mesa-dri \
          intel-media-va-driver-non-free \
          vainfo \
@@ -49,10 +59,16 @@ RUN python3 -m venv /opt/obs/venv \
     && /opt/obs/venv/bin/pip install --no-cache-dir obsws-python
 
 COPY infra/docker/obs/config/ /opt/obs/config/
+COPY infra/docker/obs/script/ /opt/obs/script/
 COPY infra/docker/obs/entrypoint.sh /opt/obs/entrypoint.sh
 COPY infra/docker/obs/healthcheck.sh /opt/obs/healthcheck.sh
 COPY bin/obs-browser-refresh /opt/obs/bin/obs-browser-refresh
-RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh /opt/obs/bin/obs-browser-refresh
+RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh \
+             /opt/obs/bin/obs-browser-refresh /opt/obs/script/*.sh
+
+# Per-program supervisor configs live in /etc/supervisor/conf.d/. The
+# default supervisord.conf from the package globs *.conf out of that dir.
+COPY infra/docker/obs/supervisor/ /etc/supervisor/conf.d/
 
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -23,11 +23,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # msttcorefonts wants EULA pre-acceptance for unattended install. Trebuchet MS
 # is used by some onscreen text scene-sources.
+#
+# Display stack: sway (headless Wayland compositor) + wayvnc (Wayland VNC
+# server). Replaces the previous Xvfb / fluxbox / x11vnc trio so OBS's
+# OpenGL hits the iGPU instead of falling back to Mesa llvmpipe. supervisor
+# manages sway/wayvnc/obs/browser-refresh as separate programs with
+# Wayland-socket-wait dependency on sway. See Dockerfile (amd64) for the
+# longer comment.
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
       | debconf-set-selections \
     && apt-get update && apt-get install -y --no-install-recommends \
-      xvfb x11vnc fluxbox feh tini gettext-base procps x11-utils \
-      ca-certificates dbus-x11 libgl1-mesa-dri \
+      sway wayvnc xwayland supervisor feh tini gettext-base procps \
+      ca-certificates libgl1-mesa-dri \
       fonts-dejavu-core ttf-mscorefonts-installer \
       # OBS runtime deps (mirrors the build deps with -dev stripped) \
       libavcodec60 libavdevice60 libavfilter9 libavformat60 libavutil58 \
@@ -73,10 +80,16 @@ RUN ldconfig
 RUN find /usr/local -name chrome-sandbox -exec chmod 4755 {} +
 
 COPY infra/docker/obs/config/ /opt/obs/config/
+COPY infra/docker/obs/script/ /opt/obs/script/
 COPY infra/docker/obs/entrypoint.sh /opt/obs/entrypoint.sh
 COPY infra/docker/obs/healthcheck.sh /opt/obs/healthcheck.sh
 COPY bin/obs-browser-refresh /opt/obs/bin/obs-browser-refresh
-RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh /opt/obs/bin/obs-browser-refresh
+RUN chmod +x /opt/obs/entrypoint.sh /opt/obs/healthcheck.sh \
+             /opt/obs/bin/obs-browser-refresh /opt/obs/script/*.sh
+
+# Per-program supervisor configs live in /etc/supervisor/conf.d/. The
+# default supervisord.conf from the package globs *.conf out of that dir.
+COPY infra/docker/obs/supervisor/ /etc/supervisor/conf.d/
 
 COPY assets/twitch-overlay-left.png assets/twitch-overlay-right.png /opt/tripbot/assets/
 

--- a/infra/docker/obs/config/global.ini
+++ b/infra/docker/obs/config/global.ini
@@ -1,9 +1,13 @@
 [General]
-; arm64 + Mesa llvmpipe + this CEF build can't paint via the shared-texture
-; path. With BrowserHWAccel=true, obs-browser advertises shared-texture mode
-; to CEF; CEF still calls the software OnPaint callback, which early-returns
-; under sharing_available and drops every frame. Disabling hwaccel keeps
-; OnPaint on the gs_texture_set_image path that actually composites.
+; BrowserHWAccel was disabled originally to work around a Mesa-llvmpipe +
+; arm64-CEF interaction: with hwaccel on, obs-browser advertises the
+; shared-texture path to CEF, which then calls the software OnPaint
+; callback, which early-returns under sharing_available and drops every
+; frame. The Wayland refactor moved OBS's OpenGL onto the iGPU (no more
+; llvmpipe), so the shared-texture path may now work end-to-end. Keeping
+; this false for the initial Wayland rollout to limit blast radius; flip
+; to true and re-test as a separate change once the new display stack
+; has been stable for a while.
 ;
 ; OBS 32 reads BrowserHWAccel from appConfig (global.ini), not userConfig
 ; (user.ini), so this is the only place the setting actually takes effect.

--- a/infra/docker/obs/config/sway-headless.conf
+++ b/infra/docker/obs/config/sway-headless.conf
@@ -1,0 +1,33 @@
+# sway compositor config for headless OBS containers.
+#
+# WLR_BACKENDS=headless (set by entrypoint.sh) makes wlroots create a
+# virtual output named HEADLESS-1 instead of probing real DRM connectors.
+# That's what lets us drive the iGPU's render engine via GBM/EGL without
+# any monitor physically attached to the host's HDMI/DP ports.
+
+# Resolution matches the previous Xvfb framebuffer (1920x1200) so the OBS
+# canvas + the centred 1920x1080 streaming region fit identically. Modeline
+# at 60Hz matches OBS_FPS_COMMON=60 in the high-quality preset.
+output HEADLESS-1 resolution 1920x1200@60Hz position 0,0
+output * bg #000000 solid_color
+
+# No physical input devices in a headless container; tell sway not to
+# wait for any. (Belt-and-braces with WLR_LIBINPUT_NO_DEVICES=1.)
+seat seat0 hide_cursor 0
+
+# OBS is the only meaningful client and should fill the output. Disable
+# title bars + borders so the canvas takes the whole framebuffer. Match
+# by app_id (Qt6/Wayland sets it to com.obsproject.Studio).
+for_window [app_id="com.obsproject.Studio"] fullscreen enable, border none
+
+# Tiling vs. floating doesn't matter with a single client, but force
+# tiling so any incidental popups (file dialogs, etc.) don't end up
+# stacked on top of the streaming canvas in an unpredictable way.
+default_orientation horizontal
+workspace_layout default
+
+# No keybindings are useful here (headless, VNC clients can't reliably
+# round-trip Wayland keysyms through the wayvnc → libei path anyway).
+# An empty binding set keeps sway from logging "no bindings" warnings.
+
+# vim: set ft=swayconfig:

--- a/infra/docker/obs/config/user.ini
+++ b/infra/docker/obs/config/user.ini
@@ -5,7 +5,7 @@ LastVersion=503316482
 ; The program preview is the in-app render OBS draws to its main window
 ; on top of the encoder pipeline. Source rendering still happens for the
 ; stream output regardless; disabling the preview skips the extra
-; composite+blit to the Xvfb framebuffer. VNC into :5900 still shows the
+; composite+blit to the Wayland surface. VNC into :5900 still shows the
 ; OBS UI (just no live preview pane).
 PreviewEnabled=false
 WarnBeforeStoppingStream=false

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # Called by infra/docker/obs/Dockerfile{,.arm64} (ENTRYPOINT via tini):
-# OBS container entrypoint — seeds OBS config, starts Xvfb/fluxbox/x11vnc,
-# launches OBS, and runs the hourly browser-source refresh loop.
+# OBS container entrypoint — seeds OBS config from templates, then hands off
+# to supervisor which manages sway/wayvnc/obs/browser-refresh.
+#
+# Display stack: sway (headless Wayland compositor on /dev/dri/card0) +
+# wayvnc (VNC server, attaches to sway) + OBS as a Wayland-native Qt6
+# client. Replaces the previous Xvfb+fluxbox+x11vnc trio so OBS's OpenGL
+# composite hits the iGPU instead of Mesa llvmpipe.
 set -euo pipefail
 
 echo "OBS container, tripbot version $(cat /etc/tripbot/version 2>/dev/null || echo dev) (sha: $(cat /etc/tripbot/sha 2>/dev/null || echo unknown))"
@@ -93,50 +98,22 @@ esac
 mkdir -p "$OBS_HOME/plugin_config/obs-websocket"
 envsubst < /opt/obs/config/obs-websocket.json.tmpl > "$OBS_HOME/plugin_config/obs-websocket/config.json"
 
-obs_args=(--disable-shutdown-check --collection 'Tripbot' --profile 'ADanaLife' --scene 'Main')
-
+# Render service.json only when STREAM_KEY is set. start-obs.sh keys off
+# this file's existence to decide whether to pass --startstreaming.
 if [[ -n "${STREAM_KEY:-}" ]]; then
   echo "STREAM_KEY set; configuring Twitch and starting stream."
   envsubst < /opt/obs/config/service.json.tmpl \
     > "$OBS_HOME/basic/profiles/ADanaLife/service.json"
-  obs_args+=(--startstreaming)
 else
-  echo "STREAM_KEY not set; OBS will start idle. VNC into :5902 to inspect."
+  echo "STREAM_KEY not set; OBS will start idle. VNC into :5900 to inspect."
+  rm -f "$OBS_HOME/basic/profiles/ADanaLife/service.json"
 fi
 
-export DISPLAY=:0
+# Shared Wayland runtime dir. start-sway.sh creates it with 0700; export
+# it here so any debugging exec'd in the container picks it up too.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/runtime-root}"
 
-rm -f /tmp/.X11-unix/X0 /tmp/.X0-lock
-Xvfb "$DISPLAY" -screen 0 1920x1200x24 &
-sleep 1
-
-# Pin the OBS main window to the center of the 1920x1200 Xvfb display via
-# fluxbox's apps file. Without this rule OBS opens at fluxbox's default
-# top-left corner, leaving most of the framebuffer empty in VNC. Match by
-# WM_CLASS=obs (stable across version/profile/scene title changes).
-mkdir -p "$HOME/.fluxbox"
-cat > "$HOME/.fluxbox/apps" <<'EOF'
-[app] (class=obs)
-  [Position] (CENTER)	{0 0}
-[end]
-EOF
-
-fluxbox &
-sleep 1
-
-x11vnc -display "$DISPLAY" -forever -shared -rfbport 5900 -passwd "${VNC_PASSWD:-123456}" &
-
-# Hourly refresh of every browser source via the local obs-websocket port,
-# working around the CEF per-frame memory leak that otherwise OOMs OBS at
-# the 3Gi pod limit overnight. PR #555 capped browser-source render rate
-# to slow the bleed; this loop drops accumulated render state on a fixed
-# cycle so RSS stays bounded across multi-day uptimes.
-(
-  while sleep 3600; do
-    OBS_WEBSOCKET_HOST=localhost OBS_WEBSOCKET_PORT=4455 \
-      timeout 60 /opt/obs/venv/bin/python /opt/obs/bin/obs-browser-refresh \
-      || echo "[browser-refresh] failed (will retry next cycle)" >&2
-  done
-) &
-
-exec obs "${obs_args[@]}"
+# Hand off to supervisord. It manages sway, wayvnc, obs, and the hourly
+# browser-source refresh (with each program's start order + Wayland-socket
+# dependency handled in script/start-*.sh).
+exec supervisord -n -c /etc/supervisor/supervisord.conf

--- a/infra/docker/obs/healthcheck.sh
+++ b/infra/docker/obs/healthcheck.sh
@@ -1,32 +1,30 @@
 #!/usr/bin/env bash
-# Called by infra/docker/obs/Dockerfile{,.arm64} (HEALTHCHECK CMD).
-# Healthy when:
+# Called by infra/docker/obs/Dockerfile{,.arm64} (HEALTHCHECK CMD) and by
+# the OBS deployment's livenessProbe. Healthy when:
 #   - the obs process is alive
-#   - the X server responds
+#   - sway is reachable (compositor is up)
 #   - the OBS-32 safe-mode crash dialog is NOT up
 #
 # Why specifically the safe-mode dialog: it appears on top of an empty
 # desktop instead of the OBS main window, blocking everything until a
 # human dismisses it. Other OBS modals ("Missing Files", etc.) leave
-# the main window functional and are tolerable. Detection: walk
-# _NET_CLIENT_LIST and fail when any window has WM_CLASS=obs,
-# _NET_WM_STATE_MODAL, and a WM_NAME containing "Crash Detected".
+# the main window functional and are tolerable. Detection: walk the
+# sway tree and fail when any node has a "Crash Detected" title.
 set -u
-export DISPLAY=:0
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/runtime-root}"
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
+export SWAYSOCK="$XDG_RUNTIME_DIR/sway-ipc.sock"
 
 pgrep -x obs >/dev/null || exit 1
-xdpyinfo >/dev/null 2>&1 || exit 1
 
-for wid in $(xprop -root _NET_CLIENT_LIST 2>/dev/null | grep -oE '0x[0-9a-fA-F]+'); do
-  cls=$(xprop -id "$wid" WM_CLASS 2>/dev/null)
-  state=$(xprop -id "$wid" _NET_WM_STATE 2>/dev/null)
-  name=$(xprop -id "$wid" WM_NAME 2>/dev/null)
-  if [[ "$cls"   == *'"obs"'* ]] && \
-     [[ "$state" == *_NET_WM_STATE_MODAL* ]] && \
-     [[ "$name"  == *"Crash Detected"* ]]; then
-    echo "OBS safe-mode dialog blocking the main window: $wid" >&2
-    exit 1
-  fi
-done
+# `swaymsg -t get_tree` proves the compositor is responsive. We don't
+# need jq to walk the tree — a grep on the title field catches the
+# safe-mode dialog without adding another package dep.
+tree=$(swaymsg -t get_tree 2>/dev/null) || exit 1
+
+if grep -qE '"name":\s*"[^"]*Crash Detected[^"]*"' <<<"$tree"; then
+  echo "OBS safe-mode dialog blocking the main window" >&2
+  exit 1
+fi
 
 exit 0

--- a/infra/docker/obs/script/start-browser-refresh.sh
+++ b/infra/docker/obs/script/start-browser-refresh.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Supervisor program: hourly browser-source refresh.
+#
+# Lifted out of the entrypoint's inline `( while sleep 3600; do ...; done ) &`
+# subshell so supervisor can restart it on failure and so its logs land in
+# kubectl-logs alongside the other programs. CEF has a per-frame memory
+# leak (PR #555 capped browser-source render rate to slow the bleed, but
+# the leak is still there); refreshing every browser_source once an hour
+# drops the accumulated render state so RSS stays bounded across multi-day
+# uptimes.
+#
+# Connects via obs-websocket on localhost:4455, so it depends on OBS being
+# up and listening. supervisor's autorestart handles the case where this
+# script starts before OBS is ready (it'll just fail fast on the first
+# attempt and retry).
+set -euo pipefail
+
+# Long sleep at startup so the first refresh happens an hour after pod
+# start, not immediately on boot.
+while sleep 3600; do
+  OBS_WEBSOCKET_HOST=localhost OBS_WEBSOCKET_PORT=4455 \
+    timeout 60 /opt/obs/venv/bin/python /opt/obs/bin/obs-browser-refresh \
+    || echo "[browser-refresh] failed (will retry next cycle)" >&2
+done

--- a/infra/docker/obs/script/start-obs.sh
+++ b/infra/docker/obs/script/start-obs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Supervisor program: launch OBS as a Wayland-native Qt client.
+#
+# Replaces the entrypoint's previous `exec obs ...` line. Waits for sway's
+# Wayland socket before starting — OBS's Qt6 platform plugin can't connect
+# to the compositor before it's up.
+set -euo pipefail
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/runtime-root}"
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
+
+# Force Qt to load its Wayland QPA plugin (qt6-wayland package). Without
+# this Qt picks the highest-priority available platform, and on a system
+# with both X11 and Wayland libs present it sometimes guesses wrong.
+export QT_QPA_PLATFORM=wayland
+
+# Block until the sway socket exists.
+for _ in $(seq 1 60); do
+  if [[ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]; then
+  echo "obs: Wayland socket $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY never appeared" >&2
+  exit 1
+fi
+
+# OBS args mirror the previous entrypoint invocation. --startstreaming
+# only makes sense when service.json was rendered (STREAM_KEY was set);
+# entrypoint.sh writes a sentinel into the obs profile dir to signal that.
+obs_args=(--disable-shutdown-check --collection 'Tripbot' --profile 'ADanaLife' --scene 'Main')
+
+OBS_HOME="${HOME:-/root}/.config/obs-studio"
+if [[ -f "$OBS_HOME/basic/profiles/ADanaLife/service.json" ]]; then
+  obs_args+=(--startstreaming)
+fi
+
+exec obs "${obs_args[@]}"

--- a/infra/docker/obs/script/start-sway.sh
+++ b/infra/docker/obs/script/start-sway.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Supervisor program: launch the sway compositor with headless backends.
+#
+# Replaces the entrypoint's previous `Xvfb $DISPLAY -screen 0 ... &` line.
+# sway uses GBM under the hood to render directly to the iGPU (/dev/dri/card0),
+# unlike Xvfb which is software-only.
+set -euo pipefail
+
+# Wayland sockets / runtime files live here. tmpfs at /tmp keeps the
+# socket out of any persistent volume.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/runtime-root}"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 0700 "$XDG_RUNTIME_DIR"
+
+# wlroots: create a virtual headless output instead of probing for real
+# DRM connectors (host has none attached). Belt-and-braces: also tell it
+# not to wait for input devices that don't exist in a container.
+export WLR_BACKENDS=headless
+export WLR_LIBINPUT_NO_DEVICES=1
+
+# Pin the rendered output to the iGPU via /dev/dri/card0 (primary node,
+# KMS-capable) when present — renderD128 alone isn't enough for sway,
+# which uses GBM allocation that needs card0. Skip the pin when the
+# host doesn't expose a DRM device at all (Mac k3d / stage-1) so sway
+# can fall back to a software path; OBS rendering will be slow there
+# but the pod still boots for end-to-end pipeline testing.
+if [[ -e /dev/dri/card0 ]]; then
+  export WLR_RENDER_DRM_DEVICE=/dev/dri/card0
+else
+  echo "sway: no /dev/dri/card0; running with software renderer (Mac dev / stage-1)" >&2
+  export WLR_RENDERER=pixman
+fi
+
+export SWAYSOCK="$XDG_RUNTIME_DIR/sway-ipc.sock"
+
+exec sway -c /opt/obs/config/sway-headless.conf

--- a/infra/docker/obs/script/start-wayvnc.sh
+++ b/infra/docker/obs/script/start-wayvnc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Supervisor program: serve the headless sway output over VNC on :5900.
+#
+# Replaces the entrypoint's previous `x11vnc -display :0 ...` line.
+# Waits for sway to publish its Wayland socket before launching — wayvnc
+# connects as a Wayland client and can't bootstrap before the compositor.
+set -euo pipefail
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/runtime-root}"
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
+
+# Block until the sway socket exists. supervisor's startretries=10 catches
+# the case where sway is slow to come up after a restart.
+for _ in $(seq 1 60); do
+  if [[ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]; then
+  echo "wayvnc: Wayland socket $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY never appeared" >&2
+  exit 1
+fi
+
+# Listen on all interfaces, port 5900 (matches the EXPOSE in the
+# Dockerfile and the Service definition in k8s/apps/obs/base/). Auth
+# stays off — the Service is cluster-internal and reached via
+# `task obs:vnc:up` port-forward, mirroring the previous x11vnc setup.
+exec wayvnc 0.0.0.0 5900

--- a/infra/docker/obs/supervisor/browser-refresh.conf
+++ b/infra/docker/obs/supervisor/browser-refresh.conf
@@ -1,0 +1,10 @@
+[program:browser-refresh]
+command=/opt/obs/script/start-browser-refresh.sh
+priority=40
+autostart=true
+autorestart=true
+startsecs=2
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/infra/docker/obs/supervisor/obs.conf
+++ b/infra/docker/obs/supervisor/obs.conf
@@ -1,0 +1,15 @@
+[program:obs]
+command=/opt/obs/script/start-obs.sh
+priority=30
+autostart=true
+# OBS exiting is the load-bearing failure for the pod — if it can't be
+# restarted by supervisor, we want the pod to fail its liveness probe and
+# get rescheduled rather than running in a "headless compositor with no
+# producer" state. So bound the restart attempts.
+autorestart=true
+startsecs=5
+startretries=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/infra/docker/obs/supervisor/sway.conf
+++ b/infra/docker/obs/supervisor/sway.conf
@@ -1,0 +1,10 @@
+[program:sway]
+command=/opt/obs/script/start-sway.sh
+priority=10
+autostart=true
+autorestart=true
+startsecs=2
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/infra/docker/obs/supervisor/wayvnc.conf
+++ b/infra/docker/obs/supervisor/wayvnc.conf
@@ -1,0 +1,11 @@
+[program:wayvnc]
+command=/opt/obs/script/start-wayvnc.sh
+priority=20
+autostart=true
+autorestart=true
+startsecs=2
+startretries=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -65,7 +65,7 @@ func (a *App) db() *gorm.DB {
 }
 
 var defaultApp = &App{
-	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
+	CurrentVideo: func() video.Video { return video.CurrentlyPlaying() },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
 	Onscreens: realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost)},
 	VLC:       realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -11,8 +11,10 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/kelvins/geocoder"
 	"gorm.io/gorm"
@@ -65,8 +67,8 @@ func (a *App) db() *gorm.DB {
 var defaultApp = &App{
 	CurrentVideo: func() video.Video { return video.CurrentlyPlaying },
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
-	Onscreens: realOnscreens{},
-	VLC:       realVLC{},
+	Onscreens: realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost)},
+	VLC:       realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},
 	Video:     realVideo{},
 	IRC:       realIRC{},
 	Sessions:  realSessions{},

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -7,8 +7,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,6 +26,12 @@ import (
 var lastHelloTime time.Time = time.Now()
 
 var currentVersion string
+
+// versionFilePath is the build-time-baked version file path. Released
+// container images write the tag here (see infra/docker/*/Dockerfile);
+// outside a container the file won't exist and versionCmd falls back to
+// "dev". Overridable in tests.
+var versionFilePath = "/etc/tripbot/version"
 
 // this is the scoreboard name used for counting correct guesses
 const guessScoreboard = "guess_state_total"
@@ -77,25 +81,30 @@ func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !version", "username", user.Username)
 
-	if helpers.RunningOnWindows() {
-		a.IRC.Say("Sorry, I can't answer that right now")
-		return
-	}
-
-	// check if we already know the version
+	// Cache the lookup — the file is baked at image build time, so its
+	// contents don't change for the lifetime of the process.
 	if currentVersion == "" {
-		// run the shell script to get current tripbot version
-		scriptPath := filepath.Join(helpers.ProjectRoot(), "bin", "current-version.sh")
-		out, err := exec.Command(scriptPath).Output()
-		if err != nil {
-			slog.ErrorContext(ctx, "failed to get current version", "err", err)
-			a.IRC.Say("Failed to get current version :(")
-			return
-		}
-		currentVersion = strings.TrimSpace(string(out))
+		currentVersion = readBuildVersion(ctx)
 	}
 
 	a.IRC.Say("Current version is " + currentVersion)
+}
+
+// readBuildVersion reads the build-time-baked tag from versionFilePath
+// (written by the release Dockerfiles). When the file is missing or
+// empty — i.e. local `go run` outside a container — returns "dev" to
+// match the ldflag default used by the /version HTTP handler.
+func readBuildVersion(ctx context.Context) string {
+	raw, err := os.ReadFile(versionFilePath)
+	if err != nil {
+		slog.DebugContext(ctx, "version file not present, falling back to dev", "err", err, "file", versionFilePath)
+		return "dev"
+	}
+	v := strings.TrimSpace(string(raw))
+	if v == "" {
+		return "dev"
+	}
+	return v
 }
 
 func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -2,6 +2,8 @@ package chatbot
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -442,6 +444,81 @@ func TestVersionCmd_MessageFormat(t *testing.T) {
 
 	if !strings.HasPrefix(out(), "Current version is ") {
 		t.Errorf("unexpected message format: %q", out())
+	}
+}
+
+func TestVersionCmd_ReadsFromVersionFile(t *testing.T) {
+	app := newTestApp(video.Video{})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version")
+	if err := os.WriteFile(path, []byte("v9.9.9-from-file\n"), 0o644); err != nil {
+		t.Fatalf("seed version file: %v", err)
+	}
+
+	origPath := versionFilePath
+	versionFilePath = path
+	currentVersion = ""
+	defer func() {
+		versionFilePath = origPath
+		currentVersion = ""
+	}()
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "v9.9.9-from-file") {
+		t.Errorf("expected version read from file, got %q", out())
+	}
+}
+
+func TestVersionCmd_FallsBackToDevWhenFileMissing(t *testing.T) {
+	app := newTestApp(video.Video{})
+
+	origPath := versionFilePath
+	versionFilePath = filepath.Join(t.TempDir(), "does-not-exist")
+	currentVersion = ""
+	defer func() {
+		versionFilePath = origPath
+		currentVersion = ""
+	}()
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "dev") {
+		t.Errorf("expected 'dev' fallback in output, got %q", out())
+	}
+}
+
+func TestVersionCmd_FallsBackToDevWhenFileEmpty(t *testing.T) {
+	app := newTestApp(video.Video{})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version")
+	if err := os.WriteFile(path, []byte("   \n"), 0o644); err != nil {
+		t.Fatalf("seed empty version file: %v", err)
+	}
+
+	origPath := versionFilePath
+	versionFilePath = path
+	currentVersion = ""
+	defer func() {
+		versionFilePath = origPath
+		currentVersion = ""
+	}()
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.versionCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if !strings.Contains(out(), "dev") {
+		t.Errorf("expected 'dev' fallback for whitespace-only file, got %q", out())
 	}
 }
 

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Onscreens is the subset of the onscreens-client surface that chatbot
-// commands depend on. Tests inject a fake; production uses the package-backed
+// commands depend on. Tests inject a fake; production uses the
 // realOnscreens adapter wired in defaultApp.
 type Onscreens interface {
 	ShowFlag(ctx context.Context, dur time.Duration) error
@@ -18,21 +18,25 @@ type Onscreens interface {
 	ShowTimewarp(ctx context.Context) error
 }
 
-// realOnscreens delegates to pkg/onscreens-client.
-type realOnscreens struct{}
+// realOnscreens delegates to a constructed *onscreensClient.Client. The
+// concrete Client instance is owned by the App (wired up in defaultApp),
+// not read off a package-level global in pkg/onscreens-client.
+type realOnscreens struct {
+	c *onscreensClient.Client
+}
 
-func (realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
-	return onscreensClient.ShowFlag(ctx, dur)
+func (r realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
+	return r.c.ShowFlag(ctx, dur)
 }
-func (realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][]string) error {
-	return onscreensClient.ShowLeaderboard(ctx, title, lb)
+func (r realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][]string) error {
+	return r.c.ShowLeaderboard(ctx, title, lb)
 }
-func (realOnscreens) HideMiddleText(ctx context.Context) error {
-	return onscreensClient.HideMiddleText(ctx)
+func (r realOnscreens) HideMiddleText(ctx context.Context) error {
+	return r.c.HideMiddleText(ctx)
 }
-func (realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
-	return onscreensClient.ShowMiddleText(ctx, msg)
+func (r realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
+	return r.c.ShowMiddleText(ctx, msg)
 }
-func (realOnscreens) ShowTimewarp(ctx context.Context) error {
-	return onscreensClient.ShowTimewarp(ctx)
+func (r realOnscreens) ShowTimewarp(ctx context.Context) error {
+	return r.c.ShowTimewarp(ctx)
 }

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -25,10 +25,10 @@ type Video interface {
 // realVideo delegates to pkg/video.
 type realVideo struct{}
 
-func (realVideo) Current() video.Video { return video.CurrentlyPlaying }
+func (realVideo) Current() video.Video { return video.CurrentlyPlaying() }
 func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
 	video.GetCurrentlyPlaying(ctx)
-	return video.CurrentlyPlaying
+	return video.CurrentlyPlaying()
 }
 func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
 	return video.FindRandomByState(ctx, state)

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -8,8 +8,8 @@ import (
 
 // VLC is the subset of the vlc-client surface that chatbot commands depend
 // on (timewarp, jump, skip, back). Tests inject a fake; production uses the
-// package-backed realVLC adapter wired in defaultApp. Mirrors the Onscreens
-// injection pattern.
+// realVLC adapter wired in defaultApp. Mirrors the Onscreens injection
+// pattern.
 type VLC interface {
 	PlayRandom(ctx context.Context) error
 	PlayFileInPlaylist(ctx context.Context, filename string) error
@@ -17,14 +17,18 @@ type VLC interface {
 	Back(ctx context.Context, n int) error
 }
 
-// realVLC delegates to pkg/vlc-client.
-type realVLC struct{}
+// realVLC delegates to a constructed *vlcClient.Client. The concrete Client
+// instance is owned by the App (wired up in defaultApp), not read off a
+// package-level global in pkg/vlc-client.
+type realVLC struct {
+	c *vlcClient.Client
+}
 
-func (realVLC) PlayRandom(ctx context.Context) error {
-	return vlcClient.PlayRandom(ctx)
+func (r realVLC) PlayRandom(ctx context.Context) error {
+	return r.c.PlayRandom(ctx)
 }
-func (realVLC) PlayFileInPlaylist(ctx context.Context, filename string) error {
-	return vlcClient.PlayFileInPlaylist(ctx, filename)
+func (r realVLC) PlayFileInPlaylist(ctx context.Context, filename string) error {
+	return r.c.PlayFileInPlaylist(ctx, filename)
 }
-func (realVLC) Skip(ctx context.Context, n int) error { return vlcClient.Skip(ctx, n) }
-func (realVLC) Back(ctx context.Context, n int) error { return vlcClient.Back(ctx, n) }
+func (r realVLC) Skip(ctx context.Context, n int) error { return r.c.Skip(ctx, n) }
+func (r realVLC) Back(ctx context.Context, n int) error { return r.c.Back(ctx, n) }

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -9,16 +9,13 @@ import (
 	"strings"
 	"time"
 
-	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/users"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// Client talks to the onscreens-server HTTP API. Construct via New(host); the
-// package-level defaultClient is wired up at init for callers that still hit
-// the free-function shims below.
+// Client talks to the onscreens-server HTTP API. Construct via New(host).
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
@@ -33,12 +30,6 @@ func New(host string) *Client {
 		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 	}
 }
-
-// defaultClient is the package-level Client used by the free-function shims
-// below. It exists so callers that haven't been migrated yet (pkg/video,
-// cmd/tripbot's cron registration) keep working. New consumers should
-// construct their own *Client via New().
-var defaultClient = New(c.Conf.OnscreensServerHost)
 
 func (c *Client) HideMiddleText(ctx context.Context) error {
 	_, err := c.get(ctx, c.serverURL+"/onscreens/middle/hide")
@@ -160,19 +151,3 @@ func (c *Client) get(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
-
-// ---- package-level shims (transitional) ----
-// Each free function calls the corresponding method on defaultClient. These
-// preserve the existing public surface for unmigrated callers (pkg/video,
-// cmd/tripbot). New consumers should construct their own *Client via New().
-
-func HideMiddleText(ctx context.Context) error                { return defaultClient.HideMiddleText(ctx) }
-func ShowMiddleText(ctx context.Context, msg string) error    { return defaultClient.ShowMiddleText(ctx, msg) }
-func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
-	return defaultClient.ShowLeaderboard(ctx, title, leaderboard)
-}
-func ShowGuessLeaderboard(ctx context.Context)                  { defaultClient.ShowGuessLeaderboard(ctx) }
-func ShowTimewarp(ctx context.Context) error                    { return defaultClient.ShowTimewarp(ctx) }
-func ShowFlag(ctx context.Context, dur time.Duration) error     { return defaultClient.ShowFlag(ctx, dur) }
-func ShowGPSImage(ctx context.Context, dur time.Duration) error { return defaultClient.ShowGPSImage(ctx, dur) }
-func HideGPSImage(ctx context.Context) error                    { return defaultClient.HideGPSImage(ctx) }

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -16,15 +16,32 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-var onscreensServerURL = "http://" + c.Conf.OnscreensServerHost
+// Client talks to the onscreens-server HTTP API. Construct via New(host); the
+// package-level defaultClient is wired up at init for callers that still hit
+// the free-function shims below.
+type Client struct {
+	serverURL  string
+	httpClient *http.Client
+}
 
-// httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans and propagate W3C tracecontext headers.
-// See pkg/vlc-client for the same pattern.
-var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+// New returns a Client pointed at the given onscreens-server host. The HTTP
+// transport is OTel-instrumented so outbound calls produce spans and
+// propagate W3C tracecontext headers.
+func New(host string) *Client {
+	return &Client{
+		serverURL:  "http://" + host,
+		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+	}
+}
 
-func HideMiddleText(ctx context.Context) error {
-	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/middle/hide")
+// defaultClient is the package-level Client used by the free-function shims
+// below. It exists so callers that haven't been migrated yet (pkg/video,
+// cmd/tripbot's cron registration) keep working. New consumers should
+// construct their own *Client via New().
+var defaultClient = New(c.Conf.OnscreensServerHost)
+
+func (c *Client) HideMiddleText(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/onscreens/middle/hide")
 	if err != nil {
 		slog.ErrorContext(ctx, "error hiding middle onscreen", "err", err)
 		return err
@@ -32,10 +49,10 @@ func HideMiddleText(ctx context.Context) error {
 	return nil
 }
 
-func ShowMiddleText(ctx context.Context, msg string) error {
-	url := onscreensServerURL + "/onscreens/middle/show"
+func (c *Client) ShowMiddleText(ctx context.Context, msg string) error {
+	url := c.serverURL + "/onscreens/middle/show"
 	url = fmt.Sprintf("%s?msg=%s", url, helpers.Base64Encode(msg))
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing middle onscreen", "err", err)
 		return err
@@ -43,13 +60,13 @@ func ShowMiddleText(ctx context.Context, msg string) error {
 	return err
 }
 
-func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
+func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
 	content := users.LeaderboardContent(title, leaderboard)
 
-	url := onscreensServerURL + "/onscreens/leaderboard/show"
+	url := c.serverURL + "/onscreens/leaderboard/show"
 	url = fmt.Sprintf("%s?content=%s", url, helpers.Base64Encode(content))
 
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing leaderboard onscreen", "err", err)
 		return err
@@ -58,7 +75,7 @@ func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) 
 }
 
 //TODO: this is taken right from the !guessleaderboard command, DRY it?
-func ShowGuessLeaderboard(ctx context.Context) {
+func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
 	// select users to show in leaderboard
 	size := 10
 	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
@@ -75,11 +92,11 @@ func ShowGuessLeaderboard(ctx context.Context) {
 	}
 
 	// display leaderboard on screen
-	ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
+	c.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 }
 
-func ShowTimewarp(ctx context.Context) error {
-	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/timewarp/show")
+func (c *Client) ShowTimewarp(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/onscreens/timewarp/show")
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing timewarp onscreen", "err", err)
 		return err
@@ -87,11 +104,11 @@ func ShowTimewarp(ctx context.Context) error {
 	return nil
 }
 
-func ShowFlag(ctx context.Context, dur time.Duration) error {
+func (c *Client) ShowFlag(ctx context.Context, dur time.Duration) error {
 	//TODO: bring this back
-	// url := onscreensServerURL + "/onscreens/flag/show"
+	// url := c.serverURL + "/onscreens/flag/show"
 	// url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	// _, err := getUrl(ctx, url)
+	// _, err := c.get(ctx, url)
 	// if err != nil {
 	// 	slog.ErrorContext(ctx, "error showing flag onscreen", "err", err)
 	// 	return err
@@ -99,10 +116,10 @@ func ShowFlag(ctx context.Context, dur time.Duration) error {
 	return nil
 }
 
-func ShowGPSImage(ctx context.Context, dur time.Duration) error {
-	url := onscreensServerURL + "/onscreens/gps/show"
+func (c *Client) ShowGPSImage(ctx context.Context, dur time.Duration) error {
+	url := c.serverURL + "/onscreens/gps/show"
 	url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing gps onscreen", "err", err)
 		return err
@@ -110,8 +127,8 @@ func ShowGPSImage(ctx context.Context, dur time.Duration) error {
 	return nil
 }
 
-func HideGPSImage(ctx context.Context) error {
-	_, err := getUrl(ctx, onscreensServerURL+"/onscreens/gps/hide")
+func (c *Client) HideGPSImage(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/onscreens/gps/hide")
 	if err != nil {
 		slog.ErrorContext(ctx, "error hiding gps onscreen", "err", err)
 		return err
@@ -120,13 +137,13 @@ func HideGPSImage(ctx context.Context) error {
 }
 
 //TODO: move this to a common location
-func getUrl(ctx context.Context, url string) (string, error) {
+func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		slog.ErrorContext(ctx, "error building request to onscreens server", "err", err)
 		return "", err
 	}
-	response, err := httpClient.Do(req)
+	response, err := c.httpClient.Do(req)
 	if err != nil {
 		slog.ErrorContext(ctx, "error connecting to onscreens server", "err", err)
 		return "", err
@@ -143,3 +160,19 @@ func getUrl(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
+
+// ---- package-level shims (transitional) ----
+// Each free function calls the corresponding method on defaultClient. These
+// preserve the existing public surface for unmigrated callers (pkg/video,
+// cmd/tripbot). New consumers should construct their own *Client via New().
+
+func HideMiddleText(ctx context.Context) error                { return defaultClient.HideMiddleText(ctx) }
+func ShowMiddleText(ctx context.Context, msg string) error    { return defaultClient.ShowMiddleText(ctx, msg) }
+func ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
+	return defaultClient.ShowLeaderboard(ctx, title, leaderboard)
+}
+func ShowGuessLeaderboard(ctx context.Context)                  { defaultClient.ShowGuessLeaderboard(ctx) }
+func ShowTimewarp(ctx context.Context) error                    { return defaultClient.ShowTimewarp(ctx) }
+func ShowFlag(ctx context.Context, dur time.Duration) error     { return defaultClient.ShowFlag(ctx, dur) }
+func ShowGPSImage(ctx context.Context, dur time.Duration) error { return defaultClient.ShowGPSImage(ctx, dur) }
+func HideGPSImage(ctx context.Context) error                    { return defaultClient.HideGPSImage(ctx) }

--- a/pkg/onscreens-server/handlers_test.go
+++ b/pkg/onscreens-server/handlers_test.go
@@ -12,7 +12,7 @@ import (
 // input before reaching the onscreen singletons.
 
 func TestOnscreensMiddleHandlerInvalidBase64Returns422(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/middle/show?msg=!!!not-base64!!!", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "show"})
@@ -26,7 +26,7 @@ func TestOnscreensMiddleHandlerInvalidBase64Returns422(t *testing.T) {
 }
 
 func TestOnscreensMiddleHandlerMissingMsgReturns417(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/middle/show", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "show"})
@@ -40,7 +40,7 @@ func TestOnscreensMiddleHandlerMissingMsgReturns417(t *testing.T) {
 }
 
 func TestOnscreensMiddleHandlerUnknownActionReturns417(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/middle/explode", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "explode"})
@@ -54,7 +54,7 @@ func TestOnscreensMiddleHandlerUnknownActionReturns417(t *testing.T) {
 }
 
 func TestOnscreensLeaderboardHandlerInvalidBase64Returns422(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/leaderboard/show?content=!!!", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "show"})
@@ -68,7 +68,7 @@ func TestOnscreensLeaderboardHandlerInvalidBase64Returns422(t *testing.T) {
 }
 
 func TestOnscreensFlagHandlerUnknownActionReturns417(t *testing.T) {
-	s := testServer()
+	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/flag/explode", nil)
 	req = mux.SetURLVars(req, map[string]string{"action": "explode"})

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -74,12 +74,16 @@ func New(cfg Config) *Server {
 }
 
 // Start brings up the HTTP listener serving all /onscreens/* routes plus
-// the standard /health, /version, /metrics surface. It blocks until the
-// listener returns; callers typically fatal on a non-nil error.
+// the standard /health, /version, /metrics surface. It blocks until either
+// ListenAndServe returns an error or ctx is canceled (typically by the
+// process-level signal handler in cmd/onscreens-server). Callers should
+// fatal on a non-nil error.
 //
-// ctx is currently only used to feed graceful-shutdown plumbing for
-// future use; the listener itself is shut down by the process-level
-// signal handler in cmd/onscreens-server.
+// When ctx is canceled Start returns nil; the caller is responsible for
+// invoking Shutdown with its own deadline so in-flight requests get a
+// chance to drain. The split keeps Start's return contract simple
+// (listener-error vs. clean-stop) and lets the signal handler control
+// the shutdown deadline.
 func (s *Server) Start(ctx context.Context) error {
 	slog.InfoContext(ctx, "starting onscreens-server web server", "bind", c.Conf.OnscreensServerBindAddress)
 
@@ -149,10 +153,38 @@ func (s *Server) Start(ctx context.Context) error {
 		Handler:        otelhttp.NewHandler(app, c.Conf.ServerType),
 	}
 
-	if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	// Run ListenAndServe in a goroutine so Start can block on ctx.Done()
+	// and return cleanly when the signal handler cancels the context. The
+	// caller calls Shutdown after Start returns to drain in-flight
+	// requests with its chosen deadline. ErrServerClosed is the expected
+	// return after Shutdown is called and is not surfaced as an error.
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	select {
+	case err := <-serverErr:
 		return err
+	case <-ctx.Done():
+		return nil
 	}
-	return nil
+}
+
+// Shutdown gracefully stops the HTTP listener, allowing in-flight
+// requests up to ctx's deadline to complete before closing connections.
+// Returns the error from http.Server.Shutdown so callers can log or act
+// on a timeout. Safe to call once Start has returned (or concurrently
+// while Start is blocked on ctx.Done()); calling on a zero-value Server
+// (Start never ran) is a no-op.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.http == nil {
+		return nil
+	}
+	return s.http.Shutdown(ctx)
 }
 
 // versionHandler returns build metadata as JSON. The tag comes from the

--- a/pkg/onscreens-server/setup_test.go
+++ b/pkg/onscreens-server/setup_test.go
@@ -1,7 +1,7 @@
 package onscreensServer
 
 import (
-	"sync"
+	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
@@ -14,20 +14,16 @@ func init() {
 	terrors.Initialize(*c.Conf, "test")
 }
 
-// testServer constructs a *Server once per test binary and reuses it
-// across tests. Constructing fresh per test would be cleaner but each
-// New() call spawns the seven background goroutines (rotator loops +
-// expiry sweepers); the current tests are read-only against handler
-// validation paths so the shared instance is fine and saves the
-// goroutine churn.
-var (
-	testServerOnce sync.Once
-	testServerInst *Server
-)
-
-func testServer() *Server {
-	testServerOnce.Do(func() {
-		testServerInst = New(Config{Version: "test"})
-	})
-	return testServerInst
+// newTestServer constructs a fresh *Server for the calling test, giving
+// each test real state isolation rather than the cross-test sharing the
+// old sync.Once helper provided.
+//
+// New() spawns the seven onscreens' background goroutines (rotator loops +
+// expiry sweepers). They have no stop hook today, so each test leaks its
+// goroutines for the duration of the test process. That's fine for state
+// isolation — every *Server has its own onscreen singletons, and the
+// leaked goroutines only touch the *Server that spawned them.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	return New(Config{Version: "test"})
 }

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -8,17 +8,37 @@ import (
 	"strings"
 	"time"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
-// CurrentlyPlaying is the video that is currently playing
-var CurrentlyPlaying Video
+// Player owns the state of "what's currently playing" and the clients that
+// drive the VLC playback + onscreens overlays. Construct via NewPlayer; the
+// package-level defaultPlayer is wired up at init for callers that still hit
+// the free-function shims below.
+type Player struct {
+	CurrentlyPlaying Video // exported because external callers used to read video.CurrentlyPlaying
+	curVid, preVid   string
+	timeStarted      time.Time
+	onscreens        *onscreensClient.Client
+	vlc              *vlcClient.Client
+}
 
-// these are used to keep track of the current video
-var curVid, preVid string
-var timeStarted time.Time
+// NewPlayer returns a Player with its own Onscreens + VLC clients.
+func NewPlayer(onscreens *onscreensClient.Client, vlc *vlcClient.Client) *Player {
+	return &Player{onscreens: onscreens, vlc: vlc}
+}
+
+// defaultPlayer is the package-level Player used by the free-function shims
+// below. Exists so callers that aren't constructor-injected (cmd/tripbot
+// bootstrap, script/collect-gps) keep working. New consumers should construct
+// their own *Player via NewPlayer().
+var defaultPlayer = NewPlayer(
+	onscreensClient.New(c.Conf.OnscreensServerHost),
+	vlcClient.New(c.Conf.VlcServerHost),
+)
 
 // GetCurrentlyPlaying will use lsof to figure out
 // which dashcam video is currently playing (seriously).
@@ -27,52 +47,55 @@ var timeStarted time.Time
 // trace spans for cron.video.GetCurrentlyPlaying ticks will nest the
 // underlying VLC poll and GPS-image toggles as children.
 //TODO: consider making this return a video struct
-func GetCurrentlyPlaying(ctx context.Context) {
+func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 	var err error
 
 	// save the video we used last time
-	preVid = curVid
+	p.preVid = p.curVid
 
 	// figure out what's currently playing
 	if helpers.RunningOnDarwin() {
-		curVid = figureOutCurrentVideo(ctx)
+		p.curVid = p.figureOutCurrentVideo(ctx)
 	} else {
-		curVid = vlcClient.CurrentlyPlaying(ctx)
+		p.curVid = p.vlc.CurrentlyPlaying(ctx)
 	}
 
 	// if the currently-playing video has changed
-	if curVid != preVid {
+	if p.curVid != p.preVid {
 		// reset the stopwatch
-		timeStarted = time.Now()
+		p.timeStarted = time.Now()
 
 		// share the Video with the system
-		CurrentlyPlaying, err = LoadOrCreate(ctx, curVid)
+		p.CurrentlyPlaying, err = LoadOrCreate(ctx, p.curVid)
 		if err != nil {
-			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", curVid)
+			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", p.curVid)
 		}
 
 		slog.InfoContext(ctx, "now playing",
-			"file", CurrentlyPlaying.File(),
-			"state", helpers.StateToStateAbbrev(CurrentlyPlaying.State),
+			"file", p.CurrentlyPlaying.File(),
+			"state", helpers.StateToStateAbbrev(p.CurrentlyPlaying.State),
 		)
 
 		// show the no-GPS image
-		if CurrentlyPlaying.Flagged {
+		if p.CurrentlyPlaying.Flagged {
 			//TODO: kinda cludgy that we hardcode 60s here
-			onscreensClient.ShowGPSImage(ctx, 60 * time.Second)
+			p.onscreens.ShowGPSImage(ctx, 60*time.Second)
 		} else {
-			onscreensClient.HideGPSImage(ctx)
+			p.onscreens.HideGPSImage(ctx)
 		}
 	}
 }
 
 // CurrentProgress represents how long the video has been playing
 // it will be useful eventually for choosing the exact right screenshot
-func CurrentProgress() time.Duration {
-	return time.Since(timeStarted)
+func (p *Player) CurrentProgress() time.Duration {
+	return time.Since(p.timeStarted)
 }
 
-func figureOutCurrentVideo(ctx context.Context) string {
+// Current returns the currently-playing video.
+func (p *Player) Current() Video { return p.CurrentlyPlaying }
+
+func (p *Player) figureOutCurrentVideo(ctx context.Context) string {
 	if helpers.RunningOnWindows() {
 		slog.ErrorContext(ctx, "can't run script on windows")
 		return ""
@@ -87,3 +110,12 @@ func figureOutCurrentVideo(ctx context.Context) string {
 	}
 	return outString
 }
+
+// ---- package-level shims (transitional) ----
+// Each free function calls the corresponding method on defaultPlayer. These
+// preserve the existing public surface for unmigrated callers. New consumers
+// should construct their own *Player via NewPlayer().
+
+func GetCurrentlyPlaying(ctx context.Context) { defaultPlayer.GetCurrentlyPlaying(ctx) }
+func CurrentProgress() time.Duration          { return defaultPlayer.CurrentProgress() }
+func CurrentlyPlaying() Video                 { return defaultPlayer.Current() }

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -7,13 +7,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// Client talks to the vlc-server HTTP API. Construct via New(host); the
-// package-level defaultClient is wired up at init for callers that still hit
-// the free-function shims below.
+// Client talks to the vlc-server HTTP API. Construct via New(host).
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
@@ -33,11 +30,6 @@ func New(host string) *Client {
 		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 	}
 }
-
-// defaultClient is the package-level Client used by the free-function shims
-// below. It exists so callers that haven't been migrated yet (pkg/video)
-// keep working. New consumers should construct their own *Client via New().
-var defaultClient = New(c.Conf.VlcServerHost)
 
 // CurrentlyPlaying finds the currently-playing video path
 func (c *Client) CurrentlyPlaying(ctx context.Context) string {
@@ -116,16 +108,3 @@ func (c *Client) get(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
-
-// ---- package-level shims (transitional) ----
-// Each free function calls the corresponding method on defaultClient. These
-// preserve the existing public surface for unmigrated callers (pkg/video).
-// New consumers should construct their own *Client via New().
-
-func CurrentlyPlaying(ctx context.Context) string         { return defaultClient.CurrentlyPlaying(ctx) }
-func PlayRandom(ctx context.Context) error                { return defaultClient.PlayRandom(ctx) }
-func PlayFileInPlaylist(ctx context.Context, filename string) error {
-	return defaultClient.PlayFileInPlaylist(ctx, filename)
-}
-func Skip(ctx context.Context, n int) error { return defaultClient.Skip(ctx, n) }
-func Back(ctx context.Context, n int) error { return defaultClient.Back(ctx, n) }

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -11,19 +11,37 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-//TODO: eventually support HTTPS
-var vlcServerURL = "http://" + c.Conf.VlcServerHost
+// Client talks to the vlc-server HTTP API. Construct via New(host); the
+// package-level defaultClient is wired up at init for callers that still hit
+// the free-function shims below.
+type Client struct {
+	serverURL  string
+	httpClient *http.Client
+}
 
-// httpClient wraps the default transport with OpenTelemetry instrumentation
-// so outbound calls produce spans and propagate W3C tracecontext headers.
-// Callers must pass ctx so the propagation has an active span to attach to —
-// passing context.Background() will still send the request, just without a
-// parent span linking it to the caller's trace.
-var httpClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+// New returns a Client pointed at the given vlc-server host. The HTTP
+// transport is OTel-instrumented so outbound calls produce spans and
+// propagate W3C tracecontext headers. Callers must pass ctx so the
+// propagation has an active span to attach to — passing context.Background()
+// will still send the request, just without a parent span linking it to the
+// caller's trace.
+//
+//TODO: eventually support HTTPS
+func New(host string) *Client {
+	return &Client{
+		serverURL:  "http://" + host,
+		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+	}
+}
+
+// defaultClient is the package-level Client used by the free-function shims
+// below. It exists so callers that haven't been migrated yet (pkg/video)
+// keep working. New consumers should construct their own *Client via New().
+var defaultClient = New(c.Conf.VlcServerHost)
 
 // CurrentlyPlaying finds the currently-playing video path
-func CurrentlyPlaying(ctx context.Context) string {
-	response, err := getUrl(ctx, vlcServerURL+"/vlc/current")
+func (c *Client) CurrentlyPlaying(ctx context.Context) string {
+	response, err := c.get(ctx, c.serverURL+"/vlc/current")
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to determine current video", "err", err)
 		return ""
@@ -32,8 +50,8 @@ func CurrentlyPlaying(ctx context.Context) string {
 }
 
 // PlayRandom plays a random file from the playlist
-func PlayRandom(ctx context.Context) error {
-	_, err := getUrl(ctx, vlcServerURL+"/vlc/random")
+func (c *Client) PlayRandom(ctx context.Context) error {
+	_, err := c.get(ctx, c.serverURL+"/vlc/random")
 	if err != nil {
 		slog.ErrorContext(ctx, "error playing random video", "err", err)
 		return err
@@ -42,9 +60,9 @@ func PlayRandom(ctx context.Context) error {
 }
 
 // PlayFileInPlaylist plays a given file
-func PlayFileInPlaylist(ctx context.Context, filename string) error {
-	url := vlcServerURL + "/vlc/play/" + filename
-	_, err := getUrl(ctx, url)
+func (c *Client) PlayFileInPlaylist(ctx context.Context, filename string) error {
+	url := c.serverURL + "/vlc/play/" + filename
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error playing file", "err", err)
 		return err
@@ -52,12 +70,12 @@ func PlayFileInPlaylist(ctx context.Context, filename string) error {
 	return nil
 }
 
-func Skip(ctx context.Context, n int) error {
-	url := vlcServerURL + "/vlc/skip"
+func (c *Client) Skip(ctx context.Context, n int) error {
+	url := c.serverURL + "/vlc/skip"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error skipping video", "err", err)
 		return err
@@ -65,12 +83,12 @@ func Skip(ctx context.Context, n int) error {
 	return nil
 }
 
-func Back(ctx context.Context, n int) error {
-	url := vlcServerURL + "/vlc/back"
+func (c *Client) Back(ctx context.Context, n int) error {
+	url := c.serverURL + "/vlc/back"
 	if n > 0 {
 		url = fmt.Sprintf("%s/%d", url, n)
 	}
-	_, err := getUrl(ctx, url)
+	_, err := c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error going back to a video", "err", err)
 		return err
@@ -79,13 +97,13 @@ func Back(ctx context.Context, n int) error {
 }
 
 //TODO: move this to a common location
-func getUrl(ctx context.Context, url string) (string, error) {
+func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		slog.ErrorContext(ctx, "error building request to VLC server", "err", err)
 		return "", err
 	}
-	response, err := httpClient.Do(req)
+	response, err := c.httpClient.Do(req)
 	if err != nil {
 		slog.ErrorContext(ctx, "error connecting to VLC server", "err", err)
 		return "", err
@@ -98,3 +116,16 @@ func getUrl(ctx context.Context, url string) (string, error) {
 	}
 	return string(contents), nil
 }
+
+// ---- package-level shims (transitional) ----
+// Each free function calls the corresponding method on defaultClient. These
+// preserve the existing public surface for unmigrated callers (pkg/video).
+// New consumers should construct their own *Client via New().
+
+func CurrentlyPlaying(ctx context.Context) string         { return defaultClient.CurrentlyPlaying(ctx) }
+func PlayRandom(ctx context.Context) error                { return defaultClient.PlayRandom(ctx) }
+func PlayFileInPlaylist(ctx context.Context, filename string) error {
+	return defaultClient.PlayFileInPlaylist(ctx, filename)
+}
+func Skip(ctx context.Context, n int) error { return defaultClient.Skip(ctx, n) }
+func Back(ctx context.Context, n int) error { return defaultClient.Back(ctx, n) }

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -12,8 +12,24 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// healthcheck URL, for tools to verify the stream is alive
-func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+// livenessHandler answers /health/ and /health/live. Liveness is a
+// process-is-alive signal — if this handler runs at all, the answer is
+// yes. Don't consult libvlc here; deeper checks belong on /health/ready
+// (a stuck player should fail readiness, not get the pod restarted).
+func (s *Server) livenessHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "OK")
+}
+
+// readinessHandler answers /health/ready by consulting Server.Health(),
+// which reflects libvlc player state. Returns 503 with the error message
+// when the player isn't in a state that can serve a viewer, so K8s
+// readiness probes will pull the pod out of rotation while the player
+// recovers (vs. liveness, which would restart the process).
+func (s *Server) readinessHandler(w http.ResponseWriter, r *http.Request) {
+	if err := s.Health(); err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
 	fmt.Fprintf(w, "OK")
 }
 

--- a/pkg/vlc-server/handlers_test.go
+++ b/pkg/vlc-server/handlers_test.go
@@ -86,3 +86,41 @@ func TestCatchAllHandlerGet404(t *testing.T) {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
+
+// liveness is a process-is-alive signal — must answer OK regardless of
+// player state. Construct a Server with no Player to confirm.
+func TestLivenessHandlerAlwaysOK(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/health/live", nil)
+	rec := httptest.NewRecorder()
+
+	s.livenessHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// readiness must fail with 503 when the player isn't initialized. We
+// can't easily simulate a *libvlc.Player in a particular MediaState from
+// a unit test (would need a real libvlc backend), so this covers the
+// nil-Player branch — the same branch Health() returns the "player not
+// initialized" error from.
+func TestReadinessHandlerNilPlayer503(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
+	rec := httptest.NewRecorder()
+
+	s.readinessHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestHealthNilPlayerReturnsError(t *testing.T) {
+	s := &Server{}
+	if err := s.Health(); err == nil {
+		t.Fatal("expected error from Health() with nil Player, got nil")
+	}
+}

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -26,12 +26,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// shutdownTimeout is how long Shutdown waits for in-flight requests to
-// finish before forcing connections closed. 15s is the typical sweet spot:
-// long enough that healthy requests complete, short enough that a stuck
-// handler doesn't block process exit indefinitely.
-const shutdownTimeout = 15 * time.Second
-
 // Config is the construction-time configuration passed to New. It carries
 // only the runtime knobs the binary needs to inject at startup; everything
 // else flows in via the package-level c.Conf read from env.
@@ -54,30 +48,58 @@ type Server struct {
 }
 
 // New constructs a Server, initializing libvlc and loading media off disk.
-// Returns an error if libvlc init or media loading fails.
+// Returns a fully-initialized *Server on success, or (nil, err) on failure
+// with any libvlc resources already allocated released before returning so
+// the caller never has to clean up after a partial init.
 func New(cfg Config) (*Server, error) {
 	s := &Server{Version: cfg.Version}
 	if err := s.initPlayer(); err != nil {
+		s.releasePartial()
 		return nil, err
 	}
 	return s, nil
 }
 
+// releasePartial releases any libvlc resources allocated before an init
+// failure inside New. Mirrors Shutdown's release order (Player.Stop →
+// Player.Release → libvlc.Release) and tolerates fields being nil because
+// the failure may have happened before each was set.
+func (s *Server) releasePartial() {
+	if s.Player != nil {
+		if err := s.Player.Stop(); err != nil {
+			slog.Error("error stopping player during partial-init cleanup", "err", err)
+		}
+		if err := s.Player.Release(); err != nil {
+			slog.Error("error releasing player during partial-init cleanup", "err", err)
+		}
+	}
+	// libvlc.Release is safe to call even if startVLC failed before
+	// libvlc.Init returned successfully — the underlying C ref-count
+	// gate handles the no-op case. Always call it so that the libvlc
+	// instance allocated in startVLC doesn't leak.
+	if err := libvlc.Release(); err != nil {
+		slog.Error("error releasing libvlc during partial-init cleanup", "err", err)
+	}
+}
+
 // Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
-// via signal.NotifyContext) the server stops accepting new connections and
-// waits up to shutdownTimeout for in-flight requests to complete before
-// returning.
+// via signal.NotifyContext) it returns so the caller can invoke
+// Shutdown(ctx) to drain in-flight HTTP requests with a bounded ctx and
+// release libvlc.
 func (s *Server) Start(ctx context.Context) {
 	slog.InfoContext(ctx, "starting VLC web server", "bind", c.Conf.VlcServerBindAddress)
 
 	r := mux.NewRouter()
 
-	// healthcheck endpoints
+	// healthcheck endpoints. /health/ + /health/live answer process-alive
+	// (shallow); /health/ready consults libvlc player state via Health()
+	// so K8s readiness probes pull the pod out of rotation if the player
+	// stalls (without restarting the process).
 	//TODO: handle HEAD requests here too
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.Handle("/", tagged("/health/", s.healthHandler))
-	hp.Handle("/live", tagged("/health/live", s.healthHandler))
-	hp.Handle("/ready", tagged("/health/ready", s.healthHandler))
+	hp.Handle("/", tagged("/health/", s.livenessHandler))
+	hp.Handle("/live", tagged("/health/live", s.livenessHandler))
+	hp.Handle("/ready", tagged("/health/ready", s.readinessHandler))
 
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")
@@ -165,12 +187,9 @@ func (s *Server) Start(ctx context.Context) {
 			terrors.FatalContext(ctx, err, "couldn't start server")
 		}
 	case <-ctx.Done():
-		slog.InfoContext(ctx, "shutting down VLC web server")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := s.http.Shutdown(shutdownCtx); err != nil {
-			slog.ErrorContext(shutdownCtx, "error during VLC web server shutdown", "err", err)
-		}
+		// Return so the caller can run Shutdown(ctx) with a bounded ctx;
+		// that's where http.Server.Shutdown is invoked.
+		slog.InfoContext(ctx, "VLC web server ctx canceled, returning to let caller shut down")
 	}
 }
 

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -1,6 +1,8 @@
 package vlcServer
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -111,23 +113,64 @@ func (s *Server) initPlayer() error {
 	return s.loadMedia()
 }
 
-// Shutdown cleans up VLC as best it can. The release order (player.Stop →
-// player.Release → libvlc.Release) is order-sensitive — releasing the
-// libvlc instance before the player segfaults. Preserve verbatim.
+// Health returns nil when the server is ready to serve a viewer, or an
+// error describing why it isn't. Used by /health/ready (readinessHandler)
+// so K8s readiness probes reflect libvlc player state.
+//
+// Healthy means s.Player is non-nil AND its libvlc MediaState is one of
+// the "active" states: Opening, Buffering, Playing, Paused. Stopped,
+// Ended, Error, and NothingSpecial are treated as unhealthy — Ended is
+// excluded conservatively because while a looping playlist passes
+// through it between clips, a sustained Ended generally indicates a
+// stalled player (the loop logic isn't advancing), and we'd rather fail
+// readiness too eagerly than too lazily.
+func (s *Server) Health() error {
+	if s.Player == nil {
+		return errors.New("player not initialized")
+	}
+	state, err := s.Player.MediaState()
+	if err != nil {
+		return fmt.Errorf("reading player state: %w", err)
+	}
+	switch state {
+	case libvlc.MediaOpening, libvlc.MediaBuffering, libvlc.MediaPlaying, libvlc.MediaPaused:
+		return nil
+	default:
+		return fmt.Errorf("player not running (state=%v)", state)
+	}
+}
+
+// Shutdown drains the HTTP server (bounded by ctx) then cleans up libvlc.
+// The libvlc release order (player.Stop → player.Release → libvlc.Release)
+// is order-sensitive — releasing the libvlc instance before the player
+// segfaults. Preserve verbatim.
+//
+// New guarantees that on success s.Player is non-nil; on failure New
+// releases any partially-allocated libvlc resources itself and returns
+// (nil, err). Callers that hold a non-nil *Server therefore never observe
+// a nil Player, so this method assumes both fields are valid.
+//
+// s.http may be nil if Shutdown is called before Start populated it; in
+// that case there's nothing to drain and we skip straight to libvlc
+// cleanup.
 //
 //TODO: are there more things to close gracefully?
-func (s *Server) Shutdown() {
+func (s *Server) Shutdown(ctx context.Context) {
+	if s.http != nil {
+		slog.InfoContext(ctx, "shutting down VLC web server")
+		if err := s.http.Shutdown(ctx); err != nil {
+			slog.ErrorContext(ctx, "error during VLC web server shutdown", "err", err)
+		}
+	}
 	if helpers.RunningOnDarwin() {
 		slog.Info("not stopping VLC on darwin")
 		return
 	}
-	if s.Player != nil {
-		if err := s.Player.Stop(); err != nil {
-			slog.Error("error stopping player", "err", err)
-		}
-		if err := s.Player.Release(); err != nil {
-			slog.Error("error releasing player", "err", err)
-		}
+	if err := s.Player.Stop(); err != nil {
+		slog.Error("error stopping player", "err", err)
+	}
+	if err := s.Player.Release(); err != nil {
+		slog.Error("error releasing player", "err", err)
 	}
 	if err := libvlc.Release(); err != nil {
 		slog.Error("error releasing libvlc", "err", err)

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -43,7 +43,7 @@ func main() {
 		}
 		// preload the currently-playing vid
 		video.GetCurrentlyPlaying(context.Background())
-		videoFile = video.CurrentlyPlaying.String()
+		videoFile = video.CurrentlyPlaying().String()
 	}
 
 	// a file was passed in via the CLI


### PR DESCRIPTION
## Summary

Minor release. Six PRs since v2.10.0:

- **OBS Wayland display stack** — Sway headless + wayvnc + Qt6 Wayland, supervised by supervisord. Gets the 1080p60 composite off Mesa llvmpipe (~14 CPU cores) and onto the iGPU; unblocks the `_tex` zero-copy VAAPI variant. ([#597](https://github.com/adanalife/tripbot/pull/597/changes))
- **No-globals refactor — finished.** `pkg/video` → `*Player`, `pkg/onscreens-client` + `pkg/vlc-client` → `*Client`, post-refactor polish on `vlc-server` / `onscreens-server`. ([#594](https://github.com/adanalife/tripbot/pull/594/changes), [#595](https://github.com/adanalife/tripbot/pull/595/changes), [#596](https://github.com/adanalife/tripbot/pull/596/changes), [#600](https://github.com/adanalife/tripbot/pull/600/changes))
- **`!version` reads `/etc/tripbot/version` directly**, drops the per-invocation `git remote update` + `git describe` shell-out. ([#598](https://github.com/adanalife/tripbot/pull/598/changes))

Full CHANGELOG entry on this branch.

## Test plan

- [ ] CI green
- [ ] Tag bump fires on merge (`#minor` → v2.11.0)
- [ ] Discord release notification posts
- [ ] OBS pod comes up cleanly on the Wayland stack in stage-1 / prod-1
- [ ] Tripbot pod comes up cleanly; `!version` returns the new tag from chat