### PR TITLE
feat(twitch): broadcaster-token OAuth flow for subscribers/followers

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,16 +38,18 @@ tasks:
       - ENV=testing bin/devenv run --rm test bash
 
   auth:bootstrap:
-    desc: One-time Twitch OAuth bootstrap; writes refresh token to oauth_tokens. Run on host (needs a browser); bring up Postgres first (`bin/devenv up -d db migrate` locally, or `task tripbot:db:up` in infra for cluster DB).
+    desc: Bootstrap BOTH Twitch OAuth identities (bot + broadcaster) back-to-back. Run on host (needs a browser); bring up Postgres first (`bin/devenv up -d db migrate` locally, or `task tripbot:db:up` in infra for cluster DB). Sign in as the bot account when the first browser tab opens, then as the broadcaster on the second.
+    cmds:
+      - task: auth:bootstrap:bot
+      - task: auth:bootstrap:broadcaster
+
+  auth:bootstrap:bot:
+    desc: Bootstrap the bot's Twitch OAuth token (chat:read/edit etc.). Writes the row to oauth_tokens keyed by BOT_USERNAME.
     env:
-      # Local-bootstrap defaults. Override at the shell to point elsewhere.
       ENV: '{{.ENV | default "development"}}'
       DATABASE_HOST: '{{.DATABASE_HOST | default "localhost"}}'
       EXTERNAL_URL: '{{.EXTERNAL_URL | default "http://localhost:8080"}}'
     cmds:
-      # Pull Twitch app credentials from SM so they never live in env.docker.
-      # `mise exec --` activates the pinned Go toolchain in task's
-      # non-interactive subshell (where ~/.zshrc isn't sourced).
       - |
         secret=$(aws-vault exec adanalife-stage -- \
           aws secretsmanager get-secret-value \
@@ -56,7 +58,24 @@ tasks:
         export TWITCH_CLIENT_ID=$(echo "$secret" | jq -r .TWITCH_CLIENT_ID)
         export TWITCH_CLIENT_SECRET=$(echo "$secret" | jq -r .TWITCH_CLIENT_SECRET)
         printf '\a'
-        mise exec -- go run ./cmd/auth-bootstrap
+        mise exec -- go run ./cmd/auth-bootstrap --account=bot
+
+  auth:bootstrap:broadcaster:
+    desc: Bootstrap the broadcaster's Twitch OAuth token (channel:read:subscriptions, moderator:read:followers, user:edit:broadcast). Writes the row to oauth_tokens keyed by CHANNEL_NAME. Required for subscriber/follower polling.
+    env:
+      ENV: '{{.ENV | default "development"}}'
+      DATABASE_HOST: '{{.DATABASE_HOST | default "localhost"}}'
+      EXTERNAL_URL: '{{.EXTERNAL_URL | default "http://localhost:8080"}}'
+    cmds:
+      - |
+        secret=$(aws-vault exec adanalife-stage -- \
+          aws secretsmanager get-secret-value \
+          --secret-id k8s/tripbot/twitch-creds \
+          --query SecretString --output text)
+        export TWITCH_CLIENT_ID=$(echo "$secret" | jq -r .TWITCH_CLIENT_ID)
+        export TWITCH_CLIENT_SECRET=$(echo "$secret" | jq -r .TWITCH_CLIENT_SECRET)
+        printf '\a'
+        mise exec -- go run ./cmd/auth-bootstrap --account=broadcaster
 
   # Release smoke flow — see vault/tripbot/release-checklist.md.
   # Targets the local k3d cluster running the stage-1 overlay

--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -5,7 +5,8 @@
 //
 // Flow:
 //   1. Verify DB reachable.
-//   2. Generate CSRF state, build authorize URL with mytwitch.Scopes.
+//   2. Generate CSRF state, build authorize URL with mytwitch.BotScopes
+//      (or mytwitch.BroadcasterScopes via --account=broadcaster).
 //   3. Spin up a tiny localhost:8080 HTTP listener for the OAuth callback.
 //   4. Open the browser to the authorize URL. Dana signs in as tripbot4000.
 //   5. Twitch redirects to localhost:8080/auth/callback. The handler validates
@@ -58,7 +59,7 @@ func main() {
 
 	state := oauthstate.New()
 	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
-		Scopes:       mytwitch.Scopes,
+		Scopes:       mytwitch.BotScopes,
 		ResponseType: "code",
 		State:        state,
 	})

--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -1,17 +1,23 @@
-// cmd/auth-bootstrap is the one-time interactive Twitch OAuth bootstrap.
+// cmd/auth-bootstrap is the interactive Twitch OAuth bootstrap.
 // Runs locally (on Dana's laptop) against the cluster Postgres via port-forward
-// to populate the oauth_tokens row that the cluster tripbot pod consumes at
-// boot.
+// to populate oauth_tokens rows that the cluster tripbot pod consumes at boot.
+//
+// Two identities need separate consent — the bot (chat:read/edit IRC) and
+// the broadcaster (channel:read:subscriptions etc.). Pick one per run via
+// --account=bot|broadcaster.
 //
 // Flow:
 //   1. Verify DB reachable.
-//   2. Generate CSRF state, build authorize URL with mytwitch.BotScopes
-//      (or mytwitch.BroadcasterScopes via --account=broadcaster).
+//   2. Generate CSRF state, build authorize URL with BotScopes or
+//      BroadcasterScopes per --account. ForceVerify=true so Twitch re-prompts
+//      which account to sign in as (instead of silently reusing the session
+//      cookie from the previous leg).
 //   3. Spin up a tiny localhost:8080 HTTP listener for the OAuth callback.
-//   4. Open the browser to the authorize URL. Dana signs in as tripbot4000.
+//   4. Open the browser to the authorize URL. Sign in as the matching account.
 //   5. Twitch redirects to localhost:8080/auth/callback. The handler validates
 //      state, exchanges the code via mytwitch.GenerateUserAccessToken (which
-//      Upserts the row), and signals completion.
+//      Upserts the row keyed by whichever account signed in), and signals
+//      completion.
 //   6. Exit cleanly.
 //
 // The Twitch app's registered redirect URI is http://localhost:8080/auth/callback;
@@ -21,6 +27,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"log/slog"
@@ -46,6 +53,19 @@ const (
 )
 
 func main() {
+	account := flag.String("account", "bot", "which account to bootstrap: bot (chat:read/edit, etc.) or broadcaster (channel:read:subscriptions, moderator:read:followers, etc.)")
+	flag.Parse()
+
+	var scopes []string
+	switch *account {
+	case "bot":
+		scopes = mytwitch.BotScopes
+	case "broadcaster":
+		scopes = mytwitch.BroadcasterScopes
+	default:
+		log.Fatalf("--account must be 'bot' or 'broadcaster', got %q", *account)
+	}
+
 	// Verify the DB is reachable before any user-facing work; if the
 	// port-forward isn't up this is where it surfaces.
 	if database.Connection() == nil {
@@ -59,9 +79,14 @@ func main() {
 
 	state := oauthstate.New()
 	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
-		Scopes:       mytwitch.BotScopes,
+		Scopes:       scopes,
 		ResponseType: "code",
-		State:        state,
+		// Force-verify makes Twitch re-prompt which account to sign in as,
+		// rather than silently reusing the session cookie from a prior leg.
+		// Without this, running bot then broadcaster back-to-back would just
+		// re-bootstrap whichever account Twitch's session is on.
+		ForceVerify: true,
+		State:       state,
 	})
 
 	done := make(chan error, 1)
@@ -100,7 +125,7 @@ func main() {
 		_ = srv.Shutdown(ctx)
 	}()
 
-	slog.Info("opening browser for Twitch sign-in")
+	slog.Info("opening browser for Twitch sign-in", "account", *account)
 	slog.Info("visit URL", "url", authURL)
 	// Skip browser open in headless environments (e.g. the k8s Job).
 	if os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != "" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {

--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -36,7 +36,7 @@ import (
 	"runtime"
 	"time"
 
-	_ "github.com/adanalife/tripbot/pkg/config/tripbot" // env loader via package init
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
@@ -45,23 +45,34 @@ import (
 )
 
 const (
-	listenAddr     = "localhost:8080"
-	callbackPath   = "/auth/callback"
-	flowTimeout    = 5 * time.Minute
-	shutdownGrace  = 5 * time.Second
-	successHTML    = `<!doctype html><html><head><meta charset="utf-8"><title>tripbot — bootstrap success</title><style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style></head><body><div><h1>Success</h1><p>Refresh token persisted. You may close this tab.</p></div></body></html>`
+	listenAddr    = "localhost:8080"
+	callbackPath  = "/auth/callback"
+	flowTimeout   = 5 * time.Minute
+	shutdownGrace = 5 * time.Second
+	// %s = expectedLogin, %s = --account flag value
+	successHTML = `<!doctype html><html><head><meta charset="utf-8"><title>tripbot — bootstrap success</title><style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style></head><body><div><h1>Success</h1><p>Refresh token persisted for <strong>%s</strong> (%s account). You may close this tab.</p></div></body></html>`
+	// %s = got login, %s = expected login, %s = expected account ("bot"/"broadcaster")
+	mismatchHTML = `<!doctype html><html><head><meta charset="utf-8"><title>tripbot — wrong account</title><style>body{background:#3a0000;color:#fff;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}div{max-width:520px}code{background:#000;padding:2px 5px;border-radius:3px}</style></head><body><div><h1>Wrong account</h1><p>You signed in as <code>%s</code>, but this leg expected <code>%s</code> (the <strong>%s</strong> account).</p><p>No token was written. Sign out of Twitch in this browser (or open an incognito window), then re-run the bootstrap task.</p></div></body></html>`
 )
 
 func main() {
 	account := flag.String("account", "bot", "which account to bootstrap: bot (chat:read/edit, etc.) or broadcaster (channel:read:subscriptions, moderator:read:followers, etc.)")
 	flag.Parse()
 
-	var scopes []string
+	var (
+		scopes        []string
+		expectedLogin string
+		stateAccount  oauthstate.Account
+	)
 	switch *account {
 	case "bot":
 		scopes = mytwitch.BotScopes
+		expectedLogin = c.Conf.BotUsername
+		stateAccount = oauthstate.AccountBot
 	case "broadcaster":
 		scopes = mytwitch.BroadcasterScopes
+		expectedLogin = c.Conf.ChannelName
+		stateAccount = oauthstate.AccountBroadcaster
 	default:
 		log.Fatalf("--account must be 'bot' or 'broadcaster', got %q", *account)
 	}
@@ -77,7 +88,7 @@ func main() {
 		log.Fatalf("could not build Twitch client: %v", err)
 	}
 
-	state := oauthstate.New()
+	state := oauthstate.New(stateAccount)
 	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
 		Scopes:       scopes,
 		ResponseType: "code",
@@ -92,7 +103,7 @@ func main() {
 	done := make(chan error, 1)
 	mux := http.NewServeMux()
 	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
-		if !oauthstate.Validate(r.URL.Query().Get("state")) {
+		if _, ok := oauthstate.Validate(r.URL.Query().Get("state")); !ok {
 			http.Error(w, "invalid or expired state", http.StatusBadRequest)
 			done <- errors.New("state validation failed")
 			return
@@ -103,13 +114,21 @@ func main() {
 			done <- errors.New("no code")
 			return
 		}
-		if err := mytwitch.GenerateUserAccessToken(code); err != nil {
-			http.Error(w, "code exchange failed: "+err.Error(), http.StatusInternalServerError)
+		if err := mytwitch.GenerateUserAccessToken(code, expectedLogin); err != nil {
+			var mismatch *mytwitch.ErrIdentityMismatch
+			if errors.As(err, &mismatch) {
+				// Friendly browser page; no row was written.
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintf(w, mismatchHTML, mismatch.Got, mismatch.Expected, mismatch.AccountID)
+			} else {
+				http.Error(w, "code exchange failed: "+err.Error(), http.StatusInternalServerError)
+			}
 			done <- err
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprint(w, successHTML)
+		fmt.Fprintf(w, successHTML, expectedLogin, *account)
 		done <- nil
 	})
 
@@ -135,9 +154,13 @@ func main() {
 	select {
 	case err := <-done:
 		if err != nil {
+			var mismatch *mytwitch.ErrIdentityMismatch
+			if errors.As(err, &mismatch) {
+				log.Fatalf("bootstrap failed: %s\nNo token was written. Sign out of Twitch (or use a fresh incognito browser) and re-run `task auth:bootstrap:%s`.", mismatch.Error(), *account)
+			}
 			log.Fatalf("bootstrap failed: %v", err)
 		}
-		slog.Info("bootstrap successful, refresh token persisted to oauth_tokens")
+		slog.Info("bootstrap successful, refresh token persisted to oauth_tokens", "login", expectedLogin, "account", *account)
 	case <-time.After(flowTimeout):
 		log.Fatalf("timed out after %s waiting for Twitch callback", flowTimeout)
 	}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -98,10 +98,22 @@ func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 // authInitHandler kicks off an OAuth Authorization Code flow from a browser.
 // Generates a state, redirects (302) to Twitch's authorize URL with the
-// configured Scopes. The cluster pod serves this for emergency re-bootstrap
-// when Dana isn't near a laptop; locally cmd/auth-bootstrap does its own
-// equivalent without going through the public Ingress.
+// scope set for the requested account (?account=bot|broadcaster, default bot).
+// ForceVerify=true so Twitch re-prompts which account to sign in as instead
+// of silently reusing the session cookie. The cluster pod serves this for
+// emergency re-bootstrap when Dana isn't near a laptop; locally
+// cmd/auth-bootstrap does its own equivalent without going through Ingress.
 func authInitHandler(w http.ResponseWriter, r *http.Request) {
+	scopes := mytwitch.BotScopes
+	switch r.URL.Query().Get("account") {
+	case "", "bot":
+		// default
+	case "broadcaster":
+		scopes = mytwitch.BroadcasterScopes
+	default:
+		http.Error(w, "account must be 'bot' or 'broadcaster'", http.StatusBadRequest)
+		return
+	}
 	client, err := helixClient()
 	if err != nil {
 		slog.ErrorContext(r.Context(), "helix client unavailable for /auth/init", "err", err)
@@ -110,8 +122,9 @@ func authInitHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	state := oauthstate.New()
 	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
-		Scopes:       mytwitch.BotScopes,
+		Scopes:       scopes,
 		ResponseType: "code",
+		ForceVerify:  true,
 		State:        state,
 	})
 	http.Redirect(w, r, authURL, http.StatusFound)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/nicklaw5/helix/v2"
@@ -68,12 +69,14 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // authCallbackHandler completes the OAuth Authorization Code flow. Validates
-// the CSRF state, exchanges the code for an access+refresh token via helix,
-// and persists the row (mytwitch.GenerateUserAccessToken handles the helix
-// call + Upsert).
+// the CSRF state (which round-trips the account selector from /auth/init),
+// derives the expected Twitch login from the account, exchanges the code via
+// helix, and persists the row (mytwitch.GenerateUserAccessToken handles the
+// helix call + identity-sanity-check + Upsert).
 func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	state := r.URL.Query().Get("state")
-	if !oauthstate.Validate(state) {
+	account, ok := oauthstate.Validate(state)
+	if !ok {
 		http.Error(w, "invalid or expired state", http.StatusBadRequest)
 		return
 	}
@@ -85,15 +88,32 @@ func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := generateUserAccessToken(code); err != nil {
+	expectedLogin := ""
+	switch account {
+	case oauthstate.AccountBot:
+		expectedLogin = c.Conf.BotUsername
+	case oauthstate.AccountBroadcaster:
+		expectedLogin = c.Conf.ChannelName
+	}
+
+	if err := generateUserAccessToken(code, expectedLogin); err != nil {
+		var mismatch *mytwitch.ErrIdentityMismatch
+		if errors.As(err, &mismatch) {
+			slog.WarnContext(r.Context(), "OAuth bootstrap identity mismatch; no row written",
+				"expected", mismatch.Expected, "got", mismatch.Got, "account", mismatch.AccountID)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, authMismatchHTML, mismatch.Got, mismatch.Expected, mismatch.AccountID, mismatch.AccountID)
+			return
+		}
 		slog.ErrorContext(r.Context(), "GenerateUserAccessToken failed", "err", err)
 		http.Error(w, "failed to exchange code: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	slog.InfoContext(r.Context(), "received token from twitch via auth callback")
+	slog.InfoContext(r.Context(), "received token from twitch via auth callback", "account", account, "login", expectedLogin)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, authSuccessHTML)
+	fmt.Fprintf(w, authSuccessHTML, expectedLogin, string(account))
 }
 
 // authInitHandler kicks off an OAuth Authorization Code flow from a browser.
@@ -105,11 +125,13 @@ func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 // cmd/auth-bootstrap does its own equivalent without going through Ingress.
 func authInitHandler(w http.ResponseWriter, r *http.Request) {
 	scopes := mytwitch.BotScopes
+	account := oauthstate.AccountBot
 	switch r.URL.Query().Get("account") {
 	case "", "bot":
 		// default
 	case "broadcaster":
 		scopes = mytwitch.BroadcasterScopes
+		account = oauthstate.AccountBroadcaster
 	default:
 		http.Error(w, "account must be 'bot' or 'broadcaster'", http.StatusBadRequest)
 		return
@@ -120,7 +142,7 @@ func authInitHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "auth unavailable", http.StatusInternalServerError)
 		return
 	}
-	state := oauthstate.New()
+	state := oauthstate.New(account)
 	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
 		Scopes:       scopes,
 		ResponseType: "code",
@@ -133,12 +155,25 @@ func authInitHandler(w http.ResponseWriter, r *http.Request) {
 // authSuccessHTML is the body returned after a successful code exchange.
 // Inline so the handler doesn't depend on a template file; if this needs
 // styling beyond a few lines, move to an embed.FS template.
+// %s = the discovered login, %s = the account ("bot"/"broadcaster").
 const authSuccessHTML = `<!doctype html>
 <html>
 <head><meta charset="utf-8"><title>tripbot — auth success</title>
 <style>body{background:#0a0a0a;color:#eee;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>
 </head>
-<body><div><h1>Success</h1><p>You may close this tab.</p></div></body>
+<body><div><h1>Success</h1><p>Refresh token persisted for <strong>%s</strong> (%s account). You may close this tab.</p></div></body>
+</html>`
+
+// authMismatchHTML is returned when the discovered Twitch login doesn't
+// match the expected identity for the flow. No row is written.
+// %s = got login, %s = expected login, %s = account ("bot"/"broadcaster"),
+// %s = account again (for the retry-link query param).
+const authMismatchHTML = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>tripbot — wrong account</title>
+<style>body{background:#3a0000;color:#fff;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}div{max-width:540px}code{background:#000;padding:2px 5px;border-radius:3px}a{color:#9cf}</style>
+</head>
+<body><div><h1>Wrong account</h1><p>You signed in as <code>%s</code>, but this leg expected <code>%s</code> (the <strong>%s</strong> account).</p><p>No token was written. Sign out of Twitch in this browser (or open an incognito window), then <a href="/auth/init?account=%s">click here to retry</a>.</p></div></body>
 </html>`
 
 // return a favicon if anyone asks for one

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -110,7 +110,7 @@ func authInitHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	state := oauthstate.New()
 	authURL := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
-		Scopes:       mytwitch.Scopes,
+		Scopes:       mytwitch.BotScopes,
 		ResponseType: "code",
 		State:        state,
 	})

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -57,7 +57,7 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 
 // withStubGenerateUserAccessToken swaps the package-level generator so the
 // /auth/callback handler can be tested without round-tripping to Twitch.
-func withStubGenerateUserAccessToken(t *testing.T, stub func(string) error) {
+func withStubGenerateUserAccessToken(t *testing.T, stub func(string, string) error) {
 	t.Helper()
 	saved := generateUserAccessToken
 	generateUserAccessToken = stub
@@ -65,7 +65,7 @@ func withStubGenerateUserAccessToken(t *testing.T, stub func(string) error) {
 }
 
 func TestAuthCallbackHandler_NoStateReturns400(t *testing.T) {
-	withStubGenerateUserAccessToken(t, func(string) error {
+	withStubGenerateUserAccessToken(t, func(string, string) error {
 		t.Fatal("generator should not be called when state is missing")
 		return nil
 	})
@@ -80,7 +80,7 @@ func TestAuthCallbackHandler_NoStateReturns400(t *testing.T) {
 }
 
 func TestAuthCallbackHandler_BadStateReturns400(t *testing.T) {
-	withStubGenerateUserAccessToken(t, func(string) error {
+	withStubGenerateUserAccessToken(t, func(string, string) error {
 		t.Fatal("generator should not be called when state is invalid")
 		return nil
 	})
@@ -95,8 +95,8 @@ func TestAuthCallbackHandler_BadStateReturns400(t *testing.T) {
 }
 
 func TestAuthCallbackHandler_NoCodeReturns400(t *testing.T) {
-	state := oauthstate.New()
-	withStubGenerateUserAccessToken(t, func(string) error {
+	state := oauthstate.New(oauthstate.AccountBot)
+	withStubGenerateUserAccessToken(t, func(string, string) error {
 		t.Fatal("generator should not be called when code is missing")
 		return nil
 	})
@@ -111,10 +111,11 @@ func TestAuthCallbackHandler_NoCodeReturns400(t *testing.T) {
 }
 
 func TestAuthCallbackHandler_HappyPath(t *testing.T) {
-	state := oauthstate.New()
-	var gotCode string
-	withStubGenerateUserAccessToken(t, func(code string) error {
+	state := oauthstate.New(oauthstate.AccountBot)
+	var gotCode, gotExpected string
+	withStubGenerateUserAccessToken(t, func(code, expected string) error {
 		gotCode = code
+		gotExpected = expected
 		return nil
 	})
 
@@ -128,6 +129,11 @@ func TestAuthCallbackHandler_HappyPath(t *testing.T) {
 	if gotCode != "the-code" {
 		t.Errorf("generator got code %q, want %q", gotCode, "the-code")
 	}
+	// expected login should be BotUsername (from c.Conf) since the state
+	// stashed AccountBot. Empty string here means the routing didn't fire.
+	if gotExpected == "" {
+		t.Errorf("generator got empty expected login; want BotUsername-derived value")
+	}
 	if !strings.Contains(rec.Header().Get("Content-Type"), "text/html") {
 		t.Errorf("Content-Type %q is not html", rec.Header().Get("Content-Type"))
 	}
@@ -137,8 +143,8 @@ func TestAuthCallbackHandler_HappyPath(t *testing.T) {
 }
 
 func TestAuthCallbackHandler_GeneratorErrorReturns500(t *testing.T) {
-	state := oauthstate.New()
-	withStubGenerateUserAccessToken(t, func(string) error {
+	state := oauthstate.New(oauthstate.AccountBot)
+	withStubGenerateUserAccessToken(t, func(string, string) error {
 		return errors.New("twitch broke")
 	})
 
@@ -152,8 +158,8 @@ func TestAuthCallbackHandler_GeneratorErrorReturns500(t *testing.T) {
 }
 
 func TestAuthCallbackHandler_StateIsSingleUse(t *testing.T) {
-	state := oauthstate.New()
-	withStubGenerateUserAccessToken(t, func(string) error { return nil })
+	state := oauthstate.New(oauthstate.AccountBot)
+	withStubGenerateUserAccessToken(t, func(string, string) error { return nil })
 
 	// First call consumes the state and succeeds.
 	req1 := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=x", nil)

--- a/pkg/server/oauthstate/oauthstate.go
+++ b/pkg/server/oauthstate/oauthstate.go
@@ -2,6 +2,11 @@
 // the OAuth Authorization Code flow. Generators stash a random token before
 // redirecting to the IdP; validators consume it on the callback.
 //
+// State entries can carry an Account selector — the identity the flow was
+// initiated for ("bot" or "broadcaster"). Callbacks read the account back
+// on Validate so they can sanity-check the discovered identity against the
+// expectation set at /auth/init time.
+//
 // State entries auto-expire after a short TTL and are single-use (deleted on
 // successful Validate). The in-memory store is process-local — fine for the
 // callback flow where the same process serves /auth/init and /auth/callback,
@@ -18,14 +23,30 @@ import (
 // TTL is how long a state token remains valid after New.
 const TTL = 5 * time.Minute
 
-var (
-	mu    sync.Mutex
-	store = map[string]time.Time{} // state -> expiry
-	now   = time.Now              // overridable in tests
+// Account is the identity selector carried through an OAuth flow.
+// Empty value = flow doesn't enforce an identity check (legacy).
+type Account string
+
+const (
+	AccountUnchecked   Account = ""
+	AccountBot         Account = "bot"
+	AccountBroadcaster Account = "broadcaster"
 )
 
-// New mints a fresh state token, stores it with TTL, and returns it.
-func New() string {
+type entry struct {
+	expiry  time.Time
+	account Account
+}
+
+var (
+	mu    sync.Mutex
+	store = map[string]entry{}
+	now   = time.Now // overridable in tests
+)
+
+// New mints a fresh state token, stashes the account selector + TTL, and
+// returns the token. Pass AccountUnchecked when no identity check is wanted.
+func New(account Account) string {
 	var buf [32]byte
 	if _, err := rand.Read(buf[:]); err != nil {
 		// crypto/rand failure is a process-wide problem; panic is acceptable.
@@ -33,34 +54,38 @@ func New() string {
 	}
 	state := hex.EncodeToString(buf[:])
 	mu.Lock()
-	store[state] = now().Add(TTL)
+	store[state] = entry{expiry: now().Add(TTL), account: account}
 	mu.Unlock()
 	return state
 }
 
-// Validate consumes the state token. Returns true exactly once per New().
-// Subsequent calls (or expired/unknown states) return false.
-func Validate(state string) bool {
+// Validate consumes the state token. Returns the stashed Account and true
+// exactly once per New(). Subsequent calls (or expired/unknown states)
+// return AccountUnchecked, false.
+func Validate(state string) (Account, bool) {
 	if state == "" {
-		return false
+		return AccountUnchecked, false
 	}
 	mu.Lock()
 	defer mu.Unlock()
 	sweepLocked()
-	exp, ok := store[state]
+	e, ok := store[state]
 	if !ok {
-		return false
+		return AccountUnchecked, false
 	}
 	delete(store, state)
-	return now().Before(exp)
+	if !now().Before(e.expiry) {
+		return AccountUnchecked, false
+	}
+	return e.account, true
 }
 
 // sweepLocked drops expired entries. Called from Validate so we never grow
 // the store unboundedly when state tokens go unused.
 func sweepLocked() {
 	t := now()
-	for k, exp := range store {
-		if !t.Before(exp) {
+	for k, e := range store {
+		if !t.Before(e.expiry) {
 			delete(store, k)
 		}
 	}

--- a/pkg/server/oauthstate/oauthstate_test.go
+++ b/pkg/server/oauthstate/oauthstate_test.go
@@ -10,12 +10,12 @@ func resetStore(t *testing.T) {
 	savedNow := now
 	t.Cleanup(func() {
 		mu.Lock()
-		store = map[string]time.Time{}
+		store = map[string]entry{}
 		mu.Unlock()
 		now = savedNow
 	})
 	mu.Lock()
-	store = map[string]time.Time{}
+	store = map[string]entry{}
 	mu.Unlock()
 }
 
@@ -23,7 +23,7 @@ func TestNew_GeneratesUniqueStates(t *testing.T) {
 	resetStore(t)
 	seen := map[string]struct{}{}
 	for i := 0; i < 100; i++ {
-		s := New()
+		s := New(AccountUnchecked)
 		if s == "" {
 			t.Fatal("New returned empty state")
 		}
@@ -36,19 +36,31 @@ func TestNew_GeneratesUniqueStates(t *testing.T) {
 
 func TestValidate_Hit(t *testing.T) {
 	resetStore(t)
-	s := New()
-	if !Validate(s) {
+	s := New(AccountUnchecked)
+	if _, ok := Validate(s); !ok {
 		t.Fatal("expected Validate(New()) to return true")
+	}
+}
+
+func TestValidate_RoundTripsAccount(t *testing.T) {
+	resetStore(t)
+	s := New(AccountBroadcaster)
+	got, ok := Validate(s)
+	if !ok {
+		t.Fatal("expected Validate to succeed")
+	}
+	if got != AccountBroadcaster {
+		t.Errorf("Validate returned account %q, want %q", got, AccountBroadcaster)
 	}
 }
 
 func TestValidate_DoubleUseRejected(t *testing.T) {
 	resetStore(t)
-	s := New()
-	if !Validate(s) {
+	s := New(AccountBot)
+	if _, ok := Validate(s); !ok {
 		t.Fatal("first Validate should succeed")
 	}
-	if Validate(s) {
+	if _, ok := Validate(s); ok {
 		t.Fatal("second Validate of same state should fail (single-use)")
 	}
 }
@@ -57,24 +69,24 @@ func TestValidate_ExpiredRejected(t *testing.T) {
 	resetStore(t)
 	t0 := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 	now = func() time.Time { return t0 }
-	s := New()
+	s := New(AccountBot)
 	// advance past TTL
 	now = func() time.Time { return t0.Add(TTL + time.Second) }
-	if Validate(s) {
+	if _, ok := Validate(s); ok {
 		t.Fatal("expired state should not validate")
 	}
 }
 
 func TestValidate_UnknownRejected(t *testing.T) {
 	resetStore(t)
-	if Validate("not-a-real-state") {
+	if _, ok := Validate("not-a-real-state"); ok {
 		t.Fatal("unknown state should not validate")
 	}
 }
 
 func TestValidate_EmptyStringRejected(t *testing.T) {
 	resetStore(t)
-	if Validate("") {
+	if _, ok := Validate(""); ok {
 		t.Fatal("empty state should not validate")
 	}
 }
@@ -85,7 +97,7 @@ func TestSweepClearsExpiredEntries(t *testing.T) {
 	now = func() time.Time { return t0 }
 	// generate several states that will expire
 	for i := 0; i < 5; i++ {
-		New()
+		New(AccountUnchecked)
 	}
 	mu.Lock()
 	beforeSweep := len(store)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -30,20 +30,31 @@ import (
 // can see remaining headroom without waiting for a 429.
 var helixHTTPClient = &http.Client{Transport: rateLimitRecorder{next: otelhttp.NewTransport(http.DefaultTransport)}}
 
-// Scopes is the OAuth scope set requested for the bot account. Single source
-// of truth — referenced by Client() (App Access Token request),
-// GenerateUserAccessToken (initial user-token exchange), and any code that
-// builds an authorize URL (cmd/auth-bootstrap, /auth/init).
+// BotScopes is the OAuth scope set requested for the bot account
+// (c.Conf.BotUsername — `tripbot4000` in prod). chat:read + chat:edit are
+// required for IRC; moderator:read:chatters lets the bot read the viewer
+// list on a channel where it is a moderator.
 //
-// chat:read + chat:edit are required for IRC. The remaining scopes preserve
-// the broadcast + subscription Helix calls the bot already made.
-var Scopes = []string{
+// Broadcaster-gated endpoints (GetSubscriptions, GetChannelFollows total)
+// authorize against the broadcaster identity, not the bot — those live in
+// BroadcasterScopes. See [[../decisions/...]] / vault/tripbot/tripbot/TODO.md
+// "Subscriber/follower data" item for the identity-vs-scope distinction.
+var BotScopes = []string{
 	"chat:read",
 	"chat:edit",
-	"channel:read:subscriptions",
-	"user:edit:broadcast",
 	"moderator:read:chatters",
+}
+
+// BroadcasterScopes is the OAuth scope set requested for the broadcaster
+// account (c.Conf.ChannelName — `adanalife_` in prod). These are the
+// Helix scopes that authorize against the channel owner's identity:
+// channel:read:subscriptions for GetSubscriptions, moderator:read:followers
+// for GetChannelFollows total, user:edit:broadcast for channel.update
+// (title/category changes).
+var BroadcasterScopes = []string{
+	"channel:read:subscriptions",
 	"moderator:read:followers",
+	"user:edit:broadcast",
 }
 
 // ErrNoToken signals "no oauth_tokens row for the bot account; run the
@@ -103,7 +114,7 @@ func Client() (*helix.Client, error) {
 		slog.Error("error creating client", "err", err)
 	}
 
-	resp, err := client.RequestAppAccessToken(Scopes)
+	resp, err := client.RequestAppAccessToken(append(append([]string{}, BotScopes...), BroadcasterScopes...))
 	if err != nil {
 		slog.Error("error getting app access token from twitch", "err", err)
 	}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -61,22 +61,33 @@ var BroadcasterScopes = []string{
 // bootstrap CLI." Re-exported from oauthtokens for caller convenience.
 var ErrNoToken = oauthtokens.ErrNoToken
 
-// currentTwitchClient is the lazy-initialized helix client.
+// currentTwitchClient is the lazy-initialized bot helix client. IRC auth +
+// any Helix endpoint authorized against the bot's identity goes through this.
 var currentTwitchClient *helix.Client
 
+// broadcasterTwitchClient is the lazy-initialized broadcaster helix client.
+// Endpoints that authorize against the channel-owner identity (GetSubscriptions,
+// GetChannelFollows total, channel.update, mod actions) go through this — the
+// bot client would 401 since the user-access-token's identity matters, not
+// just its scope set.
+var broadcasterTwitchClient *helix.Client
+
 // ClientID, ClientSecret are set from env at init.
-// AppAccessToken is set in Client() (Client Credentials grant).
+// AppAccessToken is set in Client() (Client Credentials grant) and shared by
+// both helix clients.
 var (
 	ClientID       string
 	ClientSecret   string
 	AppAccessToken string
 )
 
-// tokenMu guards currentUserToken. RWMutex because reads (IRCAuthToken,
-// CurrentUserAccessToken) outnumber writes (LoadFromDB, refresh).
+// tokenMu guards both currentUserToken (bot) and currentBroadcasterToken.
+// RWMutex because reads (IRCAuthToken, CurrentUserAccessToken) outnumber
+// writes (LoadFromDB, refresh).
 var (
-	tokenMu          sync.RWMutex
-	currentUserToken oauthtokens.Token
+	tokenMu                 sync.RWMutex
+	currentUserToken        oauthtokens.Token
+	currentBroadcasterToken oauthtokens.Token
 )
 
 // init requires the static credentials needed to build a helix client.
@@ -125,23 +136,82 @@ func Client() (*helix.Client, error) {
 	return client, err
 }
 
-// LoadFromDB pulls the row for the configured bot account into in-memory
-// state. cmd/tripbot calls this once at boot before chatbot.Initialize; the
-// returned error is checked for ErrNoToken so the cold-start message points
-// at the bootstrap CLI.
+// BroadcasterClient returns the helix client that carries the broadcaster's
+// user-access-token, lazy-building it on first call. Calls authorizing
+// against the channel-owner identity (GetSubscriptions, GetChannelFollows
+// total, channel.update) must go through this client; the bot client would
+// 401 on those endpoints.
+//
+// The App Access Token is reused from Client(); each helix.Client only needs
+// the per-identity user-access-token to differ.
+func BroadcasterClient() (*helix.Client, error) {
+	if broadcasterTwitchClient != nil {
+		return broadcasterTwitchClient, nil
+	}
+	// Ensure Client() ran so AppAccessToken is set.
+	if _, err := Client(); err != nil {
+		return nil, err
+	}
+	client, err := helix.NewClient(&helix.Options{
+		ClientID:     ClientID,
+		ClientSecret: ClientSecret,
+		RedirectURI:  c.Conf.ExternalURL + "/auth/callback",
+		HTTPClient:   helixHTTPClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("twitch: building broadcaster client: %w", err)
+	}
+	if AppAccessToken != "" {
+		client.SetAppAccessToken(AppAccessToken)
+	}
+	tokenMu.RLock()
+	if currentBroadcasterToken.AccessToken != "" {
+		client.SetUserAccessToken(currentBroadcasterToken.AccessToken)
+	}
+	tokenMu.RUnlock()
+	broadcasterTwitchClient = client
+	return client, nil
+}
+
+// LoadFromDB loads both the bot row and the broadcaster row from oauth_tokens.
+// The bot row is required (no IRC without it). The broadcaster row is
+// optional — when missing, broadcaster-gated Helix calls skip until it's
+// seeded via `task tripbot:auth:bootstrap:broadcaster`.
+//
+// Returns ErrNoToken only when the bot row is missing.
 func LoadFromDB() error {
-	t, err := oauthtokens.Get("twitch", c.Conf.BotUsername)
+	botUser := c.Conf.BotUsername
+	broadcasterUser := c.Conf.ChannelName
+
+	t, err := oauthtokens.Get("twitch", botUser)
 	if err != nil {
 		return err
 	}
 	tokenMu.Lock()
 	currentUserToken = t
 	tokenMu.Unlock()
-
-	// If the helix client is already built, prime its user-access-token so
-	// follow-up Helix calls that need user-scoped permissions work.
 	if currentTwitchClient != nil {
 		currentTwitchClient.SetUserAccessToken(t.AccessToken)
+	}
+
+	if broadcasterUser == "" || broadcasterUser == botUser {
+		return nil
+	}
+	bt, berr := oauthtokens.Get("twitch", broadcasterUser)
+	if berr != nil {
+		if errors.Is(berr, oauthtokens.ErrNoToken) {
+			slog.Warn("no broadcaster oauth_tokens row; subscriber/follower polling will skip until `task tripbot:auth:bootstrap:broadcaster` seeds it",
+				"broadcaster", broadcasterUser)
+			return nil
+		}
+		slog.Error("failed to load broadcaster oauth_tokens row", "err", berr, "broadcaster", broadcasterUser)
+		return nil
+	}
+	tokenMu.Lock()
+	currentBroadcasterToken = bt
+	tokenMu.Unlock()
+	if broadcasterTwitchClient != nil {
+		broadcasterTwitchClient.SetUserAccessToken(bt.AccessToken)
 	}
 	return nil
 }

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -239,18 +239,36 @@ func CurrentUserAccessToken() string {
 // GenerateUserAccessToken exchanges a code for an access+refresh token,
 // derives the authenticated username via helix.GetUsers (so bootstrap is
 // account-agnostic — the row is keyed by whoever signed in at consent),
-// and Upserts. If the resulting row matches BOT_USERNAME, also primes the
-// in-memory state so the running bot picks up the rotated token.
+// and Upserts. When the discovered identity matches the bot or the
+// broadcaster, the matching in-memory slot + helix client is also primed
+// so the running pod picks up the rotated token without a restart.
+//
+// Uses a one-shot helix client for the code exchange + GetUsers discovery
+// so the shared bot client's user-access-token is never clobbered by the
+// bootstrap of an unrelated identity.
 //
 // Returns error (no longer swallows). Callers: /auth/callback handler,
 // cmd/auth-bootstrap.
 func GenerateUserAccessToken(code string) error {
-	client, err := Client()
-	if err != nil {
+	// Ensure App Access Token is set so the one-shot client can fall back
+	// for endpoints that allow app auth.
+	if _, err := Client(); err != nil {
 		return err
 	}
+	bootstrapClient, err := helix.NewClient(&helix.Options{
+		ClientID:     ClientID,
+		ClientSecret: ClientSecret,
+		RedirectURI:  c.Conf.ExternalURL + "/auth/callback",
+		HTTPClient:   helixHTTPClient,
+	})
+	if err != nil {
+		return fmt.Errorf("twitch: building bootstrap client: %w", err)
+	}
+	if AppAccessToken != "" {
+		bootstrapClient.SetAppAccessToken(AppAccessToken)
+	}
 
-	resp, err := client.RequestUserAccessToken(code)
+	resp, err := bootstrapClient.RequestUserAccessToken(code)
 	if err != nil {
 		return err
 	}
@@ -261,8 +279,8 @@ func GenerateUserAccessToken(code string) error {
 	// Set the access token so GetUsers identifies the caller from the
 	// Authorization header (helix.UsersParams without IDs/Logins returns
 	// the authenticated user).
-	client.SetUserAccessToken(resp.Data.AccessToken)
-	usersResp, err := client.GetUsers(&helix.UsersParams{})
+	bootstrapClient.SetUserAccessToken(resp.Data.AccessToken)
+	usersResp, err := bootstrapClient.GetUsers(&helix.UsersParams{})
 	if err != nil {
 		return err
 	}
@@ -290,50 +308,99 @@ func GenerateUserAccessToken(code string) error {
 		return err
 	}
 
-	// Bootstrapping a non-bot account (e.g. the broadcaster) writes the row
-	// but doesn't change the running bot's IRC session.
-	if u.Login == c.Conf.BotUsername {
+	// Route the rotated token into the right in-memory slot. Unknown identity
+	// = row written but in-memory unchanged (logged so the operator notices).
+	switch u.Login {
+	case c.Conf.BotUsername:
 		tokenMu.Lock()
 		currentUserToken = tok
 		tokenMu.Unlock()
+		if currentTwitchClient != nil {
+			currentTwitchClient.SetUserAccessToken(tok.AccessToken)
+		}
+	case c.Conf.ChannelName:
+		tokenMu.Lock()
+		currentBroadcasterToken = tok
+		tokenMu.Unlock()
+		if broadcasterTwitchClient != nil {
+			broadcasterTwitchClient.SetUserAccessToken(tok.AccessToken)
+		}
+	default:
+		slog.Warn("OAuth bootstrap completed for unknown identity; oauth_tokens row written but in-memory state unchanged",
+			"login", u.Login, "bot", c.Conf.BotUsername, "broadcaster", c.Conf.ChannelName)
 	}
 	return nil
 }
 
-// RefreshUserAccessToken is the hourly cron entry point. Reads the bot's row,
-// refreshes if within 30 minutes of expiry, and writes the rotated tokens
-// back. A Postgres advisory lock fences concurrent rotation between local
-// dev and a cluster pod sharing the same Twitch account.
+// RefreshUserAccessToken is the hourly cron entry point. Rotates both the
+// bot's and the broadcaster's user-access-tokens if either is within 30
+// minutes of expiry. Each leg uses its own Postgres advisory lock so two
+// running tripbots (local dev + cluster pod) sharing the same account can't
+// race the rotation.
+func RefreshUserAccessToken(ctx context.Context) {
+	botUser := c.Conf.BotUsername
+	broadcasterUser := c.Conf.ChannelName
+
+	refreshOne(ctx, botUser, applyBotToken)
+
+	if broadcasterUser != "" && broadcasterUser != botUser {
+		refreshOne(ctx, broadcasterUser, applyBroadcasterToken)
+	}
+}
+
+// applyBotToken writes the rotated token into the bot slot + primes the
+// bot helix client. Passed to refreshOne so the per-identity slot logic
+// stays out of the refresh dance itself.
+func applyBotToken(tok oauthtokens.Token) {
+	tokenMu.Lock()
+	currentUserToken = tok
+	tokenMu.Unlock()
+	if currentTwitchClient != nil {
+		currentTwitchClient.SetUserAccessToken(tok.AccessToken)
+	}
+}
+
+// applyBroadcasterToken writes the rotated token into the broadcaster slot
+// + primes the broadcaster helix client.
+func applyBroadcasterToken(tok oauthtokens.Token) {
+	tokenMu.Lock()
+	currentBroadcasterToken = tok
+	tokenMu.Unlock()
+	if broadcasterTwitchClient != nil {
+		broadcasterTwitchClient.SetUserAccessToken(tok.AccessToken)
+	}
+}
+
+// refreshOne rotates a single (provider="twitch", username) row if within
+// 30 minutes of expiry. applyInMemory writes the rotated token into the
+// matching in-memory slot — also called on the empty-token path so the
+// caller's slot gets blanked (forcing reconnect / re-bootstrap signalling).
 //
 // TODO: helix client surface should move behind an interface so this
 // function can be unit-tested without a real Twitch round-trip.
-func RefreshUserAccessToken(ctx context.Context) {
-	botUser := c.Conf.BotUsername
-
-	acquired, release, err := oauthtokens.TryRefreshLock("twitch", botUser)
+func refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token)) {
+	acquired, release, err := oauthtokens.TryRefreshLock("twitch", username)
 	if err != nil {
-		slog.ErrorContext(ctx, "oauth refresh lock acquisition failed", "err", err)
+		slog.ErrorContext(ctx, "oauth refresh lock acquisition failed", "err", err, "username", username)
 		return
 	}
 	if !acquired {
 		// Another process is rotating. Wait briefly, re-read the rotated
 		// row, sync in-memory.
 		time.Sleep(2 * time.Second)
-		t, gerr := oauthtokens.Get("twitch", botUser)
+		t, gerr := oauthtokens.Get("twitch", username)
 		if gerr != nil {
-			slog.ErrorContext(ctx, "post-contention re-read failed", "err", gerr)
+			slog.ErrorContext(ctx, "post-contention re-read failed", "err", gerr, "username", username)
 			return
 		}
-		tokenMu.Lock()
-		currentUserToken = t
-		tokenMu.Unlock()
+		applyInMemory(t)
 		return
 	}
 	defer release()
 
-	t, err := oauthtokens.Get("twitch", botUser)
+	t, err := oauthtokens.Get("twitch", username)
 	if err != nil {
-		slog.ErrorContext(ctx, "no oauth_tokens row to refresh", "err", err)
+		slog.ErrorContext(ctx, "no oauth_tokens row to refresh", "err", err, "username", username)
 		return
 	}
 
@@ -343,24 +410,22 @@ func RefreshUserAccessToken(ctx context.Context) {
 
 	client, err := Client()
 	if err != nil {
-		slog.ErrorContext(ctx, "helix client unavailable for refresh", "err", err)
+		slog.ErrorContext(ctx, "helix client unavailable for refresh", "err", err, "username", username)
 		return
 	}
 	resp, err := client.RefreshUserAccessToken(t.RefreshToken)
 	if err != nil {
-		_ = oauthtokens.IncrementFailCount("twitch", botUser)
-		slog.ErrorContext(ctx, "twitch refresh API failed", "err", err)
+		_ = oauthtokens.IncrementFailCount("twitch", username)
+		slog.ErrorContext(ctx, "twitch refresh API failed", "err", err, "username", username)
 		return
 	}
 	if resp == nil || resp.Data.AccessToken == "" {
 		// Empty body typically means invalid_grant (refresh token revoked).
-		// Treat as terminal — blank in-memory so IRC reconnect fails loudly,
-		// and Sentry surfaces the failure for re-bootstrap.
-		_ = oauthtokens.IncrementFailCount("twitch", botUser)
-		tokenMu.Lock()
-		currentUserToken.AccessToken = ""
-		tokenMu.Unlock()
-		slog.ErrorContext(ctx, "oauth refresh failed; need re-bootstrap", "err", errors.New("empty access token in refresh response"))
+		// Treat as terminal — blank in-memory so callers fail loudly, and
+		// Sentry surfaces the failure for re-bootstrap.
+		_ = oauthtokens.IncrementFailCount("twitch", username)
+		applyInMemory(oauthtokens.Token{})
+		slog.ErrorContext(ctx, "oauth refresh failed; need re-bootstrap", "err", errors.New("empty access token in refresh response"), "username", username)
 		return
 	}
 
@@ -374,14 +439,10 @@ func RefreshUserAccessToken(ctx context.Context) {
 		Scopes:       strings.Join(resp.Data.Scopes, " "),
 	}
 	if err := oauthtokens.Upsert(rotated); err != nil {
-		slog.ErrorContext(ctx, "post-refresh Upsert failed", "err", err)
+		slog.ErrorContext(ctx, "post-refresh Upsert failed", "err", err, "username", username)
 		return
 	}
 
-	tokenMu.Lock()
-	currentUserToken = rotated
-	tokenMu.Unlock()
-	client.SetUserAccessToken(rotated.AccessToken)
-
-	slog.InfoContext(ctx, "refreshed user access token")
+	applyInMemory(rotated)
+	slog.InfoContext(ctx, "refreshed user access token", "username", username)
 }

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -236,20 +236,38 @@ func CurrentUserAccessToken() string {
 	return currentUserToken.AccessToken
 }
 
+// ErrIdentityMismatch is returned by GenerateUserAccessToken when the
+// discovered identity (via helix.GetUsers) doesn't match expectedLogin.
+// Callers should surface it with retry guidance; the wrong-identity row is
+// NOT written to oauth_tokens — the check runs before Upsert.
+type ErrIdentityMismatch struct {
+	Expected  string
+	Got       string
+	AccountID string // "bot" or "broadcaster" — for the retry hint
+}
+
+func (e *ErrIdentityMismatch) Error() string {
+	return fmt.Sprintf("twitch: bootstrap identity mismatch — expected %q (%s) but signed in as %q. Sign out of Twitch in this browser and retry, making sure to authenticate as %q.",
+		e.Expected, e.AccountID, e.Got, e.Expected)
+}
+
 // GenerateUserAccessToken exchanges a code for an access+refresh token,
-// derives the authenticated username via helix.GetUsers (so bootstrap is
-// account-agnostic — the row is keyed by whoever signed in at consent),
-// and Upserts. When the discovered identity matches the bot or the
-// broadcaster, the matching in-memory slot + helix client is also primed
-// so the running pod picks up the rotated token without a restart.
+// derives the authenticated username via helix.GetUsers, sanity-checks it
+// against expectedLogin (when non-empty), then Upserts. When the discovered
+// identity matches the bot or the broadcaster, the matching in-memory slot +
+// helix client is also primed so the running pod picks up the rotated token
+// without a restart.
+//
+// The expectedLogin check runs BEFORE Upsert so a wrong-identity sign-in
+// doesn't pollute oauth_tokens. Pass "" to skip the check (legacy callers).
 //
 // Uses a one-shot helix client for the code exchange + GetUsers discovery
 // so the shared bot client's user-access-token is never clobbered by the
 // bootstrap of an unrelated identity.
 //
-// Returns error (no longer swallows). Callers: /auth/callback handler,
-// cmd/auth-bootstrap.
-func GenerateUserAccessToken(code string) error {
+// Returns error (no longer swallows); ErrIdentityMismatch on identity check
+// failure. Callers: /auth/callback handler, cmd/auth-bootstrap.
+func GenerateUserAccessToken(code string, expectedLogin string) error {
 	// Ensure App Access Token is set so the one-shot client can fall back
 	// for endpoints that allow app auth.
 	if _, err := Client(); err != nil {
@@ -294,6 +312,18 @@ func GenerateUserAccessToken(code string) error {
 		return errors.New("twitch: GetUsers returned no users")
 	}
 	u := usersResp.Data.Users[0]
+
+	// Sanity check: the discovered identity must match what the caller
+	// initiated the flow for. Catches the "clicked the bot link with the
+	// wrong browser already signed in as broadcaster" case BEFORE the row
+	// gets written.
+	if expectedLogin != "" && u.Login != expectedLogin {
+		hint := "bot"
+		if expectedLogin == c.Conf.ChannelName {
+			hint = "broadcaster"
+		}
+		return &ErrIdentityMismatch{Expected: expectedLogin, Got: u.Login, AccountID: hint}
+	}
 
 	tok := oauthtokens.Token{
 		Provider:     "twitch",

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -1,6 +1,8 @@
 package twitch
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -142,6 +144,27 @@ func TestBroadcasterTokenLoaded_TrueWhenSet(t *testing.T) {
 
 	if !broadcasterTokenLoaded() {
 		t.Error("broadcasterTokenLoaded() = false with token set; want true")
+	}
+}
+
+func TestErrIdentityMismatch_MessageNamesBoth(t *testing.T) {
+	err := &ErrIdentityMismatch{Expected: "tripbot4000", Got: "adanalife_", AccountID: "bot"}
+	msg := err.Error()
+	for _, want := range []string{"tripbot4000", "adanalife_", "bot"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ErrIdentityMismatch.Error() = %q; missing %q", msg, want)
+		}
+	}
+}
+
+func TestErrIdentityMismatch_ErrorsAs(t *testing.T) {
+	var orig error = &ErrIdentityMismatch{Expected: "x", Got: "y", AccountID: "broadcaster"}
+	var target *ErrIdentityMismatch
+	if !errors.As(orig, &target) {
+		t.Fatal("errors.As did not extract *ErrIdentityMismatch")
+	}
+	if target.Expected != "x" || target.Got != "y" || target.AccountID != "broadcaster" {
+		t.Errorf("extracted: %+v", target)
 	}
 }
 

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -52,35 +52,35 @@ func TestCurrentUserAccessToken_ReturnsRaw(t *testing.T) {
 	}
 }
 
-func TestScopes_IncludesIRCScopes(t *testing.T) {
+func TestBotScopes_IncludesIRCBotScopes(t *testing.T) {
 	required := []string{"chat:read", "chat:edit"}
 	have := map[string]bool{}
-	for _, s := range Scopes {
+	for _, s := range BotScopes {
 		have[s] = true
 	}
 	for _, r := range required {
 		if !have[r] {
-			t.Errorf("Scopes missing required IRC scope %q (have %v)", r, Scopes)
+			t.Errorf("BotScopes missing required IRC scope %q (have %v)", r, BotScopes)
 		}
 	}
 }
 
-func TestScopes_NoDuplicates(t *testing.T) {
+func TestBotScopes_NoDuplicates(t *testing.T) {
 	seen := map[string]bool{}
-	for _, s := range Scopes {
+	for _, s := range BotScopes {
 		if seen[s] {
-			t.Errorf("duplicate scope %q in Scopes", s)
+			t.Errorf("duplicate scope %q in BotScopes", s)
 		}
 		seen[s] = true
 	}
 }
 
-func TestScopes_DropsOpenID(t *testing.T) {
+func TestBotScopes_DropsOpenID(t *testing.T) {
 	// openid was in the previous scope set but the bot doesn't read ID
 	// claims; dropping it shrinks the consent screen and reduces surface.
-	for _, s := range Scopes {
+	for _, s := range BotScopes {
 		if s == "openid" {
-			t.Errorf("Scopes still includes openid; expected drop")
+			t.Errorf("BotScopes still includes openid; expected drop")
 		}
 	}
 }

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -18,6 +18,17 @@ func resetToken(t *testing.T) {
 	})
 }
 
+// resetBroadcasterToken restores currentBroadcasterToken after a mutation.
+func resetBroadcasterToken(t *testing.T) {
+	t.Helper()
+	saved := currentBroadcasterToken
+	t.Cleanup(func() {
+		tokenMu.Lock()
+		currentBroadcasterToken = saved
+		tokenMu.Unlock()
+	})
+}
+
 func TestIRCAuthToken_PrefixesOauth(t *testing.T) {
 	resetToken(t)
 	tokenMu.Lock()
@@ -82,6 +93,55 @@ func TestBotScopes_DropsOpenID(t *testing.T) {
 		if s == "openid" {
 			t.Errorf("BotScopes still includes openid; expected drop")
 		}
+	}
+}
+
+func TestBroadcasterScopes_IncludesSubscriptionsAndFollowers(t *testing.T) {
+	required := []string{"channel:read:subscriptions", "moderator:read:followers"}
+	have := map[string]bool{}
+	for _, s := range BroadcasterScopes {
+		have[s] = true
+	}
+	for _, r := range required {
+		if !have[r] {
+			t.Errorf("BroadcasterScopes missing required scope %q (have %v)", r, BroadcasterScopes)
+		}
+	}
+}
+
+func TestBroadcasterScopes_DisjointFromBotScopes(t *testing.T) {
+	// The two scope sets serve different identities; if a scope appears in
+	// both it suggests confusion about which token authorizes which call.
+	bot := map[string]bool{}
+	for _, s := range BotScopes {
+		bot[s] = true
+	}
+	for _, s := range BroadcasterScopes {
+		if bot[s] {
+			t.Errorf("scope %q appears in both BotScopes and BroadcasterScopes", s)
+		}
+	}
+}
+
+func TestBroadcasterTokenLoaded_FalseWhenEmpty(t *testing.T) {
+	resetBroadcasterToken(t)
+	tokenMu.Lock()
+	currentBroadcasterToken = oauthtokens.Token{}
+	tokenMu.Unlock()
+
+	if broadcasterTokenLoaded() {
+		t.Error("broadcasterTokenLoaded() = true with empty token; want false")
+	}
+}
+
+func TestBroadcasterTokenLoaded_TrueWhenSet(t *testing.T) {
+	resetBroadcasterToken(t)
+	tokenMu.Lock()
+	currentBroadcasterToken = oauthtokens.Token{AccessToken: "broadcaster-tok"}
+	tokenMu.Unlock()
+
+	if !broadcasterTokenLoaded() {
+		t.Error("broadcasterTokenLoaded() = false with token set; want true")
 	}
 }
 

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -43,15 +43,26 @@ func getChannelID(username string) string {
 }
 
 // GetSubscribers pulls down the most recent list of subscribers.
+// Authorizes against the broadcaster identity — the bot's user-access-token
+// can't read the channel owner's subs no matter what scopes it has.
 // ctx is forward-compat plumbing for nesting helix HTTP under the parent
 // cron span; the helix client doesn't accept ctx yet, but the log lines
 // get a trace_id link via slog.InfoContext.
 func GetSubscribers(ctx context.Context) {
+	if !broadcasterTokenLoaded() {
+		slog.InfoContext(ctx, "skipping GetSubscribers: no broadcaster oauth_tokens row")
+		return
+	}
+	bclient, err := BroadcasterClient()
+	if err != nil {
+		slog.ErrorContext(ctx, "broadcaster helix client unavailable", "err", err)
+		return
+	}
 	//TODO: should we do this elsewhere as well?
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
 	}
-	resp, err := currentTwitchClient.GetSubscriptions(&helix.SubscriptionsParams{
+	resp, err := bclient.GetSubscriptions(&helix.SubscriptionsParams{
 		BroadcasterID: ChannelID,
 	})
 	if err != nil {
@@ -62,8 +73,6 @@ func GetSubscribers(ctx context.Context) {
 		// keep the prior subscriber list rather than zeroing it out
 		return
 	}
-
-	// spew.Dump(resp)
 
 	// reset the current subscriber list
 	subscribers = []string{}
@@ -83,12 +92,22 @@ func GetSubscribers(ctx context.Context) {
 }
 
 // GetFollowerCount fetches the current total follower count for the
-// channel. ctx is forward-compat plumbing (see GetSubscribers).
+// channel. Authorizes against the broadcaster identity (moderator:read:followers
+// on the channel-owner token). ctx is forward-compat plumbing (see GetSubscribers).
 func GetFollowerCount(ctx context.Context) {
+	if !broadcasterTokenLoaded() {
+		slog.InfoContext(ctx, "skipping GetFollowerCount: no broadcaster oauth_tokens row")
+		return
+	}
+	bclient, err := BroadcasterClient()
+	if err != nil {
+		slog.ErrorContext(ctx, "broadcaster helix client unavailable", "err", err)
+		return
+	}
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
 	}
-	resp, err := currentTwitchClient.GetChannelFollows(&helix.GetChannelFollowsParams{
+	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
 		BroadcasterID: ChannelID,
 	})
 	if err != nil {
@@ -112,17 +131,28 @@ func UserIsSubscriber(username string) bool {
 	return false
 }
 
-// UserIsFollower returns true if the user follows the channel
+// UserIsFollower returns true if the user follows the channel.
+// Authorizes against the broadcaster identity (moderator:read:followers).
+// When the broadcaster token isn't loaded yet, fail closed.
 func UserIsFollower(username string) bool {
 	// I can't follow myself so just do this
 	if c.UserIsAdmin(username) {
 		return true
 	}
 
+	if !broadcasterTokenLoaded() {
+		return false
+	}
+	bclient, err := BroadcasterClient()
+	if err != nil {
+		slog.Error("broadcaster helix client unavailable", "err", err)
+		return false
+	}
+
 	// get the channel ID for the given user
 	userID := getChannelID(username)
 
-	resp, err := currentTwitchClient.GetChannelFollows(&helix.GetChannelFollowsParams{
+	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
 		BroadcasterID: ChannelID,
 		UserID:        userID,
 	})
@@ -140,4 +170,13 @@ func UserIsFollower(username string) bool {
 	}
 	return true
 
+}
+
+// broadcasterTokenLoaded reports whether the broadcaster's user-access-token
+// has been populated. Cheaper than building the helix client just to discover
+// the user-token slot is empty.
+func broadcasterTokenLoaded() bool {
+	tokenMu.RLock()
+	defer tokenMu.RUnlock()
+	return currentBroadcasterToken.AccessToken != ""
 }


### PR DESCRIPTION
## Summary

Adds a second OAuth flow that consents the broadcaster account (`adanalife_` in prod, `adanalife_staging` in stage), so subscriber/follower polling stops 401'ing.

Surfaced 2026-05-19 when prod-1's freshly-bootstrapped tripbot logged:
> `helix GetSubscriptions returned 401: Missing scope: channel:read:subscriptions or channel_subscriptions`

The surprise wasn't the scope — it's that Twitch's `GetSubscriptions` authorizes against the **broadcaster** identity, and the only row in `oauth_tokens` belongs to `tripbot4000`. Even with `channel:read:subscriptions` granted, that scope on the bot's token reads the **bot's** subs (vacuous), not the broadcaster's. The token identity matters, not just the scope.

This PR is path (1) from the vault TODO — broadcaster-token OAuth, no public ingress needed.

## What changes

- `pkg/twitch`: split `Scopes` into `BotScopes` + `BroadcasterScopes`; add a second `*helix.Client` + in-memory token slot for the broadcaster; `LoadFromDB` loads both rows.
- `GetSubscribers`, `GetFollowerCount`, `UserIsFollower` route through the broadcaster client.
- `RefreshUserAccessToken` cron rotates both rows.
- `cmd/auth-bootstrap`: `--account=bot|broadcaster` flag picks the scope set; `ForceVerify: true` so Twitch re-prompts between runs.
- Taskfile target runs both legs back-to-back.

## Test plan

- [ ] `mise exec -- go test ./...` passes
- [ ] `mise exec -- go build ./...` passes
- [ ] Run `task tripbot:auth:bootstrap` locally; verify two `oauth_tokens` rows exist (`tripbot4000`, `adanalife_`)
- [ ] Deploy to stage-1; verify `helix GetSubscriptions` no longer 401s
- [ ] Verify `twitch_subscribers_total` OTel gauge emits a non-zero value in Grafana
- [ ] Verify `RefreshUserAccessToken` rotates both rows (check `last_refresh_at` advances on both)