### PR TITLE
test(video): cover Player state transitions and GPS overlay toggling

### DIFF
--- a/pkg/video/setup_test.go
+++ b/pkg/video/setup_test.go
@@ -1,0 +1,101 @@
+package video
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/database"
+	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// installMockDB stands up a sqlmock-backed *gorm.DB and installs it as the
+// process-wide singleton via database.SetGormDB. db.go's load/create/save
+// helpers (which read from database.GormDB() directly) will route to the mock
+// instead of attempting a real postgres connection.
+//
+// SkipDefaultTransaction stops GORM from wrapping every write in BEGIN/COMMIT,
+// which would otherwise force every test to mock those bookends.
+//
+// Mirrors the pattern from pkg/chatbot/mockdb_test.go.
+func installMockDB(t *testing.T) sqlmock.Sqlmock {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	database.SetGormDB(gdb)
+	t.Cleanup(func() {
+		database.SetGormDB(nil)
+		_ = sqlDB.Close()
+	})
+	return mock
+}
+
+// recordedCalls captures URL paths hit on a fake server.
+type recordedCalls struct {
+	paths []string
+}
+
+func (r *recordedCalls) add(p string) { r.paths = append(r.paths, p) }
+
+// fakeVLCServer stands up an httptest.Server that responds to /vlc/current
+// with the value pointed to by current. Tests mutate *current to change what
+// the next Player.GetCurrentlyPlaying call observes.
+//
+// Returns a *vlc-client.Client configured to talk to the fake.
+func fakeVLCServer(t *testing.T, current *string) *vlcClient.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/vlc/current" {
+			_, _ = w.Write([]byte(*current))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	// vlcClient.New(host) builds the URL as "http://" + host, so strip the
+	// scheme from the httptest URL before handing it over.
+	return vlcClient.New(strings.TrimPrefix(srv.URL, "http://"))
+}
+
+// fakeOnscreensServer stands up an httptest.Server that records calls to the
+// GPS show/hide endpoints. Tests assert on rec.paths to verify which overlay
+// transitions fired.
+//
+// Returns a *onscreens-client.Client configured to talk to the fake and a
+// pointer to the recorded-calls struct.
+func fakeOnscreensServer(t *testing.T) (*onscreensClient.Client, *recordedCalls) {
+	t.Helper()
+	rec := &recordedCalls{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/onscreens/gps/show", "/onscreens/gps/hide":
+			rec.add(r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return onscreensClient.New(strings.TrimPrefix(srv.URL, "http://")), rec
+}
+
+// expectLoadHit queues a sqlmock expectation for a successful load() — i.e.
+// db.go's `SELECT ... WHERE slug = ?` returning one row with the given
+// id/slug/flagged. State and other columns are left zero.
+func expectLoadHit(mock sqlmock.Sqlmock, id int, slug string, flagged bool) {
+	mock.ExpectQuery(`SELECT \* FROM "videos" WHERE slug = `).
+		WithArgs(slug, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "slug", "flagged"}).
+			AddRow(id, slug, flagged))
+}

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -1,0 +1,219 @@
+package video
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// These tests cover the *Player state-machine introduced in #600. Before the
+// refactor, GetCurrentlyPlaying was a package-level function with package-level
+// state — no way to exercise the transition / GPS-overlay-toggle behaviour
+// without standing up real HTTP + DB. Now the Player is constructable, so we
+// can point it at httptest-backed clients and a sqlmock-backed gorm.DB.
+//
+// Darwin path (figureOutCurrentVideo via lsof script) is not exercised here;
+// the Linux path is what runs in production and what CI tests against. The
+// non-Darwin guard on the relevant tests keeps the assertions stable when
+// running `go test` locally on a Mac.
+
+// skipIfDarwin no-ops the test when GOOS=darwin. GetCurrentlyPlaying picks
+// the figureOutCurrentVideo path on Darwin (lsof + bin/current-file.sh),
+// bypassing the vlc client entirely — so the fake vlc server's response
+// would be ignored and the test would shell out for real.
+func skipIfDarwin(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "darwin" {
+		t.Skip("GetCurrentlyPlaying takes the lsof path on darwin; covered in CI (linux)")
+	}
+}
+
+func TestPlayer_Current_ZeroBeforeAnyCall(t *testing.T) {
+	onscreens, _ := fakeOnscreensServer(t)
+	vlcCurrent := ""
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	got := p.Current()
+	if got != (Video{}) {
+		t.Errorf("Current() before any GetCurrentlyPlaying call = %+v, want zero Video", got)
+	}
+}
+
+func TestPlayer_GetCurrentlyPlaying_FirstCall_FlaggedShowsGPS(t *testing.T) {
+	skipIfDarwin(t)
+	mock := installMockDB(t)
+	onscreens, rec := fakeOnscreensServer(t)
+	vlcCurrent := "2018_0514_224801_013.MP4"
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	// DB returns a flagged video for the slug derived from vlcCurrent.
+	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
+
+	p.GetCurrentlyPlaying(context.Background())
+
+	if p.Current().Slug != "2018_0514_224801_013" {
+		t.Errorf("CurrentlyPlaying.Slug = %q, want %q", p.Current().Slug, "2018_0514_224801_013")
+	}
+	if !p.Current().Flagged {
+		t.Error("expected CurrentlyPlaying.Flagged = true (staged in mock rows)")
+	}
+	if len(rec.paths) != 1 || rec.paths[0] != "/onscreens/gps/show" {
+		t.Errorf("expected single ShowGPSImage call (/onscreens/gps/show), got %v", rec.paths)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPlayer_GetCurrentlyPlaying_FirstCall_NotFlaggedHidesGPS(t *testing.T) {
+	skipIfDarwin(t)
+	mock := installMockDB(t)
+	onscreens, rec := fakeOnscreensServer(t)
+	vlcCurrent := "2019_0615_183000_001.MP4"
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	expectLoadHit(mock, 7, "2019_0615_183000_001", false)
+
+	p.GetCurrentlyPlaying(context.Background())
+
+	if p.Current().Flagged {
+		t.Error("expected CurrentlyPlaying.Flagged = false (staged in mock rows)")
+	}
+	if len(rec.paths) != 1 || rec.paths[0] != "/onscreens/gps/hide" {
+		t.Errorf("expected single HideGPSImage call (/onscreens/gps/hide), got %v", rec.paths)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
+	skipIfDarwin(t)
+	mock := installMockDB(t)
+	onscreens, rec := fakeOnscreensServer(t)
+	vlcCurrent := "2018_0514_224801_013.MP4"
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	// Only one DB hit expected — the second GetCurrentlyPlaying call sees
+	// curVid == preVid and short-circuits before reaching LoadOrCreate.
+	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
+
+	p.GetCurrentlyPlaying(context.Background())
+	timeStartedAfterFirst := p.timeStarted
+
+	// Tiny sleep so a stray timeStarted reset would be observable.
+	time.Sleep(2 * time.Millisecond)
+
+	p.GetCurrentlyPlaying(context.Background())
+
+	if p.timeStarted != timeStartedAfterFirst {
+		t.Error("expected timeStarted unchanged across same-vid calls; got a reset")
+	}
+	if len(rec.paths) != 1 {
+		t.Errorf("expected exactly one onscreens call (from first transition), got %d: %v", len(rec.paths), rec.paths)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *testing.T) {
+	skipIfDarwin(t)
+	mock := installMockDB(t)
+	onscreens, rec := fakeOnscreensServer(t)
+	vlcCurrent := "2018_0514_224801_013.MP4"
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	// First vid: flagged → ShowGPSImage.
+	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
+	// Second vid: not flagged → HideGPSImage.
+	expectLoadHit(mock, 2, "2019_0615_183000_001", false)
+
+	p.GetCurrentlyPlaying(context.Background())
+	firstStart := p.timeStarted
+	firstSlug := p.Current().Slug
+
+	// Flip the vlc-server's reported path; sleep so any reset to timeStarted
+	// is observable as a strictly-greater value.
+	vlcCurrent = "2019_0615_183000_001.MP4"
+	time.Sleep(2 * time.Millisecond)
+
+	p.GetCurrentlyPlaying(context.Background())
+
+	if p.preVid != "2018_0514_224801_013.MP4" {
+		t.Errorf("preVid after transition = %q, want %q", p.preVid, "2018_0514_224801_013.MP4")
+	}
+	if p.curVid != "2019_0615_183000_001.MP4" {
+		t.Errorf("curVid after transition = %q, want %q", p.curVid, "2019_0615_183000_001.MP4")
+	}
+	if !p.timeStarted.After(firstStart) {
+		t.Error("expected timeStarted reset to a later instant on transition")
+	}
+	if p.Current().Slug == firstSlug {
+		t.Errorf("CurrentlyPlaying.Slug unchanged after transition (still %q)", firstSlug)
+	}
+	wantOverlay := []string{"/onscreens/gps/show", "/onscreens/gps/hide"}
+	if len(rec.paths) != len(wantOverlay) {
+		t.Fatalf("expected overlay sequence %v, got %v", wantOverlay, rec.paths)
+	}
+	for i, want := range wantOverlay {
+		if rec.paths[i] != want {
+			t.Errorf("overlay call %d: want %q, got %q", i, want, rec.paths[i])
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPlayer_CurrentProgress_TracksTimeSinceStart(t *testing.T) {
+	skipIfDarwin(t)
+	mock := installMockDB(t)
+	onscreens, _ := fakeOnscreensServer(t)
+	vlcCurrent := "2018_0514_224801_013.MP4"
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
+
+	p.GetCurrentlyPlaying(context.Background())
+	time.Sleep(10 * time.Millisecond)
+
+	got := p.CurrentProgress()
+	if got < 5*time.Millisecond {
+		t.Errorf("CurrentProgress() = %v, expected at least ~10ms since GetCurrentlyPlaying", got)
+	}
+	if got > time.Second {
+		t.Errorf("CurrentProgress() = %v, suspiciously large for a 10ms sleep", got)
+	}
+}
+
+func TestPlayer_GetCurrentlyPlaying_EmptyVlcResult_NoTransition(t *testing.T) {
+	skipIfDarwin(t)
+	// No mockDB needed — when vlc returns "" on the very first call,
+	// curVid stays "" and equals preVid (also ""), so LoadOrCreate is
+	// never invoked. installMockDB-less SetGormDB is left at nil; any
+	// DB hit would NPE and fail the test loudly.
+	onscreens, rec := fakeOnscreensServer(t)
+	vlcCurrent := ""
+	vlc := fakeVLCServer(t, &vlcCurrent)
+	p := NewPlayer(onscreens, vlc)
+
+	p.GetCurrentlyPlaying(context.Background())
+
+	if p.curVid != "" || p.preVid != "" {
+		t.Errorf("curVid/preVid after empty-vlc first call = (%q, %q); want (\"\",\"\")", p.curVid, p.preVid)
+	}
+	if len(rec.paths) != 0 {
+		t.Errorf("expected no overlay calls on no-transition path, got %v", rec.paths)
+	}
+	if p.Current() != (Video{}) {
+		t.Errorf("Current() after empty-vlc first call = %+v, want zero Video", p.Current())
+	}
+}


### PR DESCRIPTION
## Summary

Adds the first test file for `pkg/video`. Now that `*Player` is constructable (via [#600](https://github.com/adanalife/tripbot/pull/600/changes)), its `GetCurrentlyPlaying` state machine — vid-transition detection, `timeStarted` reset on transition, and GPS-image toggle based on the new vid's `Flagged` field — can be exercised against `httptest`-backed `*Client` instances and a sqlmock-backed `gorm.DB`.

Coverage on `pkg/video` goes from 0% to 36% of statements.

## Coverage

- `Current()` returns zero `Video{}` before any `GetCurrentlyPlaying` call
- First call (empty -> some vid): state populated, GPS overlay toggled per `Flagged`
  - Flagged=true -> `/onscreens/gps/show`
  - Flagged=false -> `/onscreens/gps/hide`
- Same-vid call: no transition, no overlay call, no DB hit, `timeStarted` unchanged
- Different-vid call: transition detected, state updated, `timeStarted` resets, overlay toggled for new `Flagged`
- `CurrentProgress()` reflects time since the latest transition (10ms sleep -> >=5ms reading)
- Empty vlc result on first call: no transition (preVid="" == curVid=""), no DB hit, no overlay call

## DB-mocking approach

Followed the chatbot pattern (`pkg/chatbot/mockdb_test.go`): sqlmock-backed `*gorm.DB` installed via `database.SetGormDB`, staged `SELECT * FROM videos WHERE slug = ?` rows for each transition. No INSERT plumbing needed — tests target the load-hit path so the create branch in `db.go` isn't exercised here (out of scope for this PR; future `db_test.go` can cover that).

## Test plan

- [x] `task test` passes (cached `ok pkg/video`)
- [x] `task test:cover` runs all 7 new `TestPlayer_*` cases on Linux with `--- PASS` on each
- [x] `go vet ./pkg/video/...` clean
- [x] `go build ./pkg/video/... ./pkg/chatbot/... ./pkg/onscreens-client/... ./pkg/vlc-client/...` clean
- [x] Darwin runs skip transition tests cleanly (the lsof path bypasses the vlc client); the non-Darwin `Current()` test still runs
- [x] No production code changed (only new `_test.go` files)