### PR TITLE
OBS: point WLR_RENDER_DRM_DEVICE at the render node, not card0

### DIFF
--- a/infra/docker/obs/script/start-sway.sh
+++ b/infra/docker/obs/script/start-sway.sh
@@ -2,8 +2,8 @@
 # Supervisor program: launch the sway compositor with headless backends.
 #
 # Replaces the entrypoint's previous `Xvfb $DISPLAY -screen 0 ... &` line.
-# sway uses GBM under the hood to render directly to the iGPU (/dev/dri/card0),
-# unlike Xvfb which is software-only.
+# sway uses GBM under the hood to render directly to the iGPU's render
+# node (/dev/dri/renderD128), unlike Xvfb which is software-only.
 set -euo pipefail
 
 # Wayland sockets / runtime files live here. tmpfs at /tmp keeps the
@@ -18,16 +18,18 @@ chmod 0700 "$XDG_RUNTIME_DIR"
 export WLR_BACKENDS=headless
 export WLR_LIBINPUT_NO_DEVICES=1
 
-# Pin the rendered output to the iGPU via /dev/dri/card0 (primary node,
-# KMS-capable) when present — renderD128 alone isn't enough for sway,
-# which uses GBM allocation that needs card0. Skip the pin when the
-# host doesn't expose a DRM device at all (Mac k3d / stage-1) so sway
-# can fall back to a software path; OBS rendering will be slow there
-# but the pod still boots for end-to-end pipeline testing.
-if [[ -e /dev/dri/card0 ]]; then
-  export WLR_RENDER_DRM_DEVICE=/dev/dri/card0
+# Pin the rendered output to the iGPU via the render node (renderD128).
+# wlroots' renderer specifically REQUIRES a DRM render node and rejects
+# the primary node /dev/dri/card0 with `'/dev/dri/card0' is not a DRM
+# render node` — card0 is for KMS/scanout, not for GPU compute, which
+# is all the headless backend needs. Skip the pin when the host doesn't
+# expose a render node at all (Mac k3d / stage-1) so sway falls back to
+# a software renderer; OBS rendering is slow there but the pod still
+# boots for end-to-end pipeline testing.
+if [[ -e /dev/dri/renderD128 ]]; then
+  export WLR_RENDER_DRM_DEVICE=/dev/dri/renderD128
 else
-  echo "sway: no /dev/dri/card0; running with software renderer (Mac dev / stage-1)" >&2
+  echo "sway: no /dev/dri/renderD128; running with software renderer (Mac dev / stage-1)" >&2
   export WLR_RENDERER=pixman
 fi
 


### PR DESCRIPTION
## Summary

One-line fix to `start-sway.sh`: wlroots requires a DRM render node, not the primary node. `/dev/dri/card0` → `/dev/dri/renderD128`. Add `#patch` to bump v2.11.0 → v2.11.1.

## Why

The Wayland refactor shipped in [#597](https://github.com/adanalife/tripbot/pull/597/changes) (v2.11.0) brought up cleanly on prod-1 — all four supervisor programs entered RUNNING, OBS streamed to Twitch — but the iGPU acceleration didn't engage. OBS startup log:

```
00:00:00.003 [ERROR] [wlr] [render/wlr_renderer.c:309] '/dev/dri/card0' is not a DRM render node
...
libEGL warning: MESA-LOADER: failed to retrieve device information
libEGL warning: failed to get driver name for fd -1
libEGL warning: egl: failed to create dri2 screen
warning: Unable to open DRM render node.
info: Loading up OpenGL on adapter Mesa llvmpipe (LLVM 20.1.2, 256 bits)
```

Cascade:
1. wlroots rejected `WLR_RENDER_DRM_DEVICE=/dev/dri/card0` because card0 is the primary (KMS scanout) node, not a render node
2. sway silently fell back to pixman software renderer
3. Mesa EGL on the OBS client couldn't get a hardware device handle from the compositor (`failed to create dri2 screen`)
4. OBS fell back to llvmpipe

So we got Wayland but not the iGPU acceleration. Net CPU profile from v2.10.0 (X11 + llvmpipe + VAAPI encode) to v2.11.0 (Wayland + pixman/llvmpipe + VAAPI encode) was basically unchanged.

The fix: point at the render node. The headless backend doesn't need KMS scanout (no display attached) — it only needs GPU compute, which lives on the render node.

## Test plan

- [ ] CI green
- [ ] Cut a release with `#patch` to ship v2.11.1
- [ ] Rollout OBS on prod-1; expect to see:
  - No more `'/dev/dri/card0' is not a DRM render node` ERROR
  - No more `libEGL` MESA-LOADER warnings
  - `Loading up OpenGL on adapter Mesa Intel(R) Graphics ...` (or similar `iris` driver name) instead of `Mesa llvmpipe`
  - `Failed to import VA surface texture` warnings GONE (zero-copy `_tex` path now works)
  - XPU Manager: render engine utilization climbs from 0% to active
  - OBS pod CPU drops materially (target: well under the current ~1487%)

The Mac-dev / stage-1 fallback path is preserved — if `/dev/dri/renderD128` doesn't exist (no iGPU passthrough), sway uses pixman software renderer same as before.