### PR TITLE
OBS: flip BrowserHWAccel=true now that GL is on the iGPU

### DIFF
--- a/infra/docker/obs/config/global.ini
+++ b/infra/docker/obs/config/global.ini
@@ -1,14 +1,14 @@
 [General]
-; BrowserHWAccel was disabled originally to work around a Mesa-llvmpipe +
-; arm64-CEF interaction: with hwaccel on, obs-browser advertises the
-; shared-texture path to CEF, which then calls the software OnPaint
-; callback, which early-returns under sharing_available and drops every
-; frame. The Wayland refactor moved OBS's OpenGL onto the iGPU (no more
-; llvmpipe), so the shared-texture path may now work end-to-end. Keeping
-; this false for the initial Wayland rollout to limit blast radius; flip
-; to true and re-test as a separate change once the new display stack
-; has been stable for a while.
+; obs-browser advertises the GL shared-texture path to CEF, which then
+; renders browser sources into a texture OBS samples directly — no
+; CPU readback per frame. The shared-texture handoff needs both ends
+; on a real GL device; before the v2.11.x Wayland refactor OBS's GL
+; was on Mesa llvmpipe (CPU rasterizer), so CEF's shared-texture
+; OnPaint callback would early-return under sharing_available and drop
+; every frame. Post-Wayland (OBS on Intel iris driver via EGL+Wayland)
+; the handoff completes end-to-end on the iGPU's DRM-PRIME ring, the
+; same buffer-sharing fabric VAAPI's _tex encoder uses.
 ;
 ; OBS 32 reads BrowserHWAccel from appConfig (global.ini), not userConfig
 ; (user.ini), so this is the only place the setting actually takes effect.
-BrowserHWAccel=false
+BrowserHWAccel=true


### PR DESCRIPTION
## Summary

Two-character edit to `infra/docker/obs/config/global.ini`: `BrowserHWAccel=false` → `=true`. With Wayland+iGPU GL in place from the v2.11.x line, the CEF shared-texture path that this flag enables should now work end-to-end.

## Why

`BrowserHWAccel` was originally disabled (the `false` value was added long before the Wayland refactor) to work around a Mesa-llvmpipe + arm64-CEF interaction: obs-browser advertises the GL shared-texture path to CEF, which inspects the shared-context availability and — when OBS's GL was on llvmpipe (no real device) — early-returns under `sharing_available` in CEF's `OnPaint` callback, dropping every frame. The workaround was to leave hwaccel off and force CEF onto its software-paint fallback (full CPU framebuffer per frame, readback into OBS).

The v2.11.0 → v2.11.1 chain moved OBS's GL onto the iGPU's iris driver via EGL+Wayland. The shared-texture handoff now has real GL on both ends — same DRM-PRIME buffer-sharing ring that VAAPI's `_tex` encoder uses. The original blocker is gone.

## What changes

- `global.ini`: `BrowserHWAccel=true`
- Comment block rewritten to capture today's state (was: "keep false until Wayland stable", now: "Wayland IS stable, hwaccel works")

## Expected wins

- Lower CPU per browser source (no more software-paint CPU readback per frame)
- More consistent browser-source frame rate at the configured 2fps
- One less CPU↔GPU copy per browser-source frame on the composite hot path

11 browser sources today (leaderboard, GPS, left/right rotating, middle text, flag, timewarp, etc.) so per-source savings compound.

## Test plan

- [ ] CI green
- [ ] Roll on prod-1
- [ ] Verify obs-browser-page processes still render — open the stream on Twitch and confirm onscreens (leaderboard, GPS, flag, etc.) are still visible and updating
- [ ] Check OBS log for any CEF/browser errors that didn't appear before
- [ ] Compare obs-browser-page CPU per process: was ~0.3-2% each on v2.11.1 (software paint); expect ~0.1-0.5% each (texture handoff)
- [ ] If anything looks wrong on the browser-source side, revert to `false` and we re-evaluate