### PR TITLE
feat(eventsub): WebSocket listener for real-time follow + subscribe events

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -16,6 +16,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/eventsub"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
@@ -94,7 +95,40 @@ func main() {
 	setUpTwitchClient() // required for the below
 	updateSubscribers()
 	getCurrentUsers()
+	startEventSub(shutdownCtx)
 	connectToTwitch()
+}
+
+// startEventSub kicks off the EventSub WebSocket listener in a goroutine
+// so real-time follow/subscribe events fire chat shouts without a 5min
+// polling delay. Skipped (logged, not fatal) when the broadcaster row
+// isn't loaded — the bot still runs without real-time alerts.
+func startEventSub(ctx context.Context) {
+	token := mytwitch.BroadcasterUserAccessToken()
+	if token == "" {
+		slog.WarnContext(ctx, "skipping eventsub: no broadcaster oauth_tokens row; bootstrap with `task tripbot:auth:bootstrap:broadcaster`")
+		return
+	}
+	if mytwitch.ChannelID == "" {
+		// getChannelID is lazy on first call; calling GetSubscribers /
+		// GetFollowerCount typically populates it. updateSubscribers()
+		// above already ran, so this is belt-and-suspenders.
+		slog.WarnContext(ctx, "skipping eventsub: ChannelID not yet resolved")
+		return
+	}
+	go func() {
+		err := eventsub.Run(ctx, eventsub.Config{
+			ClientID:          mytwitch.ClientID,
+			BroadcasterToken:  token,
+			BroadcasterUserID: mytwitch.ChannelID,
+		}, eventsub.Handlers{
+			OnFollow:    chatbot.AnnounceNewFollower,
+			OnSubscribe: chatbot.AnnounceSubscriber,
+		})
+		if err != nil && !errors.Is(err, context.Canceled) {
+			slog.ErrorContext(ctx, "eventsub run terminated", "err", err)
+		}
+	}()
 }
 
 // createRandomSeed ensures that random numbers will be random

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/jmoiron/sqlx v1.4.0
+	github.com/joeyak/go-twitch-eventsub/v3 v3.0.1
 	github.com/joho/godotenv v1.5.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kelvins/geocoder v0.0.0-20231112130812-98d82c75e49b
@@ -27,6 +28,7 @@ require (
 	github.com/nathan-osman/go-sunrise v1.1.0
 	github.com/nicklaw5/helix/v2 v2.34.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/samber/slog-sentry/v2 v2.10.3
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/slok/go-http-metrics v0.13.0
 	github.com/unrolled/secure v1.17.0
@@ -56,6 +58,7 @@ require (
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coder/websocket v1.8.12 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -86,7 +89,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/samber/slog-common v0.21.0 // indirect
-	github.com/samber/slog-sentry/v2 v2.10.3 // indirect
 	github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2 // indirect
 	github.com/urfave/negroni v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/common-nighthawk/go-figure v0.0.0-20200609044655-c4b36f998cf2/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
@@ -114,6 +116,8 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/joeyak/go-twitch-eventsub/v3 v3.0.1 h1:Hc3XsHdhgmmU/kyoQs3qeLmTUGBzqJtAUUkgvbYq4T0=
+github.com/joeyak/go-twitch-eventsub/v3 v3.0.1/go.mod h1:rpqOjYP1ftWDj3H4D8fA58AdOpkvK9YvODoduDpPCQU=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonas-p/go-shp v0.1.1 h1:LY81nN67DBCz6VNFn2kS64CjmnDo9IP8rmSkTvhO9jE=

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -1,0 +1,31 @@
+package chatbot
+
+import (
+	"fmt"
+
+	"github.com/adanalife/tripbot/pkg/users"
+)
+
+// AnnounceNewFollower says a thank-you to a new follower in chat. Wired
+// from pkg/eventsub on channel.follow v2 events.
+func AnnounceNewFollower(username string) {
+	sayFn(fmt.Sprintf("Thank you for the follow, @%s", username))
+}
+
+// AnnounceSubscriber says a thank-you to a new subscriber, gives every
+// currently-logged-in viewer +1 mile, and announces the bonus. Wired
+// from pkg/eventsub on channel.subscribe events.
+//
+// isGift / tier round-trip from the EventSub payload so callers /
+// future enhancements can branch on them; today only the username drives
+// the chat shout. Gift-sub thanks (channel.subscription.gift) and
+// resub-with-message handling (channel.subscription.message) are
+// separate event types — wire them through pkg/eventsub.Handlers as
+// they're added.
+func AnnounceSubscriber(username string, isGift bool, tier string) {
+	_ = isGift
+	_ = tier
+	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
+	users.GiveEveryoneMiles(1.0)
+	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", len(users.LoggedIn)))
+}

--- a/pkg/eventsub/eventsub.go
+++ b/pkg/eventsub/eventsub.go
@@ -1,0 +1,118 @@
+// Package eventsub bootstraps the Twitch EventSub WebSocket client and
+// dispatches typed events to caller-provided handlers.
+//
+// EventSub creates Twitch-side subscriptions authorized against the
+// broadcaster identity; this package consumes the broadcaster's
+// user-access-token + Twitch user ID and wraps
+// github.com/joeyak/go-twitch-eventsub/v3.
+//
+// Lifecycle: Run blocks until the context is cancelled or the WebSocket
+// session terminates fatally. The library handles session_reconnect
+// frames transparently; cmd/tripbot is expected to call Run in a
+// goroutine and survive a Run-returns-error.
+//
+// Subscriptions are created in the OnWelcome callback (per Twitch's
+// protocol — you can't subscribe until you have a session ID). If a
+// subscribe call fails the error is logged and Run continues; partial
+// subscription state is more useful than none.
+package eventsub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	twitch "github.com/joeyak/go-twitch-eventsub/v3"
+)
+
+// Handlers carries the per-event callbacks the caller wants registered.
+// All fields optional — leave a callback nil to skip subscribing to
+// that event entirely (no Twitch-side subscription is created either).
+type Handlers struct {
+	OnFollow    func(username string)
+	OnSubscribe func(username string, isGift bool, tier string)
+}
+
+// Config is the static input Run needs to subscribe. ClientID matches
+// the Twitch app's client ID; BroadcasterToken is the broadcaster's
+// user-access-token (no "oauth:" prefix); BroadcasterUserID is the
+// numeric Twitch user ID — used for both broadcaster_user_id and
+// moderator_user_id conditions on channel.follow v2.
+type Config struct {
+	ClientID          string
+	BroadcasterToken  string
+	BroadcasterUserID string
+}
+
+// Run dials the EventSub WebSocket, subscribes to the events for which
+// Handlers has non-nil callbacks, and blocks until ctx is cancelled or
+// the connection terminates. Returns nil on graceful ctx-driven
+// shutdown; an error on connection failure or fatal protocol error.
+func Run(ctx context.Context, cfg Config, h Handlers) error {
+	if cfg.ClientID == "" || cfg.BroadcasterToken == "" || cfg.BroadcasterUserID == "" {
+		return errors.New("eventsub: Config requires ClientID, BroadcasterToken, and BroadcasterUserID")
+	}
+
+	client := twitch.NewClient()
+
+	client.OnError(func(err error) {
+		slog.ErrorContext(ctx, "eventsub client error", "err", err)
+	})
+
+	client.OnRevoke(func(msg twitch.RevokeMessage) {
+		slog.WarnContext(ctx, "eventsub subscription revoked by twitch — re-bootstrap broadcaster",
+			"type", msg.Payload.Subscription.Type, "status", msg.Payload.Subscription.Status)
+	})
+
+	if h.OnFollow != nil {
+		client.OnEventChannelFollow(func(e twitch.EventChannelFollow) {
+			h.OnFollow(e.UserName)
+		})
+	}
+	if h.OnSubscribe != nil {
+		client.OnEventChannelSubscribe(func(e twitch.EventChannelSubscribe) {
+			h.OnSubscribe(e.UserName, e.IsGift, e.Tier)
+		})
+	}
+
+	client.OnWelcome(func(msg twitch.WelcomeMessage) {
+		sid := msg.Payload.Session.ID
+		slog.InfoContext(ctx, "eventsub welcome received; subscribing", "session_id", sid)
+
+		if h.OnFollow != nil {
+			subscribe(ctx, cfg, sid, twitch.SubChannelFollow, map[string]string{
+				// channel.follow v2 requires both — moderator is the
+				// identity reading the follow data; broadcaster is the
+				// channel being followed. Same user in our case.
+				"broadcaster_user_id": cfg.BroadcasterUserID,
+				"moderator_user_id":   cfg.BroadcasterUserID,
+			})
+		}
+		if h.OnSubscribe != nil {
+			subscribe(ctx, cfg, sid, twitch.SubChannelSubscribe, map[string]string{
+				"broadcaster_user_id": cfg.BroadcasterUserID,
+			})
+		}
+	})
+
+	return client.ConnectWithContext(ctx)
+}
+
+// subscribe creates a single Twitch-side subscription. Errors are
+// logged but don't abort Run — losing one event type is better than
+// losing all of them.
+func subscribe(ctx context.Context, cfg Config, sessionID string, ev twitch.EventSubscription, cond map[string]string) {
+	_, err := twitch.SubscribeEventWithContext(ctx, twitch.SubscribeRequest{
+		SessionID:   sessionID,
+		ClientID:    cfg.ClientID,
+		AccessToken: cfg.BroadcasterToken,
+		Event:       ev,
+		Condition:   cond,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "eventsub subscribe failed", "err", fmt.Errorf("event %s: %w", ev, err))
+		return
+	}
+	slog.InfoContext(ctx, "eventsub subscribed", "event", string(ev))
+}

--- a/pkg/eventsub/eventsub_test.go
+++ b/pkg/eventsub/eventsub_test.go
@@ -1,0 +1,30 @@
+package eventsub
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRun_RejectsEmptyConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"empty everything", Config{}},
+		{"missing ClientID", Config{BroadcasterToken: "t", BroadcasterUserID: "u"}},
+		{"missing BroadcasterToken", Config{ClientID: "c", BroadcasterUserID: "u"}},
+		{"missing BroadcasterUserID", Config{ClientID: "c", BroadcasterToken: "t"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Run(context.Background(), tc.cfg, Handlers{})
+			if err == nil {
+				t.Fatal("Run with incomplete Config should return error; got nil")
+			}
+			if !strings.Contains(err.Error(), "Config") {
+				t.Errorf("err message %q should mention Config", err.Error())
+			}
+		})
+	}
+}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -236,6 +236,15 @@ func CurrentUserAccessToken() string {
 	return currentUserToken.AccessToken
 }
 
+// BroadcasterUserAccessToken returns the broadcaster's raw access token
+// (no oauth: prefix), or "" if no broadcaster row has been loaded.
+// Consumed by pkg/eventsub when subscribing to broadcaster-gated events.
+func BroadcasterUserAccessToken() string {
+	tokenMu.RLock()
+	defer tokenMu.RUnlock()
+	return currentBroadcasterToken.AccessToken
+}
+
 // ErrIdentityMismatch is returned by GenerateUserAccessToken when the
 // discovered identity (via helix.GetUsers) doesn't match expectedLogin.
 // Callers should surface it with retry guidance; the wrong-identity row is


### PR DESCRIPTION
## Summary

PR 1 of the EventSub WebSocket sequence. Replaces the v2.9.1-deleted Helix-Webhooks path with a WebSocket-transport equivalent — no public ingress needed, works from prod-1 as-is.

Real-time `channel.follow` v2 and `channel.subscribe` events fire chat shouts (`Thank you for the follow, @X` / `Thank you for the sub, @Y; enjoy your !bonusmiles`). The +1 mile-for-everyone bonus on new subs is preserved from the original v2.9.1 helpers.

## What's in this PR

- **`pkg/eventsub`** — new package wrapping [joeyak/go-twitch-eventsub/v3](https://github.com/joeyak/go-twitch-eventsub). `Run(ctx, Config, Handlers) error` dials the WS, subscribes to events the caller wants, blocks until ctx done. Library handles `session_reconnect` transparently.
- **`pkg/chatbot.AnnounceNewFollower` / `AnnounceSubscriber`** restored from #569's deletion. Adapted to the post-injection `sayFn` indirection.
- **`mytwitch.BroadcasterUserAccessToken()`** — accessor mirroring `CurrentUserAccessToken()` so `pkg/eventsub` can read the broadcaster's token at startup.
- **`cmd/tripbot.startEventSub(ctx)`** — kicks off `eventsub.Run` in a goroutine after the Twitch client is up. Skips (warn, not fatal) if the broadcaster row isn't loaded — the bot still runs without real-time alerts.

## Follow-up PRs

Per the [vault TODO](../../tree/master/vault/tripbot/tripbot/TODO.md) (private), the rest of the series:

- PR 2 — audience events: `channel.raid`, `channel.cheer`, `channel.subscription.gift`, `channel.subscription.message`
- PR 3 — stream-state: `stream.online` / `stream.offline`
- PR 4 — channel point redemptions
- PR 5 — moderation + audit: `channel.ban`, `channel.moderator.add/remove`, `channel.update`

Each subsequent PR is small: extend `Handlers`, add a `subscribe` call in `OnWelcome`, restore/build a handler.

## Test plan

- [ ] `mise exec -- go test ./...` passes
- [ ] `mise exec -- go build ./...` passes
- [ ] On a host with broadcaster row bootstrapped: tail logs, see `eventsub welcome received` + `eventsub subscribed event=channel.follow` + `eventsub subscribed event=channel.subscribe`
- [ ] Trigger a test follow on `adanalife_staging`; verify chat shout fires
- [ ] On a host without broadcaster row: log shows `skipping eventsub: no broadcaster oauth_tokens row` — bot continues running