### PR TITLE
vlc-server: optional VAAPI transcode stage in sout chain

### DIFF
--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -46,6 +46,16 @@ type VlcServerConfig struct {
 	// `window` and `both` need a vout module that can actually open a
 	// window (Linux: VLC_VOUT=x11; Windows: libvlc default).
 	VlcOutput string `default:"rtsp" envconfig:"VLC_OUTPUT"`
+	// VlcSoutTranscode inserts a VAAPI transcode stage before the RTP
+	// packetizer. With :sout-keep, the encoder + RTSP listener stay warm
+	// across libvlc playlist transitions, so OBS sees a steady output
+	// stream rather than an EOS / reconnect cycle on every clip change.
+	// Requires a VAAPI-capable iGPU reachable to libvlc (Intel iHD via
+	// /dev/dri/renderD128 — prod-1 minipc); leave false on hosts without
+	// that path (stage-1, local hostPath) since libavcodec's h264_vaapi
+	// encoder will fail to initialize. Pair with VLC_AVCODEC_HW=vaapi
+	// to keep decode + encode on the same hardware pipeline.
+	VlcSoutTranscode bool `default:"false" envconfig:"VLC_SOUT_TRANSCODE"`
 	// VlcCanvasWidth / VlcCanvasHeight set both the libvlc --width/--height
 	// and --canvas-width/--canvas-height. Defaults are today's hardcoded
 	// 1920x1080.

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -45,19 +45,34 @@ var vlcCmdFlags []string
 //   rtsp   — RTSP listener only (container default).
 //   window — no sout; libvlc plays to its native window via --vout.
 //   both   — duplicate to a local display target and the RTSP listener.
+//
+// When VLC_SOUT_TRANSCODE is set, the RTP leg is wrapped in a libavcodec
+// VAAPI transcode stage. Together with :sout-keep, that keeps the encoder
+// pipeline warm across input changes — shrinking the visible gap when
+// libvlc swaps clips (natural EOS, !skip/!back, !timewarp, !jump). The
+// transcode is rtsp-only; the `window` display leg in `both` mode stays
+// passthrough (a dev preview doesn't need the re-encode round-trip).
 func mediaOptions() []string {
 	const rtspChain = "rtp{sdp=rtsp://:8554/dashcam}"
+	rtspLeg := rtspChain
+	if c.Conf.VlcSoutTranscode {
+		// venc=avcodec{codec=h264_vaapi} routes encoding through
+		// libavcodec's VAAPI backend; vb is kbps; keyint matches a 2s
+		// GOP at 30fps so OBS recovers quickly if it ever does fall
+		// off the stream.
+		rtspLeg = "transcode{vcodec=h264,venc=avcodec{codec=h264_vaapi,strict=-2},vb=4000,fps=30,width=1920,height=1080,keyint=60}:" + rtspChain
+	}
 	switch c.Conf.VlcOutput {
 	case "window":
 		return nil
 	case "both":
 		return []string{
-			":sout=#duplicate{dst=display,dst=" + rtspChain + "}",
+			":sout=#duplicate{dst=display,dst=" + rtspLeg + "}",
 			":sout-keep",
 		}
 	case "rtsp":
 		return []string{
-			":sout=#" + rtspChain,
+			":sout=#" + rtspLeg,
 			":sout-keep",
 		}
 	default:


### PR DESCRIPTION
## Summary

Adds `VLC_SOUT_TRANSCODE` (default `false`). When set, wraps the rtp output in a libavcodec `h264_vaapi` transcode stage. Combined with the existing `:sout-keep`, this keeps the encoder + RTSP listener warm across libvlc input changes — so OBS's `ffmpeg_source` no longer sees a clip-boundary disconnect/reconnect cycle.

This is **PR 1 of 3** in a flash-fix-v2 pass. The visible-flash post-#582 has two remaining sources:
- Output-side: every libvlc input change tears down the RTP frame flow long enough that OBS drops the connection. This PR keeps that flow warm via a hardware-encoded continuous output.
- Input-side: file-open latency on NAS-mounted media. PRs 2 (page-cache priming) and 3 (NFS tuning + OBS source tightening) attack that floor.

Off by default so stage-1 / local hostPath envs (no iGPU reachable) keep the passthrough path. Prod-1 flips it on via the overlay env.

## Companion PR

- **adanalife/infra#518** — prod-1 overlay sets `VLC_SOUT_TRANSCODE=true` and pins `VLC_AVCODEC_HW=vaapi` (was `any`, switched to explicit so silent software-fallback fails loudly — the same class that bit the OBS encoder in #584). Either PR can merge first; the env vars are inert without this binary, and this binary defaults the flag off without that overlay.

## Verification on prod-1 (post-rollout)

- VLC `-vv` log shows `avcodec encoder` selecting `h264_vaapi` (not falling back to x264)
- `vainfo` inside the vlc-server pod reports iHD driver active (already confirmed in #584)
- XPU Manager's `xpum_engine_utilization{engine="video"}` ticks up during stream
- OBS log no longer shows `[Media Source 'Dashcam']: Disconnected. Reconnecting...` on clip transitions

## Test plan

- [x] `go build ./...` (macOS, VLC.app cgo path)
- [x] `go test ./pkg/vlc-server/` passes
- [ ] Image build on `feat/vlc-vaapi-transcode` rolled to prod-1 vlc-server pod
- [ ] VAAPI engagement confirmed via the three verification points above
- [ ] Visual check: transition flash on natural EOS and `!timewarp`