### PR TITLE
Revert VLC VAAPI transcode (#615) — approach abandoned

### DIFF
--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -46,16 +46,6 @@ type VlcServerConfig struct {
 	// `window` and `both` need a vout module that can actually open a
 	// window (Linux: VLC_VOUT=x11; Windows: libvlc default).
 	VlcOutput string `default:"rtsp" envconfig:"VLC_OUTPUT"`
-	// VlcSoutTranscode inserts a VAAPI transcode stage before the RTP
-	// packetizer. With :sout-keep, the encoder + RTSP listener stay warm
-	// across libvlc playlist transitions, so OBS sees a steady output
-	// stream rather than an EOS / reconnect cycle on every clip change.
-	// Requires a VAAPI-capable iGPU reachable to libvlc (Intel iHD via
-	// /dev/dri/renderD128 — prod-1 minipc); leave false on hosts without
-	// that path (stage-1, local hostPath) since libavcodec's h264_vaapi
-	// encoder will fail to initialize. Pair with VLC_AVCODEC_HW=vaapi
-	// to keep decode + encode on the same hardware pipeline.
-	VlcSoutTranscode bool `default:"false" envconfig:"VLC_SOUT_TRANSCODE"`
 	// VlcCanvasWidth / VlcCanvasHeight set both the libvlc --width/--height
 	// and --canvas-width/--canvas-height. Defaults are today's hardcoded
 	// 1920x1080.

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -45,34 +45,19 @@ var vlcCmdFlags []string
 //   rtsp   — RTSP listener only (container default).
 //   window — no sout; libvlc plays to its native window via --vout.
 //   both   — duplicate to a local display target and the RTSP listener.
-//
-// When VLC_SOUT_TRANSCODE is set, the RTP leg is wrapped in a libavcodec
-// VAAPI transcode stage. Together with :sout-keep, that keeps the encoder
-// pipeline warm across input changes — shrinking the visible gap when
-// libvlc swaps clips (natural EOS, !skip/!back, !timewarp, !jump). The
-// transcode is rtsp-only; the `window` display leg in `both` mode stays
-// passthrough (a dev preview doesn't need the re-encode round-trip).
 func mediaOptions() []string {
 	const rtspChain = "rtp{sdp=rtsp://:8554/dashcam}"
-	rtspLeg := rtspChain
-	if c.Conf.VlcSoutTranscode {
-		// venc=avcodec{codec=h264_vaapi} routes encoding through
-		// libavcodec's VAAPI backend; vb is kbps; keyint matches a 2s
-		// GOP at 30fps so OBS recovers quickly if it ever does fall
-		// off the stream.
-		rtspLeg = "transcode{vcodec=h264,venc=avcodec{codec=h264_vaapi,strict=-2},vb=4000,fps=30,width=1920,height=1080,keyint=60}:" + rtspChain
-	}
 	switch c.Conf.VlcOutput {
 	case "window":
 		return nil
 	case "both":
 		return []string{
-			":sout=#duplicate{dst=display,dst=" + rtspLeg + "}",
+			":sout=#duplicate{dst=display,dst=" + rtspChain + "}",
 			":sout-keep",
 		}
 	case "rtsp":
 		return []string{
-			":sout=#" + rtspLeg,
+			":sout=#" + rtspChain,
 			":sout-keep",
 		}
 	default:


### PR DESCRIPTION
Reverts #615.

VLC can't drive VAAPI **encoding** through its `transcode` module — its VAAPI module is decode-only, and `venc=avcodec{codec=h264_vaapi}` fails to open without an explicit VAAPI device + hw_frames_ctx that VLC doesn't wire up. On prod-1 the chain failed to initialize, VLC's RTSP server returned `DESCRIBE 500`, and OBS couldn't pull the dashcam at all (stream down, not just flashing). Confirmed `vainfo` shows the hardware is capable (iHD 24.1.0, H.264 encode entrypoints present) — the limitation is VLC, not the GPU.

This reverts the inert config + sout-chain code. Companion infra revert: **adanalife/infra#519** (removes the prod-1 overlay env that activated it).

The transition-flash work continues, but at the right layer: OBS holding the last frame through the brief clip-boundary gap, plus page-cache priming to shrink the gap. VLC stays on passthrough RTP + VAAPI **decode** (which works).

Note: a stopgap `kubectl set env VLC_SOUT_TRANSCODE=false` is live on the prod-1 deployment to restore the stream. Once this revert ships and the new image deploys, the flag-reading code is gone and the override is inert — clean it up with `kubectl set env deployment/vlc-server -n default VLC_SOUT_TRANSCODE-` after the infra revert is applied.

## Test plan

- [x] `go build ./...` + `go test ./pkg/vlc-server/` (pre-revert state restored)
- [x] No remaining `VLC_SOUT_TRANSCODE` / `VlcSoutTranscode` references