### PR TITLE
vlc-server: page-cache priming to close the inter-clip gap

### DIFF
--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -85,6 +85,11 @@ func main() {
 	// SIGINT/SIGTERM.
 	srv.StartStatsPoller(shutdownCtx, 5*time.Second)
 
+	// pre-warm upcoming clips into the page cache so libvlc's next-file
+	// open hits warm pages instead of a cold NAS round-trip — collapses
+	// the inter-clip gap that flashes the scene background in OBS.
+	srv.StartPrimer(shutdownCtx, 5*time.Second)
+
 	// poll the OBS WebSocket for streaming state + render/output stats.
 	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -62,6 +62,25 @@ type VlcServerConfig struct {
 	VlcCanvasWidth  int `default:"1920" envconfig:"VLC_CANVAS_WIDTH"`
 	VlcCanvasHeight int `default:"1080" envconfig:"VLC_CANVAS_HEIGHT"`
 
+	// VlcPrimeEnabled turns on page-cache priming: a background goroutine
+	// pre-reads upcoming clips into the kernel page cache so libvlc's file
+	// open hits warm pages instead of a cold NAS round-trip. That collapses
+	// the inter-clip frame gap that makes OBS's ffmpeg_source briefly
+	// disconnect — revealing the scene background + "broken video" overlay
+	// — on clip transitions and !timewarp. Safe to leave on everywhere; on
+	// a fast local disk the warm read is cheap and the gap is already small.
+	VlcPrimeEnabled bool `default:"true" envconfig:"VLC_PRIME_ENABLED"`
+	// VlcPrimePositionThreshold is how far (0..1) into the current clip the
+	// primer waits before warming the next sequential file. 0.5 = halfway;
+	// clips run minutes, so this leaves ample lead time before EOS while
+	// avoiding warming a file we might never reach if a jump intervenes.
+	VlcPrimePositionThreshold float64 `default:"0.5" envconfig:"VLC_PRIME_POSITION_THRESHOLD"`
+	// VlcPrimeBytes caps how many bytes of each file the primer reads into
+	// cache. 0 = whole file (safest: covers both the MP4 moov atom wherever
+	// it sits and the initial GOPs libvlc decodes at open). Set a cap only
+	// if cache memory or NAS bandwidth ever becomes a concern.
+	VlcPrimeBytes int64 `default:"0" envconfig:"VLC_PRIME_BYTES"`
+
 	// VLCPidFile is where the vlc-server PID file lives
 	VLCPidFile string `default:"/opt/data/run/vlc-server.pid" envconfig:"VLC_PIDFILE"`
 

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -123,8 +123,9 @@ func (s *Server) vlcSkipHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) vlcRandomHandler(w http.ResponseWriter, r *http.Request) {
-	// play a random file
-	err := s.PlayRandom()
+	// play a random file, preferring the pre-warmed index so !timewarp
+	// jumps to an already-cached clip instead of a cold NAS open.
+	err := s.PlayWarmRandom()
 	if err != nil {
 		http.Error(w, "error playing random", http.StatusInternalServerError)
 	}

--- a/pkg/vlc-server/primer.go
+++ b/pkg/vlc-server/primer.go
@@ -1,0 +1,147 @@
+package vlcServer
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math/rand"
+	"os"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
+)
+
+// The visible "flash" between clips is OBS's ffmpeg_source briefly
+// disconnecting while libvlc opens the next file off the NAS — long
+// enough that the Dashcam layer goes transparent and the scene
+// background + "broken video" overlay show through. The dominant cost is
+// NAS first-byte / metadata latency on a cold file open. Priming attacks
+// that directly: read upcoming files into the kernel page cache ahead of
+// time so libvlc's open hits warm pages instead of a cold round-trip.
+//
+// Two primers run off one poll loop:
+//   - sequential: once the current clip passes VlcPrimePositionThreshold,
+//     warm the next playlist file so the natural EOS transition is smooth.
+//   - random: keep one pre-picked, warmed index ready so !timewarp jumps
+//     to an already-warm file (PlayWarmRandom consumes it).
+
+// warmCache reads a file into the kernel page cache. Bounded by limit
+// bytes (0 = whole file). Fire-and-forget: errors are logged, not
+// returned, since a failed warm just means the open is no faster than
+// before — never worse.
+func warmCache(ctx context.Context, path string, limit int64) {
+	f, err := os.Open(path)
+	if err != nil {
+		slog.WarnContext(ctx, "prime: could not open file to warm cache", "file", path, "err", err)
+		return
+	}
+	defer f.Close()
+
+	var r io.Reader = f
+	if limit > 0 {
+		r = io.LimitReader(f, limit)
+	}
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		slog.WarnContext(ctx, "prime: error reading file to warm cache", "file", path, "err", err)
+	}
+}
+
+// StartPrimer launches the priming goroutine. No-op when disabled or when
+// there's nothing to prime (e.g. an empty corpus in tests).
+func (s *Server) StartPrimer(ctx context.Context, interval time.Duration) {
+	if !c.Conf.VlcPrimeEnabled {
+		slog.InfoContext(ctx, "page-cache priming disabled (VLC_PRIME_ENABLED=false)")
+		return
+	}
+	if len(s.VideoPaths) == 0 {
+		slog.WarnContext(ctx, "page-cache priming: no video paths, not starting primer")
+		return
+	}
+	s.primeCtx = ctx
+	slog.InfoContext(ctx, "starting page-cache primer", "interval", interval, "videos", len(s.VideoPaths))
+	go s.prime(ctx, interval)
+}
+
+func (s *Server) prime(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// warm an initial random so the first !timewarp is fast too.
+	s.refreshWarmRandom(ctx)
+
+	lastWarmedNext := -1
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if s.Player == nil {
+				continue
+			}
+			// keep a warm random ready for the next !timewarp.
+			s.ensureWarmRandom(ctx)
+
+			pos, err := s.Player.MediaPosition()
+			if err != nil {
+				continue
+			}
+			if float64(pos) < c.Conf.VlcPrimePositionThreshold {
+				continue
+			}
+			next := nextIndex(s.currentIndex(), 1, len(s.VideoPaths))
+			if next < 0 || next >= len(s.VideoPaths) || next == lastWarmedNext {
+				continue
+			}
+			lastWarmedNext = next
+			go warmCache(ctx, s.VideoPaths[next], c.Conf.VlcPrimeBytes)
+		}
+	}
+}
+
+// ensureWarmRandom warms a fresh random index if none is currently ready.
+func (s *Server) ensureWarmRandom(ctx context.Context) {
+	s.primeMu.Lock()
+	ready := s.warmRandomIdx >= 0
+	s.primeMu.Unlock()
+	if !ready {
+		s.refreshWarmRandom(ctx)
+	}
+}
+
+// refreshWarmRandom picks a new random index, records it, and warms it in
+// the background.
+func (s *Server) refreshWarmRandom(ctx context.Context) {
+	n := len(s.VideoPaths)
+	if n == 0 {
+		return
+	}
+	idx := rand.Intn(n)
+	s.primeMu.Lock()
+	s.warmRandomIdx = idx
+	s.primeMu.Unlock()
+	go warmCache(ctx, s.VideoPaths[idx], c.Conf.VlcPrimeBytes)
+}
+
+// PlayWarmRandom plays the pre-warmed random index when one is ready,
+// then kicks off warming a fresh one for next time. Falls back to a cold
+// PlayRandom if no warm index is available (e.g. priming disabled, or a
+// second !timewarp before the refresh completed).
+func (s *Server) PlayWarmRandom() error {
+	s.primeMu.Lock()
+	idx := s.warmRandomIdx
+	s.warmRandomIdx = -1
+	s.primeMu.Unlock()
+
+	if idx < 0 || idx >= len(s.VideoFiles) {
+		return s.PlayRandom()
+	}
+
+	err := s.playAtIndex(idx)
+
+	ctx := s.primeCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go s.refreshWarmRandom(ctx)
+	return err
+}

--- a/pkg/vlc-server/primer_test.go
+++ b/pkg/vlc-server/primer_test.go
@@ -1,0 +1,79 @@
+package vlcServer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, name string, size int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	return path
+}
+
+func TestWarmCacheReadsFileWithoutError(t *testing.T) {
+	path := writeTempFile(t, "clip.MP4", 4096)
+	// Should complete without panic/error for a readable file (whole-file
+	// read) and for a bounded read.
+	warmCache(context.Background(), path, 0)
+	warmCache(context.Background(), path, 1024)
+}
+
+func TestWarmCacheMissingFileIsNoop(t *testing.T) {
+	// A missing file must not panic — warming is best-effort.
+	warmCache(context.Background(), "/nonexistent/clip.MP4", 0)
+}
+
+func TestRefreshWarmRandomSetsInRangeIndex(t *testing.T) {
+	s := &Server{
+		warmRandomIdx: -1,
+		VideoPaths: []string{
+			writeTempFile(t, "a.MP4", 16),
+			writeTempFile(t, "b.MP4", 16),
+			writeTempFile(t, "c.MP4", 16),
+		},
+	}
+	s.refreshWarmRandom(context.Background())
+
+	s.primeMu.Lock()
+	idx := s.warmRandomIdx
+	s.primeMu.Unlock()
+
+	if idx < 0 || idx >= len(s.VideoPaths) {
+		t.Fatalf("warmRandomIdx = %d, want in [0,%d)", idx, len(s.VideoPaths))
+	}
+}
+
+func TestRefreshWarmRandomEmptyCorpusLeavesNoneReady(t *testing.T) {
+	s := &Server{warmRandomIdx: -1}
+	s.refreshWarmRandom(context.Background())
+
+	s.primeMu.Lock()
+	idx := s.warmRandomIdx
+	s.primeMu.Unlock()
+
+	if idx != -1 {
+		t.Fatalf("warmRandomIdx = %d, want -1 (nothing to warm)", idx)
+	}
+}
+
+func TestEnsureWarmRandomKeepsExistingReady(t *testing.T) {
+	s := &Server{
+		warmRandomIdx: 1,
+		VideoPaths:    []string{writeTempFile(t, "a.MP4", 16), writeTempFile(t, "b.MP4", 16)},
+	}
+	s.ensureWarmRandom(context.Background())
+
+	s.primeMu.Lock()
+	idx := s.warmRandomIdx
+	s.primeMu.Unlock()
+
+	if idx != 1 {
+		t.Fatalf("warmRandomIdx = %d, want 1 (should not refresh when one is ready)", idx)
+	}
+}

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
@@ -43,8 +44,21 @@ type Server struct {
 	Playlist   *libvlc.ListPlayer
 	MediaList  *libvlc.MediaList
 	VideoFiles []string
+	// VideoPaths holds the full filesystem path for each entry in
+	// VideoFiles (same order / index). The primer reads these to warm the
+	// page cache; VideoFiles stays basename-only for the existing
+	// index/lookup logic.
+	VideoPaths []string
 
 	http *http.Server
+
+	// primer state. warmRandomIdx is a pre-picked, cache-warmed random
+	// index kept ready so !timewarp jumps to an already-warm file instead
+	// of a cold NAS open; -1 means none ready. primeCtx scopes the
+	// fire-and-forget warm goroutines to the server lifecycle.
+	primeMu       sync.Mutex
+	warmRandomIdx int
+	primeCtx      context.Context
 }
 
 // New constructs a Server, initializing libvlc and loading media off disk.
@@ -52,7 +66,7 @@ type Server struct {
 // with any libvlc resources already allocated released before returning so
 // the caller never has to clean up after a partial init.
 func New(cfg Config) (*Server, error) {
-	s := &Server{Version: cfg.Version}
+	s := &Server{Version: cfg.Version, warmRandomIdx: -1}
 	if err := s.initPlayer(); err != nil {
 		s.releasePartial()
 		return nil, err

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -322,6 +322,9 @@ func (s *Server) loadLocalMedia() error {
 		return fmt.Errorf("error walking VideoDir: %w", err)
 	}
 
+	// keep full paths parallel to VideoFiles so the primer can warm them.
+	s.VideoPaths = filePaths
+
 	// loop over the files and add their paths to VLC
 	for _, file := range filePaths {
 		media, err := libvlc.NewMediaFromPath(file)


### PR DESCRIPTION
## Summary

Closes the visible flash between clips at its root cause. The flash is OBS's `ffmpeg_source` briefly disconnecting while libvlc opens the next file off the NAS — long enough that the Dashcam layer goes transparent and the scene `Background` + `Broken video warning` overlay show through. The dominant cost is NAS first-byte / metadata latency on a **cold** file open.

A background primer pre-reads upcoming clips into the kernel page cache so libvlc's open hits warm pages instead of a cold round-trip. Two primers run off one 5s poll loop:

- **Sequential** — once the current clip passes `VLC_PRIME_POSITION_THRESHOLD` (default 0.5), warm the next playlist file so the natural EOS transition is smooth.
- **Random** — keep one pre-picked, warmed index ready so `!timewarp` (the worst offender — a cold random jump with no read-ahead) lands on an already-cached clip. `PlayWarmRandom` consumes it and immediately warms a fresh one.

Tunable via `VLC_PRIME_ENABLED` / `VLC_PRIME_POSITION_THRESHOLD` / `VLC_PRIME_BYTES` (0 = whole file). On by default; cheap on fast local disks where the gap is already small.

## Context

This is the load-bearing fix in the flash-fix-v2 pass, after the VAAPI-transcode approach was abandoned (reverted in #617). Pairs with NFS mount tuning (infra, separate PR) which reduces the cold-open latency the primer is racing against, and an OBS buffering bump (separate) as cheap insurance on the residual.

`!jump <state>` (a cold, unpredictable target) isn't covered here — it can pre-warm via a follow-up `/vlc/prime` endpoint + chatbot orchestration if it proves necessary; `!timewarp` is the common case.

## Test plan

- [x] `go build ./...` + `go test ./pkg/vlc-server/` (macOS, VLC.app cgo path)
- [x] New unit tests: `warmCache` (read + bounded + missing-file no-op), `refreshWarmRandom` (in-range index, empty-corpus no-op), `ensureWarmRandom` (keeps existing)
- [ ] Deployed to prod-1; confirm OBS no longer logs `[Media Source 'Dashcam']: Disconnected. Reconnecting...` on natural transitions and `!timewarp`
- [ ] Visual check on the live stream: transition no longer reveals the background/overlay