### PR TITLE
OBS: default noVNC to local scaling + autoconnect

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -69,7 +69,7 @@ ARG NOVNC_VERSION=1.7.0
 RUN curl -fsSL "https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz" \
       | tar -xz -C /opt \
     && mv "/opt/noVNC-${NOVNC_VERSION}" /opt/novnc \
-    && ln -sf /opt/novnc/vnc.html /opt/novnc/index.html
+    && printf '%s\n' '<!doctype html><title>OBS noVNC</title><meta http-equiv="refresh" content="0; url=vnc.html?resize=scale&amp;autoconnect=true&amp;reconnect=true">' > /opt/novnc/index.html
 
 COPY infra/docker/obs/config/ /opt/obs/config/
 COPY infra/docker/obs/script/ /opt/obs/script/

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -77,7 +77,7 @@ ARG NOVNC_VERSION=1.7.0
 RUN curl -fsSL "https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz" \
       | tar -xz -C /opt \
     && mv "/opt/noVNC-${NOVNC_VERSION}" /opt/novnc \
-    && ln -sf /opt/novnc/vnc.html /opt/novnc/index.html
+    && printf '%s\n' '<!doctype html><title>OBS noVNC</title><meta http-equiv="refresh" content="0; url=vnc.html?resize=scale&amp;autoconnect=true&amp;reconnect=true">' > /opt/novnc/index.html
 
 # Copy the compiled OBS install tree from the pre-baked base image. cmake
 # --install laid the tree out under /opt/obs-install (mapped to /usr/local on


### PR DESCRIPTION
## Summary
Replaces the noVNC `index.html` symlink with a redirect to `vnc.html?resize=scale&autoconnect=true&reconnect=true`, so opening `https://obs.prod.whereisdana.today` scales the whole OBS canvas to fit the browser window and connects without a manual click.

## Why
Default noVNC opens 1:1 with scrollbars, so the 1920×1080 OBS canvas overflows a smaller browser window. `resize=scale` fits it client-side (preserving aspect ratio) — `scale`, **not** `remote`, so the sway output stays 1920×1080 and the OBS composition is untouched. `autoconnect`/`reconnect` make it a one-open, stays-connected experience.

## Test plan
- [ ] After release + deploy: open `https://obs.prod.whereisdana.today` → redirects to `vnc.html?resize=scale&autoconnect=true`, auto-connects, whole canvas visible scaled-to-fit.
- Immediate check against the *current* live pod (proves the param works pre-release): `https://obs.prod.whereisdana.today/vnc.html?resize=scale&autoconnect=true`.

## Notes
- Needs a release to deploy (image rebuild). Cheap to bundle into the next release rather than cutting one just for this.