### PR TITLE
Start tripbot degraded instead of crashlooping when Twitch/token is unavailable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,6 +31,23 @@ tasks:
     cmds:
       - ENV=testing bin/devenv run --rm test go test -race ./...
 
+  # Native macOS test runner — host mise + VLC.app's bundled libvlc, no
+  # docker. Mirrors vlc-server:build:macos's CGO incantation (rpath is
+  # required for `go test` too, per vault/tripbot/vlc-server/gotchas.md).
+  # `dotenv` injects .env.testing's keys as real env vars so the config
+  # loader resolves them from the environment — `go test` runs each package
+  # from its own dir, so the .env.testing file itself isn't on the path.
+  test:macos:
+    desc: Run all unit tests natively on macOS (host mise, no docker)
+    platforms: [darwin]
+    dotenv: ['.env.testing']
+    env:
+      ENV: testing
+      CGO_CFLAGS: -I/Applications/VLC.app/Contents/MacOS/include
+      CGO_LDFLAGS: -L/Applications/VLC.app/Contents/MacOS/lib -Wl,-rpath,/Applications/VLC.app/Contents/MacOS/lib -Wno-error=incompatible-function-pointer-types
+    cmds:
+      - mise exec -- go test ./...
+
   shell:
     desc: Open an interactive Go-toolchain shell inside the test container
     interactive: true

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -91,8 +91,8 @@ func main() {
 	findInitialVideo()
 	users.InitLeaderboard(context.Background())
 	startCron()
-	loadTwitchToken()   // must precede chatbot.Initialize — provides the IRC token
-	setUpTwitchClient() // required for the below
+	loadTwitchToken(shutdownCtx) // must precede chatbot.Initialize — provides the IRC token
+	setUpTwitchClient()          // required for the below
 	updateSubscribers()
 	getCurrentUsers()
 	startEventSub(shutdownCtx)
@@ -191,15 +191,50 @@ func startCron() {
 }
 
 // loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
-// Refuses to start if the row is missing — pointing at the bootstrap CLI
-// is louder than running IRC-less.
-func loadTwitchToken() {
+// Non-fatal: when the row is missing (e.g. auth-bootstrap hasn't run yet
+// against a freshly-restored DB) or the DB is briefly unreachable, the bot
+// comes up with limited functionality and reports not-ready, polling in the
+// background until the token lands — rather than crashlooping. A crashing pod
+// after a wipe also raced the DB restore's migrate init (see the 2026-05-20
+// convergence-wipe notes); staying up-but-not-ready avoids that. Readiness,
+// not a process crash, is what keeps the bot out of service until it can talk
+// to Twitch.
+func loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
-		if errors.Is(err, mytwitch.ErrNoToken) {
-			slog.Error("refusing to start: no oauth_tokens row for bot", "bot_username", c.Conf.BotUsername, "fix", "task tripbot:auth:bootstrap")
-			os.Exit(1)
+		slog.WarnContext(ctx, "no usable Twitch token at boot; starting not-ready and polling",
+			"bot_username", c.Conf.BotUsername,
+			"fix", "task tripbot:auth:bootstrap",
+			"err", err)
+		go pollForTwitchToken(ctx)
+	}
+}
+
+// pollForTwitchToken retries LoadFromDB until the bot's oauth_tokens row is
+// available, then syncs the freshly-loaded IRC token into the client so
+// connectToTwitch's reconnect loop authenticates on its next attempt. Started
+// only when the token was missing at boot; stops on shutdown.
+func pollForTwitchToken(ctx context.Context) {
+	const interval = 15 * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := mytwitch.LoadFromDB(); err != nil {
+				slog.WarnContext(ctx, "still waiting for Twitch token", "err", err)
+				continue
+			}
+			slog.InfoContext(ctx, "Twitch token loaded; bot will connect on next attempt")
+			// Push the freshly-loaded token into the (already-constructed)
+			// IRC client so the connect loop's next try uses it instead of
+			// the empty token captured at chatbot.Initialize.
+			if tok := mytwitch.IRCAuthToken(); tok != "" && client != nil {
+				client.SetIRCToken(tok)
+			}
+			return
 		}
-		terrors.Fatal(err, "failed to load Twitch token from DB")
 	}
 }
 

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -228,11 +228,23 @@ func connectToTwitch() {
 	client.Join(c.Conf.ChannelName)
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
+	// Flip readiness on once the IRC connection is established so the
+	// readiness probe (/health/ready) reports live. Until then — and after
+	// any disconnect below — the pod stays up but not-ready.
+	client.OnConnect(func() {
+		slog.Info("connected to Twitch chat")
+		server.SetReady(true)
+	})
+
 	// actually connect to Twitch
 	// wrapped in a loop in case twitch goes down
 	for {
 		slog.Info("initializing connection to Twitch")
+		// Connect blocks while connected and returns when the connection
+		// drops; mark not-ready so the probe reflects the gap until the
+		// next OnConnect fires.
 		err := client.Connect()
+		server.SetReady(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -10,7 +10,6 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
-	terrors "github.com/adanalife/tripbot/pkg/errors"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
@@ -84,10 +83,12 @@ func Initialize() *twitch.Client {
 	// set up geocoder (for translating coords to places)
 	geocoder.ApiKey = c.Conf.GoogleMapsAPIKey
 
-	// initialize the twitch API client
-	_, err = mytwitch.Client()
-	if err != nil {
-		terrors.Fatal(err, "unable to create twitch API client")
+	// initialize the twitch API client. Non-fatal: if Twitch is unreachable
+	// at boot, log and continue so the process stays up (readiness reports
+	// not-ready until the IRC connection lands). mytwitch.Client() doesn't
+	// cache on failure, so callers retry once Twitch is back.
+	if _, err = mytwitch.Client(); err != nil {
+		slog.Error("twitch API client unavailable at startup; continuing", "err", err)
 	}
 
 	// The IRC token comes from the DB-backed oauth_tokens row populated by

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"sync/atomic"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
@@ -35,9 +36,32 @@ func SetVersion(v string) {
 	}
 }
 
-//TODO: write real healthchecks for ready vs live
-// healthcheck URL, for tools to verify the bot is alive
-func healthHandler(w http.ResponseWriter, r *http.Request) {
+// ready reports whether the bot has established its Twitch IRC connection.
+// /health/ready returns 503 until it flips true, so the orchestrator keeps
+// the pod running (no crashloop) but marks it not-live until Twitch is
+// reachable. cmd/tripbot flips it via SetReady on IRC connect / disconnect.
+var ready atomic.Bool
+
+// SetReady updates the readiness state reported by /health/ready.
+func SetReady(r bool) {
+	ready.Store(r)
+}
+
+// liveHandler is the liveness probe: the process is up and serving HTTP.
+// Always 200 — a failing liveness probe restarts the pod, which is exactly
+// what we want to avoid while waiting on Twitch.
+func liveHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "OK")
+}
+
+// readyHandler is the readiness probe: 200 once the Twitch IRC connection is
+// established, 503 otherwise. Keeps the pod up but not-live until Twitch is
+// reachable, and recovers on its own once the connection lands.
+func readyHandler(w http.ResponseWriter, r *http.Request) {
+	if !ready.Load() {
+		http.Error(w, "not ready: awaiting Twitch connection", http.StatusServiceUnavailable)
+		return
+	}
 	fmt.Fprintf(w, "OK")
 }
 

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -11,17 +11,41 @@ import (
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 )
 
-func TestHealthHandler(t *testing.T) {
+func TestLiveHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health/live", nil)
 	rec := httptest.NewRecorder()
 
-	healthHandler(rec, req)
+	liveHandler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
 	}
 	if rec.Body.String() != "OK" {
 		t.Fatalf("got body %q, want %q", rec.Body.String(), "OK")
+	}
+}
+
+func TestReadyHandler(t *testing.T) {
+	defer SetReady(false) // reset package state for other tests
+
+	// not ready by default: 503
+	SetReady(false)
+	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
+	rec := httptest.NewRecorder()
+	readyHandler(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("not-ready: got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	// ready once Twitch connection is established: 200
+	SetReady(true)
+	rec = httptest.NewRecorder()
+	readyHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ready: got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != "OK" {
+		t.Fatalf("ready: got body %q, want %q", rec.Body.String(), "OK")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,8 +45,8 @@ func Start(ctx context.Context) {
 
 	// healthcheck endpoints
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.Handle("/live", tagged("/health/live", healthHandler))
-	hp.Handle("/ready", tagged("/health/ready", healthHandler))
+	hp.Handle("/live", tagged("/health/live", liveHandler))
+	hp.Handle("/ready", tagged("/health/ready", readyHandler))
 
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -122,18 +122,24 @@ func Client() (*helix.Client, error) {
 		HTTPClient:  helixHTTPClient,
 	})
 	if err != nil {
-		slog.Error("error creating client", "err", err)
+		slog.Error("error creating twitch API client", "err", err)
+		return nil, err
 	}
 
 	resp, err := client.RequestAppAccessToken(append(append([]string{}, BotScopes...), BroadcasterScopes...))
 	if err != nil {
+		// Twitch unreachable: RequestAppAccessToken returns a nil resp, so
+		// don't touch resp.Data here (it would panic). Leave currentTwitchClient
+		// uncached so the next call retries once Twitch is back — caching a
+		// tokenless client would pin an empty App Access Token forever.
 		slog.Error("error getting app access token from twitch", "err", err)
+		return nil, err
 	}
 	AppAccessToken = resp.Data.AccessToken
 	client.SetAppAccessToken(AppAccessToken)
 
 	currentTwitchClient = client
-	return client, err
+	return client, nil
 }
 
 // BroadcasterClient returns the helix client that carries the broadcaster's

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -20,7 +20,12 @@ var subscribers []string
 
 // getChannelID makes a request to twitch to get the user ID for the channel
 func getChannelID(username string) string {
-	resp, err := currentTwitchClient.GetUsers(&helix.UsersParams{
+	client, err := Client()
+	if err != nil {
+		slog.Error("twitch API client unavailable", "err", err)
+		return ""
+	}
+	resp, err := client.GetUsers(&helix.UsersParams{
 		Logins: []string{username},
 	})
 	if err != nil {

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -35,6 +35,11 @@ func Chatters() map[string]struct{} {
 // endpoint and updates the in-memory state. Requires the bot account to be a
 // moderator of the channel (moderator:read:chatters scope).
 func UpdateChatters() {
+	client, err := Client()
+	if err != nil {
+		slog.Error("twitch API client unavailable", "err", err)
+		return
+	}
 	if ChannelID == "" {
 		ChannelID = getChannelID(c.Conf.ChannelName)
 	}
@@ -42,7 +47,7 @@ func UpdateChatters() {
 		BotID = getChannelID(c.Conf.BotUsername)
 	}
 
-	resp, err := currentTwitchClient.GetChannelChatChatters(&helix.GetChatChattersParams{
+	resp, err := client.GetChannelChatChatters(&helix.GetChatChattersParams{
 		BroadcasterID: ChannelID,
 		ModeratorID:   BotID,
 	})


### PR DESCRIPTION
## Why

After a cluster wipe, tripbot crashlooped — and a crashing pod is the wrong failure mode in a cluster. Two separate crash paths, both fixed here so the bot **comes up with limited functionality and reports not-ready** instead of dying. Readiness (not a process crash) is what keeps it out of service until it can talk to Twitch.

The crashlooping pod wasn't just noisy: after the 2026-05-20 convergence wipe its migrate init **raced the DB restore** and left `schema_migrations` dirty, needing manual cleanup.

## Crash path 1 — Twitch unreachable (nil-panic)

When Twitch is down, helix's `RequestAppAccessToken` returns a **nil** response, and `mytwitch.Client()` dereferenced `resp.Data.AccessToken` on it — a nil-pointer panic that fired before `chatbot.Initialize`'s `terrors.Fatal` even ran.

- `mytwitch.Client()` — guard the nil response; don't cache a tokenless client on failure so callers retry once Twitch is back.
- `getChannelID` / `UpdateChatters` — route through `Client()` so they tolerate the now-uncached (nil) client instead of dereferencing the global.
- `chatbot.Initialize` — log-and-continue instead of `terrors.Fatal`.

## Crash path 2 — missing oauth_tokens row (the post-wipe culprit)

After a wipe the oauth_tokens row isn't in the DB dump, so `loadTwitchToken` hit `os.Exit(1)` ("refusing to start: no oauth_tokens row") until `auth-bootstrap` ran.

- `loadTwitchToken` is now non-fatal: the bot comes up (HTTP, cron, DB-backed features), reports not-ready, and **polls `LoadFromDB` in the background** until the row lands — then pushes the loaded IRC token into the client so the connect loop authenticates on its next attempt.

## Readiness probe

- `/health/ready` now returns **503 until the IRC connection is established**, flipping to 200 via the IRC `OnConnect` callback and back to not-ready on disconnect.
- `/health/live` stays always-200 so the orchestrator doesn't restart the pod while it waits.

tripbot is outbound-only (no Ingress), so readiness here is a **status/rollout** signal — an honest `0/1` in `kubectl` and rollout gating during deploys — not inbound traffic gating. The k8s probes already point at these paths; no infra change needed.

## Tooling (separate commit)

Adds `task test:macos` — a host-based (mise, no docker) test runner. The general `test` target still shells into the docker `test` service that the `golang-development-with-mise` ADR superseded; there was a `vlc-server:build:macos` task but no host test runner. Mirrors that CGO incantation and uses go-task's `dotenv` to inject `.env.testing`.

## Test

`task test:macos` — full suite green.

## Out of scope

Surfacing the OAuth authorize URL in the logs while not-ready — Dana has that shelved in a separate branch (deferred while tripbot has no Ingress).