### PR TITLE
Surface OAuth re-auth URL in logs when token missing/expired

### DIFF
--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -144,8 +144,12 @@ func main() {
 		_ = srv.Shutdown(ctx)
 	}()
 
-	slog.Info("opening browser for Twitch sign-in", "account", *account)
-	slog.Info("visit URL", "url", authURL)
+	// Make the target identity unmistakable up front — with three envs and up
+	// to six bot/broadcaster accounts, "which login do I pick?" is the easy
+	// mistake. expectedLogin is the exact Twitch account to sign in as; a
+	// mismatch is caught at the callback and writes no token.
+	slog.Info("SIGN IN TO TWITCH AS THIS ACCOUNT", "login_as", expectedLogin, "account", *account)
+	slog.Info("opening browser for Twitch sign-in", "url", authURL)
 	// Skip browser open in headless environments (e.g. the k8s Job).
 	if os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != "" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		helpers.OpenInBrowser(authURL)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -204,6 +204,7 @@ func loadTwitchToken(ctx context.Context) {
 		slog.WarnContext(ctx, "no usable Twitch token at boot; starting not-ready and polling",
 			"bot_username", c.Conf.BotUsername,
 			"fix", "task tripbot:auth:bootstrap",
+			"reauth_url", mytwitch.AuthInitURL("bot"),
 			"err", err)
 		go pollForTwitchToken(ctx)
 	}
@@ -223,7 +224,8 @@ func pollForTwitchToken(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := mytwitch.LoadFromDB(); err != nil {
-				slog.WarnContext(ctx, "still waiting for Twitch token", "err", err)
+				slog.WarnContext(ctx, "still waiting for Twitch token",
+					"reauth_url", mytwitch.AuthInitURL("bot"), "err", err)
 				continue
 			}
 			slog.InfoContext(ctx, "Twitch token loaded; bot will connect on next attempt")
@@ -288,6 +290,11 @@ func connectToTwitch() {
 				// so the next Connect attempt uses the current credentials.
 				if tok := mytwitch.IRCAuthToken(); tok != "" {
 					client.SetIRCToken(tok)
+				} else {
+					// No valid in-memory token to fall back on — the refresh
+					// cron blanked it (revoked/invalid_grant). Surface the
+					// re-bootstrap link so re-auth is a click, not a task run.
+					slog.Error("IRC auth failed and no valid token to retry with; re-bootstrap needed", "bot_username", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
 				}
 			}
 			time.Sleep(time.Minute)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -106,7 +106,9 @@ func main() {
 func startEventSub(ctx context.Context) {
 	token := mytwitch.BroadcasterUserAccessToken()
 	if token == "" {
-		slog.WarnContext(ctx, "skipping eventsub: no broadcaster oauth_tokens row; bootstrap with `task tripbot:auth:bootstrap:broadcaster`")
+		slog.WarnContext(ctx, "skipping eventsub: no broadcaster oauth_tokens row; bootstrap with `task tripbot:auth:bootstrap:broadcaster`",
+			"login_as", c.Conf.ChannelName,
+			"reauth_url", mytwitch.AuthInitURL("broadcaster"))
 		return
 	}
 	if mytwitch.ChannelID == "" {
@@ -202,7 +204,7 @@ func startCron() {
 func loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
 		slog.WarnContext(ctx, "no usable Twitch token at boot; starting not-ready and polling",
-			"bot_username", c.Conf.BotUsername,
+			"login_as", c.Conf.BotUsername,
 			"fix", "task tripbot:auth:bootstrap",
 			"reauth_url", mytwitch.AuthInitURL("bot"),
 			"err", err)
@@ -225,6 +227,7 @@ func pollForTwitchToken(ctx context.Context) {
 		case <-ticker.C:
 			if err := mytwitch.LoadFromDB(); err != nil {
 				slog.WarnContext(ctx, "still waiting for Twitch token",
+					"login_as", c.Conf.BotUsername,
 					"reauth_url", mytwitch.AuthInitURL("bot"), "err", err)
 				continue
 			}
@@ -294,7 +297,7 @@ func connectToTwitch() {
 					// No valid in-memory token to fall back on — the refresh
 					// cron blanked it (revoked/invalid_grant). Surface the
 					// re-bootstrap link so re-auth is a click, not a task run.
-					slog.Error("IRC auth failed and no valid token to retry with; re-bootstrap needed", "bot_username", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
+					slog.Error("IRC auth failed and no valid token to retry with; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
 				}
 			}
 			time.Sleep(time.Minute)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -61,6 +61,32 @@ var BroadcasterScopes = []string{
 // bootstrap CLI." Re-exported from oauthtokens for caller convenience.
 var ErrNoToken = oauthtokens.ErrNoToken
 
+// AuthInitURL returns the operator-facing re-bootstrap URL for the given
+// account ("bot" or "broadcaster"). Visiting it kicks off the OAuth flow —
+// pkg/server's /auth/init handler mints a fresh CSRF state and 302-redirects to
+// Twitch — so re-auth is a click from any browser instead of running the
+// bootstrap CLI from a laptop.
+//
+// We deliberately surface THIS URL in logs (the "token missing/expired" sites)
+// rather than the fully-formed Twitch authorize URL. The latter embeds a
+// single-use CSRF state with a 5-minute TTL (oauthstate.TTL) — it would be
+// stale by the time anyone read the log — and that state would ship to
+// Loki/Sentry. /auth/init carries no secret: client_id isn't sensitive, and no
+// state exists until the redirect is generated server-side on click.
+func AuthInitURL(account string) string {
+	return c.Conf.ExternalURL + "/auth/init?account=" + account
+}
+
+// accountLabel maps an oauth_tokens username to the /auth/init account
+// selector ("bot" or "broadcaster"). The broadcaster identity only exists
+// when ChannelName differs from BotUsername; everything else is the bot.
+func accountLabel(username string) string {
+	if username == c.Conf.ChannelName && username != c.Conf.BotUsername {
+		return "broadcaster"
+	}
+	return "bot"
+}
+
 // currentTwitchClient is the lazy-initialized bot helix client. IRC auth +
 // any Helix endpoint authorized against the bot's identity goes through this.
 var currentTwitchClient *helix.Client
@@ -470,7 +496,7 @@ func refreshOne(ctx context.Context, username string, applyInMemory func(oauthto
 		// Sentry surfaces the failure for re-bootstrap.
 		_ = oauthtokens.IncrementFailCount("twitch", username)
 		applyInMemory(oauthtokens.Token{})
-		slog.ErrorContext(ctx, "oauth refresh failed; need re-bootstrap", "err", errors.New("empty access token in refresh response"), "username", username)
+		slog.ErrorContext(ctx, "oauth refresh failed; need re-bootstrap", "err", errors.New("empty access token in refresh response"), "username", username, "reauth_url", AuthInitURL(accountLabel(username)))
 		return
 	}
 

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -233,7 +233,8 @@ func LoadFromDB() error {
 	if berr != nil {
 		if errors.Is(berr, oauthtokens.ErrNoToken) {
 			slog.Warn("no broadcaster oauth_tokens row; subscriber/follower polling will skip until `task tripbot:auth:bootstrap:broadcaster` seeds it",
-				"broadcaster", broadcasterUser)
+				"login_as", broadcasterUser,
+				"reauth_url", AuthInitURL("broadcaster"))
 			return nil
 		}
 		slog.Error("failed to load broadcaster oauth_tokens row", "err", berr, "broadcaster", broadcasterUser)
@@ -496,7 +497,7 @@ func refreshOne(ctx context.Context, username string, applyInMemory func(oauthto
 		// Sentry surfaces the failure for re-bootstrap.
 		_ = oauthtokens.IncrementFailCount("twitch", username)
 		applyInMemory(oauthtokens.Token{})
-		slog.ErrorContext(ctx, "oauth refresh failed; need re-bootstrap", "err", errors.New("empty access token in refresh response"), "username", username, "reauth_url", AuthInitURL(accountLabel(username)))
+		slog.ErrorContext(ctx, "oauth refresh failed; need re-bootstrap", "err", errors.New("empty access token in refresh response"), "login_as", username, "reauth_url", AuthInitURL(accountLabel(username)))
 		return
 	}
 

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -182,6 +182,14 @@ func TestAuthInitURL_BuildsInitPath(t *testing.T) {
 	}
 }
 
+func TestAuthInitURL_BroadcasterAccount(t *testing.T) {
+	got := AuthInitURL("broadcaster")
+	want := c.Conf.ExternalURL + "/auth/init?account=broadcaster"
+	if got != want {
+		t.Errorf("AuthInitURL(\"broadcaster\") = %q, want %q", got, want)
+	}
+}
+
 func TestAccountLabel_BotUsernameIsBot(t *testing.T) {
 	if got := accountLabel(c.Conf.BotUsername); got != "bot" {
 		t.Errorf("accountLabel(bot username) = %q, want \"bot\"", got)

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
 )
 
@@ -165,6 +166,31 @@ func TestErrIdentityMismatch_ErrorsAs(t *testing.T) {
 	}
 	if target.Expected != "x" || target.Got != "y" || target.AccountID != "broadcaster" {
 		t.Errorf("extracted: %+v", target)
+	}
+}
+
+func TestAuthInitURL_BuildsInitPath(t *testing.T) {
+	got := AuthInitURL("bot")
+	want := c.Conf.ExternalURL + "/auth/init?account=bot"
+	if got != want {
+		t.Errorf("AuthInitURL(\"bot\") = %q, want %q", got, want)
+	}
+	// No CSRF state / secret should ever leak into the logged URL — it's the
+	// indirection path, not the fully-formed Twitch authorize URL.
+	if strings.Contains(got, "state=") || strings.Contains(got, "client_id=") {
+		t.Errorf("AuthInitURL leaked a sensitive query param: %q", got)
+	}
+}
+
+func TestAccountLabel_BotUsernameIsBot(t *testing.T) {
+	if got := accountLabel(c.Conf.BotUsername); got != "bot" {
+		t.Errorf("accountLabel(bot username) = %q, want \"bot\"", got)
+	}
+}
+
+func TestAccountLabel_UnknownDefaultsToBot(t *testing.T) {
+	if got := accountLabel("some-unrelated-login"); got != "bot" {
+		t.Errorf("accountLabel(unknown) = %q, want \"bot\"", got)
 	}
 }
 


### PR DESCRIPTION
## What

When the bot's Twitch token can't be used, the logs carry a `reauth_url` attribute pointing at `/auth/init` so re-auth is a click instead of running the bootstrap CLI from a laptop. Surfaces:

1. **Boot** — `loadTwitchToken`'s non-fatal "no usable Twitch token" warning (`cmd/tripbot/tripbot.go`).
2. **Polling** — the `pollForTwitchToken` "still waiting" log (recurs every 15s so the link stays findable while waiting).
3. **Hourly refresh** — `refreshOne` terminal failure (empty access token → revoked/`invalid_grant`) in `pkg/twitch/authentication.go`.
4. **IRC connect** — `connectToTwitch` when `ErrLoginAuthenticationFailed` fires and there's no valid in-memory token to retry with.

Both the **bot and broadcaster** links are surfaced (the broadcaster's missing-token path — `LoadFromDB` + `startEventSub` — previously logged no link). Every reauth surface also logs a `login_as` attribute = the exact Twitch account to sign in as (bot username or channel name), and the **auth-bootstrap CLI** logs the same up front before opening the browser. With three envs and up to six bot/broadcaster accounts, `login_as` removes the "which login?" guesswork.

New `mytwitch.AuthInitURL(account)` helper builds the URL; `accountLabel(username)` maps the refresh row's username to the `bot`/`broadcaster` selector.

Rebased onto #624 (start-degraded-instead-of-crashlooping), so the `reauth_url` now rides the non-fatal token-missing path + background poller rather than the old `os.Exit(1)`.

## Makes the link clickable: depends on the infra EXTERNAL_URL change

`AuthInitURL` builds the URL from `EXTERNAL_URL`. Today that's `http://localhost:8080` in the cloud envs, so the logged link only works via port-forward. The companion infra change ([infra#557](https://github.com/adanalife/infra/pull/557/changes), **merged**) repointed `EXTERNAL_URL` at the internal Traefik Ingress host (`https://tripbot.{prod,stage,dev}.whereisdana.today`), so the logged link becomes **clickable from any on-LAN browser** — no port-forward, no CLI. The OAuth round-trip (`/auth/init` → Twitch → `/auth/callback`) then completes against the Ingress and the poller picks up the freshly-written token.

This code is independent of that value (it logs whatever `EXTERNAL_URL` is), and infra#557 is now merged with the Twitch redirect URIs registered, so the logged link is live (pending a `kubectl rollout restart deploy/tripbot` to pick up the new config). dev is forward-prepared but waits on cert-manager on the bees cluster.

## Security tradeoff (the caveat from the TODO)

We log the **`/auth/init` indirection URL**, not the fully-formed Twitch authorize URL:

- The Twitch authorize URL embeds a single-use CSRF `state` with a 5-minute TTL (`oauthstate.TTL`) — stale by the time anyone reads the log, and it would land in Loki/Sentry.
- `/auth/init` carries **no secret**: `client_id` isn't sensitive, and no `state` exists until the redirect is generated server-side on click. A test asserts the URL contains no `state=`/`client_id=`.

## Test

`task test:macos` — full suite green, including `TestAuthInitURL_BuildsInitPath`, `TestAccountLabel_BotUsernameIsBot`, `TestAccountLabel_UnknownDefaultsToBot`.

Closes the "Surface the OAuth login link(s) in the logs" TODO.


