### PR TITLE
Throttle the token-poll warning + show login_as in the reauth URL

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -222,7 +222,7 @@ func pollForTwitchToken(ctx context.Context) {
 	// logged the reauth link once, so re-surfacing it every 15s is just noise.
 	const (
 		interval = 15 * time.Second
-		logEvery = 5 * time.Minute
+		logEvery = 15 * time.Minute
 	)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -217,18 +217,30 @@ func loadTwitchToken(ctx context.Context) {
 // connectToTwitch's reconnect loop authenticates on its next attempt. Started
 // only when the token was missing at boot; stops on shutdown.
 func pollForTwitchToken(ctx context.Context) {
-	const interval = 15 * time.Second
+	// Check often so the token is picked up promptly once it lands, but log
+	// the "still waiting" warning at a much slower cadence — boot already
+	// logged the reauth link once, so re-surfacing it every 15s is just noise.
+	const (
+		interval = 15 * time.Second
+		logEvery = 5 * time.Minute
+	)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	// Suppress the first poll-failure log: loadTwitchToken just logged the
+	// same warning at boot. The next one waits a full logEvery.
+	lastLogged := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			if err := mytwitch.LoadFromDB(); err != nil {
-				slog.WarnContext(ctx, "still waiting for Twitch token",
-					"login_as", c.Conf.BotUsername,
-					"reauth_url", mytwitch.AuthInitURL("bot"), "err", err)
+				if time.Since(lastLogged) >= logEvery {
+					slog.WarnContext(ctx, "still waiting for Twitch token",
+						"login_as", c.Conf.BotUsername,
+						"reauth_url", mytwitch.AuthInitURL("bot"), "err", err)
+					lastLogged = time.Now()
+				}
 				continue
 			}
 			slog.InfoContext(ctx, "Twitch token loaded; bot will connect on next attempt")

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -73,8 +74,18 @@ var ErrNoToken = oauthtokens.ErrNoToken
 // stale by the time anyone read the log — and that state would ship to
 // Loki/Sentry. /auth/init carries no secret: client_id isn't sensitive, and no
 // state exists until the redirect is generated server-side on click.
+//
+// We also append login_as=<username> — the exact Twitch account to sign in
+// as. The /auth/init handler ignores it (it keys off account=bot|broadcaster);
+// it's purely so the username is visible in the browser's address bar, matching
+// the login_as attribute in the logs.
 func AuthInitURL(account string) string {
-	return c.Conf.ExternalURL + "/auth/init?account=" + account
+	login := c.Conf.BotUsername
+	if account == "broadcaster" {
+		login = c.Conf.ChannelName
+	}
+	return c.Conf.ExternalURL + "/auth/init?account=" + account +
+		"&login_as=" + url.QueryEscape(login)
 }
 
 // accountLabel maps an oauth_tokens username to the /auth/init account

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -171,7 +171,7 @@ func TestErrIdentityMismatch_ErrorsAs(t *testing.T) {
 
 func TestAuthInitURL_BuildsInitPath(t *testing.T) {
 	got := AuthInitURL("bot")
-	want := c.Conf.ExternalURL + "/auth/init?account=bot"
+	want := c.Conf.ExternalURL + "/auth/init?account=bot&login_as=" + c.Conf.BotUsername
 	if got != want {
 		t.Errorf("AuthInitURL(\"bot\") = %q, want %q", got, want)
 	}
@@ -184,7 +184,7 @@ func TestAuthInitURL_BuildsInitPath(t *testing.T) {
 
 func TestAuthInitURL_BroadcasterAccount(t *testing.T) {
 	got := AuthInitURL("broadcaster")
-	want := c.Conf.ExternalURL + "/auth/init?account=broadcaster"
+	want := c.Conf.ExternalURL + "/auth/init?account=broadcaster&login_as=" + c.Conf.ChannelName
 	if got != want {
 		t.Errorf("AuthInitURL(\"broadcaster\") = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## What

Two log-ergonomics follow-ups to [#625](https://github.com/adanalife/tripbot/pull/625/changes).

### 1. Throttle the "still waiting for Twitch token" poll warning

`pollForTwitchToken` (`cmd/tripbot/tripbot.go`) checks `LoadFromDB` every 15s and logged a WARN on **every** failed check — ~240 warnings/hour while a pod waits on re-auth.

- Keep the **15s poll** so a freshly-landed token is picked up promptly.
- Log the "still waiting" warning at most **every 15m**.
- Suppress the *first* poll-failure log — `loadTwitchToken` already logs the link once at boot, so the URL still shows up immediately on startup and the next poll-log waits a full 15m.

### 2. Append `login_as=<username>` to the reauth URL

`AuthInitURL` now appends the exact Twitch account to sign in as (`login_as=tripbot4000`, etc.) — `BotUsername` for the bot leg, `ChannelName` for the broadcaster leg. The `/auth/init` handler keys off `?account=bot|broadcaster` and **ignores** `login_as`, so this is purely cosmetic: it makes the username visible in the browser address bar, matching the `login_as` log attribute.

## Test

`task test:macos` — full suite green, including the updated `TestAuthInitURL_*`.