### PR TITLE
Add a landing page on the tripbot Ingress root

### DIFF
--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -280,15 +280,17 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   /* logo is the monochrome black mark; invert to white on the dark bg */
   .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(1); opacity:.92; display:block; margin:0 0 16px; }
   h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 4px; letter-spacing:.02em; }
+  .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:2px 7px; border-radius:5px; font-size:.5em; font-weight:normal; letter-spacing:0; vertical-align:middle; }
   .meta { color:#888; margin:0 0 2px; font-size:.92em; }
-  .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:1px 7px; border-radius:5px; font-size:.92em; }
   .accounts { color:#666; margin:0 0 24px; font-size:.85em; }
   h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
   ul { list-style:none; margin:0; padding:0; }
   .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
   .row .name { flex:1; }
-  .row .detail { color:#888; font-size:.92em; }
   .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
+  /* status hugs the far right and right-aligns so it forms a clean column,
+     aligned whether or not the row carries a version */
+  .row .status { color:#888; font-size:.92em; text-align:right; min-width:5.5em; }
   .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
   .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
   .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
@@ -305,8 +307,8 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   <!-- A Dana Life mark, referenced from the website (the single owner of brand
        assets) rather than copied in — see vault general/logo.md. -->
   <img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44">
-  <h1>tripbot</h1>
-  <p class="meta">env <code class="env">{{.Env}}</code> · up {{.Uptime}} · {{.Chatters}} in chat</p>
+  <h1>tripbot <code class="env">{{.Env}}</code></h1>
+  <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
 
   <h2>status</h2>
@@ -315,8 +317,8 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
     <li class="row">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
-      <span class="detail">{{.Detail}}</span>
       {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
+      <span class="status">{{.Detail}}</span>
     </li>
     {{end}}
   </ul>
@@ -330,7 +332,7 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   </p>
   {{end}}
 
-  <h2>links</h2>
+  <h2>dashboards</h2>
   <nav class="links">
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -36,9 +36,9 @@ var (
 )
 
 const (
-	// grafanaURL points at the Grafana Cloud dashboards list (the TripBot
-	// folder lives there). Fixed — the org URL doesn't vary by environment.
-	grafanaURL = "https://adanalife.grafana.net/dashboards"
+	// grafanaURL points at the TripBot dashboards folder in Grafana Cloud.
+	// Fixed — the org URL doesn't vary by environment.
+	grafanaURL = "https://adanalife.grafana.net/dashboards/f/fflhs4m586io0e"
 	// githubURL is the tripbot source repo (vlc-server + obs live here too).
 	githubURL = "https://github.com/adanalife/tripbot"
 	// traefikURL / hubbleURL are the cluster's platform dashboards. They live

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"context"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+)
+
+// startedAt marks process start so the landing page can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
+
+// healthClient is the short-timeout client used for the sibling-service status
+// ping. 2s keeps a slow or hung vlc-server from stalling the landing render.
+var healthClient = &http.Client{Timeout: 2 * time.Second}
+
+// grafanaURL points at the Grafana Cloud dashboards list (the TripBot folder
+// lives there). Fixed — the org URL doesn't vary by environment.
+const grafanaURL = "https://adanalife.grafana.net/dashboards"
+
+// serviceStatus is one row in the landing page's status table.
+type serviceStatus struct {
+	Name   string
+	OK     bool
+	Detail string
+}
+
+// navLink is one entry in the landing page's links list.
+type navLink struct {
+	Label string
+	URL   string
+}
+
+// landingData is the template payload.
+type landingData struct {
+	Channel  string
+	Env      string
+	Uptime   string
+	Services []serviceStatus
+	Links    []navLink
+}
+
+// landingHandler serves the human-facing root page on the tripbot Ingress: a
+// lightweight status overview (tripbot's own readiness + a live vlc-server
+// ping) plus links out to OBS, Grafana, and the Twitch channel. Replaces the
+// bare 404 that used to sit on "/".
+func landingHandler(w http.ResponseWriter, r *http.Request) {
+	data := landingData{
+		Channel:  c.Conf.ChannelName,
+		Env:      c.Conf.Environment,
+		Uptime:   time.Since(startedAt).Round(time.Second).String(),
+		Services: gatherStatus(r.Context()),
+		Links:    gatherLinks(),
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := landingTmpl.Execute(w, data); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't render landing page", "err", err)
+	}
+}
+
+// gatherStatus reports tripbot's own readiness (in-memory, free) and pings
+// vlc-server's readiness endpoint over the in-cluster Service DNS. The ping is
+// best-effort: any failure (DNS, timeout, non-2xx) renders as not-OK rather
+// than erroring the page.
+func gatherStatus(ctx context.Context) []serviceStatus {
+	tripbot := serviceStatus{Name: "tripbot", OK: ready.Load()}
+	if tripbot.OK {
+		tripbot.Detail = "ready"
+	} else {
+		tripbot.Detail = "degraded (awaiting Twitch)"
+	}
+
+	vlc := serviceStatus{Name: "vlc-server"}
+	if c.Conf.VlcServerHost != "" {
+		vlc.OK = pingHealthy(ctx, "http://"+c.Conf.VlcServerHost+"/health/ready")
+	}
+	if vlc.OK {
+		vlc.Detail = "healthy"
+	} else {
+		vlc.Detail = "unreachable"
+	}
+
+	return []serviceStatus{tripbot, vlc}
+}
+
+// pingHealthy GETs a readiness URL and reports whether it answered 2xx within
+// the client timeout.
+func pingHealthy(ctx context.Context, rawURL string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// gatherLinks builds the external-link list: OBS's Ingress (derived from this
+// bot's own EXTERNAL_URL by swapping the leading subdomain label), the Grafana
+// dashboards, and the Twitch channel. Entries whose URL can't be derived are
+// dropped rather than rendered broken.
+func gatherLinks() []navLink {
+	links := []navLink{}
+	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
+		links = append(links, navLink{Label: "OBS (noVNC)", URL: obs})
+	}
+	links = append(links, navLink{Label: "Grafana dashboards", URL: grafanaURL})
+	if c.Conf.ChannelName != "" {
+		links = append(links, navLink{Label: "Twitch channel", URL: "https://twitch.tv/" + c.Conf.ChannelName})
+	}
+	return links
+}
+
+// siblingURL rewrites externalURL's leading hostname label to service, e.g.
+// https://tripbot.prod.whereisdana.today -> https://obs.prod.whereisdana.today.
+// Returns "" when externalURL isn't a multi-label FQDN (e.g. localhost), since
+// there's no sibling Ingress to point at in that case.
+func siblingURL(externalURL, service string) string {
+	u, err := url.Parse(externalURL)
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	_, rest, found := strings.Cut(u.Hostname(), ".")
+	if !found {
+		return ""
+	}
+	u.Host = service + "." + rest
+	return u.String()
+}
+
+var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tripbot — {{.Channel}}</title>
+<style>
+  :root { color-scheme: dark; }
+  body { background:#0a0a0a; color:#eee; font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",monospace; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
+  main { width:min(92vw,420px); padding:32px; }
+  h1 { font-size:20px; margin:0 0 4px; letter-spacing:.02em; }
+  .meta { color:#888; margin:0 0 24px; font-size:13px; }
+  h2 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
+  ul { list-style:none; margin:0; padding:0; }
+  .svc { display:flex; align-items:center; gap:10px; padding:6px 0; border-bottom:1px solid #1c1c1c; }
+  .svc .name { flex:1; }
+  .svc .detail { color:#888; font-size:13px; }
+  .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
+  .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
+  .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
+  a { color:#58a6ff; text-decoration:none; display:block; padding:6px 0; border-bottom:1px solid #1c1c1c; }
+  a:hover { color:#9cf; }
+</style>
+</head>
+<body>
+<main>
+  <h1>tripbot</h1>
+  <p class="meta">channel <strong>{{.Channel}}</strong> · env {{.Env}} · up {{.Uptime}}</p>
+
+  <h2>status</h2>
+  <ul>
+    {{range .Services}}
+    <li class="svc">
+      <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
+      <span class="name">{{.Name}}</span>
+      <span class="detail">{{.Detail}}</span>
+    </li>
+    {{end}}
+  </ul>
+
+  <h2>links</h2>
+  <ul>
+    {{range .Links}}
+    <li><a href="{{.URL}}">{{.Label}} →</a></li>
+    {{end}}
+  </ul>
+</main>
+</body>
+</html>`))

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -100,6 +100,7 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
 	}
 
+	sha := buildSHA()
 	data := landingData{
 		Channel:  c.Conf.ChannelName,
 		Env:      c.Conf.Environment,
@@ -108,9 +109,9 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		Chatters: chatterCount(),
 		Services: gatherStatus(vlcOK, vlcVer),
 		Now:      currentVideo(vlcOK),
-		Links:    gatherLinks(),
+		Links:    gatherLinks(sha),
 	}
-	if sha := buildSHA(); sha != "" {
+	if sha != "" {
 		data.SHA = sha[:min(7, len(sha))]
 		data.CommitURL = commitURL(sha)
 	}
@@ -220,9 +221,9 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 
 // gatherLinks builds the external-link list: OBS's Ingress (derived from this
 // bot's own EXTERNAL_URL by swapping the leading subdomain label), the Grafana
-// dashboards, the Twitch channel, and the GitHub source repo. Entries whose
-// URL can't be derived are dropped rather than rendered broken.
-func gatherLinks() []navLink {
+// dashboards, the Twitch channel, and the changelog as of the deployed commit.
+// Entries whose URL can't be derived are dropped rather than rendered broken.
+func gatherLinks(sha string) []navLink {
 	links := []navLink{}
 	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
 		links = append(links, navLink{Label: "OBS (noVNC)", URL: obs})
@@ -231,8 +232,19 @@ func gatherLinks() []navLink {
 	if c.Conf.ChannelName != "" {
 		links = append(links, navLink{Label: "Twitch channel", URL: "https://twitch.tv/" + c.Conf.ChannelName})
 	}
-	links = append(links, navLink{Label: "GitHub (source)", URL: githubURL})
+	links = append(links, navLink{Label: "Changelog", URL: changelogURL(sha)})
 	return links
+}
+
+// changelogURL links to CHANGELOG.md as of the deployed commit, so it shows the
+// changelog for exactly what's running. Falls back to the default branch when
+// the sha is unknown (e.g. a build without embedded VCS info).
+func changelogURL(sha string) string {
+	ref := "master"
+	if sha != "" {
+		ref = sha
+	}
+	return githubURL + "/blob/" + ref + "/CHANGELOG.md"
 }
 
 // siblingURL rewrites externalURL's leading hostname label to service, e.g.

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -2,14 +2,17 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"html/template"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strings"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -21,14 +24,24 @@ var startedAt = time.Now()
 // ping. 2s keeps a slow or hung vlc-server from stalling the landing render.
 var healthClient = &http.Client{Timeout: 2 * time.Second}
 
-// currentlyPlaying is overridable in tests; by default it reads pkg/video's
-// in-process notion of the current video (refreshed by a 60s cron tick), so
-// the landing page costs nothing to show "now playing".
-var currentlyPlaying = video.CurrentlyPlaying
+// currentlyPlaying / currentProgress are overridable in tests; by default they
+// read pkg/video's in-process state (refreshed by a 60s cron tick), so the
+// landing page costs nothing to show "now playing".
+var (
+	currentlyPlaying = video.CurrentlyPlaying
+	currentProgress  = video.CurrentProgress
+	// chatterCount is the in-memory count of users in chat, refreshed ~60s by
+	// the UpdateSession cron. Overridable in tests.
+	chatterCount = mytwitch.ChatterCount
+)
 
-// grafanaURL points at the Grafana Cloud dashboards list (the TripBot folder
-// lives there). Fixed — the org URL doesn't vary by environment.
-const grafanaURL = "https://adanalife.grafana.net/dashboards"
+const (
+	// grafanaURL points at the Grafana Cloud dashboards list (the TripBot
+	// folder lives there). Fixed — the org URL doesn't vary by environment.
+	grafanaURL = "https://adanalife.grafana.net/dashboards"
+	// githubURL is the tripbot source repo (vlc-server + obs live here too).
+	githubURL = "https://github.com/adanalife/tripbot"
+)
 
 // serviceStatus is one row in the landing page's status table.
 type serviceStatus struct {
@@ -37,26 +50,31 @@ type serviceStatus struct {
 	Detail string
 }
 
+// nowPlaying is the current-video summary shown when vlc-server is healthy.
+type nowPlaying struct {
+	File     string
+	State    string
+	Progress string
+}
+
 // navLink is one entry in the landing page's links list.
 type navLink struct {
 	Label string
 	URL   string
 }
 
-// nowPlaying is the current-video summary shown when vlc-server is healthy.
-type nowPlaying struct {
-	File  string
-	State string
-}
-
 // landingData is the template payload.
 type landingData struct {
-	Channel  string
-	Env      string
-	Uptime   string
-	Services []serviceStatus
-	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
-	Links    []navLink
+	Channel   string
+	Env       string
+	Uptime    string
+	Version   string // tripbot's own build tag
+	SHA       string // short git sha
+	CommitURL string // link to the build's commit on GitHub (empty if no sha)
+	Chatters  int    // users currently in chat
+	Services  []serviceStatus
+	Now       *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Links     []navLink
 }
 
 // landingHandler serves the human-facing root page on the tripbot Ingress: a
@@ -68,13 +86,25 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 	vlcOK := c.Conf.VlcServerHost != "" &&
 		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
 
+	// vlc-server's build tag — one extra in-cluster GET, only when it's up.
+	vlcVersion := ""
+	if vlcOK {
+		vlcVersion = fetchVersion(r.Context(), c.Conf.VlcServerHost)
+	}
+
 	data := landingData{
 		Channel:  c.Conf.ChannelName,
 		Env:      c.Conf.Environment,
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
-		Services: gatherStatus(vlcOK),
+		Version:  versionTag,
+		Chatters: chatterCount(),
+		Services: gatherStatus(vlcOK, vlcVersion),
 		Now:      currentVideo(vlcOK),
 		Links:    gatherLinks(),
+	}
+	if sha := buildSHA(); sha != "" {
+		data.SHA = sha[:min(7, len(sha))]
+		data.CommitURL = githubURL + "/commit/" + sha
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -84,10 +114,10 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
-// the already-computed vlc-server health. The vlc ping is best-effort: any
-// failure (DNS, timeout, non-2xx) renders as not-OK rather than erroring the
-// page.
-func gatherStatus(vlcOK bool) []serviceStatus {
+// the already-computed vlc-server health (with its build tag when reachable).
+// The vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as
+// not-OK rather than erroring the page.
+func gatherStatus(vlcOK bool, vlcVersion string) []serviceStatus {
 	tripbot := serviceStatus{Name: "tripbot", OK: ready.Load()}
 	if tripbot.OK {
 		tripbot.Detail = "ready"
@@ -98,6 +128,9 @@ func gatherStatus(vlcOK bool) []serviceStatus {
 	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}
 	if vlcOK {
 		vlc.Detail = "healthy"
+		if vlcVersion != "" {
+			vlc.Detail = "healthy · " + vlcVersion
+		}
 	}
 
 	return []serviceStatus{tripbot, vlc}
@@ -115,7 +148,45 @@ func currentVideo(vlcOK bool) *nowPlaying {
 	if v.Slug == "" {
 		return nil
 	}
-	return &nowPlaying{File: v.File(), State: v.State}
+	return &nowPlaying{
+		File:     v.File(),
+		State:    v.State,
+		Progress: currentProgress().Round(time.Second).String(),
+	}
+}
+
+// buildSHA returns the binary's embedded VCS revision (via Go's -buildvcs), or
+// "" for builds without it (e.g. `go test`). Same source versionHandler uses.
+func buildSHA() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				return s.Value
+			}
+		}
+	}
+	return ""
+}
+
+// fetchVersion GETs a sibling service's /version endpoint and returns its tag,
+// or "" on any error. Uses the same short-timeout client as the health ping.
+func fetchVersion(ctx context.Context, host string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+host+"/version", nil)
+	if err != nil {
+		return ""
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	var v struct {
+		Tag string `json:"tag"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return ""
+	}
+	return v.Tag
 }
 
 // pingHealthy GETs a readiness URL and reports whether it answered 2xx within
@@ -135,8 +206,8 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 
 // gatherLinks builds the external-link list: OBS's Ingress (derived from this
 // bot's own EXTERNAL_URL by swapping the leading subdomain label), the Grafana
-// dashboards, and the Twitch channel. Entries whose URL can't be derived are
-// dropped rather than rendered broken.
+// dashboards, the Twitch channel, and the GitHub source repo. Entries whose
+// URL can't be derived are dropped rather than rendered broken.
 func gatherLinks() []navLink {
 	links := []navLink{}
 	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
@@ -146,6 +217,7 @@ func gatherLinks() []navLink {
 	if c.Conf.ChannelName != "" {
 		links = append(links, navLink{Label: "Twitch channel", URL: "https://twitch.tv/" + c.Conf.ChannelName})
 	}
+	links = append(links, navLink{Label: "GitHub (source)", URL: githubURL})
 	return links
 }
 
@@ -176,7 +248,9 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   :root { color-scheme: dark; }
   body { background:#0a0a0a; color:#eee; font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",monospace; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
   main { width:min(92vw,420px); padding:32px; }
-  h1 { font-size:20px; margin:0 0 4px; letter-spacing:.02em; }
+  h1 { font-size:20px; margin:0 0 2px; letter-spacing:.02em; }
+  .ver { color:#666; margin:0 0 10px; font-size:12px; }
+  .ver a { display:inline; padding:0; border:0; }
   .meta { color:#888; margin:0 0 24px; font-size:13px; }
   h2 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
   ul { list-style:none; margin:0; padding:0; }
@@ -196,7 +270,8 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
 <body>
 <main>
   <h1>tripbot</h1>
-  <p class="meta">channel <strong>{{.Channel}}</strong> · env {{.Env}} · up {{.Uptime}}</p>
+  {{if .Version}}<p class="ver">{{.Version}}{{if .SHA}} · <a href="{{.CommitURL}}">{{.SHA}}</a>{{end}}</p>{{end}}
+  <p class="meta">channel <strong>{{.Channel}}</strong> · env {{.Env}} · up {{.Uptime}} · {{.Chatters}} in chat</p>
 
   <h2>status</h2>
   <ul>
@@ -214,6 +289,7 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   <p class="now">
     <span class="file">{{.File}}</span>
     {{if .State}}<span class="state">· {{.State}}</span>{{end}}
+    {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
   </p>
   {{end}}
 

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -280,10 +280,17 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>tripbot — {{.Channel}}</title>
+<!-- favicons referenced from the website (single owner of brand assets) — see
+     vault general/logo.md; apple-touch-icon gives a home-screen icon on phones -->
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.dana.lol/assets/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.dana.lol/assets/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.dana.lol/assets/apple-touch-icon.png">
 <style>
   :root { color-scheme: dark; }
   body { background:#0a0a0a; color:#eee; font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",monospace; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
   main { width:min(92vw,420px); padding:32px; }
+  /* logo is the monochrome black mark; invert to white on the dark bg */
+  .logo { width:44px; height:44px; filter:invert(1); opacity:.92; display:block; margin:0 0 14px; }
   h1 { font-size:20px; margin:0 0 2px; letter-spacing:.02em; }
   .ver { color:#666; margin:0 0 10px; font-size:12px; }
   .meta { color:#888; margin:0 0 24px; font-size:13px; }
@@ -305,6 +312,9 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
 </head>
 <body>
 <main>
+  <!-- A Dana Life mark, referenced from the website (the single owner of brand
+       assets) rather than copied in — see vault general/logo.md. -->
+  <img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44">
   <h1>tripbot</h1>
   {{if .Version}}<p class="ver">{{.Version}}{{if .SHA}} · <a href="{{.CommitURL}}">{{.SHA}}</a>{{end}}</p>{{end}}
   <p class="meta">channel <strong><a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a></strong> · env {{.Env}} · up {{.Uptime}} · {{.Chatters}} in chat</p>

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -54,7 +54,7 @@ type serviceStatus struct {
 	OK         bool
 	Detail     string
 	Version    string // optional build tag (e.g. vlc-server's, from /version)
-	VersionURL string // commit link for Version, when the sha is known
+	VersionURL string // changelog link (at the build's sha) for Version
 }
 
 // versionInfo is the subset of a service's /version JSON the page uses.
@@ -78,23 +78,24 @@ type navLink struct {
 
 // landingData is the template payload.
 type landingData struct {
-	Channel   string
-	Env       string
-	Uptime    string
-	Version   string // tripbot's own build tag
-	SHA       string // short git sha
-	CommitURL string // link to the build's commit on GitHub (empty if no sha)
-	Chatters  int    // users currently in chat
-	Services  []serviceStatus
-	Now       *nowPlaying // nil when vlc is unhealthy or nothing is playing
-	Links     []navLink
+	Channel      string // broadcaster Twitch username
+	Bot          string // bot Twitch username
+	Env          string
+	Uptime       string
+	Version      string // tripbot's own build tag
+	SHA          string // short git sha
+	ChangelogURL string // link to CHANGELOG.md at the build's sha
+	Chatters     int    // users currently in chat
+	Services     []serviceStatus
+	Now          *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Links        []navLink
 }
 
 // landingHandler serves the human-facing root page on the tripbot Ingress: a
 // lightweight status overview (tripbot's own readiness + a live vlc-server
-// ping), the currently-playing video when vlc is up, and links out to OBS,
-// Grafana, and the Twitch channel. Replaces the bare 404 that used to sit on
-// "/".
+// ping, each version linking to its changelog), the currently-playing video
+// when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
+// / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
 func landingHandler(w http.ResponseWriter, r *http.Request) {
 	vlcOK := c.Conf.VlcServerHost != "" &&
 		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
@@ -107,18 +108,19 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 
 	sha := buildSHA()
 	data := landingData{
-		Channel:  c.Conf.ChannelName,
-		Env:      c.Conf.Environment,
-		Uptime:   time.Since(startedAt).Round(time.Second).String(),
-		Version:  versionTag,
-		Chatters: chatterCount(),
-		Services: gatherStatus(vlcOK, vlcVer),
-		Now:      currentVideo(vlcOK),
-		Links:    gatherLinks(sha),
+		Channel:      c.Conf.ChannelName,
+		Bot:          c.Conf.BotUsername,
+		Env:          c.Conf.Environment,
+		Uptime:       time.Since(startedAt).Round(time.Second).String(),
+		Version:      versionTag,
+		ChangelogURL: changelogURL(sha),
+		Chatters:     chatterCount(),
+		Services:     gatherStatus(vlcOK, vlcVer),
+		Now:          currentVideo(vlcOK),
+		Links:        gatherLinks(),
 	}
 	if sha != "" {
 		data.SHA = sha[:min(7, len(sha))]
-		data.CommitURL = commitURL(sha)
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -143,18 +145,10 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo) []serviceStatus {
 	if vlcOK {
 		vlc.Detail = "healthy"
 		vlc.Version = vlcVer.Tag
-		vlc.VersionURL = commitURL(vlcVer.Sha) // same repo as tripbot
+		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
 	}
 
 	return []serviceStatus{tripbot, vlc}
-}
-
-// commitURL links a git sha to its commit on GitHub, or "" when sha is empty.
-func commitURL(sha string) string {
-	if sha == "" {
-		return ""
-	}
-	return githubURL + "/commit/" + sha
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -224,12 +218,12 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
-// gatherLinks builds the external-link list: OBS's Ingress (derived from this
-// bot's own EXTERNAL_URL by swapping the leading subdomain label), the Grafana
-// dashboards, the Traefik + Hubble platform dashboards, the Twitch channel, and
-// the changelog as of the deployed commit. Entries whose URL can't be derived
-// are dropped rather than rendered broken.
-func gatherLinks(sha string) []navLink {
+// gatherLinks builds the dashboard-link list: OBS's Ingress (derived from this
+// bot's own EXTERNAL_URL by swapping the leading subdomain label), plus the
+// Grafana / Traefik / Hubble platform dashboards. Twitch profiles are rendered
+// in the accounts section and the changelog hangs off the version tags, so
+// neither appears here. Entries whose URL can't be derived are dropped.
+func gatherLinks() []navLink {
 	links := []navLink{}
 	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
 		links = append(links, navLink{Label: "OBS (noVNC)", URL: obs})
@@ -239,10 +233,6 @@ func gatherLinks(sha string) []navLink {
 		navLink{Label: "Traefik dashboard", URL: traefikURL},
 		navLink{Label: "Hubble UI", URL: hubbleURL},
 	)
-	if c.Conf.ChannelName != "" {
-		links = append(links, navLink{Label: "Twitch channel", URL: "https://twitch.tv/" + c.Conf.ChannelName})
-	}
-	links = append(links, navLink{Label: "Changelog", URL: changelogURL(sha)})
 	return links
 }
 
@@ -286,28 +276,29 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
 <link rel="icon" type="image/png" sizes="16x16" href="https://www.dana.lol/assets/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="https://www.dana.lol/assets/apple-touch-icon.png">
 <style>
-  :root { color-scheme: dark; }
-  body { background:#0a0a0a; color:#eee; font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",monospace; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
-  main { width:min(92vw,420px); padding:32px; }
+  :root { color-scheme: dark; --mono: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  body { background:#0a0a0a; color:#eee; font:clamp(14px,0.5vw + 11px,18px)/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
+  main { width:min(92vw,520px); padding:clamp(24px,4vw,48px); }
   /* logo is the monochrome black mark; invert to white on the dark bg */
-  .logo { width:44px; height:44px; filter:invert(1); opacity:.92; display:block; margin:0 0 14px; }
-  h1 { font-size:20px; margin:0 0 2px; letter-spacing:.02em; }
-  .ver { color:#666; margin:0 0 10px; font-size:12px; }
-  .meta { color:#888; margin:0 0 24px; font-size:13px; }
-  h2 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
+  .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(1); opacity:.92; display:block; margin:0 0 16px; }
+  h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 2px; letter-spacing:.02em; }
+  .ver { color:#666; margin:0 0 12px; font-size:.85em; }
+  .meta { color:#888; margin:0 0 28px; font-size:.92em; }
+  .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:1px 7px; border-radius:5px; font-size:.92em; }
+  h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:26px 0 8px; }
   ul { list-style:none; margin:0; padding:0; }
-  .svc { display:flex; align-items:center; gap:10px; padding:6px 0; border-bottom:1px solid #1c1c1c; }
-  .svc .name { flex:1; }
-  .svc .detail { color:#888; font-size:13px; }
+  .row { display:flex; align-items:center; gap:10px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
+  .row .name { flex:1; }
+  .row .detail { color:#888; font-size:.92em; text-align:right; }
   .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
   .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
   .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
-  .now { margin:0; padding:6px 0; }
-  .now .file { word-break:break-all; }
+  .now { margin:0; padding:7px 0; }
+  .now .file { font-family:var(--mono); word-break:break-all; }
   .now .state { color:#888; }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
-  .links a { display:block; padding:6px 0; border-bottom:1px solid #1c1c1c; }
+  .links a { display:block; padding:7px 0; border-bottom:1px solid #1c1c1c; }
 </style>
 </head>
 <body>
@@ -316,13 +307,13 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
        assets) rather than copied in — see vault general/logo.md. -->
   <img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44">
   <h1>tripbot</h1>
-  {{if .Version}}<p class="ver">{{.Version}}{{if .SHA}} · <a href="{{.CommitURL}}">{{.SHA}}</a>{{end}}</p>{{end}}
-  <p class="meta">channel <strong><a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a></strong> · env {{.Env}} · up {{.Uptime}} · {{.Chatters}} in chat</p>
+  {{if .Version}}<p class="ver"><a href="{{.ChangelogURL}}">{{.Version}}</a>{{if .SHA}} · {{.SHA}}{{end}}</p>{{end}}
+  <p class="meta">env <code class="env">{{.Env}}</code> · up {{.Uptime}} · {{.Chatters}} in chat</p>
 
   <h2>status</h2>
   <ul>
     {{range .Services}}
-    <li class="svc">
+    <li class="row">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
       <span class="detail">{{.Detail}}{{if .Version}} · {{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}{{end}}</span>
@@ -338,6 +329,12 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
     {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
   </p>
   {{end}}
+
+  <h2>accounts</h2>
+  <ul>
+    <li class="row"><span class="name">broadcaster</span><span class="detail"><a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a></span></li>
+    <li class="row"><span class="name">bot</span><span class="detail"><a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></span></li>
+  </ul>
 
   <h2>links</h2>
   <ul class="links">

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -45,9 +45,17 @@ const (
 
 // serviceStatus is one row in the landing page's status table.
 type serviceStatus struct {
-	Name   string
-	OK     bool
-	Detail string
+	Name       string
+	OK         bool
+	Detail     string
+	Version    string // optional build tag (e.g. vlc-server's, from /version)
+	VersionURL string // commit link for Version, when the sha is known
+}
+
+// versionInfo is the subset of a service's /version JSON the page uses.
+type versionInfo struct {
+	Tag string `json:"tag"`
+	Sha string `json:"sha"`
 }
 
 // nowPlaying is the current-video summary shown when vlc-server is healthy.
@@ -86,10 +94,10 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 	vlcOK := c.Conf.VlcServerHost != "" &&
 		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
 
-	// vlc-server's build tag — one extra in-cluster GET, only when it's up.
-	vlcVersion := ""
+	// vlc-server's build info — one extra in-cluster GET, only when it's up.
+	var vlcVer versionInfo
 	if vlcOK {
-		vlcVersion = fetchVersion(r.Context(), c.Conf.VlcServerHost)
+		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
 	}
 
 	data := landingData{
@@ -98,13 +106,13 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
 		Version:  versionTag,
 		Chatters: chatterCount(),
-		Services: gatherStatus(vlcOK, vlcVersion),
+		Services: gatherStatus(vlcOK, vlcVer),
 		Now:      currentVideo(vlcOK),
 		Links:    gatherLinks(),
 	}
 	if sha := buildSHA(); sha != "" {
 		data.SHA = sha[:min(7, len(sha))]
-		data.CommitURL = githubURL + "/commit/" + sha
+		data.CommitURL = commitURL(sha)
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -117,7 +125,7 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 // the already-computed vlc-server health (with its build tag when reachable).
 // The vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as
 // not-OK rather than erroring the page.
-func gatherStatus(vlcOK bool, vlcVersion string) []serviceStatus {
+func gatherStatus(vlcOK bool, vlcVer versionInfo) []serviceStatus {
 	tripbot := serviceStatus{Name: "tripbot", OK: ready.Load()}
 	if tripbot.OK {
 		tripbot.Detail = "ready"
@@ -128,12 +136,19 @@ func gatherStatus(vlcOK bool, vlcVersion string) []serviceStatus {
 	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}
 	if vlcOK {
 		vlc.Detail = "healthy"
-		if vlcVersion != "" {
-			vlc.Detail = "healthy · " + vlcVersion
-		}
+		vlc.Version = vlcVer.Tag
+		vlc.VersionURL = commitURL(vlcVer.Sha) // same repo as tripbot
 	}
 
 	return []serviceStatus{tripbot, vlc}
+}
+
+// commitURL links a git sha to its commit on GitHub, or "" when sha is empty.
+func commitURL(sha string) string {
+	if sha == "" {
+		return ""
+	}
+	return githubURL + "/commit/" + sha
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -168,25 +183,24 @@ func buildSHA() string {
 	return ""
 }
 
-// fetchVersion GETs a sibling service's /version endpoint and returns its tag,
-// or "" on any error. Uses the same short-timeout client as the health ping.
-func fetchVersion(ctx context.Context, host string) string {
+// fetchVersion GETs a sibling service's /version endpoint and returns its build
+// tag + sha, or a zero versionInfo on any error. Uses the same short-timeout
+// client as the health ping.
+func fetchVersion(ctx context.Context, host string) versionInfo {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+host+"/version", nil)
 	if err != nil {
-		return ""
+		return versionInfo{}
 	}
 	resp, err := healthClient.Do(req)
 	if err != nil {
-		return ""
+		return versionInfo{}
 	}
 	defer resp.Body.Close()
-	var v struct {
-		Tag string `json:"tag"`
-	}
+	var v versionInfo
 	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return ""
+		return versionInfo{}
 	}
-	return v.Tag
+	return v
 }
 
 // pingHealthy GETs a readiness URL and reports whether it answered 2xx within
@@ -250,7 +264,6 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   main { width:min(92vw,420px); padding:32px; }
   h1 { font-size:20px; margin:0 0 2px; letter-spacing:.02em; }
   .ver { color:#666; margin:0 0 10px; font-size:12px; }
-  .ver a { display:inline; padding:0; border:0; }
   .meta { color:#888; margin:0 0 24px; font-size:13px; }
   h2 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
   ul { list-style:none; margin:0; padding:0; }
@@ -263,15 +276,16 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   .now { margin:0; padding:6px 0; }
   .now .file { word-break:break-all; }
   .now .state { color:#888; }
-  a { color:#58a6ff; text-decoration:none; display:block; padding:6px 0; border-bottom:1px solid #1c1c1c; }
+  a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
+  .links a { display:block; padding:6px 0; border-bottom:1px solid #1c1c1c; }
 </style>
 </head>
 <body>
 <main>
   <h1>tripbot</h1>
   {{if .Version}}<p class="ver">{{.Version}}{{if .SHA}} · <a href="{{.CommitURL}}">{{.SHA}}</a>{{end}}</p>{{end}}
-  <p class="meta">channel <strong>{{.Channel}}</strong> · env {{.Env}} · up {{.Uptime}} · {{.Chatters}} in chat</p>
+  <p class="meta">channel <strong><a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a></strong> · env {{.Env}} · up {{.Uptime}} · {{.Chatters}} in chat</p>
 
   <h2>status</h2>
   <ul>
@@ -279,7 +293,7 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
     <li class="svc">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
-      <span class="detail">{{.Detail}}</span>
+      <span class="detail">{{.Detail}}{{if .Version}} · {{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}{{end}}</span>
     </li>
     {{end}}
   </ul>
@@ -294,7 +308,7 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   {{end}}
 
   <h2>links</h2>
-  <ul>
+  <ul class="links">
     {{range .Links}}
     <li><a href="{{.URL}}">{{.Label}} →</a></li>
     {{end}}

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/video"
 )
 
 // startedAt marks process start so the landing page can report uptime. Set at
@@ -19,6 +20,11 @@ var startedAt = time.Now()
 // healthClient is the short-timeout client used for the sibling-service status
 // ping. 2s keeps a slow or hung vlc-server from stalling the landing render.
 var healthClient = &http.Client{Timeout: 2 * time.Second}
+
+// currentlyPlaying is overridable in tests; by default it reads pkg/video's
+// in-process notion of the current video (refreshed by a 60s cron tick), so
+// the landing page costs nothing to show "now playing".
+var currentlyPlaying = video.CurrentlyPlaying
 
 // grafanaURL points at the Grafana Cloud dashboards list (the TripBot folder
 // lives there). Fixed — the org URL doesn't vary by environment.
@@ -37,25 +43,37 @@ type navLink struct {
 	URL   string
 }
 
+// nowPlaying is the current-video summary shown when vlc-server is healthy.
+type nowPlaying struct {
+	File  string
+	State string
+}
+
 // landingData is the template payload.
 type landingData struct {
 	Channel  string
 	Env      string
 	Uptime   string
 	Services []serviceStatus
+	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
 	Links    []navLink
 }
 
 // landingHandler serves the human-facing root page on the tripbot Ingress: a
 // lightweight status overview (tripbot's own readiness + a live vlc-server
-// ping) plus links out to OBS, Grafana, and the Twitch channel. Replaces the
-// bare 404 that used to sit on "/".
+// ping), the currently-playing video when vlc is up, and links out to OBS,
+// Grafana, and the Twitch channel. Replaces the bare 404 that used to sit on
+// "/".
 func landingHandler(w http.ResponseWriter, r *http.Request) {
+	vlcOK := c.Conf.VlcServerHost != "" &&
+		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
+
 	data := landingData{
 		Channel:  c.Conf.ChannelName,
 		Env:      c.Conf.Environment,
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
-		Services: gatherStatus(r.Context()),
+		Services: gatherStatus(vlcOK),
+		Now:      currentVideo(vlcOK),
 		Links:    gatherLinks(),
 	}
 
@@ -65,11 +83,11 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// gatherStatus reports tripbot's own readiness (in-memory, free) and pings
-// vlc-server's readiness endpoint over the in-cluster Service DNS. The ping is
-// best-effort: any failure (DNS, timeout, non-2xx) renders as not-OK rather
-// than erroring the page.
-func gatherStatus(ctx context.Context) []serviceStatus {
+// gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
+// the already-computed vlc-server health. The vlc ping is best-effort: any
+// failure (DNS, timeout, non-2xx) renders as not-OK rather than erroring the
+// page.
+func gatherStatus(vlcOK bool) []serviceStatus {
 	tripbot := serviceStatus{Name: "tripbot", OK: ready.Load()}
 	if tripbot.OK {
 		tripbot.Detail = "ready"
@@ -77,17 +95,27 @@ func gatherStatus(ctx context.Context) []serviceStatus {
 		tripbot.Detail = "degraded (awaiting Twitch)"
 	}
 
-	vlc := serviceStatus{Name: "vlc-server"}
-	if c.Conf.VlcServerHost != "" {
-		vlc.OK = pingHealthy(ctx, "http://"+c.Conf.VlcServerHost+"/health/ready")
-	}
-	if vlc.OK {
+	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}
+	if vlcOK {
 		vlc.Detail = "healthy"
-	} else {
-		vlc.Detail = "unreachable"
 	}
 
 	return []serviceStatus{tripbot, vlc}
+}
+
+// currentVideo summarizes the currently-playing video for the page, but only
+// when vlc is healthy (a stale value while vlc is down would be misleading).
+// Reads pkg/video's in-process value — no extra call. Returns nil when nothing
+// is playing yet (empty slug).
+func currentVideo(vlcOK bool) *nowPlaying {
+	if !vlcOK {
+		return nil
+	}
+	v := currentlyPlaying()
+	if v.Slug == "" {
+		return nil
+	}
+	return &nowPlaying{File: v.File(), State: v.State}
 }
 
 // pingHealthy GETs a readiness URL and reports whether it answered 2xx within
@@ -158,6 +186,9 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
   .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
   .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
+  .now { margin:0; padding:6px 0; }
+  .now .file { word-break:break-all; }
+  .now .state { color:#888; }
   a { color:#58a6ff; text-decoration:none; display:block; padding:6px 0; border-bottom:1px solid #1c1c1c; }
   a:hover { color:#9cf; }
 </style>
@@ -177,6 +208,14 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
     </li>
     {{end}}
   </ul>
+
+  {{with .Now}}
+  <h2>now playing</h2>
+  <p class="now">
+    <span class="file">{{.File}}</span>
+    {{if .State}}<span class="state">· {{.State}}</span>{{end}}
+  </p>
+  {{end}}
 
   <h2>links</h2>
   <ul>

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -78,17 +78,14 @@ type navLink struct {
 
 // landingData is the template payload.
 type landingData struct {
-	Channel      string // broadcaster Twitch username
-	Bot          string // bot Twitch username
-	Env          string
-	Uptime       string
-	Version      string // tripbot's own build tag
-	SHA          string // short git sha
-	ChangelogURL string // link to CHANGELOG.md at the build's sha
-	Chatters     int    // users currently in chat
-	Services     []serviceStatus
-	Now          *nowPlaying // nil when vlc is unhealthy or nothing is playing
-	Links        []navLink
+	Channel  string // broadcaster Twitch username
+	Bot      string // bot Twitch username
+	Env      string
+	Uptime   string
+	Chatters int // users currently in chat
+	Services []serviceStatus
+	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Links    []navLink
 }
 
 // landingHandler serves the human-facing root page on the tripbot Ingress: a
@@ -106,21 +103,15 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
 	}
 
-	sha := buildSHA()
 	data := landingData{
-		Channel:      c.Conf.ChannelName,
-		Bot:          c.Conf.BotUsername,
-		Env:          c.Conf.Environment,
-		Uptime:       time.Since(startedAt).Round(time.Second).String(),
-		Version:      versionTag,
-		ChangelogURL: changelogURL(sha),
-		Chatters:     chatterCount(),
-		Services:     gatherStatus(vlcOK, vlcVer),
-		Now:          currentVideo(vlcOK),
-		Links:        gatherLinks(),
-	}
-	if sha != "" {
-		data.SHA = sha[:min(7, len(sha))]
+		Channel:  c.Conf.ChannelName,
+		Bot:      c.Conf.BotUsername,
+		Env:      c.Conf.Environment,
+		Uptime:   time.Since(startedAt).Round(time.Second).String(),
+		Chatters: chatterCount(),
+		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
+		Now:      currentVideo(vlcOK),
+		Links:    gatherLinks(),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -130,11 +121,18 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
-// the already-computed vlc-server health (with its build tag when reachable).
-// The vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as
-// not-OK rather than erroring the page.
-func gatherStatus(vlcOK bool, vlcVer versionInfo) []serviceStatus {
-	tripbot := serviceStatus{Name: "tripbot", OK: ready.Load()}
+// the already-computed vlc-server health. Each row carries its build tag in a
+// version column linking to that build's changelog: tripbot's own tag (at sha,
+// the running binary's VCS revision) and vlc-server's (from its /version). The
+// vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as not-OK
+// rather than erroring the page.
+func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
+	tripbot := serviceStatus{
+		Name:       "tripbot",
+		OK:         ready.Load(),
+		Version:    versionTag,
+		VersionURL: changelogURL(sha),
+	}
 	if tripbot.OK {
 		tripbot.Detail = "ready"
 	} else {
@@ -226,12 +224,12 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 func gatherLinks() []navLink {
 	links := []navLink{}
 	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
-		links = append(links, navLink{Label: "OBS (noVNC)", URL: obs})
+		links = append(links, navLink{Label: "obs", URL: obs})
 	}
 	links = append(links,
-		navLink{Label: "Grafana dashboards", URL: grafanaURL},
-		navLink{Label: "Traefik dashboard", URL: traefikURL},
-		navLink{Label: "Hubble UI", URL: hubbleURL},
+		navLink{Label: "grafana", URL: grafanaURL},
+		navLink{Label: "traefik", URL: traefikURL},
+		navLink{Label: "hubble", URL: hubbleURL},
 	)
 	return links
 }
@@ -281,15 +279,16 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   main { width:min(92vw,520px); padding:clamp(24px,4vw,48px); }
   /* logo is the monochrome black mark; invert to white on the dark bg */
   .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(1); opacity:.92; display:block; margin:0 0 16px; }
-  h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 2px; letter-spacing:.02em; }
-  .ver { color:#666; margin:0 0 12px; font-size:.85em; }
-  .meta { color:#888; margin:0 0 28px; font-size:.92em; }
+  h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 4px; letter-spacing:.02em; }
+  .meta { color:#888; margin:0 0 2px; font-size:.92em; }
   .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:1px 7px; border-radius:5px; font-size:.92em; }
-  h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:26px 0 8px; }
+  .accounts { color:#666; margin:0 0 24px; font-size:.85em; }
+  h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
   ul { list-style:none; margin:0; padding:0; }
-  .row { display:flex; align-items:center; gap:10px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
+  .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
   .row .name { flex:1; }
-  .row .detail { color:#888; font-size:.92em; text-align:right; }
+  .row .detail { color:#888; font-size:.92em; }
+  .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
   .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
   .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
   .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
@@ -298,7 +297,7 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   .now .state { color:#888; }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
-  .links a { display:block; padding:7px 0; border-bottom:1px solid #1c1c1c; }
+  .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
 </style>
 </head>
 <body>
@@ -307,8 +306,8 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
        assets) rather than copied in — see vault general/logo.md. -->
   <img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44">
   <h1>tripbot</h1>
-  {{if .Version}}<p class="ver"><a href="{{.ChangelogURL}}">{{.Version}}</a>{{if .SHA}} · {{.SHA}}{{end}}</p>{{end}}
   <p class="meta">env <code class="env">{{.Env}}</code> · up {{.Uptime}} · {{.Chatters}} in chat</p>
+  <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
 
   <h2>status</h2>
   <ul>
@@ -316,7 +315,8 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
     <li class="row">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
-      <span class="detail">{{.Detail}}{{if .Version}} · {{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}{{end}}</span>
+      <span class="detail">{{.Detail}}</span>
+      {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
     </li>
     {{end}}
   </ul>
@@ -330,18 +330,10 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   </p>
   {{end}}
 
-  <h2>accounts</h2>
-  <ul>
-    <li class="row"><span class="name">broadcaster</span><span class="detail"><a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a></span></li>
-    <li class="row"><span class="name">bot</span><span class="detail"><a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></span></li>
-  </ul>
-
   <h2>links</h2>
-  <ul class="links">
-    {{range .Links}}
-    <li><a href="{{.URL}}">{{.Label}} →</a></li>
-    {{end}}
-  </ul>
+  <nav class="links">
+    {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
+  </nav>
 </main>
 </body>
 </html>`))

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -41,6 +41,11 @@ const (
 	grafanaURL = "https://adanalife.grafana.net/dashboards"
 	// githubURL is the tripbot source repo (vlc-server + obs live here too).
 	githubURL = "https://github.com/adanalife/tripbot"
+	// traefikURL / hubbleURL are the cluster's platform dashboards. They live
+	// in kube-system as a single prod-zone install shared across envs, so
+	// (unlike OBS) they aren't derived per-environment.
+	traefikURL = "https://traefik.prod.whereisdana.today"
+	hubbleURL  = "https://hubble.prod.whereisdana.today"
 )
 
 // serviceStatus is one row in the landing page's status table.
@@ -221,14 +226,19 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 
 // gatherLinks builds the external-link list: OBS's Ingress (derived from this
 // bot's own EXTERNAL_URL by swapping the leading subdomain label), the Grafana
-// dashboards, the Twitch channel, and the changelog as of the deployed commit.
-// Entries whose URL can't be derived are dropped rather than rendered broken.
+// dashboards, the Traefik + Hubble platform dashboards, the Twitch channel, and
+// the changelog as of the deployed commit. Entries whose URL can't be derived
+// are dropped rather than rendered broken.
 func gatherLinks(sha string) []navLink {
 	links := []navLink{}
 	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
 		links = append(links, navLink{Label: "OBS (noVNC)", URL: obs})
 	}
-	links = append(links, navLink{Label: "Grafana dashboards", URL: grafanaURL})
+	links = append(links,
+		navLink{Label: "Grafana dashboards", URL: grafanaURL},
+		navLink{Label: "Traefik dashboard", URL: traefikURL},
+		navLink{Label: "Hubble UI", URL: hubbleURL},
+	)
 	if c.Conf.ChannelName != "" {
 		links = append(links, navLink{Label: "Twitch channel", URL: "https://twitch.tv/" + c.Conf.ChannelName})
 	}

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/video"
@@ -30,12 +31,17 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetReady(false)
 	SetReady(true)
 
-	// stand in for vlc-server's readiness endpoint
+	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/health/ready" {
-			t.Errorf("vlc ping hit %q, want /health/ready", r.URL.Path)
+		switch r.URL.Path {
+		case "/health/ready":
+			w.WriteHeader(http.StatusOK)
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag":"v9.9.9-vlc"}`))
+		default:
+			t.Errorf("unexpected vlc request %q", r.URL.Path)
 		}
-		w.WriteHeader(http.StatusOK)
 	}))
 	defer vlc.Close()
 
@@ -45,7 +51,12 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
 		c.Conf.Environment = "production"
 	})
-	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"})
+	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
+	withChatterCount(t, 12)
+
+	saved := versionTag
+	defer func() { versionTag = saved }()
+	SetVersion("v1.2.3")
 
 	rec := httptest.NewRecorder()
 	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -56,14 +67,18 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	body := rec.Body.String()
 	for _, want := range []string{
 		"adanalife",                          // channel
+		"v1.2.3",                             // tripbot build tag
 		"ready",                              // tripbot status
-		"healthy",                            // vlc status (ping succeeded)
+		"healthy · v9.9.9-vlc",               // vlc status + fetched version tag
+		"12 in chat",                         // chatter count
 		"now playing",                        // now-playing section shown when vlc healthy
 		"wy_0042.MP4",                        // current video file
 		"Wyoming",                            // current video state
+		"3m12s",                              // clip progress
 		"https://obs.prod.whereisdana.today", // derived OBS link
 		grafanaURL,                           // grafana link
 		"https://twitch.tv/adanalife",        // twitch link
+		githubURL,                            // github link
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
@@ -83,7 +98,7 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	})
 	// even with a video loaded, an unhealthy vlc hides "now playing" rather
 	// than showing a possibly-stale value.
-	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"})
+	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
 	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -119,11 +134,20 @@ func withConf(t *testing.T, set func()) {
 	set()
 }
 
-// withCurrentlyPlaying swaps the package-level currentlyPlaying seam so the
-// landing handler sees a fixed video without driving pkg/video's player.
-func withCurrentlyPlaying(t *testing.T, v video.Video) {
+// withCurrentlyPlaying swaps the currentlyPlaying / currentProgress seams so
+// the landing handler sees a fixed video + progress without driving the player.
+func withCurrentlyPlaying(t *testing.T, v video.Video, progress time.Duration) {
 	t.Helper()
-	saved := currentlyPlaying
+	savedV, savedP := currentlyPlaying, currentProgress
 	currentlyPlaying = func() video.Video { return v }
-	t.Cleanup(func() { currentlyPlaying = saved })
+	currentProgress = func() time.Duration { return progress }
+	t.Cleanup(func() { currentlyPlaying, currentProgress = savedV, savedP })
+}
+
+// withChatterCount swaps the chatterCount seam to a fixed value.
+func withChatterCount(t *testing.T, n int) {
+	t.Helper()
+	saved := chatterCount
+	chatterCount = func() int { return n }
+	t.Cleanup(func() { chatterCount = saved })
 }

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/video"
 )
 
 func TestSiblingURL(t *testing.T) {
@@ -44,6 +45,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
 		c.Conf.Environment = "production"
 	})
+	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"})
 
 	rec := httptest.NewRecorder()
 	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -53,12 +55,15 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		"adanalife",                           // channel
-		"ready",                               // tripbot status
-		"healthy",                             // vlc status (ping succeeded)
-		"https://obs.prod.whereisdana.today",  // derived OBS link
-		grafanaURL,                            // grafana link
-		"https://twitch.tv/adanalife",         // twitch link
+		"adanalife",                          // channel
+		"ready",                              // tripbot status
+		"healthy",                            // vlc status (ping succeeded)
+		"now playing",                        // now-playing section shown when vlc healthy
+		"wy_0042.MP4",                        // current video file
+		"Wyoming",                            // current video state
+		"https://obs.prod.whereisdana.today", // derived OBS link
+		grafanaURL,                           // grafana link
+		"https://twitch.tv/adanalife",        // twitch link
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
@@ -76,6 +81,9 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 		c.Conf.ChannelName = "adanalife"
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
 	})
+	// even with a video loaded, an unhealthy vlc hides "now playing" rather
+	// than showing a possibly-stale value.
+	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"})
 
 	rec := httptest.NewRecorder()
 	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -89,6 +97,9 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	}
 	if !strings.Contains(body, "unreachable") {
 		t.Errorf("body should report vlc unreachable; got %q", body)
+	}
+	if strings.Contains(body, "now playing") {
+		t.Errorf("now-playing should be hidden when vlc is unhealthy; got %q", body)
 	}
 }
 
@@ -106,4 +117,13 @@ func withConf(t *testing.T, set func()) {
 		c.Conf.Environment = saved.env
 	})
 	set()
+}
+
+// withCurrentlyPlaying swaps the package-level currentlyPlaying seam so the
+// landing handler sees a fixed video without driving pkg/video's player.
+func withCurrentlyPlaying(t *testing.T, v video.Video) {
+	t.Helper()
+	saved := currentlyPlaying
+	currentlyPlaying = func() video.Video { return v }
+	t.Cleanup(func() { currentlyPlaying = saved })
 }

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+)
+
+func TestSiblingURL(t *testing.T) {
+	cases := []struct {
+		in, service, want string
+	}{
+		{"https://tripbot.prod.whereisdana.today", "obs", "https://obs.prod.whereisdana.today"},
+		{"https://tripbot.stage.whereisdana.today", "obs", "https://obs.stage.whereisdana.today"},
+		{"http://localhost:8080", "obs", ""}, // not an FQDN — no sibling Ingress
+		{"", "obs", ""},
+	}
+	for _, tc := range cases {
+		if got := siblingURL(tc.in, tc.service); got != tc.want {
+			t.Errorf("siblingURL(%q, %q) = %q, want %q", tc.in, tc.service, got, tc.want)
+		}
+	}
+}
+
+func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
+	defer SetReady(false)
+	SetReady(true)
+
+	// stand in for vlc-server's readiness endpoint
+	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health/ready" {
+			t.Errorf("vlc ping hit %q, want /health/ready", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer vlc.Close()
+
+	withConf(t, func() {
+		c.Conf.VlcServerHost = strings.TrimPrefix(vlc.URL, "http://")
+		c.Conf.ChannelName = "adanalife"
+		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
+		c.Conf.Environment = "production"
+	})
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"adanalife",                           // channel
+		"ready",                               // tripbot status
+		"healthy",                             // vlc status (ping succeeded)
+		"https://obs.prod.whereisdana.today",  // derived OBS link
+		grafanaURL,                            // grafana link
+		"https://twitch.tv/adanalife",         // twitch link
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
+	defer SetReady(false)
+	SetReady(false)
+
+	withConf(t, func() {
+		// unroutable host → ping fails fast / times out → vlc shown unreachable
+		c.Conf.VlcServerHost = "vlc-server.invalid:8080"
+		c.Conf.ChannelName = "adanalife"
+		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
+	})
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "degraded") {
+		t.Errorf("body should report tripbot degraded; got %q", body)
+	}
+	if !strings.Contains(body, "unreachable") {
+		t.Errorf("body should report vlc unreachable; got %q", body)
+	}
+}
+
+// withConf snapshots the config fields the landing handler reads, runs set to
+// mutate them for the test, and restores them afterward.
+func withConf(t *testing.T, set func()) {
+	t.Helper()
+	saved := struct{ vlc, channel, external, env string }{
+		c.Conf.VlcServerHost, c.Conf.ChannelName, c.Conf.ExternalURL, c.Conf.Environment,
+	}
+	t.Cleanup(func() {
+		c.Conf.VlcServerHost = saved.vlc
+		c.Conf.ChannelName = saved.channel
+		c.Conf.ExternalURL = saved.external
+		c.Conf.Environment = saved.env
+	})
+	set()
+}

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -27,6 +27,15 @@ func TestSiblingURL(t *testing.T) {
 	}
 }
 
+func TestChangelogURL(t *testing.T) {
+	if got, want := changelogURL("deadbeef"), githubURL+"/blob/deadbeef/CHANGELOG.md"; got != want {
+		t.Errorf("changelogURL(sha) = %q, want %q", got, want)
+	}
+	if got, want := changelogURL(""), githubURL+"/blob/master/CHANGELOG.md"; got != want {
+		t.Errorf("changelogURL(\"\") = %q, want %q", got, want)
+	}
+}
+
 func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetReady(false)
 	SetReady(true)
@@ -79,7 +88,8 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		"https://obs.prod.whereisdana.today", // derived OBS link
 		grafanaURL,                           // grafana link
 		"https://twitch.tv/adanalife",        // twitch link
-		githubURL,                            // github link
+		githubURL + "/blob/",                 // changelog link...
+		"/CHANGELOG.md",                      // ...to the CHANGELOG file
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -38,7 +38,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case "/version":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"tag":"v9.9.9-vlc"}`))
+			_, _ = w.Write([]byte(`{"tag":"v9.9.9-vlc","sha":"deadbeefcafe"}`))
 		default:
 			t.Errorf("unexpected vlc request %q", r.URL.Path)
 		}
@@ -66,10 +66,11 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		"adanalife",                          // channel
-		"v1.2.3",                             // tripbot build tag
-		"ready",                              // tripbot status
-		"healthy · v9.9.9-vlc",               // vlc status + fetched version tag
+		`<a href="https://twitch.tv/adanalife">adanalife</a>`, // clickable channel
+		"v1.2.3",  // tripbot build tag
+		"ready",   // tripbot status
+		"healthy", // vlc status
+		`<a href="https://github.com/adanalife/tripbot/commit/deadbeefcafe">v9.9.9-vlc</a>`, // vlc version → commit
 		"12 in chat",                         // chatter count
 		"now playing",                        // now-playing section shown when vlc healthy
 		"wy_0042.MP4",                        // current video file

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -56,7 +56,8 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 
 	withConf(t, func() {
 		c.Conf.VlcServerHost = strings.TrimPrefix(vlc.URL, "http://")
-		c.Conf.ChannelName = "adanalife"
+		c.Conf.ChannelName = "adanalife_"
+		c.Conf.BotUsername = "tripbot4000"
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
 		c.Conf.Environment = "production"
 	})
@@ -75,23 +76,22 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		`<a href="https://twitch.tv/adanalife">adanalife</a>`, // clickable channel
+		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
+		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
 		"v1.2.3",  // tripbot build tag
 		"ready",   // tripbot status
 		"healthy", // vlc status
-		`<a href="https://github.com/adanalife/tripbot/commit/deadbeefcafe">v9.9.9-vlc</a>`, // vlc version → commit
-		"12 in chat",                         // chatter count
-		"now playing",                        // now-playing section shown when vlc healthy
-		"wy_0042.MP4",                        // current video file
-		"Wyoming",                            // current video state
-		"3m12s",                              // clip progress
-		"https://obs.prod.whereisdana.today", // derived OBS link
-		grafanaURL,                           // grafana link
-		traefikURL,                           // traefik dashboard link
-		hubbleURL,                            // hubble UI link
-		"https://twitch.tv/adanalife",        // twitch link
-		githubURL + "/blob/",                 // changelog link...
-		"/CHANGELOG.md",                      // ...to the CHANGELOG file
+		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
+		"12 in chat",                          // chatter count
+		`<code class="env">production</code>`, // env in monospace chip
+		"now playing",                         // now-playing section shown when vlc healthy
+		"wy_0042.MP4",                         // current video file
+		"Wyoming",                             // current video state
+		"3m12s",                               // clip progress
+		"https://obs.prod.whereisdana.today",  // derived OBS link
+		grafanaURL,                            // grafana link
+		traefikURL,                            // traefik dashboard link
+		hubbleURL,                             // hubble UI link
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
@@ -135,12 +135,13 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 // mutate them for the test, and restores them afterward.
 func withConf(t *testing.T, set func()) {
 	t.Helper()
-	saved := struct{ vlc, channel, external, env string }{
-		c.Conf.VlcServerHost, c.Conf.ChannelName, c.Conf.ExternalURL, c.Conf.Environment,
+	saved := struct{ vlc, channel, bot, external, env string }{
+		c.Conf.VlcServerHost, c.Conf.ChannelName, c.Conf.BotUsername, c.Conf.ExternalURL, c.Conf.Environment,
 	}
 	t.Cleanup(func() {
 		c.Conf.VlcServerHost = saved.vlc
 		c.Conf.ChannelName = saved.channel
+		c.Conf.BotUsername = saved.bot
 		c.Conf.ExternalURL = saved.external
 		c.Conf.Environment = saved.env
 	})

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -87,6 +87,8 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		"3m12s",                              // clip progress
 		"https://obs.prod.whereisdana.today", // derived OBS link
 		grafanaURL,                           // grafana link
+		traefikURL,                           // traefik dashboard link
+		hubbleURL,                            // hubble UI link
 		"https://twitch.tv/adanalife",        // twitch link
 		githubURL + "/blob/",                 // changelog link...
 		"/CHANGELOG.md",                      // ...to the CHANGELOG file

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -78,9 +78,9 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	for _, want := range []string{
 		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
 		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
-		"v1.2.3",  // tripbot build tag
-		"ready",   // tripbot status
-		"healthy", // vlc status
+		"ready",                     // tripbot status
+		"healthy",                   // vlc status
+		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
 		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
 		"12 in chat",                          // chatter count
 		`<code class="env">production</code>`, // env in monospace chip
@@ -88,10 +88,14 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		"wy_0042.MP4",                         // current video file
 		"Wyoming",                             // current video state
 		"3m12s",                               // clip progress
-		"https://obs.prod.whereisdana.today",  // derived OBS link
-		grafanaURL,                            // grafana link
-		traefikURL,                            // traefik dashboard link
-		hubbleURL,                             // hubble UI link
+		`>obs</a>`,                            // one-word OBS link
+		`>grafana</a>`,                        // one-word grafana link
+		`>traefik</a>`,                        // one-word traefik link
+		`>hubble</a>`,                         // one-word hubble link
+		"https://obs.prod.whereisdana.today",  // derived OBS href
+		grafanaURL,                            // grafana href
+		traefikURL,                            // traefik href
+		hubbleURL,                             // hubble href
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -62,8 +62,11 @@ func Start(ctx context.Context) {
 	// prometheus metrics endpoint
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
+	// landing page (status overview + links) on the root path
+	r.Handle("/", tagged("/", landingHandler)).Methods("GET", "HEAD")
+
 	// catch everything else
-	r.Handle("/", tagged("/", catchAllHandler))
+	r.NotFoundHandler = tagged("/", catchAllHandler)
 
 	if c.Conf.Verbose {
 		helpers.PrintAllRoutes(r)


### PR DESCRIPTION
## What

The tripbot Ingress root (`https://tripbot.{prod,stage,dev}.whereisdana.today/`) served a bare `404`. This replaces it with a lightweight landing page (mostly a phone bookmark for Dana):

- **Status overview** — tripbot's own readiness (`ready`/`degraded`, read from the in-memory readiness flag, free) plus a live ping of **vlc-server**'s `/health/ready` over in-cluster Service DNS (`VLC_SERVER_HOST`, already in config).
- **Now playing** — when vlc is healthy, the current video file + state, read from `pkg/video`'s in-process `CurrentlyPlaying()` (refreshed by the existing 60s cron, so no extra call). Hidden when vlc is down (avoids showing a stale value) or nothing is loaded yet.
- **Links** — OBS's noVNC Ingress, the Grafana dashboards, and the Twitch channel.

The OBS link is derived from the bot's own `EXTERNAL_URL` by swapping the leading subdomain label (`tripbot.` → `obs.`), so it tracks the per-env Ingress host with no new config. For a non-FQDN `EXTERNAL_URL` (e.g. local `localhost:8080`) the OBS link is omitted rather than rendered broken.

## Notes

- Sibling pings use a 2s-timeout client so a hung vlc-server can't stall the render; any failure (DNS/timeout/non-2xx) renders as `unreachable`.
- OBS has no readiness/liveness endpoint (it's noVNC), so it's a link only — no status row.
- `catchAllHandler` moves to the router's `NotFoundHandler`, so unknown paths still `404` and log as before.
- No infra changes: there are no NetworkPolicies in the cluster, so in-cluster pod-to-pod pings work as-is.

## Test

`task test:macos` green; new tests cover the status rows (ready + vlc up/down), the "now playing" block (shown when healthy, hidden when down), and the `EXTERNAL_URL` → OBS-link derivation.