### PR TITLE
Release v2.13.1: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.13.1] — 2026-05-21
+
+Patch release. tripbot's Ingress root — previously a bare 404 — now serves a lightweight landing-page dashboard (mostly a phone bookmark): a status overview, the currently-playing clip, the broadcaster/bot accounts, and links to the OBS / Grafana / Traefik / Hubble dashboards. Also throttles the token-poll warning that spammed the logs while a pod waits on re-auth.
+
+### tripbot
+
+- **Landing-page dashboard on the Ingress root.** `/` used to 404; it now renders a small dark status page served by `pkg/server` (the old `catchAllHandler` moves to the router's `NotFoundHandler`, so unknown paths still 404). Shows a status overview — tripbot's own readiness (in-memory) plus a live in-cluster ping of vlc-server's `/health/ready` — with each service's build tag in a far-right column linking to that build's `CHANGELOG.md` at its sha (tripbot's own; vlc-server's fetched from its `/version`). When vlc is healthy it also shows the currently-playing clip (file · state · elapsed, read from `pkg/video`'s in-process value — no extra call) and the in-chat count. The header carries the environment; below it the broadcaster + bot Twitch profiles, then a row of dashboard links (OBS noVNC derived from `EXTERNAL_URL`, plus the prod-zone Grafana / Traefik / Hubble UIs). Logo + favicon are referenced from the website's published assets, not copied in. Sibling pings use a 2s-timeout client so a hung vlc-server can't stall the render. ([#628])
+
+### Logging
+
+- **Throttle the "still waiting for Twitch token" poll warning.** `pollForTwitchToken` still checks `LoadFromDB` every 15s (so a freshly-landed token is picked up promptly), but the WARN now logs at most every 15m instead of on every check (~240/hr → ~4/hr while a pod waits on re-auth); the first poll-failure log is suppressed since boot already logged the re-auth link once. Also appends `login_as=<username>` to the logged reauth URL so it names the exact account to sign in as. ([#627])
+
+[#627]: https://github.com/adanalife/tripbot/pull/627
+[#628]: https://github.com/adanalife/tripbot/pull/628
+
 ## [v2.13.0] — 2026-05-21
 
 Minor release. tripbot now boots degraded instead of crashlooping when Twitch or its OAuth token is unavailable, and surfaces a clickable re-auth link in the logs so recovery is a click rather than a CLI run. On the streaming side, the inter-clip-flash chase concludes: page-cache priming is reverted (didn't move the metric — the gap is libvlc pausing RTP, not file-open latency), and `!timewarp` instead masks the gap with a full-screen warp animation.

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -217,18 +217,30 @@ func loadTwitchToken(ctx context.Context) {
 // connectToTwitch's reconnect loop authenticates on its next attempt. Started
 // only when the token was missing at boot; stops on shutdown.
 func pollForTwitchToken(ctx context.Context) {
-	const interval = 15 * time.Second
+	// Check often so the token is picked up promptly once it lands, but log
+	// the "still waiting" warning at a much slower cadence — boot already
+	// logged the reauth link once, so re-surfacing it every 15s is just noise.
+	const (
+		interval = 15 * time.Second
+		logEvery = 15 * time.Minute
+	)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	// Suppress the first poll-failure log: loadTwitchToken just logged the
+	// same warning at boot. The next one waits a full logEvery.
+	lastLogged := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			if err := mytwitch.LoadFromDB(); err != nil {
-				slog.WarnContext(ctx, "still waiting for Twitch token",
-					"login_as", c.Conf.BotUsername,
-					"reauth_url", mytwitch.AuthInitURL("bot"), "err", err)
+				if time.Since(lastLogged) >= logEvery {
+					slog.WarnContext(ctx, "still waiting for Twitch token",
+						"login_as", c.Conf.BotUsername,
+						"reauth_url", mytwitch.AuthInitURL("bot"), "err", err)
+					lastLogged = time.Now()
+				}
 				continue
 			}
 			slog.InfoContext(ctx, "Twitch token loaded; bot will connect on next attempt")

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -1,0 +1,341 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// startedAt marks process start so the landing page can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
+
+// healthClient is the short-timeout client used for the sibling-service status
+// ping. 2s keeps a slow or hung vlc-server from stalling the landing render.
+var healthClient = &http.Client{Timeout: 2 * time.Second}
+
+// currentlyPlaying / currentProgress are overridable in tests; by default they
+// read pkg/video's in-process state (refreshed by a 60s cron tick), so the
+// landing page costs nothing to show "now playing".
+var (
+	currentlyPlaying = video.CurrentlyPlaying
+	currentProgress  = video.CurrentProgress
+	// chatterCount is the in-memory count of users in chat, refreshed ~60s by
+	// the UpdateSession cron. Overridable in tests.
+	chatterCount = mytwitch.ChatterCount
+)
+
+const (
+	// grafanaURL points at the TripBot dashboards folder in Grafana Cloud.
+	// Fixed — the org URL doesn't vary by environment.
+	grafanaURL = "https://adanalife.grafana.net/dashboards/f/fflhs4m586io0e"
+	// githubURL is the tripbot source repo (vlc-server + obs live here too).
+	githubURL = "https://github.com/adanalife/tripbot"
+	// traefikURL / hubbleURL are the cluster's platform dashboards. They live
+	// in kube-system as a single prod-zone install shared across envs, so
+	// (unlike OBS) they aren't derived per-environment.
+	traefikURL = "https://traefik.prod.whereisdana.today"
+	hubbleURL  = "https://hubble.prod.whereisdana.today"
+)
+
+// serviceStatus is one row in the landing page's status table.
+type serviceStatus struct {
+	Name       string
+	OK         bool
+	Detail     string
+	Version    string // optional build tag (e.g. vlc-server's, from /version)
+	VersionURL string // changelog link (at the build's sha) for Version
+}
+
+// versionInfo is the subset of a service's /version JSON the page uses.
+type versionInfo struct {
+	Tag string `json:"tag"`
+	Sha string `json:"sha"`
+}
+
+// nowPlaying is the current-video summary shown when vlc-server is healthy.
+type nowPlaying struct {
+	File     string
+	State    string
+	Progress string
+}
+
+// navLink is one entry in the landing page's links list.
+type navLink struct {
+	Label string
+	URL   string
+}
+
+// landingData is the template payload.
+type landingData struct {
+	Channel  string // broadcaster Twitch username
+	Bot      string // bot Twitch username
+	Env      string
+	Uptime   string
+	Chatters int // users currently in chat
+	Services []serviceStatus
+	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Links    []navLink
+}
+
+// landingHandler serves the human-facing root page on the tripbot Ingress: a
+// lightweight status overview (tripbot's own readiness + a live vlc-server
+// ping, each version linking to its changelog), the currently-playing video
+// when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
+// / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
+func landingHandler(w http.ResponseWriter, r *http.Request) {
+	vlcOK := c.Conf.VlcServerHost != "" &&
+		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
+
+	// vlc-server's build info — one extra in-cluster GET, only when it's up.
+	var vlcVer versionInfo
+	if vlcOK {
+		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
+	}
+
+	data := landingData{
+		Channel:  c.Conf.ChannelName,
+		Bot:      c.Conf.BotUsername,
+		Env:      c.Conf.Environment,
+		Uptime:   time.Since(startedAt).Round(time.Second).String(),
+		Chatters: chatterCount(),
+		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
+		Now:      currentVideo(vlcOK),
+		Links:    gatherLinks(),
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := landingTmpl.Execute(w, data); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't render landing page", "err", err)
+	}
+}
+
+// gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
+// the already-computed vlc-server health. Each row carries its build tag in a
+// version column linking to that build's changelog: tripbot's own tag (at sha,
+// the running binary's VCS revision) and vlc-server's (from its /version). The
+// vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as not-OK
+// rather than erroring the page.
+func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
+	tripbot := serviceStatus{
+		Name:       "tripbot",
+		OK:         ready.Load(),
+		Version:    versionTag,
+		VersionURL: changelogURL(sha),
+	}
+	if tripbot.OK {
+		tripbot.Detail = "ready"
+	} else {
+		tripbot.Detail = "degraded (awaiting Twitch)"
+	}
+
+	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}
+	if vlcOK {
+		vlc.Detail = "healthy"
+		vlc.Version = vlcVer.Tag
+		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
+	}
+
+	return []serviceStatus{tripbot, vlc}
+}
+
+// currentVideo summarizes the currently-playing video for the page, but only
+// when vlc is healthy (a stale value while vlc is down would be misleading).
+// Reads pkg/video's in-process value — no extra call. Returns nil when nothing
+// is playing yet (empty slug).
+func currentVideo(vlcOK bool) *nowPlaying {
+	if !vlcOK {
+		return nil
+	}
+	v := currentlyPlaying()
+	if v.Slug == "" {
+		return nil
+	}
+	return &nowPlaying{
+		File:     v.File(),
+		State:    v.State,
+		Progress: currentProgress().Round(time.Second).String(),
+	}
+}
+
+// buildSHA returns the binary's embedded VCS revision (via Go's -buildvcs), or
+// "" for builds without it (e.g. `go test`). Same source versionHandler uses.
+func buildSHA() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				return s.Value
+			}
+		}
+	}
+	return ""
+}
+
+// fetchVersion GETs a sibling service's /version endpoint and returns its build
+// tag + sha, or a zero versionInfo on any error. Uses the same short-timeout
+// client as the health ping.
+func fetchVersion(ctx context.Context, host string) versionInfo {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+host+"/version", nil)
+	if err != nil {
+		return versionInfo{}
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return versionInfo{}
+	}
+	defer resp.Body.Close()
+	var v versionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return versionInfo{}
+	}
+	return v
+}
+
+// pingHealthy GETs a readiness URL and reports whether it answered 2xx within
+// the client timeout.
+func pingHealthy(ctx context.Context, rawURL string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// gatherLinks builds the dashboard-link list: OBS's Ingress (derived from this
+// bot's own EXTERNAL_URL by swapping the leading subdomain label), plus the
+// Grafana / Traefik / Hubble platform dashboards. Twitch profiles are rendered
+// in the accounts section and the changelog hangs off the version tags, so
+// neither appears here. Entries whose URL can't be derived are dropped.
+func gatherLinks() []navLink {
+	links := []navLink{}
+	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
+		links = append(links, navLink{Label: "obs", URL: obs})
+	}
+	links = append(links,
+		navLink{Label: "grafana", URL: grafanaURL},
+		navLink{Label: "traefik", URL: traefikURL},
+		navLink{Label: "hubble", URL: hubbleURL},
+	)
+	return links
+}
+
+// changelogURL links to CHANGELOG.md as of the deployed commit, so it shows the
+// changelog for exactly what's running. Falls back to the default branch when
+// the sha is unknown (e.g. a build without embedded VCS info).
+func changelogURL(sha string) string {
+	ref := "master"
+	if sha != "" {
+		ref = sha
+	}
+	return githubURL + "/blob/" + ref + "/CHANGELOG.md"
+}
+
+// siblingURL rewrites externalURL's leading hostname label to service, e.g.
+// https://tripbot.prod.whereisdana.today -> https://obs.prod.whereisdana.today.
+// Returns "" when externalURL isn't a multi-label FQDN (e.g. localhost), since
+// there's no sibling Ingress to point at in that case.
+func siblingURL(externalURL, service string) string {
+	u, err := url.Parse(externalURL)
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	_, rest, found := strings.Cut(u.Hostname(), ".")
+	if !found {
+		return ""
+	}
+	u.Host = service + "." + rest
+	return u.String()
+}
+
+var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tripbot — {{.Channel}}</title>
+<!-- favicons referenced from the website (single owner of brand assets) — see
+     vault general/logo.md; apple-touch-icon gives a home-screen icon on phones -->
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.dana.lol/assets/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.dana.lol/assets/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.dana.lol/assets/apple-touch-icon.png">
+<style>
+  :root { color-scheme: dark; --mono: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  body { background:#0a0a0a; color:#eee; font:clamp(14px,0.5vw + 11px,18px)/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
+  main { width:min(92vw,520px); padding:clamp(24px,4vw,48px); }
+  /* logo is the monochrome black mark; invert to white on the dark bg */
+  .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(1); opacity:.92; display:block; margin:0 0 16px; }
+  h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 4px; letter-spacing:.02em; }
+  .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:2px 7px; border-radius:5px; font-size:.5em; font-weight:normal; letter-spacing:0; vertical-align:middle; }
+  .meta { color:#888; margin:0 0 2px; font-size:.92em; }
+  .accounts { color:#666; margin:0 0 24px; font-size:.85em; }
+  h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
+  ul { list-style:none; margin:0; padding:0; }
+  .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
+  .row .name { flex:1; }
+  .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
+  /* status hugs the far right and right-aligns so it forms a clean column,
+     aligned whether or not the row carries a version */
+  .row .status { color:#888; font-size:.92em; text-align:right; min-width:5.5em; }
+  .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
+  .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
+  .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
+  .now { margin:0; padding:7px 0; }
+  .now .file { font-family:var(--mono); word-break:break-all; }
+  .now .state { color:#888; }
+  a { color:#58a6ff; text-decoration:none; }
+  a:hover { color:#9cf; }
+  .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
+</style>
+</head>
+<body>
+<main>
+  <!-- A Dana Life mark, referenced from the website (the single owner of brand
+       assets) rather than copied in — see vault general/logo.md. -->
+  <img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44">
+  <h1>tripbot <code class="env">{{.Env}}</code></h1>
+  <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
+  <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
+
+  <h2>status</h2>
+  <ul>
+    {{range .Services}}
+    <li class="row">
+      <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
+      <span class="name">{{.Name}}</span>
+      {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
+      <span class="status">{{.Detail}}</span>
+    </li>
+    {{end}}
+  </ul>
+
+  {{with .Now}}
+  <h2>now playing</h2>
+  <p class="now">
+    <span class="file">{{.File}}</span>
+    {{if .State}}<span class="state">· {{.State}}</span>{{end}}
+    {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
+  </p>
+  {{end}}
+
+  <h2>dashboards</h2>
+  <nav class="links">
+    {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
+  </nav>
+</main>
+</body>
+</html>`))

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+func TestSiblingURL(t *testing.T) {
+	cases := []struct {
+		in, service, want string
+	}{
+		{"https://tripbot.prod.whereisdana.today", "obs", "https://obs.prod.whereisdana.today"},
+		{"https://tripbot.stage.whereisdana.today", "obs", "https://obs.stage.whereisdana.today"},
+		{"http://localhost:8080", "obs", ""}, // not an FQDN — no sibling Ingress
+		{"", "obs", ""},
+	}
+	for _, tc := range cases {
+		if got := siblingURL(tc.in, tc.service); got != tc.want {
+			t.Errorf("siblingURL(%q, %q) = %q, want %q", tc.in, tc.service, got, tc.want)
+		}
+	}
+}
+
+func TestChangelogURL(t *testing.T) {
+	if got, want := changelogURL("deadbeef"), githubURL+"/blob/deadbeef/CHANGELOG.md"; got != want {
+		t.Errorf("changelogURL(sha) = %q, want %q", got, want)
+	}
+	if got, want := changelogURL(""), githubURL+"/blob/master/CHANGELOG.md"; got != want {
+		t.Errorf("changelogURL(\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
+	defer SetReady(false)
+	SetReady(true)
+
+	// stand in for vlc-server: readiness ping + version endpoint
+	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health/ready":
+			w.WriteHeader(http.StatusOK)
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag":"v9.9.9-vlc","sha":"deadbeefcafe"}`))
+		default:
+			t.Errorf("unexpected vlc request %q", r.URL.Path)
+		}
+	}))
+	defer vlc.Close()
+
+	withConf(t, func() {
+		c.Conf.VlcServerHost = strings.TrimPrefix(vlc.URL, "http://")
+		c.Conf.ChannelName = "adanalife_"
+		c.Conf.BotUsername = "tripbot4000"
+		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
+		c.Conf.Environment = "production"
+	})
+	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
+	withChatterCount(t, 12)
+
+	saved := versionTag
+	defer func() { versionTag = saved }()
+	SetVersion("v1.2.3")
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
+		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
+		"ready",                     // tripbot status
+		"healthy",                   // vlc status
+		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
+		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
+		"12 in chat",                          // chatter count
+		`<code class="env">production</code>`, // env in monospace chip
+		"now playing",                         // now-playing section shown when vlc healthy
+		"wy_0042.MP4",                         // current video file
+		"Wyoming",                             // current video state
+		"3m12s",                               // clip progress
+		`>obs</a>`,                            // one-word OBS link
+		`>grafana</a>`,                        // one-word grafana link
+		`>traefik</a>`,                        // one-word traefik link
+		`>hubble</a>`,                         // one-word hubble link
+		"https://obs.prod.whereisdana.today",  // derived OBS href
+		grafanaURL,                            // grafana href
+		traefikURL,                            // traefik href
+		hubbleURL,                             // hubble href
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
+	defer SetReady(false)
+	SetReady(false)
+
+	withConf(t, func() {
+		// unroutable host → ping fails fast / times out → vlc shown unreachable
+		c.Conf.VlcServerHost = "vlc-server.invalid:8080"
+		c.Conf.ChannelName = "adanalife"
+		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
+	})
+	// even with a video loaded, an unhealthy vlc hides "now playing" rather
+	// than showing a possibly-stale value.
+	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "degraded") {
+		t.Errorf("body should report tripbot degraded; got %q", body)
+	}
+	if !strings.Contains(body, "unreachable") {
+		t.Errorf("body should report vlc unreachable; got %q", body)
+	}
+	if strings.Contains(body, "now playing") {
+		t.Errorf("now-playing should be hidden when vlc is unhealthy; got %q", body)
+	}
+}
+
+// withConf snapshots the config fields the landing handler reads, runs set to
+// mutate them for the test, and restores them afterward.
+func withConf(t *testing.T, set func()) {
+	t.Helper()
+	saved := struct{ vlc, channel, bot, external, env string }{
+		c.Conf.VlcServerHost, c.Conf.ChannelName, c.Conf.BotUsername, c.Conf.ExternalURL, c.Conf.Environment,
+	}
+	t.Cleanup(func() {
+		c.Conf.VlcServerHost = saved.vlc
+		c.Conf.ChannelName = saved.channel
+		c.Conf.BotUsername = saved.bot
+		c.Conf.ExternalURL = saved.external
+		c.Conf.Environment = saved.env
+	})
+	set()
+}
+
+// withCurrentlyPlaying swaps the currentlyPlaying / currentProgress seams so
+// the landing handler sees a fixed video + progress without driving the player.
+func withCurrentlyPlaying(t *testing.T, v video.Video, progress time.Duration) {
+	t.Helper()
+	savedV, savedP := currentlyPlaying, currentProgress
+	currentlyPlaying = func() video.Video { return v }
+	currentProgress = func() time.Duration { return progress }
+	t.Cleanup(func() { currentlyPlaying, currentProgress = savedV, savedP })
+}
+
+// withChatterCount swaps the chatterCount seam to a fixed value.
+func withChatterCount(t *testing.T, n int) {
+	t.Helper()
+	saved := chatterCount
+	chatterCount = func() int { return n }
+	t.Cleanup(func() { chatterCount = saved })
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -62,8 +62,11 @@ func Start(ctx context.Context) {
 	// prometheus metrics endpoint
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
+	// landing page (status overview + links) on the root path
+	r.Handle("/", tagged("/", landingHandler)).Methods("GET", "HEAD")
+
 	// catch everything else
-	r.Handle("/", tagged("/", catchAllHandler))
+	r.NotFoundHandler = tagged("/", catchAllHandler)
 
 	if c.Conf.Verbose {
 		helpers.PrintAllRoutes(r)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -73,8 +74,18 @@ var ErrNoToken = oauthtokens.ErrNoToken
 // stale by the time anyone read the log — and that state would ship to
 // Loki/Sentry. /auth/init carries no secret: client_id isn't sensitive, and no
 // state exists until the redirect is generated server-side on click.
+//
+// We also append login_as=<username> — the exact Twitch account to sign in
+// as. The /auth/init handler ignores it (it keys off account=bot|broadcaster);
+// it's purely so the username is visible in the browser's address bar, matching
+// the login_as attribute in the logs.
 func AuthInitURL(account string) string {
-	return c.Conf.ExternalURL + "/auth/init?account=" + account
+	login := c.Conf.BotUsername
+	if account == "broadcaster" {
+		login = c.Conf.ChannelName
+	}
+	return c.Conf.ExternalURL + "/auth/init?account=" + account +
+		"&login_as=" + url.QueryEscape(login)
 }
 
 // accountLabel maps an oauth_tokens username to the /auth/init account

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -171,7 +171,7 @@ func TestErrIdentityMismatch_ErrorsAs(t *testing.T) {
 
 func TestAuthInitURL_BuildsInitPath(t *testing.T) {
 	got := AuthInitURL("bot")
-	want := c.Conf.ExternalURL + "/auth/init?account=bot"
+	want := c.Conf.ExternalURL + "/auth/init?account=bot&login_as=" + c.Conf.BotUsername
 	if got != want {
 		t.Errorf("AuthInitURL(\"bot\") = %q, want %q", got, want)
 	}
@@ -184,7 +184,7 @@ func TestAuthInitURL_BuildsInitPath(t *testing.T) {
 
 func TestAuthInitURL_BroadcasterAccount(t *testing.T) {
 	got := AuthInitURL("broadcaster")
-	want := c.Conf.ExternalURL + "/auth/init?account=broadcaster"
+	want := c.Conf.ExternalURL + "/auth/init?account=broadcaster&login_as=" + c.Conf.ChannelName
 	if got != want {
 		t.Errorf("AuthInitURL(\"broadcaster\") = %q, want %q", got, want)
 	}


### PR DESCRIPTION
Patch release **v2.13.1** — develop → master.

## Included

- **#628 — Landing-page dashboard on the Ingress root.** `/` (previously a bare 404) now serves a lightweight status page: tripbot + vlc-server health with version→changelog links, the currently-playing clip, in-chat count, broadcaster/bot accounts, and OBS / Grafana / Traefik / Hubble dashboard links. Logo + favicon referenced from the website's published assets.
- **#627 — Throttle the token-poll warning.** The "still waiting for Twitch token" WARN now logs at most every 15m (was every 15s, ~240/hr) while a pod waits on re-auth; adds `login_as` to the logged reauth URL.

## Notes

- Default **patch** bump (v2.13.0 → v2.13.1) — no `#minor`/`#major` keyword.
- Merge with **"Create a merge commit"** (not squash), per the merge-strategy-by-target-branch ADR.
- `origin/master` was merged into this branch so the CHANGELOG carries the v2.13.0 entry (develop's lagged) and to avoid phantom divergence.
- CHANGELOG entry for v2.13.1 added, dated 2026-05-21.