### PR TITLE
landing: open Hubble link straight to the prod-1 namespace

### DIFF
--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -45,7 +45,10 @@ const (
 	// in kube-system as a single prod-zone install shared across envs, so
 	// (unlike OBS) they aren't derived per-environment.
 	traefikURL = "https://traefik.prod.whereisdana.today"
-	hubbleURL  = "https://hubble.prod.whereisdana.today"
+	// hubbleURL carries ?namespace=prod-1 so the link lands straight in prod-1's
+	// flow view instead of Hubble's "choose a namespace" page. (Single prod-zone
+	// install, so the namespace is fixed, not per-env.)
+	hubbleURL = "https://hubble.prod.whereisdana.today/?namespace=prod-1"
 )
 
 // serviceStatus is one row in the landing page's status table.


### PR DESCRIPTION
## Summary
- Append `?namespace=prod-1` to the Hubble dashboard link on the tripbot landing page, so it opens directly in prod-1's flow view instead of Hubble's "choose a namespace" page.

The Hubble UI is a single prod-zone install shared across envs, so the namespace is fixed (not derived per-environment).

## Test plan
- [x] `go test ./pkg/server/...` passes (the landing test asserts the page contains the Hubble URL)
- [ ] Click the Hubble link from the landing page → lands already scoped to prod-1