### PR TITLE
chatbot: alias "is this live" to !date

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -100,7 +100,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!date",
-			Aliases:        []string{"!datw"},
+			Aliases:        []string{"!datw", "is this live", "is this live?"},
 			Handler:        a.dateCmd,
 			RequiresFollow: true,
 		},


### PR DESCRIPTION
## Summary
- Add "is this live" and "is this live?" as aliases for `!date`, so the natural-language question routes to the command that already answers it. (Multi-word non-`!` aliases are already supported — `!report` aliases "no audio" etc.)

Leaves the sibling "massachusetts?" → `!guess ma` idea for a separate change — that one needs a fixed-param mechanism on the Command struct, not just an alias.

## Test plan
- [x] `go test ./pkg/chatbot/...` passes (incl. TestNoDuplicateTriggersOrAliases)
- [ ] In chat: typing "is this live" returns the date/uptime reply