### PR TITLE
chatbot: add !followage command

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -16,6 +16,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
@@ -112,6 +113,34 @@ func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
 	a.IRC.Say(msg)
+}
+
+func (a *App) followageCmd(ctx context.Context, user *users.User, params []string) {
+	slog.InfoContext(ctx, "ran !followage", "username", user.Username)
+
+	// bare !followage = the caller; !followage @user looks up someone else
+	username := user.Username
+	other := len(params) > 0
+	if other {
+		username = helpers.StripAtSign(params[0])
+	}
+
+	followedAt, ok := mytwitch.FollowedAt(username)
+	if !ok {
+		if other {
+			a.IRC.Say(fmt.Sprintf("@%s isn't following the channel.", username))
+		} else {
+			a.IRC.Say("You're not following yet — hit that follow button!")
+		}
+		return
+	}
+
+	dur := durafmt.Parse(time.Since(followedAt)).LimitFirstN(2)
+	if other {
+		a.IRC.Say(fmt.Sprintf("@%s has been following for %s.", username, dur))
+	} else {
+		a.IRC.Say(fmt.Sprintf("@%s, you've been following for %s. Thanks!", username, dur))
+	}
 }
 
 func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -36,6 +36,11 @@ func (a *App) buildRegistry() []Command {
 			Handler: a.uptimeCmd,
 		},
 		{
+			Trigger: "!followage",
+			Aliases: []string{"!followtime"},
+			Handler: a.followageCmd,
+		},
+		{
 			Trigger:        "!timewarp",
 			Aliases:        []string{"!timewrap", "!timeskip", "!tw", "!timewqrp", "!warp"},
 			Handler:        a.timewarpCmd,

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -175,6 +176,41 @@ func UserIsFollower(username string) bool {
 	}
 	return true
 
+}
+
+// FollowedAt returns when username started following the channel, and whether
+// they follow at all. Like UserIsFollower, it authorizes against the
+// broadcaster identity (moderator:read:followers) and fails closed: ok=false
+// when the broadcaster token isn't loaded, the lookup errors, or the user
+// doesn't follow.
+func FollowedAt(username string) (time.Time, bool) {
+	if !broadcasterTokenLoaded() {
+		return time.Time{}, false
+	}
+	bclient, err := BroadcasterClient()
+	if err != nil {
+		slog.Error("broadcaster helix client unavailable", "err", err)
+		return time.Time{}, false
+	}
+
+	userID := getChannelID(username)
+
+	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
+		BroadcasterID: ChannelID,
+		UserID:        userID,
+	})
+	if err != nil {
+		slog.Error("error getting user follows", "err", err)
+		return time.Time{}, false
+	}
+	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+		return time.Time{}, false
+	}
+
+	if resp.Data.Total < 1 || len(resp.Data.Channels) < 1 {
+		return time.Time{}, false
+	}
+	return resp.Data.Channels[0].Followed.Time, true
 }
 
 // broadcasterTokenLoaded reports whether the broadcaster's user-access-token


### PR DESCRIPTION
## Summary
- Add `!followage` (alias `!followtime`): reports how long a viewer has followed the channel. Bare `!followage` = the caller; `!followage @user` looks someone else up.
- Adds a `FollowedAt(username)` helper in `pkg/twitch` alongside the existing `UserIsFollower` — same broadcaster-token path (`moderator:read:followers`, already in the broadcaster scope set), reading the `followed_at` timestamp from Helix `GetChannelFollows`. Fails closed; non-followers get a friendly nudge.
- Duration rendered with `durafmt` (limited to 2 units, e.g. "2 years 3 months"), matching `!uptime`'s style.

Not follower-gated (a non-follower asking their status shouldn't be blocked).

## Test plan
- [x] `go build` + `go vet` + `go test ./pkg/twitch/... ./pkg/chatbot/...` pass (incl. registry no-duplicate check)
- [ ] In chat: `!followage` returns the caller's follow age; `!followage @user` works; a non-follower gets the nudge
- [ ] Confirm against prod once deployed (broadcaster token present)