### PR TITLE
eventsub: log every received event via OnRawEvent

### DIFF
--- a/pkg/eventsub/eventsub.go
+++ b/pkg/eventsub/eventsub.go
@@ -65,6 +65,20 @@ func Run(ctx context.Context, cfg Config, h Handlers) error {
 			"type", msg.Payload.Subscription.Type, "status", msg.Payload.Subscription.Status)
 	})
 
+	// Log every notification we receive, regardless of whether a typed
+	// handler above is registered for it. Cheap observability: shows in Loki
+	// what's actually firing in prod (and, by its absence, what isn't) so the
+	// per-event chat-shout treatment can be designed from real data later. The
+	// raw event JSON goes in the body, not a label — `type` is the only
+	// (low-cardinality) key worth filtering on.
+	client.OnRawEvent(func(event string, metadata twitch.MessageMetadata, subscription twitch.PayloadSubscription) {
+		slog.InfoContext(ctx, "eventsub event",
+			"type", string(subscription.Type),
+			"message_id", metadata.MessageID,
+			"payload", event,
+		)
+	})
+
 	if h.OnFollow != nil {
 		client.OnEventChannelFollow(func(e twitch.EventChannelFollow) {
 			h.OnFollow(e.UserName)


### PR DESCRIPTION
## Summary
- Register a catch-all `OnRawEvent` handler in `pkg/eventsub` that logs every received EventSub notification (`type` + `message_id` + raw `payload`), regardless of whether a typed handler is wired for it.
- Cheap, observability-first step (#2 of the "EventSub: add more event types" item): watch Loki to see what actually fires in prod, then design per-event chat shouts from real data — no design pressure now.

Events with a typed handler (follow, subscribe) get both the raw log line and their handler; that's fine and intentional. This logs every *received* event — expanding the *subscription* set to receive more types is separate follow-up.

## Test plan
- [x] `go build` + `go vet` + `go test ./pkg/eventsub/...` pass
- [ ] Watch Loki for `eventsub event` lines during live follow/sub activity