### PR TITLE
health: decouple tripbot readiness from the Twitch connection

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -195,15 +195,16 @@ func startCron() {
 // loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
 // Non-fatal: when the row is missing (e.g. auth-bootstrap hasn't run yet
 // against a freshly-restored DB) or the DB is briefly unreachable, the bot
-// comes up with limited functionality and reports not-ready, polling in the
-// background until the token lands — rather than crashlooping. A crashing pod
-// after a wipe also raced the DB restore's migrate init (see the 2026-05-20
-// convergence-wipe notes); staying up-but-not-ready avoids that. Readiness,
-// not a process crash, is what keeps the bot out of service until it can talk
-// to Twitch.
+// comes up with limited functionality and polls in the background until the
+// token lands — rather than crashlooping. A crashing pod after a wipe also
+// raced the DB restore's migrate init (see the 2026-05-20 convergence-wipe
+// notes); staying up avoids that. The pod stays Ready throughout (readiness
+// no longer gates on Twitch) so the landing page + /auth/init are reachable
+// to re-auth; "not in chat" is surfaced via the landing page + the
+// tripbot_twitch_connected gauge instead.
 func loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
-		slog.WarnContext(ctx, "no usable Twitch token at boot; starting not-ready and polling",
+		slog.WarnContext(ctx, "no usable Twitch token at boot; starting without a chat connection and polling",
 			"login_as", c.Conf.BotUsername,
 			"fix", "task tripbot:auth:bootstrap",
 			"reauth_url", mytwitch.AuthInitURL("bot"),
@@ -280,12 +281,13 @@ func connectToTwitch() {
 	client.Join(c.Conf.ChannelName)
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
-	// Flip readiness on once the IRC connection is established so the
-	// readiness probe (/health/ready) reports live. Until then — and after
-	// any disconnect below — the pod stays up but not-ready.
+	// Mark the bot connected to chat once the IRC connection is established.
+	// This drives the landing-page status row + the tripbot_twitch_connected
+	// gauge — it does NOT gate /health/ready, which stays 200 so the pod keeps
+	// serving the landing page + /auth/* even while the bot is offline.
 	client.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
-		server.SetReady(true)
+		server.SetTwitchConnected(true)
 	})
 
 	// actually connect to Twitch
@@ -293,10 +295,10 @@ func connectToTwitch() {
 	for {
 		slog.Info("initializing connection to Twitch")
 		// Connect blocks while connected and returns when the connection
-		// drops; mark not-ready so the probe reflects the gap until the
-		// next OnConnect fires.
+		// drops; mark not-in-chat so the landing page + gauge reflect the gap
+		// until the next OnConnect fires.
 		err := client.Connect()
-		server.SetReady(false)
+		server.SetTwitchConnected(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {

--- a/pkg/httpmw/health.go
+++ b/pkg/httpmw/health.go
@@ -1,0 +1,79 @@
+package httpmw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// readyCheckTimeout caps how long the whole /health/ready handler can
+// spend running its checks. Kubelet's default readiness timeout is 1s;
+// 2s here leaves enough headroom for one slow check to complete before
+// the probe gets cut, without letting a wedged dep hang the handler.
+const readyCheckTimeout = 2 * time.Second
+
+// ReadyCheck is one readiness condition the server should report on.
+// Name is rendered into the JSON response so probes (and humans) can
+// see which dep failed; Fn returns nil for healthy, error otherwise.
+type ReadyCheck struct {
+	Name string
+	Fn   func(ctx context.Context) error
+}
+
+// LivenessHandler returns 200 OK unconditionally. /health/live is the
+// kubelet's "is the process up at all?" signal — a failure here means
+// the pod gets restarted, so this should only fail if the process is
+// genuinely unrecoverable. Today that bar is "the goroutine is running
+// the handler at all," which 200 satisfies.
+func LivenessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK\n"))
+	}
+}
+
+// ReadinessHandler returns a handler that runs each check and reports
+// 200 if all pass, 503 if any fail. The JSON body lists per-check
+// status so a failing probe is debuggable from `kubectl describe pod`'s
+// probe output. With no checks, the handler always reports 200 —
+// equivalent to LivenessHandler but distinguishable on the URL. tripbot
+// registers it with no checks on purpose: its HTTP surface (landing page,
+// /auth/init, /auth/callback, /metrics) doesn't depend on the Twitch
+// connection, so the pod must stay in the Service even when the bot is
+// offline — otherwise the very page used to re-auth would 503.
+func ReadinessHandler(checks ...ReadyCheck) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), readyCheckTimeout)
+		defer cancel()
+
+		type result struct {
+			Name string `json:"name"`
+			OK   bool   `json:"ok"`
+			Err  string `json:"error,omitempty"`
+		}
+		out := make([]result, 0, len(checks))
+		allOK := true
+		for _, c := range checks {
+			err := c.Fn(ctx)
+			res := result{Name: c.Name, OK: err == nil}
+			if err != nil {
+				res.Err = err.Error()
+				allOK = false
+			}
+			out = append(out, res)
+		}
+
+		status := http.StatusOK
+		if !allOK {
+			status = http.StatusServiceUnavailable
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(struct {
+			OK     bool     `json:"ok"`
+			Checks []result `json:"checks"`
+		}{allOK, out})
+	}
+}

--- a/pkg/httpmw/health_test.go
+++ b/pkg/httpmw/health_test.go
@@ -1,0 +1,67 @@
+package httpmw
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLivenessHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	LivenessHandler()(rec, httptest.NewRequest(http.MethodGet, "/health/live", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestReadinessHandlerAllPass(t *testing.T) {
+	h := ReadinessHandler(
+		ReadyCheck{Name: "a", Fn: func(context.Context) error { return nil }},
+		ReadyCheck{Name: "b", Fn: func(context.Context) error { return nil }},
+	)
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/health/ready", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name string `json:"name"`
+			OK   bool   `json:"ok"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !body.OK || len(body.Checks) != 2 {
+		t.Fatalf("body = %+v, want ok=true and 2 checks", body)
+	}
+}
+
+func TestReadinessHandlerCheckFails(t *testing.T) {
+	h := ReadinessHandler(
+		ReadyCheck{Name: "a", Fn: func(context.Context) error { return nil }},
+		ReadyCheck{Name: "b", Fn: func(context.Context) error { return errors.New("nope") }},
+	)
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/health/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"name":"b"`) || !strings.Contains(rec.Body.String(), `"error":"nope"`) {
+		t.Fatalf("body should name the failing check, got %s", rec.Body.String())
+	}
+}
+
+func TestReadinessHandlerNoChecks(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ReadinessHandler()(rec, httptest.NewRequest(http.MethodGet, "/health/ready", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for empty check list", rec.Code)
+	}
+}

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -25,6 +25,7 @@ var (
 	scoreboardWrites  = mustCounter("tripbot_scoreboard_writes_total", "Total successful scoreboard score writes, labeled by scoreboard")
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
+	twitchConnected   = mustGauge("tripbot_twitch_connected", "1 when the bot is connected to Twitch chat (IRC), 0 otherwise")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
 
 	twitchHelixRateRemaining = mustGauge("twitch_helix_rate_limit_remaining", "Last-seen Ratelimit-Remaining header from Twitch Helix responses (per app-access bearer)")
@@ -66,6 +67,13 @@ var ScoreboardWrites = scoreboardWritesIface{counter: scoreboardWrites}
 
 // TwitchAudience exposes subscriber and follower gauge recording.
 var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followers: twitchFollowers}
+
+// TwitchConnection exposes the chat-connection gauge. Set(true) on IRC
+// connect, Set(false) on disconnect. Readiness no longer gates on the Twitch
+// connection (the pod stays in the Service so the re-auth page is reachable),
+// so this gauge — alongside the landing-page status row — is what surfaces
+// "up but not in chat" to dashboards and alerts.
+var TwitchConnection = twitchConnectionIface{gauge: twitchConnected}
 
 // TwitchHelixErrors exposes the helix-error counter; record by calling
 // TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
@@ -129,6 +137,16 @@ func (a twitchAudienceIface) SetSubscribers(n int64) {
 
 func (a twitchAudienceIface) SetFollowers(n int64) {
 	a.followers.Record(context.Background(), n)
+}
+
+type twitchConnectionIface struct{ gauge metric.Int64Gauge }
+
+func (t twitchConnectionIface) Set(connected bool) {
+	var v int64
+	if connected {
+		v = 1
+	}
+	t.gauge.Record(context.Background(), v)
 }
 
 type twitchHelixErrorsIface struct{ counter metric.Int64Counter }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/nicklaw5/helix/v2"
@@ -36,33 +37,28 @@ func SetVersion(v string) {
 	}
 }
 
-// ready reports whether the bot has established its Twitch IRC connection.
-// /health/ready returns 503 until it flips true, so the orchestrator keeps
-// the pod running (no crashloop) but marks it not-live until Twitch is
-// reachable. cmd/tripbot flips it via SetReady on IRC connect / disconnect.
-var ready atomic.Bool
+// twitchConnected reports whether the bot currently has its Twitch IRC
+// connection. It deliberately does NOT gate the readiness probe: /health/ready
+// is always 200 once the HTTP server is up (see httpmw.ReadinessHandler), so
+// the landing page, /auth/init and /auth/callback stay reachable through the
+// Ingress even when the bot is offline — otherwise the very page used to
+// re-auth a disconnected bot would 503. Instead this flag drives the
+// landing-page status row and the tripbot_twitch_connected gauge, so "up but
+// not in chat" is surfaced without pulling the pod out of the Service.
+// cmd/tripbot flips it via SetTwitchConnected on IRC connect / disconnect.
+var twitchConnected atomic.Bool
 
-// SetReady updates the readiness state reported by /health/ready.
-func SetReady(r bool) {
-	ready.Store(r)
+// SetTwitchConnected updates the chat-connection signal: the in-memory flag
+// the landing page reads and the tripbot_twitch_connected gauge.
+func SetTwitchConnected(connected bool) {
+	twitchConnected.Store(connected)
+	instrumentation.TwitchConnection.Set(connected)
 }
 
-// liveHandler is the liveness probe: the process is up and serving HTTP.
-// Always 200 — a failing liveness probe restarts the pod, which is exactly
-// what we want to avoid while waiting on Twitch.
-func liveHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "OK")
-}
-
-// readyHandler is the readiness probe: 200 once the Twitch IRC connection is
-// established, 503 otherwise. Keeps the pod up but not-live until Twitch is
-// reachable, and recovers on its own once the connection lands.
-func readyHandler(w http.ResponseWriter, r *http.Request) {
-	if !ready.Load() {
-		http.Error(w, "not ready: awaiting Twitch connection", http.StatusServiceUnavailable)
-		return
-	}
-	fmt.Fprintf(w, "OK")
+// TwitchConnected reports the last-known chat-connection state, for the
+// landing page's status row.
+func TwitchConnected() bool {
+	return twitchConnected.Load()
 }
 
 // versionHandler returns build metadata as JSON. The tag comes from the

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -11,41 +11,21 @@ import (
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 )
 
-func TestLiveHandler(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/health/live", nil)
-	rec := httptest.NewRecorder()
+// TestTwitchConnectedSignal pins the behavior split this PR introduces: the
+// chat-connection signal round-trips, but it's decoupled from the readiness
+// probe. The probe itself (httpmw.ReadinessHandler with no checks → always
+// 200) is covered in pkg/httpmw; here we just guard the signal accessors.
+func TestTwitchConnectedSignal(t *testing.T) {
+	defer SetTwitchConnected(false) // reset package state for other tests
 
-	liveHandler(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
-	}
-	if rec.Body.String() != "OK" {
-		t.Fatalf("got body %q, want %q", rec.Body.String(), "OK")
-	}
-}
-
-func TestReadyHandler(t *testing.T) {
-	defer SetReady(false) // reset package state for other tests
-
-	// not ready by default: 503
-	SetReady(false)
-	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
-	rec := httptest.NewRecorder()
-	readyHandler(rec, req)
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("not-ready: got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	SetTwitchConnected(false)
+	if TwitchConnected() {
+		t.Fatalf("after SetTwitchConnected(false), TwitchConnected() = true, want false")
 	}
 
-	// ready once Twitch connection is established: 200
-	SetReady(true)
-	rec = httptest.NewRecorder()
-	readyHandler(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("ready: got status %d, want %d", rec.Code, http.StatusOK)
-	}
-	if rec.Body.String() != "OK" {
-		t.Fatalf("ready: got body %q, want %q", rec.Body.String(), "OK")
+	SetTwitchConnected(true)
+	if !TwitchConnected() {
+		t.Fatalf("after SetTwitchConnected(true), TwitchConnected() = false, want true")
 	}
 }
 

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -129,14 +129,18 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
-		OK:         ready.Load(),
+		OK:         twitchConnected.Load(),
 		Version:    versionTag,
 		VersionURL: changelogURL(sha),
 	}
 	if tripbot.OK {
-		tripbot.Detail = "ready"
+		tripbot.Detail = "in chat"
 	} else {
-		tripbot.Detail = "degraded (awaiting Twitch)"
+		// The pod is up and serving this page — readiness no longer gates on
+		// the Twitch connection — but the bot isn't connected to chat. The red
+		// dot + this label is how that's surfaced; the re-auth links below
+		// cover the common cause (a missing/expired token).
+		tripbot.Detail = "not in chat"
 	}
 
 	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -37,8 +37,8 @@ func TestChangelogURL(t *testing.T) {
 }
 
 func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
-	defer SetReady(false)
-	SetReady(true)
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(true)
 
 	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	for _, want := range []string{
 		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
 		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
-		"ready",                     // tripbot status
+		"in chat",                   // tripbot chat-connection status
 		"healthy",                   // vlc status
 		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
 		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
@@ -104,8 +104,8 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 }
 
 func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
-	defer SetReady(false)
-	SetReady(false)
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(false)
 
 	withConf(t, func() {
 		// unroutable host → ping fails fast / times out → vlc shown unreachable
@@ -124,8 +124,8 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "degraded") {
-		t.Errorf("body should report tripbot degraded; got %q", body)
+	if !strings.Contains(body, "not in chat") {
+		t.Errorf("body should report tripbot not in chat; got %q", body)
 	}
 	if !strings.Contains(body, "unreachable") {
 		t.Errorf("body should report vlc unreachable; got %q", body)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,8 +45,12 @@ func Start(ctx context.Context) {
 
 	// healthcheck endpoints
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.Handle("/live", tagged("/health/live", liveHandler))
-	hp.Handle("/ready", tagged("/health/ready", readyHandler))
+	hp.Handle("/live", tagged("/health/live", httpmw.LivenessHandler()))
+	// /ready runs no checks: tripbot's HTTP surface (landing page, /auth/init,
+	// /auth/callback, /metrics) doesn't depend on the Twitch connection, so the
+	// pod must stay routable even when the bot is offline. Chat-connection is
+	// surfaced via the landing page + the tripbot_twitch_connected gauge.
+	hp.Handle("/ready", tagged("/health/ready", httpmw.ReadinessHandler()))
 
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")


### PR DESCRIPTION
## What

`/health/ready` returns 200 the moment the HTTP server is up, instead of gating on the Twitch IRC connection. The chat-connection state becomes a non-gating signal: a `tripbot_twitch_connected` gauge + the landing page's status row.

This is **PR 1 of 3** in the readiness/OAuth/token-self-heal redesign. It's the keystone that unblocks the other two.

## Why

The readiness probe (`readinessProbe → /health/ready`) gated on `server.SetReady`, flipped only on the IRC `OnConnect`. With a single replica, a disconnected bot — the usual state after a DB restore carries a stale/missing `oauth_tokens` row — made the pod `NotReady`, so traefik pulled it from the Service and **503'd every route, including `/` (landing page) and `/auth/init`**. The page you'd use to re-auth the bot was unreachable *because* the bot was unauthenticated. (Hit live during the 2026-05-21 mini-PC wipe; this is gate #1 of the infra readiness TODO.)

k8s readiness means "should the Service route to this pod." tripbot's HTTP surface — landing page, `/auth/init`, `/auth/callback`, `/version`, `/metrics` — doesn't depend on the chat connection, so the honest answer is "always, once serving." The "is the bot doing its job" question moves to where it belongs: a metric + the visible status row + (follow-up) a Grafana alert.

## Changes

- **`pkg/httpmw`**: add `LivenessHandler` / `ReadinessHandler` / `ReadyCheck` (lifted from the superseded #585) for a shared probe shape + JSON body. `ReadinessHandler()` with no checks → always 200.
- **tripbot `/health/{live,ready}`** now use those helpers; `/ready` runs **no checks**.
- **`server.SetReady`/`ready` → `server.SetTwitchConnected`/`twitchConnected`** — a chat-connection signal, not a probe gate. Drives:
  - new OTel gauge `tripbot_twitch_connected` (1/0),
  - the landing-page status row: **"in chat"** / **"not in chat"** (red dot when offline).
- `cmd/tripbot` flips the signal on IRC connect/disconnect; comments updated.

## Trade-off

A chat-disconnected pod now reads as **Ready** to k8s. Deliberate: with one replica, "NotReady" = total HTTP outage of the recovery surface, and there's nowhere else to route anyway. Honesty about chat state lives in the gauge + landing row + the planned alert.

## What's next (not in this PR)

- **PR 2** — landing page surfaces "Sign in as bot/broadcaster" links when a token is missing/expired (now reachable, since the pod stays in the Service).
- **PR 3** — token self-heal: re-read `oauth_tokens` from the DB on a 401 instead of caching the boot-time token forever.
- Downstream (infra): Grafana alert on `tripbot_twitch_connected == 0 for 5m`; once PR 3 lands, retire infra#565's auto-roll band-aid.

## Test plan

- [x] `task test:macos` green (incl. `pkg/httpmw`, `pkg/server`).
- [ ] On a running pod: `/health/ready` → 200 even with no Twitch connection; landing page reachable and shows "not in chat"; `/auth/init` reachable.
