### PR TITLE
landing: surface OAuth re-auth links when a token is missing/expired

### DIFF
--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -33,6 +33,10 @@ var (
 	// chatterCount is the in-memory count of users in chat, refreshed ~60s by
 	// the UpdateSession cron. Overridable in tests.
 	chatterCount = mytwitch.ChatterCount
+	// accountsNeedingReauth reports which Twitch accounts have a missing/expired
+	// token; the landing page renders a re-auth prompt for each. Overridable in
+	// tests. Reads in-memory token state — no DB or network call.
+	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
 )
 
 const (
@@ -86,6 +90,7 @@ type landingData struct {
 	Services []serviceStatus
 	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
 	Links    []navLink
+	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
 // landingHandler serves the human-facing root page on the tripbot Ingress: a
@@ -112,6 +117,7 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
 		Now:      currentVideo(vlcOK),
 		Links:    gatherLinks(),
+		Reauth:   accountsNeedingReauth(),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -304,6 +310,14 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
+  /* re-auth callout: only rendered when a token is missing/expired */
+  .reauth { background:#3a1d00; border:1px solid #6b3b00; border-radius:8px; padding:14px 16px; margin:0 0 24px; }
+  .reauth h2 { margin:0 0 8px; color:#ffb454; }
+  .reauth p { margin:0 0 10px; color:#e8c89a; font-size:.9em; }
+  .reauth .btns { display:flex; flex-wrap:wrap; gap:10px; }
+  .reauth a.btn { display:inline-block; background:#ffb454; color:#1a1100; font-weight:600; padding:8px 14px; border-radius:6px; }
+  .reauth a.btn:hover { background:#ffc578; color:#1a1100; }
+  .reauth .why { font-family:var(--mono); font-size:.85em; opacity:.85; }
 </style>
 </head>
 <body>
@@ -314,6 +328,16 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   <h1>tripbot <code class="env">{{.Env}}</code></h1>
   <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
+
+  {{if .Reauth}}
+  <div class="reauth">
+    <h2>action needed: re-authenticate</h2>
+    <p>tripbot can't talk to Twitch until these accounts are re-authorized. Sign in as the named account on each — the flow re-prompts which account to use, so sign out of Twitch (or use a private window) if it grabs the wrong one.</p>
+    <div class="btns">
+      {{range .Reauth}}<a class="btn" href="{{.InitURL}}">Sign in as {{.LoginAs}} <span class="why">({{.Account}} · {{.Reason}})</span></a>{{end}}
+    </div>
+  </div>
+  {{end}}
 
   <h2>status</h2>
   <ul>

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -39,6 +40,7 @@ func TestChangelogURL(t *testing.T) {
 func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
+	withReauth(t, nil) // healthy tokens — no re-auth callout
 
 	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -106,6 +108,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
+	withReauth(t, nil)
 
 	withConf(t, func() {
 		// unroutable host → ping fails fast / times out → vlc shown unreachable
@@ -168,4 +171,63 @@ func withChatterCount(t *testing.T, n int) {
 	saved := chatterCount
 	chatterCount = func() int { return n }
 	t.Cleanup(func() { chatterCount = saved })
+}
+
+// withReauth swaps the accountsNeedingReauth seam so the landing handler sees a
+// fixed re-auth list without depending on global in-memory token state.
+func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
+	t.Helper()
+	saved := accountsNeedingReauth
+	accountsNeedingReauth = func() []mytwitch.AccountReauth { return accounts }
+	t.Cleanup(func() { accountsNeedingReauth = saved })
+}
+
+func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(false)
+
+	withConf(t, func() {
+		c.Conf.VlcServerHost = "" // skip the vlc ping
+		c.Conf.ChannelName = "adanalife_"
+		c.Conf.BotUsername = "tripbot4000"
+		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
+	})
+	withReauth(t, []mytwitch.AccountReauth{
+		{Account: "bot", LoginAs: "tripbot4000", Reason: "missing", InitURL: "https://tripbot.prod.whereisdana.today/auth/init?account=bot&login_as=tripbot4000"},
+		{Account: "broadcaster", LoginAs: "adanalife_", Reason: "expired", InitURL: "https://tripbot.prod.whereisdana.today/auth/init?account=broadcaster&login_as=adanalife_"},
+	})
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"action needed: re-authenticate",
+		// html/template escapes & as &amp; in attribute values (valid HTML).
+		`href="https://tripbot.prod.whereisdana.today/auth/init?account=bot&amp;login_as=tripbot4000"`,
+		"Sign in as tripbot4000",
+		"(bot · missing)",
+		`href="https://tripbot.prod.whereisdana.today/auth/init?account=broadcaster&amp;login_as=adanalife_"`,
+		"Sign in as adanalife_",
+		"(broadcaster · expired)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestLandingHandler_NoReauthPromptWhenHealthy(t *testing.T) {
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(true)
+
+	withConf(t, func() { c.Conf.VlcServerHost = "" })
+	withReauth(t, nil) // all tokens healthy
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if strings.Contains(rec.Body.String(), "re-authenticate") {
+		t.Errorf("re-auth prompt should be hidden when no account needs re-auth")
+	}
 }

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -289,6 +289,61 @@ func BroadcasterUserAccessToken() string {
 	return currentBroadcasterToken.AccessToken
 }
 
+// AccountReauth describes an account whose in-memory token is missing or
+// expired and therefore needs operator re-auth. The landing page renders one
+// "Sign in as <LoginAs>" link per entry, pointing at InitURL.
+type AccountReauth struct {
+	Account string // "bot" | "broadcaster" — the /auth/init account selector
+	LoginAs string // the exact Twitch username to sign in as
+	Reason  string // "missing" | "expired" — why re-auth is needed
+	InitURL string // /auth/init URL for this account
+}
+
+// tokenReason classifies a loaded token: "" when usable, else "missing"
+// (never loaded, or blanked by a failed refresh / invalid_grant) or
+// "expired" (loaded but past ExpiresAt — a narrow window, since the refresh
+// cron normally rotates 30m ahead).
+func tokenReason(t oauthtokens.Token) string {
+	if t.AccessToken == "" {
+		return "missing"
+	}
+	if !t.ExpiresAt.IsZero() && time.Now().After(t.ExpiresAt) {
+		return "expired"
+	}
+	return ""
+}
+
+// AccountsNeedingReauth returns the bot and/or broadcaster accounts whose
+// in-memory token is missing or expired, so the landing page can prompt for
+// re-auth. Returns nil when everything's healthy. The broadcaster is only
+// considered when a distinct broadcaster identity exists (ChannelName set and
+// != BotUsername) — otherwise there's no separate row to re-auth.
+func AccountsNeedingReauth() []AccountReauth {
+	tokenMu.RLock()
+	botReason := tokenReason(currentUserToken)
+	bcastReason := tokenReason(currentBroadcasterToken)
+	tokenMu.RUnlock()
+
+	var out []AccountReauth
+	if botReason != "" {
+		out = append(out, AccountReauth{
+			Account: "bot",
+			LoginAs: c.Conf.BotUsername,
+			Reason:  botReason,
+			InitURL: AuthInitURL("bot"),
+		})
+	}
+	if c.Conf.ChannelName != "" && c.Conf.ChannelName != c.Conf.BotUsername && bcastReason != "" {
+		out = append(out, AccountReauth{
+			Account: "broadcaster",
+			LoginAs: c.Conf.ChannelName,
+			Reason:  bcastReason,
+			InitURL: AuthInitURL("broadcaster"),
+		})
+	}
+	return out
+}
+
 // ErrIdentityMismatch is returned by GenerateUserAccessToken when the
 // discovered identity (via helix.GetUsers) doesn't match expectedLogin.
 // Callers should surface it with retry guidance; the wrong-identity row is

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -234,3 +234,76 @@ func TestIRCAuthToken_ConcurrentReads(t *testing.T) {
 		}
 	}
 }
+
+// withReauthConf sets the bot/broadcaster identities AccountsNeedingReauth
+// reads and restores them afterward.
+func withReauthConf(t *testing.T, bot, channel string) {
+	t.Helper()
+	savedBot, savedChan := c.Conf.BotUsername, c.Conf.ChannelName
+	c.Conf.BotUsername, c.Conf.ChannelName = bot, channel
+	t.Cleanup(func() { c.Conf.BotUsername, c.Conf.ChannelName = savedBot, savedChan })
+}
+
+func setTokens(t *testing.T, bot, bcast oauthtokens.Token) {
+	t.Helper()
+	resetToken(t)
+	resetBroadcasterToken(t)
+	tokenMu.Lock()
+	currentUserToken, currentBroadcasterToken = bot, bcast
+	tokenMu.Unlock()
+}
+
+func TestAccountsNeedingReauth_AllHealthy(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	future := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, future, future)
+
+	if got := AccountsNeedingReauth(); got != nil {
+		t.Fatalf("AccountsNeedingReauth() = %+v, want nil when both tokens are healthy", got)
+	}
+}
+
+func TestAccountsNeedingReauth_BotMissing(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, oauthtokens.Token{}, healthy) // bot blank → missing
+
+	got := AccountsNeedingReauth()
+	if len(got) != 1 {
+		t.Fatalf("got %d accounts, want 1: %+v", len(got), got)
+	}
+	if got[0].Account != "bot" || got[0].Reason != "missing" || got[0].LoginAs != "tripbot4000" {
+		t.Errorf("entry = %+v, want bot/missing/tripbot4000", got[0])
+	}
+	if !strings.Contains(got[0].InitURL, "account=bot") {
+		t.Errorf("InitURL %q should target the bot account", got[0].InitURL)
+	}
+}
+
+func TestAccountsNeedingReauth_BroadcasterExpired(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	expired := oauthtokens.Token{AccessToken: "stale", ExpiresAt: time.Now().Add(-time.Hour)}
+	setTokens(t, healthy, expired)
+
+	got := AccountsNeedingReauth()
+	if len(got) != 1 {
+		t.Fatalf("got %d accounts, want 1: %+v", len(got), got)
+	}
+	if got[0].Account != "broadcaster" || got[0].Reason != "expired" {
+		t.Errorf("entry = %+v, want broadcaster/expired", got[0])
+	}
+}
+
+// When the bot and broadcaster are the same account, there's no separate
+// broadcaster row — a blank broadcaster slot must not produce a phantom
+// re-auth prompt.
+func TestAccountsNeedingReauth_NoSeparateBroadcaster(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "tripbot4000")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, healthy, oauthtokens.Token{}) // broadcaster slot blank, but irrelevant
+
+	if got := AccountsNeedingReauth(); got != nil {
+		t.Fatalf("AccountsNeedingReauth() = %+v, want nil when no distinct broadcaster identity", got)
+	}
+}


### PR DESCRIPTION
## What

When the bot or broadcaster Twitch token is missing or expired, the landing page renders a prominent **"action needed: re-authenticate"** callout with a **"Sign in as `<login>`"** button per account, each linking to `/auth/init?account=…`.

**PR 2 of 3.** Stacked on #634 (`feat/readiness-decouple`) — review/merge that first. The buttons are only reachable *because* PR 1 keeps the pod in the Service while the bot is disconnected.

## Why

The reauth link previously lived only in the logs (`reauth_url`), which works but is awkward to act on — you have to be tailing Loki, and external-URL handling was fiddly. The landing page is the natural home: it already renders bot/broadcaster status, it's reachable from any browser over the internal Ingress (and over Tailscale off-LAN), and `/auth/init` mints the CSRF state server-side so the link carries no secret (same safety property the logged URL relies on). The logs stay as a backup.

This is how the post-DB-restore recovery loop closes for a human: pod stays up (PR 1) → landing page shows the re-auth buttons → click → sign in → token written → bot reconnects (PR 3 makes that automatic).

## Changes

- **`pkg/twitch.AccountsNeedingReauth()`** — returns the bot and/or broadcaster accounts whose in-memory token is `missing` (blank / blanked by a failed refresh) or `expired` (past `ExpiresAt`). Reads under `tokenMu`, no DB/network. The broadcaster is only considered when a distinct broadcaster identity exists (`ChannelName != BotUsername`), so a single-identity setup never shows a phantom prompt.
- **Landing page** gains a `Reauth` field + a styled callout, read through an overridable `accountsNeedingReauth` seam (mirrors the `currentlyPlaying` / `chatterCount` seams). Only rendered when non-empty.

## Test plan

- [x] `task test:macos` green. New: `AccountsNeedingReauth` (healthy / bot-missing / broadcaster-expired / no-separate-broadcaster) + landing-page prompt-shown / prompt-hidden.
- [ ] On a running pod with a missing token: landing page shows the callout + a working sign-in button; completing the flow writes the token.

## Next

- **PR 3** — token self-heal: re-read `oauth_tokens` from the DB on a 401 so the bot reconnects on its own once a button is clicked (or `auth:bootstrap` runs), no manual roll.
