### PR TITLE
twitch: self-heal stale tokens by re-reading the DB on auth failure

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -302,16 +302,20 @@ func connectToTwitch() {
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {
-				// The IRC client holds a stale token. Sync it with the
-				// in-memory token (kept fresh by the hourly refresh cron)
-				// so the next Connect attempt uses the current credentials.
+				// The IRC client's token was rejected. Re-establish the bot
+				// token from the DB (forced refresh, then re-read the row) so a
+				// token just written by auth-bootstrap is picked up without a
+				// restart — the common case after a DB restore carries a stale
+				// row. Then sync whatever's now in memory into the IRC client
+				// for the next Connect attempt.
+				mytwitch.Reauth(context.Background(), "bot")
 				if tok := mytwitch.IRCAuthToken(); tok != "" {
 					client.SetIRCToken(tok)
 				} else {
-					// No valid in-memory token to fall back on — the refresh
-					// cron blanked it (revoked/invalid_grant). Surface the
-					// re-bootstrap link so re-auth is a click, not a task run.
-					slog.Error("IRC auth failed and no valid token to retry with; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
+					// Reauth couldn't produce a token (refresh_token revoked and
+					// no fresh row in the DB yet). Surface the re-bootstrap link
+					// so re-auth is a click; the landing page shows it too.
+					slog.Error("IRC auth failed and no valid token after reauth; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
 				}
 			}
 			time.Sleep(time.Minute)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -413,7 +413,9 @@ func GenerateUserAccessToken(code string, expectedLogin string) error {
 	if usersResp == nil {
 		return errors.New("twitch: nil response from GetUsers")
 	}
-	if checkHelixResp("GetUsers", &usersResp.ResponseCommon) {
+	// account="" — mid-bootstrap, re-reading the (not-yet-written) token would
+	// be wrong; surface the failure to the caller instead.
+	if checkHelixResp(context.Background(), "GetUsers", "", &usersResp.ResponseCommon) {
 		return fmt.Errorf("twitch: GetUsers returned %d during bootstrap", usersResp.StatusCode)
 	}
 	if len(usersResp.Data.Users) == 0 {
@@ -479,10 +481,36 @@ func RefreshUserAccessToken(ctx context.Context) {
 	botUser := c.Conf.BotUsername
 	broadcasterUser := c.Conf.ChannelName
 
-	refreshOne(ctx, botUser, applyBotToken)
+	refreshOne(ctx, botUser, applyBotToken, false)
 
 	if broadcasterUser != "" && broadcasterUser != botUser {
-		refreshOne(ctx, broadcasterUser, applyBroadcasterToken)
+		refreshOne(ctx, broadcasterUser, applyBroadcasterToken, false)
+	}
+}
+
+// Reauth re-establishes a usable user-access-token for the given account
+// ("bot" | "broadcaster") after an auth failure — an IRC login rejection or a
+// Helix 401. It forces a refresh via the stored refresh_token (skipping the
+// normal 30-minute pre-expiry window), then re-reads the row from the DB. The
+// DB is the source of truth: this picks up a token just written by the
+// auth-bootstrap flow (or by another tripbot's refresh) without a process
+// restart. When neither yields a usable token — e.g. a DB-restored row whose
+// refresh_token is also revoked — the in-memory slot is left blanked and the
+// reauth link is logged; the landing page's re-auth prompt then covers it.
+func Reauth(ctx context.Context, account string) {
+	username := c.Conf.BotUsername
+	apply := applyBotToken
+	if account == "broadcaster" {
+		username = c.Conf.ChannelName
+		apply = applyBroadcasterToken
+	}
+	refreshOne(ctx, username, apply, true)
+	// Re-read regardless of the refresh outcome: a concurrent auth-bootstrap
+	// may have written a fresh token that a refresh with the (also-stale)
+	// refresh_token couldn't produce.
+	if err := LoadFromDB(); err != nil {
+		slog.WarnContext(ctx, "reauth: no usable token after refresh + DB re-read",
+			"err", err, "login_as", username, "reauth_url", AuthInitURL(account))
 	}
 }
 
@@ -514,9 +542,15 @@ func applyBroadcasterToken(tok oauthtokens.Token) {
 // matching in-memory slot — also called on the empty-token path so the
 // caller's slot gets blanked (forcing reconnect / re-bootstrap signalling).
 //
+// force skips the 30-minute pre-expiry window: the hourly cron passes false
+// (only rotate when close to expiry), while Reauth passes true to rotate
+// immediately after an auth failure regardless of the stored ExpiresAt (which
+// is unreliable after a DB restore — the dump's expiry says "valid" but Twitch
+// has already invalidated the token).
+//
 // TODO: helix client surface should move behind an interface so this
 // function can be unit-tested without a real Twitch round-trip.
-func refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token)) {
+func refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token), force bool) {
 	acquired, release, err := oauthtokens.TryRefreshLock("twitch", username)
 	if err != nil {
 		slog.ErrorContext(ctx, "oauth refresh lock acquisition failed", "err", err, "username", username)
@@ -542,7 +576,7 @@ func refreshOne(ctx context.Context, username string, applyInMemory func(oauthto
 		return
 	}
 
-	if time.Until(t.ExpiresAt) > 30*time.Minute {
+	if !force && time.Until(t.ExpiresAt) > 30*time.Minute {
 		return
 	}
 

--- a/pkg/twitch/helix_resp.go
+++ b/pkg/twitch/helix_resp.go
@@ -1,8 +1,10 @@
 package twitch
 
 import (
-	"log/slog"
+	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
 
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/nicklaw5/helix/v2"
@@ -22,11 +24,20 @@ import (
 // When this returns true, callers should log + early-return rather than
 // trust resp.Data. endpoint is a short label used as the metric attribute
 // (e.g. "GetUsers"); it should match the helix client method name.
-func checkHelixResp(endpoint string, resp *helix.ResponseCommon) bool {
+//
+// account names the identity the call authorized against ("bot" |
+// "broadcaster"); on a 401 it triggers Reauth so the stale user-access-token
+// is re-established from the DB and the next call uses a fresh one. Pass ""
+// to opt out — for app-access-token calls (getChannelID's GetUsers) and the
+// mid-bootstrap GetUsers, where re-reading a user token wouldn't help.
+func checkHelixResp(ctx context.Context, endpoint, account string, resp *helix.ResponseCommon) bool {
 	if resp == nil || resp.StatusCode < 400 {
 		return false
 	}
-	slog.Error(fmt.Sprintf("helix %s returned %d: %s", endpoint, resp.StatusCode, resp.ErrorMessage))
+	slog.ErrorContext(ctx, fmt.Sprintf("helix %s returned %d: %s", endpoint, resp.StatusCode, resp.ErrorMessage))
 	instrumentation.TwitchHelixErrors.Inc(endpoint, resp.StatusCode)
+	if resp.StatusCode == http.StatusUnauthorized && account != "" {
+		Reauth(ctx, account)
+	}
 	return true
 }

--- a/pkg/twitch/helix_resp_test.go
+++ b/pkg/twitch/helix_resp_test.go
@@ -1,20 +1,21 @@
 package twitch
 
 import (
+	"context"
 	"testing"
 
 	"github.com/nicklaw5/helix/v2"
 )
 
 func TestCheckHelixResp_NilResponse(t *testing.T) {
-	if checkHelixResp("GetUsers", nil) {
+	if checkHelixResp(context.Background(), "GetUsers", "", nil) {
 		t.Fatal("nil response should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_Success(t *testing.T) {
 	rc := &helix.ResponseCommon{StatusCode: 200}
-	if checkHelixResp("GetUsers", rc) {
+	if checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("200 should not be treated as an error")
 	}
 }
@@ -22,23 +23,34 @@ func TestCheckHelixResp_Success(t *testing.T) {
 func TestCheckHelixResp_NoContent(t *testing.T) {
 	// 204 is still success — guard against >= 400, not != 200
 	rc := &helix.ResponseCommon{StatusCode: 204}
-	if checkHelixResp("GetUsers", rc) {
+	if checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("204 should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_ClientError(t *testing.T) {
 	// 403 was the concrete 2026-05-15 incident: bot lost mod scope on the
-	// channel, GetChannelChatChatters returned 403 with empty Data.
+	// channel, GetChannelChatChatters returned 403 with empty Data. 403 is a
+	// scope problem, not a stale token — no reauth, but still flagged.
 	rc := &helix.ResponseCommon{StatusCode: 403, ErrorMessage: "insufficient scope"}
-	if !checkHelixResp("GetChannelChatChatters", rc) {
+	if !checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", rc) {
 		t.Fatal("403 should be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_ServerError(t *testing.T) {
 	rc := &helix.ResponseCommon{StatusCode: 503, ErrorMessage: "unavailable"}
-	if !checkHelixResp("GetSubscriptions", rc) {
+	if !checkHelixResp(context.Background(), "GetSubscriptions", "broadcaster", rc) {
 		t.Fatal("5xx should be treated as an error")
+	}
+}
+
+// A 401 with account="" must still report the error but must NOT trigger
+// Reauth (which would make a live Twitch refresh call) — the app-token and
+// mid-bootstrap callsites rely on this opt-out.
+func TestCheckHelixResp_UnauthorizedNoAccountSkipsReauth(t *testing.T) {
+	rc := &helix.ResponseCommon{StatusCode: 401, ErrorMessage: "invalid oauth token"}
+	if !checkHelixResp(context.Background(), "GetUsers", "", rc) {
+		t.Fatal("401 should be treated as an error")
 	}
 }

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -36,7 +36,9 @@ func getChannelID(username string) string {
 		slog.Error("empty response from twitch")
 		return ""
 	}
-	if checkHelixResp("GetUsers", &resp.ResponseCommon) {
+	// account="" — GetUsers here authorizes against the app-access-token, not a
+	// user token, so re-reading a user token wouldn't fix a 401.
+	if checkHelixResp(context.Background(), "GetUsers", "", &resp.ResponseCommon) {
 		return ""
 	}
 
@@ -74,7 +76,7 @@ func GetSubscribers(ctx context.Context) {
 		slog.ErrorContext(ctx, "error getting subscriptions from twitch", "err", err)
 		return
 	}
-	if checkHelixResp("GetSubscriptions", &resp.ResponseCommon) {
+	if checkHelixResp(ctx, "GetSubscriptions", "broadcaster", &resp.ResponseCommon) {
 		// keep the prior subscriber list rather than zeroing it out
 		return
 	}
@@ -119,7 +121,7 @@ func GetFollowerCount(ctx context.Context) {
 		slog.ErrorContext(ctx, "error getting follower count from twitch", "err", err)
 		return
 	}
-	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+	if checkHelixResp(ctx, "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		return
 	}
 	instrumentation.TwitchAudience.SetFollowers(int64(resp.Data.Total))
@@ -165,7 +167,7 @@ func UserIsFollower(username string) bool {
 		slog.Error("error getting user follows", "err", err)
 		return false
 	}
-	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+	if checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		// fail closed: when we can't verify follow status, treat as non-follower
 		return false
 	}

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -1,7 +1,9 @@
 package twitch
 
 import (
+	"context"
 	"log/slog"
+
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/nicklaw5/helix/v2"
 )
@@ -55,7 +57,7 @@ func UpdateChatters() {
 		slog.Error("error getting chatters from twitch", "err", err)
 		return
 	}
-	if checkHelixResp("GetChannelChatChatters", &resp.ResponseCommon) {
+	if checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", &resp.ResponseCommon) {
 		// don't overwrite cached chatter state with an empty response —
 		// 4xx here means the bot lost a scope or moderator role and the
 		// next call probably succeeds once that's fixed.


### PR DESCRIPTION
## What

On a Twitch auth failure, re-establish the token from the DB instead of looping on the boot-time cached one. The IRC login path and the Helix 401 path both now refresh-then-re-read, treating the `oauth_tokens` row as the source of truth.

**PR 3 of 3.** Stacked on #635 → #634. Review/merge those first.

## Why

Tokens were read once at boot and never re-read. After a DB restore the dump carries a **stale** `oauth_tokens` row, so the running pod's IRC login and every Helix call 401'd **indefinitely** — only a manual `kubectl rollout restart` (or the infra#565 auto-roll band-aid) re-read the DB and reconnected. Hit live during the 2026-05-21 mini-PC wipe.

The hourly refresh cron didn't cover it: it only rotates within 30 min of the stored `ExpiresAt`, and a restored row reports an expiry far in the future even though Twitch has already invalidated the token.

This is the deeper fix the bot-TODO and infra#565 both pointed at. It closes the recovery loop: a DB restore or token revocation now self-heals the moment a fresh token lands in the DB (via `auth:bootstrap` or the PR 2 landing-page click) — no restart.

## Changes

- **`twitch.Reauth(ctx, account)`** — forces a refresh via the stored `refresh_token` (skipping the 30-min window), then re-reads the row from the DB and re-primes the helix client. `refreshOne` gains a `force` flag; the hourly cron still passes `force=false`.
- **IRC connect loop** calls `Reauth("bot")` on `ErrLoginAuthenticationFailed` before syncing the token (was: sync in-memory only, never re-read the DB).
- **`checkHelixResp`** now takes `ctx` + `account` and calls `Reauth` on a **401**. `account=""` opts out for the app-access-token call (`getChannelID`) and the mid-bootstrap `GetUsers`, where re-reading a user token wouldn't help. **403** (scope loss — the 2026-05-15 mod-loss incident) is unaffected; that's not token staleness.
- When neither refresh nor re-read yields a usable token (refresh_token revoked too), the slot is left blanked and the reauth link is logged — the PR 2 landing prompt covers the click-to-fix path.

## Test plan

- [x] `task test:macos` green. `checkHelixResp` tests updated to the new signature; added a 401/`account=""` case asserting it flags the error without triggering a (network) reauth.
- Note: `Reauth` / `refreshOne`'s live-refresh path isn't unit-tested (needs a real Twitch round-trip — the long-standing TODO on `refreshOne`). Verified by construction + the surrounding tests.
- [ ] On prod: restore DB with a stale token → bot 401s → run `auth:bootstrap` (no roll) → bot reconnects on its own within a retry cycle; landing page clears the re-auth prompt.

## Follow-up (infra)

Once this lands, infra#565's auto-roll band-aid is redundant (harmless to leave). Worth a Grafana alert on `tripbot_twitch_connected == 0 for 5m` (gauge added in #634).
