### PR TITLE
Release v2.14.0: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.14.0] — 2026-05-22
+
+Minor release. tripbot's readiness probe is decoupled from the Twitch connection: the pod stays in the Service — and the landing page + OAuth endpoints stay reachable — even when the bot is offline, so the page used to re-auth a disconnected bot is no longer 503'd by the very outage it fixes. The landing page now surfaces re-auth links when a token is missing/expired, and stale tokens self-heal — on an IRC/Helix auth failure the bot re-reads `oauth_tokens` from the DB, so a freshly bootstrapped token is picked up without a restart. Also ships a `!followage` command, an "is this live" alias, and full EventSub event logging.
+
+### tripbot
+
+- **Readiness decoupled from the Twitch connection.** `/health/ready` now returns 200 as soon as the HTTP server is up (via shared `pkg/httpmw` `LivenessHandler` / `ReadinessHandler` / `ReadyCheck` helpers, run with no checks for tripbot). Previously it gated on the Twitch IRC connection, so a disconnected single-replica pod was pulled from the Service and traefik 503'd every route — including the landing page and `/auth/init`. Chat-connection is now a non-gating signal: a `tripbot_twitch_connected` gauge (1/0) plus the landing-page status row ("in chat" / "not in chat"), so "up but not in chat" is surfaced without taking the pod out of rotation. ([#634])
+- **OAuth re-auth links on the landing page.** When the bot or broadcaster token is missing or expired, the landing page renders an "action needed: re-authenticate" callout with a "Sign in as `<login>`" button per account, linking to `/auth/init`. `pkg/twitch.AccountsNeedingReauth` reports which accounts need it (broadcaster only when it's a distinct identity), read under the token lock with no DB/network call. Reachable over the internal Ingress (and Tailscale off-LAN); the logged `reauth_url` stays as a backup. ([#635])
+- **Hubble dashboard link opens straight to the prod-1 namespace.** Appends `?namespace=prod-1` to the landing page's Hubble link so it lands in the flow view instead of the namespace picker (the Hubble UI is a single prod-zone install shared across envs). ([#630])
+
+### Twitch
+
+- **Self-heal stale tokens by re-reading the DB on auth failure.** Tokens were read once at boot and never re-read, so after a DB restore (stale `oauth_tokens` row) the pod 401'd indefinitely until a manual `rollout restart`. Now `twitch.Reauth(ctx, account)` forces a refresh via the stored `refresh_token` (skipping the 30-minute pre-expiry window) then re-reads the row, treating the DB as source of truth. The IRC connect loop calls it on `ErrLoginAuthenticationFailed`, and `checkHelixResp` calls it on a 401 (with `account=""` opting out the app-token and mid-bootstrap calls; 403 scope-loss is unaffected). A token written by `auth:bootstrap` — or by the landing-page re-auth click — is now picked up within one retry cycle, no restart. ([#636])
+- **Log every received EventSub event via `OnRawEvent`.** A catch-all handler in `pkg/eventsub` logs every received notification (`type` + `message_id` + raw payload), whether or not a typed handler is wired for it — an observability-first step toward designing per-event chat shouts from real Loki data. Typed events (follow, subscribe) get both the raw log line and their handler. ([#633])
+
+### chatbot
+
+- **`!followage` command** (alias `!followtime`). Reports how long a viewer has followed the channel; bare `!followage` = the caller, `!followage @user` looks someone else up. New `twitch.FollowedAt` reads `followed_at` from Helix `GetChannelFollows` on the existing broadcaster-token path; duration rendered with `durafmt` (2 units, matching `!uptime`). Not follower-gated; non-followers get a friendly nudge. ([#632])
+- **"is this live" aliased to `!date`.** The natural-language question now routes to the command that answers it (multi-word non-`!` aliases were already supported). ([#631])
+
+[#630]: https://github.com/adanalife/tripbot/pull/630
+[#631]: https://github.com/adanalife/tripbot/pull/631
+[#632]: https://github.com/adanalife/tripbot/pull/632
+[#633]: https://github.com/adanalife/tripbot/pull/633
+[#634]: https://github.com/adanalife/tripbot/pull/634
+[#635]: https://github.com/adanalife/tripbot/pull/635
+[#636]: https://github.com/adanalife/tripbot/pull/636
+
 ## [v2.13.1] — 2026-05-21
 
 Patch release. tripbot's Ingress root — previously a bare 404 — now serves a lightweight landing-page dashboard (mostly a phone bookmark): a status overview, the currently-playing clip, the broadcaster/bot accounts, and links to the OBS / Grafana / Traefik / Hubble dashboards. Also throttles the token-poll warning that spammed the logs while a pod waits on re-auth.

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -302,16 +302,20 @@ func connectToTwitch() {
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {
-				// The IRC client holds a stale token. Sync it with the
-				// in-memory token (kept fresh by the hourly refresh cron)
-				// so the next Connect attempt uses the current credentials.
+				// The IRC client's token was rejected. Re-establish the bot
+				// token from the DB (forced refresh, then re-read the row) so a
+				// token just written by auth-bootstrap is picked up without a
+				// restart — the common case after a DB restore carries a stale
+				// row. Then sync whatever's now in memory into the IRC client
+				// for the next Connect attempt.
+				mytwitch.Reauth(context.Background(), "bot")
 				if tok := mytwitch.IRCAuthToken(); tok != "" {
 					client.SetIRCToken(tok)
 				} else {
-					// No valid in-memory token to fall back on — the refresh
-					// cron blanked it (revoked/invalid_grant). Surface the
-					// re-bootstrap link so re-auth is a click, not a task run.
-					slog.Error("IRC auth failed and no valid token to retry with; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
+					// Reauth couldn't produce a token (refresh_token revoked and
+					// no fresh row in the DB yet). Surface the re-bootstrap link
+					// so re-auth is a click; the landing page shows it too.
+					slog.Error("IRC auth failed and no valid token after reauth; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
 				}
 			}
 			time.Sleep(time.Minute)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -195,15 +195,16 @@ func startCron() {
 // loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
 // Non-fatal: when the row is missing (e.g. auth-bootstrap hasn't run yet
 // against a freshly-restored DB) or the DB is briefly unreachable, the bot
-// comes up with limited functionality and reports not-ready, polling in the
-// background until the token lands — rather than crashlooping. A crashing pod
-// after a wipe also raced the DB restore's migrate init (see the 2026-05-20
-// convergence-wipe notes); staying up-but-not-ready avoids that. Readiness,
-// not a process crash, is what keeps the bot out of service until it can talk
-// to Twitch.
+// comes up with limited functionality and polls in the background until the
+// token lands — rather than crashlooping. A crashing pod after a wipe also
+// raced the DB restore's migrate init (see the 2026-05-20 convergence-wipe
+// notes); staying up avoids that. The pod stays Ready throughout (readiness
+// no longer gates on Twitch) so the landing page + /auth/init are reachable
+// to re-auth; "not in chat" is surfaced via the landing page + the
+// tripbot_twitch_connected gauge instead.
 func loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
-		slog.WarnContext(ctx, "no usable Twitch token at boot; starting not-ready and polling",
+		slog.WarnContext(ctx, "no usable Twitch token at boot; starting without a chat connection and polling",
 			"login_as", c.Conf.BotUsername,
 			"fix", "task tripbot:auth:bootstrap",
 			"reauth_url", mytwitch.AuthInitURL("bot"),
@@ -280,12 +281,13 @@ func connectToTwitch() {
 	client.Join(c.Conf.ChannelName)
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
-	// Flip readiness on once the IRC connection is established so the
-	// readiness probe (/health/ready) reports live. Until then — and after
-	// any disconnect below — the pod stays up but not-ready.
+	// Mark the bot connected to chat once the IRC connection is established.
+	// This drives the landing-page status row + the tripbot_twitch_connected
+	// gauge — it does NOT gate /health/ready, which stays 200 so the pod keeps
+	// serving the landing page + /auth/* even while the bot is offline.
 	client.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
-		server.SetReady(true)
+		server.SetTwitchConnected(true)
 	})
 
 	// actually connect to Twitch
@@ -293,10 +295,10 @@ func connectToTwitch() {
 	for {
 		slog.Info("initializing connection to Twitch")
 		// Connect blocks while connected and returns when the connection
-		// drops; mark not-ready so the probe reflects the gap until the
-		// next OnConnect fires.
+		// drops; mark not-in-chat so the landing page + gauge reflect the gap
+		// until the next OnConnect fires.
 		err := client.Connect()
-		server.SetReady(false)
+		server.SetTwitchConnected(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -16,6 +16,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
@@ -112,6 +113,34 @@ func (a *App) uptimeCmd(ctx context.Context, user *users.User, _ []string) {
 	dur := time.Now().Sub(Uptime)
 	msg := fmt.Sprintf("I have been running for %s", durafmt.Parse(dur))
 	a.IRC.Say(msg)
+}
+
+func (a *App) followageCmd(ctx context.Context, user *users.User, params []string) {
+	slog.InfoContext(ctx, "ran !followage", "username", user.Username)
+
+	// bare !followage = the caller; !followage @user looks up someone else
+	username := user.Username
+	other := len(params) > 0
+	if other {
+		username = helpers.StripAtSign(params[0])
+	}
+
+	followedAt, ok := mytwitch.FollowedAt(username)
+	if !ok {
+		if other {
+			a.IRC.Say(fmt.Sprintf("@%s isn't following the channel.", username))
+		} else {
+			a.IRC.Say("You're not following yet — hit that follow button!")
+		}
+		return
+	}
+
+	dur := durafmt.Parse(time.Since(followedAt)).LimitFirstN(2)
+	if other {
+		a.IRC.Say(fmt.Sprintf("@%s has been following for %s.", username, dur))
+	} else {
+		a.IRC.Say(fmt.Sprintf("@%s, you've been following for %s. Thanks!", username, dur))
+	}
 }
 
 func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -36,6 +36,11 @@ func (a *App) buildRegistry() []Command {
 			Handler: a.uptimeCmd,
 		},
 		{
+			Trigger: "!followage",
+			Aliases: []string{"!followtime"},
+			Handler: a.followageCmd,
+		},
+		{
 			Trigger:        "!timewarp",
 			Aliases:        []string{"!timewrap", "!timeskip", "!tw", "!timewqrp", "!warp"},
 			Handler:        a.timewarpCmd,

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -105,7 +105,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!date",
-			Aliases:        []string{"!datw"},
+			Aliases:        []string{"!datw", "is this live", "is this live?"},
 			Handler:        a.dateCmd,
 			RequiresFollow: true,
 		},

--- a/pkg/eventsub/eventsub.go
+++ b/pkg/eventsub/eventsub.go
@@ -65,6 +65,20 @@ func Run(ctx context.Context, cfg Config, h Handlers) error {
 			"type", msg.Payload.Subscription.Type, "status", msg.Payload.Subscription.Status)
 	})
 
+	// Log every notification we receive, regardless of whether a typed
+	// handler above is registered for it. Cheap observability: shows in Loki
+	// what's actually firing in prod (and, by its absence, what isn't) so the
+	// per-event chat-shout treatment can be designed from real data later. The
+	// raw event JSON goes in the body, not a label — `type` is the only
+	// (low-cardinality) key worth filtering on.
+	client.OnRawEvent(func(event string, metadata twitch.MessageMetadata, subscription twitch.PayloadSubscription) {
+		slog.InfoContext(ctx, "eventsub event",
+			"type", string(subscription.Type),
+			"message_id", metadata.MessageID,
+			"payload", event,
+		)
+	})
+
 	if h.OnFollow != nil {
 		client.OnEventChannelFollow(func(e twitch.EventChannelFollow) {
 			h.OnFollow(e.UserName)

--- a/pkg/httpmw/health.go
+++ b/pkg/httpmw/health.go
@@ -1,0 +1,79 @@
+package httpmw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// readyCheckTimeout caps how long the whole /health/ready handler can
+// spend running its checks. Kubelet's default readiness timeout is 1s;
+// 2s here leaves enough headroom for one slow check to complete before
+// the probe gets cut, without letting a wedged dep hang the handler.
+const readyCheckTimeout = 2 * time.Second
+
+// ReadyCheck is one readiness condition the server should report on.
+// Name is rendered into the JSON response so probes (and humans) can
+// see which dep failed; Fn returns nil for healthy, error otherwise.
+type ReadyCheck struct {
+	Name string
+	Fn   func(ctx context.Context) error
+}
+
+// LivenessHandler returns 200 OK unconditionally. /health/live is the
+// kubelet's "is the process up at all?" signal — a failure here means
+// the pod gets restarted, so this should only fail if the process is
+// genuinely unrecoverable. Today that bar is "the goroutine is running
+// the handler at all," which 200 satisfies.
+func LivenessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK\n"))
+	}
+}
+
+// ReadinessHandler returns a handler that runs each check and reports
+// 200 if all pass, 503 if any fail. The JSON body lists per-check
+// status so a failing probe is debuggable from `kubectl describe pod`'s
+// probe output. With no checks, the handler always reports 200 —
+// equivalent to LivenessHandler but distinguishable on the URL. tripbot
+// registers it with no checks on purpose: its HTTP surface (landing page,
+// /auth/init, /auth/callback, /metrics) doesn't depend on the Twitch
+// connection, so the pod must stay in the Service even when the bot is
+// offline — otherwise the very page used to re-auth would 503.
+func ReadinessHandler(checks ...ReadyCheck) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), readyCheckTimeout)
+		defer cancel()
+
+		type result struct {
+			Name string `json:"name"`
+			OK   bool   `json:"ok"`
+			Err  string `json:"error,omitempty"`
+		}
+		out := make([]result, 0, len(checks))
+		allOK := true
+		for _, c := range checks {
+			err := c.Fn(ctx)
+			res := result{Name: c.Name, OK: err == nil}
+			if err != nil {
+				res.Err = err.Error()
+				allOK = false
+			}
+			out = append(out, res)
+		}
+
+		status := http.StatusOK
+		if !allOK {
+			status = http.StatusServiceUnavailable
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(struct {
+			OK     bool     `json:"ok"`
+			Checks []result `json:"checks"`
+		}{allOK, out})
+	}
+}

--- a/pkg/httpmw/health_test.go
+++ b/pkg/httpmw/health_test.go
@@ -1,0 +1,67 @@
+package httpmw
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLivenessHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	LivenessHandler()(rec, httptest.NewRequest(http.MethodGet, "/health/live", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestReadinessHandlerAllPass(t *testing.T) {
+	h := ReadinessHandler(
+		ReadyCheck{Name: "a", Fn: func(context.Context) error { return nil }},
+		ReadyCheck{Name: "b", Fn: func(context.Context) error { return nil }},
+	)
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/health/ready", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name string `json:"name"`
+			OK   bool   `json:"ok"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !body.OK || len(body.Checks) != 2 {
+		t.Fatalf("body = %+v, want ok=true and 2 checks", body)
+	}
+}
+
+func TestReadinessHandlerCheckFails(t *testing.T) {
+	h := ReadinessHandler(
+		ReadyCheck{Name: "a", Fn: func(context.Context) error { return nil }},
+		ReadyCheck{Name: "b", Fn: func(context.Context) error { return errors.New("nope") }},
+	)
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/health/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"name":"b"`) || !strings.Contains(rec.Body.String(), `"error":"nope"`) {
+		t.Fatalf("body should name the failing check, got %s", rec.Body.String())
+	}
+}
+
+func TestReadinessHandlerNoChecks(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ReadinessHandler()(rec, httptest.NewRequest(http.MethodGet, "/health/ready", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for empty check list", rec.Code)
+	}
+}

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -25,6 +25,7 @@ var (
 	scoreboardWrites  = mustCounter("tripbot_scoreboard_writes_total", "Total successful scoreboard score writes, labeled by scoreboard")
 	twitchSubscribers = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers   = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
+	twitchConnected   = mustGauge("tripbot_twitch_connected", "1 when the bot is connected to Twitch chat (IRC), 0 otherwise")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
 
 	twitchHelixRateRemaining = mustGauge("twitch_helix_rate_limit_remaining", "Last-seen Ratelimit-Remaining header from Twitch Helix responses (per app-access bearer)")
@@ -66,6 +67,13 @@ var ScoreboardWrites = scoreboardWritesIface{counter: scoreboardWrites}
 
 // TwitchAudience exposes subscriber and follower gauge recording.
 var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followers: twitchFollowers}
+
+// TwitchConnection exposes the chat-connection gauge. Set(true) on IRC
+// connect, Set(false) on disconnect. Readiness no longer gates on the Twitch
+// connection (the pod stays in the Service so the re-auth page is reachable),
+// so this gauge — alongside the landing-page status row — is what surfaces
+// "up but not in chat" to dashboards and alerts.
+var TwitchConnection = twitchConnectionIface{gauge: twitchConnected}
 
 // TwitchHelixErrors exposes the helix-error counter; record by calling
 // TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
@@ -129,6 +137,16 @@ func (a twitchAudienceIface) SetSubscribers(n int64) {
 
 func (a twitchAudienceIface) SetFollowers(n int64) {
 	a.followers.Record(context.Background(), n)
+}
+
+type twitchConnectionIface struct{ gauge metric.Int64Gauge }
+
+func (t twitchConnectionIface) Set(connected bool) {
+	var v int64
+	if connected {
+		v = 1
+	}
+	t.gauge.Record(context.Background(), v)
 }
 
 type twitchHelixErrorsIface struct{ counter metric.Int64Counter }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/nicklaw5/helix/v2"
@@ -36,33 +37,28 @@ func SetVersion(v string) {
 	}
 }
 
-// ready reports whether the bot has established its Twitch IRC connection.
-// /health/ready returns 503 until it flips true, so the orchestrator keeps
-// the pod running (no crashloop) but marks it not-live until Twitch is
-// reachable. cmd/tripbot flips it via SetReady on IRC connect / disconnect.
-var ready atomic.Bool
+// twitchConnected reports whether the bot currently has its Twitch IRC
+// connection. It deliberately does NOT gate the readiness probe: /health/ready
+// is always 200 once the HTTP server is up (see httpmw.ReadinessHandler), so
+// the landing page, /auth/init and /auth/callback stay reachable through the
+// Ingress even when the bot is offline — otherwise the very page used to
+// re-auth a disconnected bot would 503. Instead this flag drives the
+// landing-page status row and the tripbot_twitch_connected gauge, so "up but
+// not in chat" is surfaced without pulling the pod out of the Service.
+// cmd/tripbot flips it via SetTwitchConnected on IRC connect / disconnect.
+var twitchConnected atomic.Bool
 
-// SetReady updates the readiness state reported by /health/ready.
-func SetReady(r bool) {
-	ready.Store(r)
+// SetTwitchConnected updates the chat-connection signal: the in-memory flag
+// the landing page reads and the tripbot_twitch_connected gauge.
+func SetTwitchConnected(connected bool) {
+	twitchConnected.Store(connected)
+	instrumentation.TwitchConnection.Set(connected)
 }
 
-// liveHandler is the liveness probe: the process is up and serving HTTP.
-// Always 200 — a failing liveness probe restarts the pod, which is exactly
-// what we want to avoid while waiting on Twitch.
-func liveHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "OK")
-}
-
-// readyHandler is the readiness probe: 200 once the Twitch IRC connection is
-// established, 503 otherwise. Keeps the pod up but not-live until Twitch is
-// reachable, and recovers on its own once the connection lands.
-func readyHandler(w http.ResponseWriter, r *http.Request) {
-	if !ready.Load() {
-		http.Error(w, "not ready: awaiting Twitch connection", http.StatusServiceUnavailable)
-		return
-	}
-	fmt.Fprintf(w, "OK")
+// TwitchConnected reports the last-known chat-connection state, for the
+// landing page's status row.
+func TwitchConnected() bool {
+	return twitchConnected.Load()
 }
 
 // versionHandler returns build metadata as JSON. The tag comes from the

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -11,41 +11,21 @@ import (
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 )
 
-func TestLiveHandler(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/health/live", nil)
-	rec := httptest.NewRecorder()
+// TestTwitchConnectedSignal pins the behavior split this PR introduces: the
+// chat-connection signal round-trips, but it's decoupled from the readiness
+// probe. The probe itself (httpmw.ReadinessHandler with no checks → always
+// 200) is covered in pkg/httpmw; here we just guard the signal accessors.
+func TestTwitchConnectedSignal(t *testing.T) {
+	defer SetTwitchConnected(false) // reset package state for other tests
 
-	liveHandler(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
-	}
-	if rec.Body.String() != "OK" {
-		t.Fatalf("got body %q, want %q", rec.Body.String(), "OK")
-	}
-}
-
-func TestReadyHandler(t *testing.T) {
-	defer SetReady(false) // reset package state for other tests
-
-	// not ready by default: 503
-	SetReady(false)
-	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
-	rec := httptest.NewRecorder()
-	readyHandler(rec, req)
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("not-ready: got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	SetTwitchConnected(false)
+	if TwitchConnected() {
+		t.Fatalf("after SetTwitchConnected(false), TwitchConnected() = true, want false")
 	}
 
-	// ready once Twitch connection is established: 200
-	SetReady(true)
-	rec = httptest.NewRecorder()
-	readyHandler(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("ready: got status %d, want %d", rec.Code, http.StatusOK)
-	}
-	if rec.Body.String() != "OK" {
-		t.Fatalf("ready: got body %q, want %q", rec.Body.String(), "OK")
+	SetTwitchConnected(true)
+	if !TwitchConnected() {
+		t.Fatalf("after SetTwitchConnected(true), TwitchConnected() = false, want true")
 	}
 }
 

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -129,14 +129,18 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
-		OK:         ready.Load(),
+		OK:         twitchConnected.Load(),
 		Version:    versionTag,
 		VersionURL: changelogURL(sha),
 	}
 	if tripbot.OK {
-		tripbot.Detail = "ready"
+		tripbot.Detail = "in chat"
 	} else {
-		tripbot.Detail = "degraded (awaiting Twitch)"
+		// The pod is up and serving this page — readiness no longer gates on
+		// the Twitch connection — but the bot isn't connected to chat. The red
+		// dot + this label is how that's surfaced; the re-auth links below
+		// cover the common cause (a missing/expired token).
+		tripbot.Detail = "not in chat"
 	}
 
 	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -33,6 +33,10 @@ var (
 	// chatterCount is the in-memory count of users in chat, refreshed ~60s by
 	// the UpdateSession cron. Overridable in tests.
 	chatterCount = mytwitch.ChatterCount
+	// accountsNeedingReauth reports which Twitch accounts have a missing/expired
+	// token; the landing page renders a re-auth prompt for each. Overridable in
+	// tests. Reads in-memory token state — no DB or network call.
+	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
 )
 
 const (
@@ -86,6 +90,7 @@ type landingData struct {
 	Services []serviceStatus
 	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
 	Links    []navLink
+	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
 // landingHandler serves the human-facing root page on the tripbot Ingress: a
@@ -112,6 +117,7 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
 		Now:      currentVideo(vlcOK),
 		Links:    gatherLinks(),
+		Reauth:   accountsNeedingReauth(),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -304,6 +310,14 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
+  /* re-auth callout: only rendered when a token is missing/expired */
+  .reauth { background:#3a1d00; border:1px solid #6b3b00; border-radius:8px; padding:14px 16px; margin:0 0 24px; }
+  .reauth h2 { margin:0 0 8px; color:#ffb454; }
+  .reauth p { margin:0 0 10px; color:#e8c89a; font-size:.9em; }
+  .reauth .btns { display:flex; flex-wrap:wrap; gap:10px; }
+  .reauth a.btn { display:inline-block; background:#ffb454; color:#1a1100; font-weight:600; padding:8px 14px; border-radius:6px; }
+  .reauth a.btn:hover { background:#ffc578; color:#1a1100; }
+  .reauth .why { font-family:var(--mono); font-size:.85em; opacity:.85; }
 </style>
 </head>
 <body>
@@ -314,6 +328,16 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   <h1>tripbot <code class="env">{{.Env}}</code></h1>
   <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
+
+  {{if .Reauth}}
+  <div class="reauth">
+    <h2>action needed: re-authenticate</h2>
+    <p>tripbot can't talk to Twitch until these accounts are re-authorized. Sign in as the named account on each — the flow re-prompts which account to use, so sign out of Twitch (or use a private window) if it grabs the wrong one.</p>
+    <div class="btns">
+      {{range .Reauth}}<a class="btn" href="{{.InitURL}}">Sign in as {{.LoginAs}} <span class="why">({{.Account}} · {{.Reason}})</span></a>{{end}}
+    </div>
+  </div>
+  {{end}}
 
   <h2>status</h2>
   <ul>

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -49,7 +49,10 @@ const (
 	// in kube-system as a single prod-zone install shared across envs, so
 	// (unlike OBS) they aren't derived per-environment.
 	traefikURL = "https://traefik.prod.whereisdana.today"
-	hubbleURL  = "https://hubble.prod.whereisdana.today"
+	// hubbleURL carries ?namespace=prod-1 so the link lands straight in prod-1's
+	// flow view instead of Hubble's "choose a namespace" page. (Single prod-zone
+	// install, so the namespace is fixed, not per-env.)
+	hubbleURL = "https://hubble.prod.whereisdana.today/?namespace=prod-1"
 )
 
 // serviceStatus is one row in the landing page's status table.

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -39,6 +40,7 @@ func TestChangelogURL(t *testing.T) {
 func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
+	withReauth(t, nil) // healthy tokens — no re-auth callout
 
 	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -106,6 +108,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
+	withReauth(t, nil)
 
 	withConf(t, func() {
 		// unroutable host → ping fails fast / times out → vlc shown unreachable
@@ -168,4 +171,63 @@ func withChatterCount(t *testing.T, n int) {
 	saved := chatterCount
 	chatterCount = func() int { return n }
 	t.Cleanup(func() { chatterCount = saved })
+}
+
+// withReauth swaps the accountsNeedingReauth seam so the landing handler sees a
+// fixed re-auth list without depending on global in-memory token state.
+func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
+	t.Helper()
+	saved := accountsNeedingReauth
+	accountsNeedingReauth = func() []mytwitch.AccountReauth { return accounts }
+	t.Cleanup(func() { accountsNeedingReauth = saved })
+}
+
+func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(false)
+
+	withConf(t, func() {
+		c.Conf.VlcServerHost = "" // skip the vlc ping
+		c.Conf.ChannelName = "adanalife_"
+		c.Conf.BotUsername = "tripbot4000"
+		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
+	})
+	withReauth(t, []mytwitch.AccountReauth{
+		{Account: "bot", LoginAs: "tripbot4000", Reason: "missing", InitURL: "https://tripbot.prod.whereisdana.today/auth/init?account=bot&login_as=tripbot4000"},
+		{Account: "broadcaster", LoginAs: "adanalife_", Reason: "expired", InitURL: "https://tripbot.prod.whereisdana.today/auth/init?account=broadcaster&login_as=adanalife_"},
+	})
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"action needed: re-authenticate",
+		// html/template escapes & as &amp; in attribute values (valid HTML).
+		`href="https://tripbot.prod.whereisdana.today/auth/init?account=bot&amp;login_as=tripbot4000"`,
+		"Sign in as tripbot4000",
+		"(bot · missing)",
+		`href="https://tripbot.prod.whereisdana.today/auth/init?account=broadcaster&amp;login_as=adanalife_"`,
+		"Sign in as adanalife_",
+		"(broadcaster · expired)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestLandingHandler_NoReauthPromptWhenHealthy(t *testing.T) {
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(true)
+
+	withConf(t, func() { c.Conf.VlcServerHost = "" })
+	withReauth(t, nil) // all tokens healthy
+
+	rec := httptest.NewRecorder()
+	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if strings.Contains(rec.Body.String(), "re-authenticate") {
+		t.Errorf("re-auth prompt should be hidden when no account needs re-auth")
+	}
 }

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -37,8 +37,8 @@ func TestChangelogURL(t *testing.T) {
 }
 
 func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
-	defer SetReady(false)
-	SetReady(true)
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(true)
 
 	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	for _, want := range []string{
 		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
 		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
-		"ready",                     // tripbot status
+		"in chat",                   // tripbot chat-connection status
 		"healthy",                   // vlc status
 		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
 		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
@@ -104,8 +104,8 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 }
 
 func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
-	defer SetReady(false)
-	SetReady(false)
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(false)
 
 	withConf(t, func() {
 		// unroutable host → ping fails fast / times out → vlc shown unreachable
@@ -124,8 +124,8 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "degraded") {
-		t.Errorf("body should report tripbot degraded; got %q", body)
+	if !strings.Contains(body, "not in chat") {
+		t.Errorf("body should report tripbot not in chat; got %q", body)
 	}
 	if !strings.Contains(body, "unreachable") {
 		t.Errorf("body should report vlc unreachable; got %q", body)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,8 +45,12 @@ func Start(ctx context.Context) {
 
 	// healthcheck endpoints
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
-	hp.Handle("/live", tagged("/health/live", liveHandler))
-	hp.Handle("/ready", tagged("/health/ready", readyHandler))
+	hp.Handle("/live", tagged("/health/live", httpmw.LivenessHandler()))
+	// /ready runs no checks: tripbot's HTTP surface (landing page, /auth/init,
+	// /auth/callback, /metrics) doesn't depend on the Twitch connection, so the
+	// pod must stay routable even when the bot is offline. Chat-connection is
+	// surfaced via the landing page + the tripbot_twitch_connected gauge.
+	hp.Handle("/ready", tagged("/health/ready", httpmw.ReadinessHandler()))
 
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -289,6 +289,61 @@ func BroadcasterUserAccessToken() string {
 	return currentBroadcasterToken.AccessToken
 }
 
+// AccountReauth describes an account whose in-memory token is missing or
+// expired and therefore needs operator re-auth. The landing page renders one
+// "Sign in as <LoginAs>" link per entry, pointing at InitURL.
+type AccountReauth struct {
+	Account string // "bot" | "broadcaster" — the /auth/init account selector
+	LoginAs string // the exact Twitch username to sign in as
+	Reason  string // "missing" | "expired" — why re-auth is needed
+	InitURL string // /auth/init URL for this account
+}
+
+// tokenReason classifies a loaded token: "" when usable, else "missing"
+// (never loaded, or blanked by a failed refresh / invalid_grant) or
+// "expired" (loaded but past ExpiresAt — a narrow window, since the refresh
+// cron normally rotates 30m ahead).
+func tokenReason(t oauthtokens.Token) string {
+	if t.AccessToken == "" {
+		return "missing"
+	}
+	if !t.ExpiresAt.IsZero() && time.Now().After(t.ExpiresAt) {
+		return "expired"
+	}
+	return ""
+}
+
+// AccountsNeedingReauth returns the bot and/or broadcaster accounts whose
+// in-memory token is missing or expired, so the landing page can prompt for
+// re-auth. Returns nil when everything's healthy. The broadcaster is only
+// considered when a distinct broadcaster identity exists (ChannelName set and
+// != BotUsername) — otherwise there's no separate row to re-auth.
+func AccountsNeedingReauth() []AccountReauth {
+	tokenMu.RLock()
+	botReason := tokenReason(currentUserToken)
+	bcastReason := tokenReason(currentBroadcasterToken)
+	tokenMu.RUnlock()
+
+	var out []AccountReauth
+	if botReason != "" {
+		out = append(out, AccountReauth{
+			Account: "bot",
+			LoginAs: c.Conf.BotUsername,
+			Reason:  botReason,
+			InitURL: AuthInitURL("bot"),
+		})
+	}
+	if c.Conf.ChannelName != "" && c.Conf.ChannelName != c.Conf.BotUsername && bcastReason != "" {
+		out = append(out, AccountReauth{
+			Account: "broadcaster",
+			LoginAs: c.Conf.ChannelName,
+			Reason:  bcastReason,
+			InitURL: AuthInitURL("broadcaster"),
+		})
+	}
+	return out
+}
+
 // ErrIdentityMismatch is returned by GenerateUserAccessToken when the
 // discovered identity (via helix.GetUsers) doesn't match expectedLogin.
 // Callers should surface it with retry guidance; the wrong-identity row is

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -413,7 +413,9 @@ func GenerateUserAccessToken(code string, expectedLogin string) error {
 	if usersResp == nil {
 		return errors.New("twitch: nil response from GetUsers")
 	}
-	if checkHelixResp("GetUsers", &usersResp.ResponseCommon) {
+	// account="" — mid-bootstrap, re-reading the (not-yet-written) token would
+	// be wrong; surface the failure to the caller instead.
+	if checkHelixResp(context.Background(), "GetUsers", "", &usersResp.ResponseCommon) {
 		return fmt.Errorf("twitch: GetUsers returned %d during bootstrap", usersResp.StatusCode)
 	}
 	if len(usersResp.Data.Users) == 0 {
@@ -479,10 +481,36 @@ func RefreshUserAccessToken(ctx context.Context) {
 	botUser := c.Conf.BotUsername
 	broadcasterUser := c.Conf.ChannelName
 
-	refreshOne(ctx, botUser, applyBotToken)
+	refreshOne(ctx, botUser, applyBotToken, false)
 
 	if broadcasterUser != "" && broadcasterUser != botUser {
-		refreshOne(ctx, broadcasterUser, applyBroadcasterToken)
+		refreshOne(ctx, broadcasterUser, applyBroadcasterToken, false)
+	}
+}
+
+// Reauth re-establishes a usable user-access-token for the given account
+// ("bot" | "broadcaster") after an auth failure — an IRC login rejection or a
+// Helix 401. It forces a refresh via the stored refresh_token (skipping the
+// normal 30-minute pre-expiry window), then re-reads the row from the DB. The
+// DB is the source of truth: this picks up a token just written by the
+// auth-bootstrap flow (or by another tripbot's refresh) without a process
+// restart. When neither yields a usable token — e.g. a DB-restored row whose
+// refresh_token is also revoked — the in-memory slot is left blanked and the
+// reauth link is logged; the landing page's re-auth prompt then covers it.
+func Reauth(ctx context.Context, account string) {
+	username := c.Conf.BotUsername
+	apply := applyBotToken
+	if account == "broadcaster" {
+		username = c.Conf.ChannelName
+		apply = applyBroadcasterToken
+	}
+	refreshOne(ctx, username, apply, true)
+	// Re-read regardless of the refresh outcome: a concurrent auth-bootstrap
+	// may have written a fresh token that a refresh with the (also-stale)
+	// refresh_token couldn't produce.
+	if err := LoadFromDB(); err != nil {
+		slog.WarnContext(ctx, "reauth: no usable token after refresh + DB re-read",
+			"err", err, "login_as", username, "reauth_url", AuthInitURL(account))
 	}
 }
 
@@ -514,9 +542,15 @@ func applyBroadcasterToken(tok oauthtokens.Token) {
 // matching in-memory slot — also called on the empty-token path so the
 // caller's slot gets blanked (forcing reconnect / re-bootstrap signalling).
 //
+// force skips the 30-minute pre-expiry window: the hourly cron passes false
+// (only rotate when close to expiry), while Reauth passes true to rotate
+// immediately after an auth failure regardless of the stored ExpiresAt (which
+// is unreliable after a DB restore — the dump's expiry says "valid" but Twitch
+// has already invalidated the token).
+//
 // TODO: helix client surface should move behind an interface so this
 // function can be unit-tested without a real Twitch round-trip.
-func refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token)) {
+func refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token), force bool) {
 	acquired, release, err := oauthtokens.TryRefreshLock("twitch", username)
 	if err != nil {
 		slog.ErrorContext(ctx, "oauth refresh lock acquisition failed", "err", err, "username", username)
@@ -542,7 +576,7 @@ func refreshOne(ctx context.Context, username string, applyInMemory func(oauthto
 		return
 	}
 
-	if time.Until(t.ExpiresAt) > 30*time.Minute {
+	if !force && time.Until(t.ExpiresAt) > 30*time.Minute {
 		return
 	}
 

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -234,3 +234,76 @@ func TestIRCAuthToken_ConcurrentReads(t *testing.T) {
 		}
 	}
 }
+
+// withReauthConf sets the bot/broadcaster identities AccountsNeedingReauth
+// reads and restores them afterward.
+func withReauthConf(t *testing.T, bot, channel string) {
+	t.Helper()
+	savedBot, savedChan := c.Conf.BotUsername, c.Conf.ChannelName
+	c.Conf.BotUsername, c.Conf.ChannelName = bot, channel
+	t.Cleanup(func() { c.Conf.BotUsername, c.Conf.ChannelName = savedBot, savedChan })
+}
+
+func setTokens(t *testing.T, bot, bcast oauthtokens.Token) {
+	t.Helper()
+	resetToken(t)
+	resetBroadcasterToken(t)
+	tokenMu.Lock()
+	currentUserToken, currentBroadcasterToken = bot, bcast
+	tokenMu.Unlock()
+}
+
+func TestAccountsNeedingReauth_AllHealthy(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	future := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, future, future)
+
+	if got := AccountsNeedingReauth(); got != nil {
+		t.Fatalf("AccountsNeedingReauth() = %+v, want nil when both tokens are healthy", got)
+	}
+}
+
+func TestAccountsNeedingReauth_BotMissing(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, oauthtokens.Token{}, healthy) // bot blank → missing
+
+	got := AccountsNeedingReauth()
+	if len(got) != 1 {
+		t.Fatalf("got %d accounts, want 1: %+v", len(got), got)
+	}
+	if got[0].Account != "bot" || got[0].Reason != "missing" || got[0].LoginAs != "tripbot4000" {
+		t.Errorf("entry = %+v, want bot/missing/tripbot4000", got[0])
+	}
+	if !strings.Contains(got[0].InitURL, "account=bot") {
+		t.Errorf("InitURL %q should target the bot account", got[0].InitURL)
+	}
+}
+
+func TestAccountsNeedingReauth_BroadcasterExpired(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	expired := oauthtokens.Token{AccessToken: "stale", ExpiresAt: time.Now().Add(-time.Hour)}
+	setTokens(t, healthy, expired)
+
+	got := AccountsNeedingReauth()
+	if len(got) != 1 {
+		t.Fatalf("got %d accounts, want 1: %+v", len(got), got)
+	}
+	if got[0].Account != "broadcaster" || got[0].Reason != "expired" {
+		t.Errorf("entry = %+v, want broadcaster/expired", got[0])
+	}
+}
+
+// When the bot and broadcaster are the same account, there's no separate
+// broadcaster row — a blank broadcaster slot must not produce a phantom
+// re-auth prompt.
+func TestAccountsNeedingReauth_NoSeparateBroadcaster(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "tripbot4000")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, healthy, oauthtokens.Token{}) // broadcaster slot blank, but irrelevant
+
+	if got := AccountsNeedingReauth(); got != nil {
+		t.Fatalf("AccountsNeedingReauth() = %+v, want nil when no distinct broadcaster identity", got)
+	}
+}

--- a/pkg/twitch/helix_resp.go
+++ b/pkg/twitch/helix_resp.go
@@ -1,8 +1,10 @@
 package twitch
 
 import (
-	"log/slog"
+	"context"
 	"fmt"
+	"log/slog"
+	"net/http"
 
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/nicklaw5/helix/v2"
@@ -22,11 +24,20 @@ import (
 // When this returns true, callers should log + early-return rather than
 // trust resp.Data. endpoint is a short label used as the metric attribute
 // (e.g. "GetUsers"); it should match the helix client method name.
-func checkHelixResp(endpoint string, resp *helix.ResponseCommon) bool {
+//
+// account names the identity the call authorized against ("bot" |
+// "broadcaster"); on a 401 it triggers Reauth so the stale user-access-token
+// is re-established from the DB and the next call uses a fresh one. Pass ""
+// to opt out — for app-access-token calls (getChannelID's GetUsers) and the
+// mid-bootstrap GetUsers, where re-reading a user token wouldn't help.
+func checkHelixResp(ctx context.Context, endpoint, account string, resp *helix.ResponseCommon) bool {
 	if resp == nil || resp.StatusCode < 400 {
 		return false
 	}
-	slog.Error(fmt.Sprintf("helix %s returned %d: %s", endpoint, resp.StatusCode, resp.ErrorMessage))
+	slog.ErrorContext(ctx, fmt.Sprintf("helix %s returned %d: %s", endpoint, resp.StatusCode, resp.ErrorMessage))
 	instrumentation.TwitchHelixErrors.Inc(endpoint, resp.StatusCode)
+	if resp.StatusCode == http.StatusUnauthorized && account != "" {
+		Reauth(ctx, account)
+	}
 	return true
 }

--- a/pkg/twitch/helix_resp_test.go
+++ b/pkg/twitch/helix_resp_test.go
@@ -1,20 +1,21 @@
 package twitch
 
 import (
+	"context"
 	"testing"
 
 	"github.com/nicklaw5/helix/v2"
 )
 
 func TestCheckHelixResp_NilResponse(t *testing.T) {
-	if checkHelixResp("GetUsers", nil) {
+	if checkHelixResp(context.Background(), "GetUsers", "", nil) {
 		t.Fatal("nil response should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_Success(t *testing.T) {
 	rc := &helix.ResponseCommon{StatusCode: 200}
-	if checkHelixResp("GetUsers", rc) {
+	if checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("200 should not be treated as an error")
 	}
 }
@@ -22,23 +23,34 @@ func TestCheckHelixResp_Success(t *testing.T) {
 func TestCheckHelixResp_NoContent(t *testing.T) {
 	// 204 is still success — guard against >= 400, not != 200
 	rc := &helix.ResponseCommon{StatusCode: 204}
-	if checkHelixResp("GetUsers", rc) {
+	if checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("204 should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_ClientError(t *testing.T) {
 	// 403 was the concrete 2026-05-15 incident: bot lost mod scope on the
-	// channel, GetChannelChatChatters returned 403 with empty Data.
+	// channel, GetChannelChatChatters returned 403 with empty Data. 403 is a
+	// scope problem, not a stale token — no reauth, but still flagged.
 	rc := &helix.ResponseCommon{StatusCode: 403, ErrorMessage: "insufficient scope"}
-	if !checkHelixResp("GetChannelChatChatters", rc) {
+	if !checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", rc) {
 		t.Fatal("403 should be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_ServerError(t *testing.T) {
 	rc := &helix.ResponseCommon{StatusCode: 503, ErrorMessage: "unavailable"}
-	if !checkHelixResp("GetSubscriptions", rc) {
+	if !checkHelixResp(context.Background(), "GetSubscriptions", "broadcaster", rc) {
 		t.Fatal("5xx should be treated as an error")
+	}
+}
+
+// A 401 with account="" must still report the error but must NOT trigger
+// Reauth (which would make a live Twitch refresh call) — the app-token and
+// mid-bootstrap callsites rely on this opt-out.
+func TestCheckHelixResp_UnauthorizedNoAccountSkipsReauth(t *testing.T) {
+	rc := &helix.ResponseCommon{StatusCode: 401, ErrorMessage: "invalid oauth token"}
+	if !checkHelixResp(context.Background(), "GetUsers", "", rc) {
+		t.Fatal("401 should be treated as an error")
 	}
 }

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -177,6 +178,41 @@ func UserIsFollower(username string) bool {
 	}
 	return true
 
+}
+
+// FollowedAt returns when username started following the channel, and whether
+// they follow at all. Like UserIsFollower, it authorizes against the
+// broadcaster identity (moderator:read:followers) and fails closed: ok=false
+// when the broadcaster token isn't loaded, the lookup errors, or the user
+// doesn't follow.
+func FollowedAt(username string) (time.Time, bool) {
+	if !broadcasterTokenLoaded() {
+		return time.Time{}, false
+	}
+	bclient, err := BroadcasterClient()
+	if err != nil {
+		slog.Error("broadcaster helix client unavailable", "err", err)
+		return time.Time{}, false
+	}
+
+	userID := getChannelID(username)
+
+	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
+		BroadcasterID: ChannelID,
+		UserID:        userID,
+	})
+	if err != nil {
+		slog.Error("error getting user follows", "err", err)
+		return time.Time{}, false
+	}
+	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+		return time.Time{}, false
+	}
+
+	if resp.Data.Total < 1 || len(resp.Data.Channels) < 1 {
+		return time.Time{}, false
+	}
+	return resp.Data.Channels[0].Followed.Time, true
 }
 
 // broadcasterTokenLoaded reports whether the broadcaster's user-access-token

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -36,7 +36,9 @@ func getChannelID(username string) string {
 		slog.Error("empty response from twitch")
 		return ""
 	}
-	if checkHelixResp("GetUsers", &resp.ResponseCommon) {
+	// account="" — GetUsers here authorizes against the app-access-token, not a
+	// user token, so re-reading a user token wouldn't fix a 401.
+	if checkHelixResp(context.Background(), "GetUsers", "", &resp.ResponseCommon) {
 		return ""
 	}
 
@@ -74,7 +76,7 @@ func GetSubscribers(ctx context.Context) {
 		slog.ErrorContext(ctx, "error getting subscriptions from twitch", "err", err)
 		return
 	}
-	if checkHelixResp("GetSubscriptions", &resp.ResponseCommon) {
+	if checkHelixResp(ctx, "GetSubscriptions", "broadcaster", &resp.ResponseCommon) {
 		// keep the prior subscriber list rather than zeroing it out
 		return
 	}
@@ -119,7 +121,7 @@ func GetFollowerCount(ctx context.Context) {
 		slog.ErrorContext(ctx, "error getting follower count from twitch", "err", err)
 		return
 	}
-	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+	if checkHelixResp(ctx, "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		return
 	}
 	instrumentation.TwitchAudience.SetFollowers(int64(resp.Data.Total))
@@ -165,7 +167,7 @@ func UserIsFollower(username string) bool {
 		slog.Error("error getting user follows", "err", err)
 		return false
 	}
-	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+	if checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		// fail closed: when we can't verify follow status, treat as non-follower
 		return false
 	}

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -205,7 +205,7 @@ func FollowedAt(username string) (time.Time, bool) {
 		slog.Error("error getting user follows", "err", err)
 		return time.Time{}, false
 	}
-	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+	if checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		return time.Time{}, false
 	}
 

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -1,7 +1,9 @@
 package twitch
 
 import (
+	"context"
 	"log/slog"
+
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/nicklaw5/helix/v2"
 )
@@ -55,7 +57,7 @@ func UpdateChatters() {
 		slog.Error("error getting chatters from twitch", "err", err)
 		return
 	}
-	if checkHelixResp("GetChannelChatChatters", &resp.ResponseCommon) {
+	if checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", &resp.ResponseCommon) {
 		// don't overwrite cached chatter state with an empty response —
 		// 4xx here means the bot lost a scope or moderator role and the
 		// next call probably succeeds once that's fixed.


### PR DESCRIPTION
## Release v2.14.0 (minor)

develop → master. Merging this (as a **merge commit**, per the release convention) fires auto-tag (`#minor` → `v2.14.0`) → release.yml builds the multi-arch images and publishes `:latest`.

### Headline

tripbot's readiness probe is **decoupled from the Twitch connection** — the pod stays in the Service (and the landing page + OAuth endpoints stay reachable) even when the bot is offline, so the page used to re-auth a disconnected bot is no longer 503'd by the very outage it fixes. The landing page now **surfaces re-auth links** when a token is missing/expired, and stale tokens **self-heal** by re-reading `oauth_tokens` from the DB on an IRC/Helix auth failure — no manual roll after a DB restore.

### Included (7 PRs since v2.13.1)

| PR | |
|----|--|
| #634 | Readiness decoupled from Twitch; `tripbot_twitch_connected` gauge |
| #635 | OAuth re-auth links on the landing page |
| #636 | Self-heal stale tokens (re-read DB on auth failure) |
| #633 | EventSub: log every received event via `OnRawEvent` |
| #632 | `!followage` command |
| #631 | "is this live" → `!date` alias |
| #630 | Landing Hubble link → prod-1 namespace |

Full notes in the CHANGELOG diff.

### After merge

Roll out **stage-1 first** for verification (see the test plan), then prod-1. Prereq for the re-auth click flow: register `https://tripbot.stage.whereisdana.today/auth/callback` on the stage Twitch app.
