### PR TITLE
fix(twitch): repair develop build — FollowedAt checkHelixResp signature

### DIFF
--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -205,7 +205,7 @@ func FollowedAt(username string) (time.Time, bool) {
 		slog.Error("error getting user follows", "err", err)
 		return time.Time{}, false
 	}
-	if checkHelixResp("GetChannelFollows", &resp.ResponseCommon) {
+	if checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		return time.Time{}, false
 	}
 


### PR DESCRIPTION
## What

One-line fix: `FollowedAt`'s `checkHelixResp` call now uses the current 4-arg signature `(ctx, endpoint, account, resp)`.

## Why — develop doesn't currently compile

A latent semantic conflict between two PRs that merged to develop:

- **#632** (`!followage`) added a `checkHelixResp("GetChannelFollows", &resp.ResponseCommon)` call in the new `FollowedAt`.
- **#636** (token self-heal) changed `checkHelixResp`'s signature to `(ctx, endpoint, account, resp)` and updated every callsite that existed at the time.

They don't textually conflict, and each PR's CI was green against a base that lacked the other — so the break only surfaced once both were on develop. `go build ./cmd/tripbot` fails:

```
pkg/twitch/twitch.go:208:41: not enough arguments in call to checkHelixResp
	have (string, *helix.ResponseCommon)
	want (context.Context, string, string, *helix.ResponseCommon)
```

Caught by the build job on the v2.14.0 release PR (#637). `go test` didn't catch it locally on either PR for the same base-skew reason.

`FollowedAt` is a broadcaster-token path with no `ctx` in scope, so it passes `context.Background()` + `"broadcaster"` — matching the sibling `GetChannelFollows` callsites (a 401 there triggers a broadcaster re-auth).

## Test plan

- [x] `CGO_ENABLED=0 go build ./cmd/tripbot ./cmd/auth-bootstrap` (mirrors the failing Dockerfile build) — passes
- [x] `task test:macos` green
