### PR TITLE
landing: derive Hubble link namespace from the environment

### DIFF
--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -49,10 +49,11 @@ const (
 	// in kube-system as a single prod-zone install shared across envs, so
 	// (unlike OBS) they aren't derived per-environment.
 	traefikURL = "https://traefik.prod.whereisdana.today"
-	// hubbleURL carries ?namespace=prod-1 so the link lands straight in prod-1's
-	// flow view instead of Hubble's "choose a namespace" page. (Single prod-zone
-	// install, so the namespace is fixed, not per-env.)
-	hubbleURL = "https://hubble.prod.whereisdana.today/?namespace=prod-1"
+	// hubbleBaseURL is the single prod-zone Hubble install on the mini-PC
+	// cluster. gatherLinks appends ?namespace=<env's namespace> so the link
+	// lands straight in that namespace's flow view instead of Hubble's "choose
+	// a namespace" page — see hubbleNamespace.
+	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
 )
 
 // serviceStatus is one row in the landing page's status table.
@@ -242,9 +243,22 @@ func gatherLinks() []navLink {
 	links = append(links,
 		navLink{Label: "grafana", URL: grafanaURL},
 		navLink{Label: "traefik", URL: traefikURL},
-		navLink{Label: "hubble", URL: hubbleURL},
+		navLink{Label: "hubble", URL: hubbleBaseURL + "?namespace=" + hubbleNamespace()},
 	)
 	return links
+}
+
+// hubbleNamespace returns the Kubernetes namespace to deep-link the Hubble flow
+// view at. Hubble is a single prod-zone install on the mini-PC cluster where
+// stage-1 and prod-1 co-tenant — the only namespaces it shows — and ENV
+// distinguishes them: production → prod-1, staging → stage-1. dev/local also
+// report ENV=staging (so they resolve to stage-1), but they run on a separate
+// cluster Hubble doesn't cover, so their link is moot regardless.
+func hubbleNamespace() string {
+	if c.Conf.IsProduction() {
+		return "prod-1"
+	}
+	return "stage-1"
 }
 
 // changelogURL links to CHANGELOG.md as of the deployed commit, so it shows the

--- a/pkg/server/landing_test.go
+++ b/pkg/server/landing_test.go
@@ -28,6 +28,22 @@ func TestSiblingURL(t *testing.T) {
 	}
 }
 
+func TestHubbleNamespace(t *testing.T) {
+	saved := c.Conf.Environment
+	t.Cleanup(func() { c.Conf.Environment = saved })
+	cases := map[string]string{
+		"production":  "prod-1",
+		"staging":     "stage-1",
+		"development": "stage-1", // shares ENV=staging; link is moot on its cluster
+	}
+	for env, want := range cases {
+		c.Conf.Environment = env
+		if got := hubbleNamespace(); got != want {
+			t.Errorf("hubbleNamespace() with ENV=%q = %q, want %q", env, got, want)
+		}
+	}
+}
+
 func TestChangelogURL(t *testing.T) {
 	if got, want := changelogURL("deadbeef"), githubURL+"/blob/deadbeef/CHANGELOG.md"; got != want {
 		t.Errorf("changelogURL(sha) = %q, want %q", got, want)
@@ -97,7 +113,8 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		"https://obs.prod.whereisdana.today",  // derived OBS href
 		grafanaURL,                            // grafana href
 		traefikURL,                            // traefik href
-		hubbleURL,                             // hubble href
+		// Environment is "production" above → hubble link carries ?namespace=prod-1
+		"https://hubble.prod.whereisdana.today/?namespace=prod-1",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)


### PR DESCRIPTION
## What

The landing-page **Hubble** link now derives its `?namespace=` from the running environment instead of being hardcoded to `prod-1` (#630): the stage-1 page deep-links into `stage-1`'s flow view, prod-1's into `prod-1`'s.

## Why

Hubble is a single prod-zone install on the mini-PC cluster where stage-1 and prod-1 co-tenant — those are the only namespaces it shows — so the deep link should match the env you're looking at. `ENV` cleanly distinguishes the two that matter: `production → prod-1`, `staging → stage-1`.

## Note on `ENV` ambiguity

dev/local also report `ENV=staging`, so they resolve to `stage-1` — but they run on a *separate* cluster this Hubble doesn't cover, so the link is moot there regardless. (A truly per-namespace-correct version would need the pod's real namespace via the downward API; not worth it for a link that's only meaningful on the two mini-PC envs.)

## Test plan

- [x] `task test:macos` green; new `TestHubbleNamespace` (production→prod-1, staging→stage-1, development→stage-1) + the existing landing test updated to assert the `?namespace=prod-1` href under `ENV=production`.
- [ ] On the stage-1 landing page, the hubble link → `https://hubble.prod.whereisdana.today/?namespace=stage-1`.
