### PR TITLE
feat: register !twitter, !instagram, !facebook, !youtube

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -80,6 +80,33 @@ func (a *App) buildRegistry() []Command {
 			},
 		},
 		{
+			Trigger: "!twitter",
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Follow on Twitter: https://twitter.com/adanalife_")
+			},
+		},
+		{
+			Trigger: "!instagram",
+			Aliases: []string{"!ig", "!insta"},
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Follow on Instagram: https://instagram.com/adanalife_")
+			},
+		},
+		{
+			Trigger: "!facebook",
+			Aliases: []string{"!fb"},
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Follow on Facebook: https://www.facebook.com/adanalifeblog")
+			},
+		},
+		{
+			Trigger: "!youtube",
+			Aliases: []string{"!yt"},
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Subscribe on YouTube: https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg")
+			},
+		},
+		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {


### PR DESCRIPTION
## Summary

The `!socialmedia` handler tells viewers to try `!twitter`, `!instagram`, `!facebook`, `!youtube` — but none of those four were registered. Viewers got silent nothing.

This adds them as inline handlers matching the existing `!discord` shape. URLs come from `website/source/_redirects` (the canonical pointers behind `dana.lol/twitter` etc).

Also throws in obvious short aliases: `!ig`/`!insta` for Instagram, `!fb` for Facebook, `!yt` for YouTube. None for Twitter (no consensus short form, and `!tw` collides with the `!timewarp` alias).

Found during a pre-launch advertised-commands audit — this is the only gap between things viewers see in rotators/help-output and things actually wired up.

## Test plan

- [ ] Deploy to stage, run `!socialmedia`, then run each of the four commands and confirm each returns its URL
- [ ] Confirm short aliases work: `!ig`, `!insta`, `!fb`, `!yt`