### PR TITLE
onscreens: extend !timewarp cover to span the cut, render as one word

### DIFF
--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -94,7 +94,7 @@
 {{if eq .Name "timewarp"}}
 <div id="warp">
   <div class="cover"><div class="streaks" id="tw-streaks"></div></div>
-  <div class="tw">TIME&nbsp;WARP</div>
+  <div class="tw">TIMEWARP</div>
 </div>
 <script>
 (function () {

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -32,11 +32,11 @@
     text-shadow: 0 0 22px rgba(180, 200, 230, 0.55), 0 4px 14px rgba(0, 0, 0, 0.6);
   }
   /* the .play class (added on the showing rising-edge) drives all the timing */
-  #warp.play .cover     { animation: tw-cover 3.4s ease-in-out forwards; }
+  #warp.play .cover     { animation: tw-cover 3.8s ease-in-out forwards; }
   #warp.play .streaks i { animation: tw-streak 1s linear infinite; }
-  #warp.play .tw        { animation: tw-text 3.4s cubic-bezier(.16, .8, .3, 1) forwards; }
-  /* cover: slam opaque (0->0.4s), hold through the gap, fade out to reveal (~2.6-3.3s) */
-  @keyframes tw-cover { 0% { opacity: 0; } 12% { opacity: 1; } 76% { opacity: 1; } 96% { opacity: 0; } 100% { opacity: 0; } }
+  #warp.play .tw        { animation: tw-text 3.8s cubic-bezier(.16, .8, .3, 1) forwards; }
+  /* cover: slam opaque (0->0.4s), hold through the gap, fade out to reveal (~3.05-3.7s) */
+  @keyframes tw-cover { 0% { opacity: 0; } 11% { opacity: 1; } 80% { opacity: 1; } 97% { opacity: 0; } 100% { opacity: 0; } }
   @keyframes tw-streak {
     0%   { transform: rotate(var(--a)) translateY(0) scaleY(0.15); opacity: 0; }
     15%  { opacity: 0.9; }
@@ -44,11 +44,11 @@
   }
   @keyframes tw-text {
     0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.25); filter: blur(10px); }
-    10%  { opacity: 1; filter: blur(0); }
-    15%  { transform: translate(-50%, -50%) scale(1.06); }
-    22%  { transform: translate(-50%, -50%) scale(1); }
-    72%  { opacity: 1; transform: translate(-50%, -50%) scale(1); filter: blur(0); }
-    90%  { opacity: 0; transform: translate(-50%, -50%) scale(1.4); filter: blur(4px); }
+    9%   { opacity: 1; filter: blur(0); }
+    13%  { transform: translate(-50%, -50%) scale(1.06); }
+    20%  { transform: translate(-50%, -50%) scale(1); }
+    76%  { opacity: 1; transform: translate(-50%, -50%) scale(1); filter: blur(0); }
+    91%  { opacity: 0; transform: translate(-50%, -50%) scale(1.4); filter: blur(4px); }
     100% { opacity: 0; }
   }
 {{else}}

--- a/pkg/onscreens-server/timewarp.go
+++ b/pkg/onscreens-server/timewarp.go
@@ -7,9 +7,9 @@ import (
 
 // timewarpDuration controls how long a !timewarp render stays "showing" before
 // the background expiry sweeper hides it. It spans the full-screen warp
-// animation in the browser source (~3.4s) with a little headroom so the cover
+// animation in the browser source (~3.8s) with a little headroom so the cover
 // is still up while the new clip's first frames decode.
-var timewarpDuration = time.Duration(4 * time.Second)
+var timewarpDuration = time.Duration(4400 * time.Millisecond)
 
 // newTimewarp constructs the timewarp *Onscreen. It checks for expiry more
 // often than the default so the onscreen flips back to hidden soon after the


### PR DESCRIPTION
## Summary

- Bumped the `!timewarp` cover animation from 3.4s → 3.8s and held the opaque phase ~400ms longer so the cover stays up through the gap between clips (it was just barely fading out before the next clip's first frames decoded).
- Raised the server-side hide timer to 4.4s to match.
- Renamed the on-screen text from "TIME WARP" → "TIMEWARP" to match the chat command spelling.

## Test plan

- [ ] Trigger `!timewarp` in chat and confirm the cover stays opaque through the H.264 discontinuity with no visible gap.
- [ ] Confirm the streaks/text still complete cleanly within the extended window.