### PR TITLE
chatbot: POST !report to Discord webhook (+ keep slog/Sentry audit trail)

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -1,11 +1,14 @@
 package chatbot
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -432,11 +435,48 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !report", "username", user.Username)
 	message := strings.Join(params, " ")
-	// Route the report through Sentry so it lands somewhere visible.
-	// Followup tracked: wire !report to a real notification surface
-	// (Discord webhook / push) so Dana actually sees it.
+	// Always log to slog (→ stderr + Sentry via the slog→Sentry handler)
+	// as the durable audit trail.
 	slog.ErrorContext(ctx, "!report", "err", fmt.Errorf("viewer report from %s: %s", user.Username, message))
+	// Fire-and-forget to Discord for real-time notification. Skipped
+	// silently when DISCORD_ALERTS_WEBHOOK is unset (e.g. local dev) —
+	// the slog/Sentry path still fires so nothing is lost.
+	if webhook := c.Conf.DiscordAlertsWebhook; webhook != "" {
+		go postReportToDiscord(webhook, user.Username, message)
+	}
 	a.IRC.Say("Thank you, I will look into this ASAP!")
+}
+
+// postReportToDiscord POSTs a viewer report to a Discord webhook.
+// Runs in a goroutine off the chat-handler path so chat doesn't block on
+// Discord latency; uses a fresh ctx with a 5s timeout because the
+// caller's ctx is already detached.
+func postReportToDiscord(webhookURL, username, message string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	payload, err := json.Marshal(map[string]string{
+		"content": fmt.Sprintf("**!report** from @%s: %s", username, message),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "discord webhook payload marshal", "err", err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		slog.ErrorContext(ctx, "discord webhook request build", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "discord webhook POST", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		slog.ErrorContext(ctx, "discord webhook non-2xx", "status", resp.StatusCode)
+	}
 }
 
 func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -39,4 +39,9 @@ type TripbotConfig struct {
 	// API (state.json, render/, asset/, plus the show/hide endpoints the
 	// chatbot drives).
 	OnscreensServerHost string `required:"true" envconfig:"ONSCREENS_SERVER_HOST"`
+
+	// DiscordAlertsWebhook is the Discord webhook URL that !report posts
+	// viewer reports to. Optional — when unset, !report falls through to
+	// slog/Sentry only and the bot keeps running.
+	DiscordAlertsWebhook string `envconfig:"DISCORD_ALERTS_WEBHOOK"`
 }


### PR DESCRIPTION
Companion to the infra-side webhook plumbing in [adanalife/infra#571](https://github.com/adanalife/infra/pull/571/changes). Together they close the launch-cutover `!report`-to-real-notification-surface item.

## What changes

- New optional config field `DiscordAlertsWebhook` (`DISCORD_ALERTS_WEBHOOK` env var) in `pkg/config/tripbot/type.go`. Optional means the bot keeps running without it — falls through to slog/Sentry only.
- `reportCmd` POSTs a Discord-webhook JSON payload (`{"content": "**!report** from @<user>: <message>"}`) when the env var is set. Runs in a goroutine off the chat-handler path with a fresh 5s-timeout context so chat doesn't block on Discord latency.
- The existing `slog.ErrorContext(ctx, "!report", "err", ...)` stays as the durable audit trail — fans out to stderr + Sentry via the slog→Sentry handler.

## Verification

- `task test:macos` green (chatbot + 13 other packages).
- Manual once the env var is wired in prod: `!report hello` in chat → Discord channel gets the message; nothing in chat blocks; Sentry still captures.

## Apply order

1. Land the infra PR first (sets up the SM container + ExternalSecret + Deployment envFrom so `DISCORD_ALERTS_WEBHOOK` is present in the pod env).
2. Populate the SM webhook URL (`aws-vault exec adanalife-prod -- aws secretsmanager put-secret-value ...`).
3. Cut a tripbot release including this change; OR cherry-pick + redeploy if waiting for the next release feels too slow.
4. Roll tripbot; test `!report` in `#adanalife_staging` first.