### PR TITLE
vlc-server: RTSP DESCRIBE self-heal watchdog with resume-from-marker

### DIFF
--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -77,7 +78,7 @@ func main() {
 		srv.Shutdown(drainCtx)
 	}()
 
-	srv.PlayRandom() // play a random video
+	resumeFromMarker(srv)
 
 	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
 	// surface them as OTel gauges. No-op when telemetry is disabled.
@@ -88,8 +89,42 @@ func main() {
 	// poll the OBS WebSocket for streaming state + render/output stats.
 	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 
+	// Self-heal watchdog: probes the local RTSP listener; after 3
+	// consecutive DESCRIBE failures (90s of sustained badness with the
+	// 30s interval), writes a resume marker and signals SIGTERM so
+	// supervisord respawns vlc-server. See pkg/vlc-server/watchdog.go.
+	srv.StartRTSPWatchdog(shutdownCtx, 30*time.Second, 3, 30*time.Second)
+
 	// start the webserver
 	srv.Start(shutdownCtx)
+}
+
+// resumeFromMarker picks the startup video. If the self-heal watchdog
+// wrote a resume marker on its previous exit, play that file; otherwise
+// start fresh with a random pick. The marker is consumed on read so a
+// crash-loop doesn't pin playback to the same broken clip forever.
+func resumeFromMarker(srv *vlcServer.Server) {
+	marker := vlcServer.ResumeMarkerPath()
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		srv.PlayRandom()
+		return
+	}
+	// Remove the marker immediately so any subsequent crash falls back to
+	// PlayRandom rather than retrying the same file.
+	if rmErr := os.Remove(marker); rmErr != nil {
+		slog.Warn("failed to remove resume marker", "err", rmErr, "marker", marker)
+	}
+	basename := strings.TrimSpace(string(data))
+	if basename == "" {
+		srv.PlayRandom()
+		return
+	}
+	slog.Info("resuming playback from watchdog marker", "video", basename, "marker", marker)
+	if err := srv.PlayVideoFile(basename); err != nil {
+		slog.Error("resume failed; falling back to PlayRandom", "err", err, "video", basename)
+		srv.PlayRandom()
+	}
 }
 
 // initializeTelemetry brings up OpenTelemetry providers (traces, metrics,

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -33,6 +33,19 @@ func (s *Server) readinessHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "OK")
 }
 
+// rtspHealthHandler answers /health/rtsp by sending a local RTSP DESCRIBE
+// against the libvlc listener. Returns 200 OK on a 200 response, 503 with
+// the failure detail otherwise. Surfaces the same signal the self-heal
+// watchdog uses so operators can probe it manually without waiting on the
+// failure threshold.
+func (s *Server) rtspHealthHandler(w http.ResponseWriter, r *http.Request) {
+	if err := probeRTSPDescribe(); err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	fmt.Fprintf(w, "OK")
+}
+
 // versionHandler returns build metadata as JSON. The tag comes from
 // Server.Version (injected via Config at construction time); sha +
 // built_at are read from the binary's embedded VCS info (Go's automatic

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -77,7 +77,11 @@ func (s *Server) vlcPlayHandler(w http.ResponseWriter, r *http.Request) {
 	videoFile := vars["video"]
 
 	spew.Dump(videoFile)
-	s.playVideoFile(videoFile)
+	if err := s.PlayVideoFile(videoFile); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't play requested video", "err", err, "video", videoFile)
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
 
 	//TODO: better response
 	fmt.Fprintf(w, "OK")

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -2,6 +2,7 @@ package vlcServer
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"math/rand"
 	"path/filepath"
@@ -14,11 +15,15 @@ func (s *Server) playAtIndex(index int) error {
 	return s.Playlist.PlayAtIndex(uint(index))
 }
 
-// playVideoFile plays a video file in the playlist
-func (s *Server) playVideoFile(vidStr string) error {
-	// extract just the filename
+// PlayVideoFile plays a video file in the playlist by basename. Returns
+// an error if the file isn't in the loaded playlist. Exported so cmd
+// callers (resume-from-marker on startup) can drive playback.
+func (s *Server) PlayVideoFile(vidStr string) error {
 	videoFile := filepath.Base(vidStr)
 	index := s.getIndex(videoFile)
+	if index < 0 {
+		return fmt.Errorf("video file not in playlist: %s", videoFile)
+	}
 	return s.playAtIndex(index)
 }
 

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -100,6 +100,7 @@ func (s *Server) Start(ctx context.Context) {
 	hp.Handle("/", tagged("/health/", s.livenessHandler))
 	hp.Handle("/live", tagged("/health/live", s.livenessHandler))
 	hp.Handle("/ready", tagged("/health/ready", s.readinessHandler))
+	hp.Handle("/rtsp", tagged("/health/rtsp", s.rtspHealthHandler))
 
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")

--- a/pkg/vlc-server/watchdog.go
+++ b/pkg/vlc-server/watchdog.go
@@ -1,0 +1,148 @@
+package vlcServer
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
+)
+
+// rtspProbeTimeout caps each DESCRIBE probe so a wedged listener can't hang
+// the watchdog loop. Also bounds the /health/rtsp handler's worst case.
+const rtspProbeTimeout = 3 * time.Second
+
+// rtspProbeAddr is the local libvlc RTSP listener we probe. The path
+// (`/dashcam`) is hardcoded to match the sout chain in vlc.go's
+// mediaOptions; keeping them coupled in code keeps the probe meaningful.
+const rtspProbeAddr = "localhost:8554"
+
+// resumeMarkerName is the file under RunDir that captures the
+// currently-playing video at self-heal time. main() consults it on startup
+// to resume playback after a watchdog-triggered restart.
+const resumeMarkerName = "vlc-server-resume-from.txt"
+
+// ResumeMarkerPath returns the absolute path to the resume marker, scoped
+// to the configured RunDir so it shares the same writable volume as the
+// pidfile.
+func ResumeMarkerPath() string {
+	return filepath.Join(c.Conf.RunDir, resumeMarkerName)
+}
+
+// probeRTSPDescribe sends a single RTSP DESCRIBE to the local listener and
+// returns nil iff the server answers with a 200 status. Used by both
+// /health/rtsp and the self-heal watchdog.
+//
+// The libvlc RTSP server can answer OPTIONS (process alive, port bound)
+// while DESCRIBE returns 500 — the silent-failure mode that motivates this
+// probe: the sout chain went away without the player crashing or releasing
+// :8554. See vault/tripbot/vlc-server/gotchas.md.
+func probeRTSPDescribe() error {
+	return probeRTSPDescribeAt(rtspProbeAddr)
+}
+
+func probeRTSPDescribeAt(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, rtspProbeTimeout)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", addr, err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(rtspProbeTimeout))
+	req := "DESCRIBE rtsp://" + addr + "/dashcam RTSP/1.0\r\n" +
+		"CSeq: 1\r\n" +
+		"Accept: application/sdp\r\n\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		return fmt.Errorf("write DESCRIBE: %w", err)
+	}
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read status: %w", err)
+	}
+	status := strings.TrimSpace(line)
+	if !strings.HasPrefix(status, "RTSP/1.0 200") {
+		return fmt.Errorf("unexpected status: %s", status)
+	}
+	return nil
+}
+
+// StartRTSPWatchdog launches a goroutine that probes the RTSP listener on
+// `interval` and, after `failureThreshold` consecutive failures, persists a
+// resume marker with the currently-playing filename and signals SIGTERM to
+// the process so the supervisor (supervisord in the container) restarts it.
+//
+// `initialDelay` lets libvlc bring up the first Media's sout chain before
+// probing starts — cold-start DESCRIBE returns 500 for a few seconds while
+// the player is still loading, which is normal.
+func (s *Server) StartRTSPWatchdog(ctx context.Context, interval time.Duration, failureThreshold int, initialDelay time.Duration) {
+	go func() {
+		slog.InfoContext(ctx, "starting RTSP watchdog",
+			"interval", interval,
+			"failure_threshold", failureThreshold,
+			"initial_delay", initialDelay,
+		)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(initialDelay):
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		consecutive := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := probeRTSPDescribe(); err != nil {
+					consecutive++
+					slog.WarnContext(ctx, "RTSP DESCRIBE failed",
+						"err", err,
+						"consecutive", consecutive,
+						"threshold", failureThreshold,
+					)
+					if consecutive >= failureThreshold {
+						s.triggerSelfHeal(ctx)
+						return
+					}
+					continue
+				}
+				if consecutive > 0 {
+					slog.InfoContext(ctx, "RTSP DESCRIBE recovered", "after_failures", consecutive)
+				}
+				consecutive = 0
+			}
+		}
+	}()
+}
+
+// triggerSelfHeal persists the resume marker and signals SIGTERM to the
+// process. The signal flows into the existing gracefulShutdown handler in
+// cmd/vlc-server, which releases libvlc + the :8554 socket before exit —
+// without that, supervisord's respawn collides with TIME_WAIT and burns
+// retries.
+func (s *Server) triggerSelfHeal(ctx context.Context) {
+	current := strings.TrimSpace(s.currentlyPlaying())
+	marker := ResumeMarkerPath()
+	if current == "" {
+		slog.WarnContext(ctx, "RTSP self-heal: no current video; skipping marker write", "marker", marker)
+	} else {
+		slog.ErrorContext(ctx, "RTSP self-heal: persisting resume marker and signaling SIGTERM",
+			"resume_from", current,
+			"marker", marker,
+		)
+		if err := os.WriteFile(marker, []byte(current), 0o644); err != nil {
+			slog.ErrorContext(ctx, "failed to write resume marker", "err", err, "marker", marker)
+		}
+	}
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		slog.ErrorContext(ctx, "failed to send SIGTERM to self; using os.Exit", "err", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/vlc-server/watchdog_test.go
+++ b/pkg/vlc-server/watchdog_test.go
@@ -1,0 +1,67 @@
+package vlcServer
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startFakeRTSP listens on a free local port and answers a single request
+// per connection with the supplied status line. Returns the addr and a
+// cleanup func. Tests use it to feed probeRTSPDescribeAt known responses
+// without needing a real libvlc.
+func startFakeRTSP(t *testing.T, statusLine string) (addr string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+				_, _ = bufio.NewReader(c).ReadString('\n')
+				_, _ = c.Write([]byte(statusLine + "\r\nCSeq: 1\r\nContent-Length: 0\r\n\r\n"))
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+func TestProbeRTSPDescribe_OK(t *testing.T) {
+	addr, stop := startFakeRTSP(t, "RTSP/1.0 200 OK")
+	defer stop()
+	if err := probeRTSPDescribeAt(addr); err != nil {
+		t.Fatalf("expected nil err, got: %v", err)
+	}
+}
+
+func TestProbeRTSPDescribe_500(t *testing.T) {
+	addr, stop := startFakeRTSP(t, "RTSP/1.0 500 Internal server error")
+	defer stop()
+	err := probeRTSPDescribeAt(addr)
+	if err == nil {
+		t.Fatal("expected error for 500 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected error mentioning 500, got: %v", err)
+	}
+}
+
+func TestProbeRTSPDescribe_NoListener(t *testing.T) {
+	// 127.0.0.1:1 is a reserved port; nothing listens there.
+	err := probeRTSPDescribeAt("127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dial") {
+		t.Fatalf("expected dial error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an in-process watchdog that probes `localhost:8554` with an RTSP DESCRIBE every 30s; after 3 consecutive failures (~90s) it persists a resume marker with the currently-playing filename and SIGTERMs the process so supervisord respawns vlc-server. The next process reads the marker and resumes from that file.
- Adds `/health/rtsp` so the same signal is curl-able for ad-hoc debugging.
- Closes a silent failure mode confirmed today across both `stage-1` and `prod-1`: libvlc's RTSP listener answered OPTIONS (200) while DESCRIBE returned 500, the player kept reporting `Playing` (`/health/ready` stayed green), but the sout chain was gone and OBS saw nothing for ~2 days. Restarting `vlc` via supervisorctl restored the chain immediately — proving pod/container restart is the right recovery action.

## Why supervisord, not the k8s livenessProbe

Restarting only `vlc` via supervisord avoids cycling onscreens-server (separate critical path for chat overlays). The watchdog SIGTERMs the process, the existing `gracefulShutdown` releases libvlc + the `:8554` socket cleanly so the respawn doesn't collide with TIME_WAIT, supervisord brings vlc back. Onscreens-server keeps serving throughout.

## Test plan

- [x] `task test:macos` — all green; new `TestProbeRTSPDescribe_*` cases cover 200/500/dial-fail paths
- [ ] Deploy to stage-1, confirm vlc-server starts, RTSP returns SDP, `curl :8080/health/rtsp` → 200
- [ ] Force a failure (e.g. transient `kill -STOP` on the process to wedge it) and confirm:
  - Watchdog logs `RTSP DESCRIBE failed` x3 then `self-heal: persisting resume marker`
  - supervisord respawns vlc
  - `vlc-server-resume-from.txt` exists momentarily under `/opt/data/run/`
  - New process logs `resuming playback from watchdog marker`
  - RTSP returns SDP again
- [ ] Soak ~24h on stage-1 with no spurious restarts before letting it bake on prod-1

## Notes

- No k8s manifest change needed. The behavior is fully in-process.
- Recovery action for prod-1's currently-broken stream: after merge + image build + deploy, the deploy itself restarts vlc-server and the new code is in place. If we want faster recovery in the meantime, `kubectl exec -n prod-1 deploy/vlc-server -- supervisorctl restart vlc` (same fix already applied to stage-1).