### PR TITLE
Release v2.15.1: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.15.1] — 2026-05-24
+
+Patch release. Closes two operational gaps surfaced in the launch cutover: viewer `!report` chat reports now POST to a Discord webhook (with the existing slog/Sentry path kept as audit trail), and vlc-server gains an in-process RTSP DESCRIBE watchdog that self-heals the silent "OPTIONS 200 / DESCRIBE 500 / OBS sees nothing" failure mode confirmed on both stage-1 and prod-1 over the past few days.
+
+### chatbot
+
+- **`!report` POSTs to a Discord webhook.** New optional `DISCORD_ALERTS_WEBHOOK` env var; when set, `!report` payloads (`**!report** from @user: <message>`) get a goroutined HTTP POST with a 5s timeout so the chat-handler path doesn't block on Discord latency. The existing `slog.ErrorContext` audit line (→ stderr + Sentry via the slog→Sentry handler) stays as the durable trail. Companion to the infra-side webhook plumbing ([adanalife/infra#571](https://github.com/adanalife/infra/pull/571/changes)). ([#645])
+
+### vlc-server
+
+- **RTSP DESCRIBE self-heal watchdog with resume-from-marker.** An in-process watchdog probes `localhost:8554` with an RTSP DESCRIBE every 30s; after 3 consecutive failures (~90s) it persists a resume marker with the currently-playing filename and SIGTERMs the process so supervisord respawns vlc-server. The next process reads the marker and resumes from that file — onscreens-server keeps serving throughout (separate supervisord program, no cycle). Also exposes the same signal as `/health/rtsp` for ad-hoc debugging. Closes a silent failure confirmed on both `stage-1` and `prod-1`: libvlc's RTSP listener answered OPTIONS (200) while DESCRIBE returned 500, `/health/ready` stayed green, but the sout chain was gone and OBS saw nothing for ~2 days. ([#646])
+
+[#645]: https://github.com/adanalife/tripbot/pull/645
+[#646]: https://github.com/adanalife/tripbot/pull/646
+
 ## [v2.15.0] — 2026-05-23
 
 Minor release. Stream audio comes alive: SomaFM's Groove Salad Classic now feeds the OBS Main scene as background music, and `!song` / `!music` chat commands report the currently-playing track. Three more advertised-but-unwired chat commands (`!twitter`, `!instagram`, `!facebook`, `!youtube` plus short aliases) get registered — `!socialmedia` had been telling viewers about commands that silently did nothing. Smaller polish: the `!timewarp` cover holds long enough to span the inter-clip cut, and the landing page's Hubble link picks the right namespace per environment.

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -77,7 +78,7 @@ func main() {
 		srv.Shutdown(drainCtx)
 	}()
 
-	srv.PlayRandom() // play a random video
+	resumeFromMarker(srv)
 
 	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
 	// surface them as OTel gauges. No-op when telemetry is disabled.
@@ -88,8 +89,42 @@ func main() {
 	// poll the OBS WebSocket for streaming state + render/output stats.
 	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 
+	// Self-heal watchdog: probes the local RTSP listener; after 3
+	// consecutive DESCRIBE failures (90s of sustained badness with the
+	// 30s interval), writes a resume marker and signals SIGTERM so
+	// supervisord respawns vlc-server. See pkg/vlc-server/watchdog.go.
+	srv.StartRTSPWatchdog(shutdownCtx, 30*time.Second, 3, 30*time.Second)
+
 	// start the webserver
 	srv.Start(shutdownCtx)
+}
+
+// resumeFromMarker picks the startup video. If the self-heal watchdog
+// wrote a resume marker on its previous exit, play that file; otherwise
+// start fresh with a random pick. The marker is consumed on read so a
+// crash-loop doesn't pin playback to the same broken clip forever.
+func resumeFromMarker(srv *vlcServer.Server) {
+	marker := vlcServer.ResumeMarkerPath()
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		srv.PlayRandom()
+		return
+	}
+	// Remove the marker immediately so any subsequent crash falls back to
+	// PlayRandom rather than retrying the same file.
+	if rmErr := os.Remove(marker); rmErr != nil {
+		slog.Warn("failed to remove resume marker", "err", rmErr, "marker", marker)
+	}
+	basename := strings.TrimSpace(string(data))
+	if basename == "" {
+		srv.PlayRandom()
+		return
+	}
+	slog.Info("resuming playback from watchdog marker", "video", basename, "marker", marker)
+	if err := srv.PlayVideoFile(basename); err != nil {
+		slog.Error("resume failed; falling back to PlayRandom", "err", err, "video", basename)
+		srv.PlayRandom()
+	}
 }
 
 // initializeTelemetry brings up OpenTelemetry providers (traces, metrics,

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -1,11 +1,14 @@
 package chatbot
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -432,11 +435,48 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !report", "username", user.Username)
 	message := strings.Join(params, " ")
-	// Route the report through Sentry so it lands somewhere visible.
-	// Followup tracked: wire !report to a real notification surface
-	// (Discord webhook / push) so Dana actually sees it.
+	// Always log to slog (→ stderr + Sentry via the slog→Sentry handler)
+	// as the durable audit trail.
 	slog.ErrorContext(ctx, "!report", "err", fmt.Errorf("viewer report from %s: %s", user.Username, message))
+	// Fire-and-forget to Discord for real-time notification. Skipped
+	// silently when DISCORD_ALERTS_WEBHOOK is unset (e.g. local dev) —
+	// the slog/Sentry path still fires so nothing is lost.
+	if webhook := c.Conf.DiscordAlertsWebhook; webhook != "" {
+		go postReportToDiscord(webhook, user.Username, message)
+	}
 	a.IRC.Say("Thank you, I will look into this ASAP!")
+}
+
+// postReportToDiscord POSTs a viewer report to a Discord webhook.
+// Runs in a goroutine off the chat-handler path so chat doesn't block on
+// Discord latency; uses a fresh ctx with a 5s timeout because the
+// caller's ctx is already detached.
+func postReportToDiscord(webhookURL, username, message string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	payload, err := json.Marshal(map[string]string{
+		"content": fmt.Sprintf("**!report** from @%s: %s", username, message),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "discord webhook payload marshal", "err", err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		slog.ErrorContext(ctx, "discord webhook request build", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "discord webhook POST", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		slog.ErrorContext(ctx, "discord webhook non-2xx", "status", resp.StatusCode)
+	}
 }
 
 func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -39,4 +39,9 @@ type TripbotConfig struct {
 	// API (state.json, render/, asset/, plus the show/hide endpoints the
 	// chatbot drives).
 	OnscreensServerHost string `required:"true" envconfig:"ONSCREENS_SERVER_HOST"`
+
+	// DiscordAlertsWebhook is the Discord webhook URL that !report posts
+	// viewer reports to. Optional — when unset, !report falls through to
+	// slog/Sentry only and the bot keeps running.
+	DiscordAlertsWebhook string `envconfig:"DISCORD_ALERTS_WEBHOOK"`
 }

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -33,6 +33,19 @@ func (s *Server) readinessHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "OK")
 }
 
+// rtspHealthHandler answers /health/rtsp by sending a local RTSP DESCRIBE
+// against the libvlc listener. Returns 200 OK on a 200 response, 503 with
+// the failure detail otherwise. Surfaces the same signal the self-heal
+// watchdog uses so operators can probe it manually without waiting on the
+// failure threshold.
+func (s *Server) rtspHealthHandler(w http.ResponseWriter, r *http.Request) {
+	if err := probeRTSPDescribe(); err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	fmt.Fprintf(w, "OK")
+}
+
 // versionHandler returns build metadata as JSON. The tag comes from
 // Server.Version (injected via Config at construction time); sha +
 // built_at are read from the binary's embedded VCS info (Go's automatic
@@ -77,7 +90,11 @@ func (s *Server) vlcPlayHandler(w http.ResponseWriter, r *http.Request) {
 	videoFile := vars["video"]
 
 	spew.Dump(videoFile)
-	s.playVideoFile(videoFile)
+	if err := s.PlayVideoFile(videoFile); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't play requested video", "err", err, "video", videoFile)
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
 
 	//TODO: better response
 	fmt.Fprintf(w, "OK")

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -2,6 +2,7 @@ package vlcServer
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"math/rand"
 	"path/filepath"
@@ -14,11 +15,15 @@ func (s *Server) playAtIndex(index int) error {
 	return s.Playlist.PlayAtIndex(uint(index))
 }
 
-// playVideoFile plays a video file in the playlist
-func (s *Server) playVideoFile(vidStr string) error {
-	// extract just the filename
+// PlayVideoFile plays a video file in the playlist by basename. Returns
+// an error if the file isn't in the loaded playlist. Exported so cmd
+// callers (resume-from-marker on startup) can drive playback.
+func (s *Server) PlayVideoFile(vidStr string) error {
 	videoFile := filepath.Base(vidStr)
 	index := s.getIndex(videoFile)
+	if index < 0 {
+		return fmt.Errorf("video file not in playlist: %s", videoFile)
+	}
 	return s.playAtIndex(index)
 }
 

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -100,6 +100,7 @@ func (s *Server) Start(ctx context.Context) {
 	hp.Handle("/", tagged("/health/", s.livenessHandler))
 	hp.Handle("/live", tagged("/health/live", s.livenessHandler))
 	hp.Handle("/ready", tagged("/health/ready", s.readinessHandler))
+	hp.Handle("/rtsp", tagged("/health/rtsp", s.rtspHealthHandler))
 
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")

--- a/pkg/vlc-server/watchdog.go
+++ b/pkg/vlc-server/watchdog.go
@@ -1,0 +1,148 @@
+package vlcServer
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
+)
+
+// rtspProbeTimeout caps each DESCRIBE probe so a wedged listener can't hang
+// the watchdog loop. Also bounds the /health/rtsp handler's worst case.
+const rtspProbeTimeout = 3 * time.Second
+
+// rtspProbeAddr is the local libvlc RTSP listener we probe. The path
+// (`/dashcam`) is hardcoded to match the sout chain in vlc.go's
+// mediaOptions; keeping them coupled in code keeps the probe meaningful.
+const rtspProbeAddr = "localhost:8554"
+
+// resumeMarkerName is the file under RunDir that captures the
+// currently-playing video at self-heal time. main() consults it on startup
+// to resume playback after a watchdog-triggered restart.
+const resumeMarkerName = "vlc-server-resume-from.txt"
+
+// ResumeMarkerPath returns the absolute path to the resume marker, scoped
+// to the configured RunDir so it shares the same writable volume as the
+// pidfile.
+func ResumeMarkerPath() string {
+	return filepath.Join(c.Conf.RunDir, resumeMarkerName)
+}
+
+// probeRTSPDescribe sends a single RTSP DESCRIBE to the local listener and
+// returns nil iff the server answers with a 200 status. Used by both
+// /health/rtsp and the self-heal watchdog.
+//
+// The libvlc RTSP server can answer OPTIONS (process alive, port bound)
+// while DESCRIBE returns 500 — the silent-failure mode that motivates this
+// probe: the sout chain went away without the player crashing or releasing
+// :8554. See vault/tripbot/vlc-server/gotchas.md.
+func probeRTSPDescribe() error {
+	return probeRTSPDescribeAt(rtspProbeAddr)
+}
+
+func probeRTSPDescribeAt(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, rtspProbeTimeout)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", addr, err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(rtspProbeTimeout))
+	req := "DESCRIBE rtsp://" + addr + "/dashcam RTSP/1.0\r\n" +
+		"CSeq: 1\r\n" +
+		"Accept: application/sdp\r\n\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		return fmt.Errorf("write DESCRIBE: %w", err)
+	}
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read status: %w", err)
+	}
+	status := strings.TrimSpace(line)
+	if !strings.HasPrefix(status, "RTSP/1.0 200") {
+		return fmt.Errorf("unexpected status: %s", status)
+	}
+	return nil
+}
+
+// StartRTSPWatchdog launches a goroutine that probes the RTSP listener on
+// `interval` and, after `failureThreshold` consecutive failures, persists a
+// resume marker with the currently-playing filename and signals SIGTERM to
+// the process so the supervisor (supervisord in the container) restarts it.
+//
+// `initialDelay` lets libvlc bring up the first Media's sout chain before
+// probing starts — cold-start DESCRIBE returns 500 for a few seconds while
+// the player is still loading, which is normal.
+func (s *Server) StartRTSPWatchdog(ctx context.Context, interval time.Duration, failureThreshold int, initialDelay time.Duration) {
+	go func() {
+		slog.InfoContext(ctx, "starting RTSP watchdog",
+			"interval", interval,
+			"failure_threshold", failureThreshold,
+			"initial_delay", initialDelay,
+		)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(initialDelay):
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		consecutive := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := probeRTSPDescribe(); err != nil {
+					consecutive++
+					slog.WarnContext(ctx, "RTSP DESCRIBE failed",
+						"err", err,
+						"consecutive", consecutive,
+						"threshold", failureThreshold,
+					)
+					if consecutive >= failureThreshold {
+						s.triggerSelfHeal(ctx)
+						return
+					}
+					continue
+				}
+				if consecutive > 0 {
+					slog.InfoContext(ctx, "RTSP DESCRIBE recovered", "after_failures", consecutive)
+				}
+				consecutive = 0
+			}
+		}
+	}()
+}
+
+// triggerSelfHeal persists the resume marker and signals SIGTERM to the
+// process. The signal flows into the existing gracefulShutdown handler in
+// cmd/vlc-server, which releases libvlc + the :8554 socket before exit —
+// without that, supervisord's respawn collides with TIME_WAIT and burns
+// retries.
+func (s *Server) triggerSelfHeal(ctx context.Context) {
+	current := strings.TrimSpace(s.currentlyPlaying())
+	marker := ResumeMarkerPath()
+	if current == "" {
+		slog.WarnContext(ctx, "RTSP self-heal: no current video; skipping marker write", "marker", marker)
+	} else {
+		slog.ErrorContext(ctx, "RTSP self-heal: persisting resume marker and signaling SIGTERM",
+			"resume_from", current,
+			"marker", marker,
+		)
+		if err := os.WriteFile(marker, []byte(current), 0o644); err != nil {
+			slog.ErrorContext(ctx, "failed to write resume marker", "err", err, "marker", marker)
+		}
+	}
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		slog.ErrorContext(ctx, "failed to send SIGTERM to self; using os.Exit", "err", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/vlc-server/watchdog_test.go
+++ b/pkg/vlc-server/watchdog_test.go
@@ -1,0 +1,67 @@
+package vlcServer
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startFakeRTSP listens on a free local port and answers a single request
+// per connection with the supplied status line. Returns the addr and a
+// cleanup func. Tests use it to feed probeRTSPDescribeAt known responses
+// without needing a real libvlc.
+func startFakeRTSP(t *testing.T, statusLine string) (addr string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+				_, _ = bufio.NewReader(c).ReadString('\n')
+				_, _ = c.Write([]byte(statusLine + "\r\nCSeq: 1\r\nContent-Length: 0\r\n\r\n"))
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+func TestProbeRTSPDescribe_OK(t *testing.T) {
+	addr, stop := startFakeRTSP(t, "RTSP/1.0 200 OK")
+	defer stop()
+	if err := probeRTSPDescribeAt(addr); err != nil {
+		t.Fatalf("expected nil err, got: %v", err)
+	}
+}
+
+func TestProbeRTSPDescribe_500(t *testing.T) {
+	addr, stop := startFakeRTSP(t, "RTSP/1.0 500 Internal server error")
+	defer stop()
+	err := probeRTSPDescribeAt(addr)
+	if err == nil {
+		t.Fatal("expected error for 500 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected error mentioning 500, got: %v", err)
+	}
+}
+
+func TestProbeRTSPDescribe_NoListener(t *testing.T) {
+	// 127.0.0.1:1 is a reserved port; nothing listens there.
+	err := probeRTSPDescribeAt("127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dial") {
+		t.Fatalf("expected dial error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Release v2.15.1 (patch)

develop → master. No `#minor` / `#major` in any commit → auto-tag defaults to a patch bump (`v2.15.1`) → release.yml builds the multi-arch images and publishes `:latest`. Merge as a **merge commit**, per the release convention.

### Headline

Closes two operational gaps surfaced in the launch cutover: viewer `!report` chat reports now POST to a Discord webhook (with the slog/Sentry audit trail kept intact), and vlc-server gains an in-process RTSP DESCRIBE watchdog that self-heals the silent "OPTIONS 200 / DESCRIBE 500 / OBS sees nothing" failure confirmed on both `stage-1` and `prod-1` over the past few days.

### Included (2 PRs since v2.15.0)

| PR | |
|----|--|
| [#646](https://github.com/adanalife/tripbot/pull/646/changes) | vlc-server: RTSP DESCRIBE self-heal watchdog with resume-from-marker |
| [#645](https://github.com/adanalife/tripbot/pull/645/changes) | chatbot: POST `!report` viewer reports to Discord webhook |

Full notes in the CHANGELOG diff.

### After merge

- For `!report` → Discord on prod-1: confirm the infra-side webhook plumbing ([adanalife/infra#571](https://github.com/adanalife/infra/pull/571/changes)) is landed and the SM secret is populated, then `task k8s:prod:tripbot:rollout` to pick up the new image and the new env var
- For the RTSP watchdog: `task k8s:stage:vlc:rollout` first; soak ~24h watching for spurious restarts before letting it bake on prod-1
- Verify pod SHAs match the release commit before feature-checking (Always pull policy can silently evict imports)
- Test `!report` from `#adanalife_staging` chat and confirm the Discord channel sees the message