### PR TITLE
chatbot: subtler SomaFM attribution — drop name from !song, add !somafm

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -209,6 +209,12 @@ func (a *App) buildRegistry() []Command {
 			Aliases: []string{"!music"},
 			Handler: a.songCmd,
 		},
+		{
+			Trigger: "!somafm",
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Stream music by SomaFM — https://somafm.com")
+			},
+		},
 	}
 }
 

--- a/pkg/chatbot/song.go
+++ b/pkg/chatbot/song.go
@@ -102,8 +102,8 @@ func (a *App) songCmd(ctx context.Context, user *users.User, _ []string) {
 	artist, title, err := a.NowPlaying.Current(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "now-playing fetch failed", "err", err)
-		a.IRC.Say("Couldn't reach SomaFM for the current track, sorry!")
+		a.IRC.Say("Couldn't reach the music source for the current track, sorry!")
 		return
 	}
-	a.IRC.Say(fmt.Sprintf("♪ Now playing on SomaFM Groove Salad Classic: %s — %s", title, artist))
+	a.IRC.Say(fmt.Sprintf("♪ Now playing: %s — %s", title, artist))
 }


### PR DESCRIPTION
## Summary

Reshapes the music attribution surface introduced in #643:

- **`!song` / `!music`** drops the "SomaFM Groove Salad Classic" prefix:
  - Before: `♪ Now playing on SomaFM Groove Salad Classic: Big Wow — Steve Cobby`
  - After: `♪ Now playing: Big Wow — Steve Cobby`
- **New `!somafm` command** gives them a quieter standing credit with their URL, discoverable by anyone curious about the music:
  - `Stream music by SomaFM — https://somafm.com`
- Error message rephrased from "Couldn't reach SomaFM…" to "Couldn't reach the music source…" so the audio-source name no longer leaks via the failure path either.

## Test plan

- [x] `task test:macos` green; existing `!song` tests still pass (they assert on artist/title only, not on the prefix).
- [ ] Stage chat: `!song` returns track-only line; `!somafm` returns the credit + URL.