### PR TITLE
onscreens: nudge !timewarp cover another 200ms to fully span the cut

### DIFF
--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -32,10 +32,10 @@
     text-shadow: 0 0 22px rgba(180, 200, 230, 0.55), 0 4px 14px rgba(0, 0, 0, 0.6);
   }
   /* the .play class (added on the showing rising-edge) drives all the timing */
-  #warp.play .cover     { animation: tw-cover 3.8s ease-in-out forwards; }
+  #warp.play .cover     { animation: tw-cover 4.0s ease-in-out forwards; }
   #warp.play .streaks i { animation: tw-streak 1s linear infinite; }
-  #warp.play .tw        { animation: tw-text 3.8s cubic-bezier(.16, .8, .3, 1) forwards; }
-  /* cover: slam opaque (0->0.4s), hold through the gap, fade out to reveal (~3.05-3.7s) */
+  #warp.play .tw        { animation: tw-text 4.0s cubic-bezier(.16, .8, .3, 1) forwards; }
+  /* cover: slam opaque (0->0.44s), hold through the gap, fade out to reveal (~3.2-3.88s) */
   @keyframes tw-cover { 0% { opacity: 0; } 11% { opacity: 1; } 80% { opacity: 1; } 97% { opacity: 0; } 100% { opacity: 0; } }
   @keyframes tw-streak {
     0%   { transform: rotate(var(--a)) translateY(0) scaleY(0.15); opacity: 0; }

--- a/pkg/onscreens-server/timewarp.go
+++ b/pkg/onscreens-server/timewarp.go
@@ -7,9 +7,9 @@ import (
 
 // timewarpDuration controls how long a !timewarp render stays "showing" before
 // the background expiry sweeper hides it. It spans the full-screen warp
-// animation in the browser source (~3.8s) with a little headroom so the cover
+// animation in the browser source (~4.0s) with a little headroom so the cover
 // is still up while the new clip's first frames decode.
-var timewarpDuration = time.Duration(4400 * time.Millisecond)
+var timewarpDuration = time.Duration(4600 * time.Millisecond)
 
 // newTimewarp constructs the timewarp *Onscreen. It checks for expiry more
 // often than the default so the onscreen flips back to hidden soon after the


### PR DESCRIPTION
## Summary

Follow-up to #642. The 3.8s cover was still fading out a hair before the next clip's first frame finished decoding — visible gap. Uniform 200ms stretch:

- Cover + text animations: **3.8s → 4.0s**
- Server-side hide timer: **4.4s → 4.6s**
- Keyframes (11/80/97) unchanged — the stretch pushes fade-start ~3.04s → 3.20s and fully-clear ~3.69s → 3.88s. The slam-in shifts 418ms → 440ms; not perceptible.

## Test plan

- [x] `task test:macos` green on `pkg/onscreens-server/...`
- [ ] Trigger `!timewarp` on stage; confirm the cover stays opaque all the way through the H.264 discontinuity with no visible gap