### PR TITLE
admin: rename "landing page" → "admin panel" everywhere

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -199,8 +199,8 @@ func startCron() {
 // token lands — rather than crashlooping. A crashing pod after a wipe also
 // raced the DB restore's migrate init (see the 2026-05-20 convergence-wipe
 // notes); staying up avoids that. The pod stays Ready throughout (readiness
-// no longer gates on Twitch) so the landing page + /auth/init are reachable
-// to re-auth; "not in chat" is surfaced via the landing page + the
+// no longer gates on Twitch) so the admin panel + /auth/init are reachable
+// to re-auth; "not in chat" is surfaced via the admin panel + the
 // tripbot_twitch_connected gauge instead.
 func loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
@@ -282,9 +282,9 @@ func connectToTwitch() {
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
 	// Mark the bot connected to chat once the IRC connection is established.
-	// This drives the landing-page status row + the tripbot_twitch_connected
+	// This drives the admin-panel status row + the tripbot_twitch_connected
 	// gauge — it does NOT gate /health/ready, which stays 200 so the pod keeps
-	// serving the landing page + /auth/* even while the bot is offline.
+	// serving the admin panel + /auth/* even while the bot is offline.
 	client.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
 		server.SetTwitchConnected(true)
@@ -295,7 +295,7 @@ func connectToTwitch() {
 	for {
 		slog.Info("initializing connection to Twitch")
 		// Connect blocks while connected and returns when the connection
-		// drops; mark not-in-chat so the landing page + gauge reflect the gap
+		// drops; mark not-in-chat so the admin panel + gauge reflect the gap
 		// until the next OnConnect fires.
 		err := client.Connect()
 		server.SetTwitchConnected(false)
@@ -314,7 +314,7 @@ func connectToTwitch() {
 				} else {
 					// Reauth couldn't produce a token (refresh_token revoked and
 					// no fresh row in the DB yet). Surface the re-bootstrap link
-					// so re-auth is a click; the landing page shows it too.
+					// so re-auth is a click; the admin panel shows it too.
 					slog.Error("IRC auth failed and no valid token after reauth; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
 				}
 			}

--- a/pkg/httpmw/health.go
+++ b/pkg/httpmw/health.go
@@ -39,7 +39,7 @@ func LivenessHandler() http.HandlerFunc {
 // status so a failing probe is debuggable from `kubectl describe pod`'s
 // probe output. With no checks, the handler always reports 200 —
 // equivalent to LivenessHandler but distinguishable on the URL. tripbot
-// registers it with no checks on purpose: its HTTP surface (landing page,
+// registers it with no checks on purpose: its HTTP surface (admin panel,
 // /auth/init, /auth/callback, /metrics) doesn't depend on the Twitch
 // connection, so the pod must stay in the Service even when the bot is
 // offline — otherwise the very page used to re-auth would 503.

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -71,7 +71,7 @@ var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followe
 // TwitchConnection exposes the chat-connection gauge. Set(true) on IRC
 // connect, Set(false) on disconnect. Readiness no longer gates on the Twitch
 // connection (the pod stays in the Service so the re-auth page is reachable),
-// so this gauge — alongside the landing-page status row — is what surfaces
+// so this gauge — alongside the admin-panel status row — is what surfaces
 // "up but not in chat" to dashboards and alerts.
 var TwitchConnection = twitchConnectionIface{gauge: twitchConnected}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -16,17 +16,17 @@ import (
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
-// startedAt marks process start so the landing page can report uptime. Set at
+// startedAt marks process start so the admin panel can report uptime. Set at
 // package load; close enough to process start for a human-readable "up Xh".
 var startedAt = time.Now()
 
 // healthClient is the short-timeout client used for the sibling-service status
-// ping. 2s keeps a slow or hung vlc-server from stalling the landing render.
+// ping. 2s keeps a slow or hung vlc-server from stalling the panel render.
 var healthClient = &http.Client{Timeout: 2 * time.Second}
 
 // currentlyPlaying / currentProgress are overridable in tests; by default they
 // read pkg/video's in-process state (refreshed by a 60s cron tick), so the
-// landing page costs nothing to show "now playing".
+// admin panel costs nothing to show "now playing".
 var (
 	currentlyPlaying = video.CurrentlyPlaying
 	currentProgress  = video.CurrentProgress
@@ -34,7 +34,7 @@ var (
 	// the UpdateSession cron. Overridable in tests.
 	chatterCount = mytwitch.ChatterCount
 	// accountsNeedingReauth reports which Twitch accounts have a missing/expired
-	// token; the landing page renders a re-auth prompt for each. Overridable in
+	// token; the admin panel renders a re-auth prompt for each. Overridable in
 	// tests. Reads in-memory token state — no DB or network call.
 	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
 )
@@ -56,7 +56,7 @@ const (
 	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
 )
 
-// serviceStatus is one row in the landing page's status table.
+// serviceStatus is one row in the admin panel's status table.
 type serviceStatus struct {
 	Name       string
 	OK         bool
@@ -78,14 +78,14 @@ type nowPlaying struct {
 	Progress string
 }
 
-// navLink is one entry in the landing page's links list.
+// navLink is one entry in the admin panel's links list.
 type navLink struct {
 	Label string
 	URL   string
 }
 
-// landingData is the template payload.
-type landingData struct {
+// adminData is the template payload.
+type adminData struct {
 	Channel  string // broadcaster Twitch username
 	Bot      string // bot Twitch username
 	Env      string
@@ -97,12 +97,12 @@ type landingData struct {
 	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
-// landingHandler serves the human-facing root page on the tripbot Ingress: a
+// adminHandler serves the human-facing root page on the tripbot Ingress: a
 // lightweight status overview (tripbot's own readiness + a live vlc-server
 // ping, each version linking to its changelog), the currently-playing video
 // when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
 // / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
-func landingHandler(w http.ResponseWriter, r *http.Request) {
+func adminHandler(w http.ResponseWriter, r *http.Request) {
 	vlcOK := c.Conf.VlcServerHost != "" &&
 		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
 
@@ -112,7 +112,7 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
 	}
 
-	data := landingData{
+	data := adminData{
 		Channel:  c.Conf.ChannelName,
 		Bot:      c.Conf.BotUsername,
 		Env:      c.Conf.Environment,
@@ -125,8 +125,8 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := landingTmpl.Execute(w, data); err != nil {
-		slog.ErrorContext(r.Context(), "couldn't render landing page", "err", err)
+	if err := adminTmpl.Execute(w, data); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't render admin panel", "err", err)
 	}
 }
 
@@ -289,7 +289,7 @@ func siblingURL(externalURL, service string) string {
 	return u.String()
 }
 
-var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
+var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -53,7 +53,7 @@ func TestChangelogURL(t *testing.T) {
 	}
 }
 
-func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
+func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
@@ -87,7 +87,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	SetVersion("v1.2.3")
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -122,7 +122,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}
 }
 
-func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
+func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
 	withReauth(t, nil)
@@ -138,7 +138,7 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -155,7 +155,7 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	}
 }
 
-// withConf snapshots the config fields the landing handler reads, runs set to
+// withConf snapshots the config fields the admin handler reads, runs set to
 // mutate them for the test, and restores them afterward.
 func withConf(t *testing.T, set func()) {
 	t.Helper()
@@ -173,7 +173,7 @@ func withConf(t *testing.T, set func()) {
 }
 
 // withCurrentlyPlaying swaps the currentlyPlaying / currentProgress seams so
-// the landing handler sees a fixed video + progress without driving the player.
+// the admin handler sees a fixed video + progress without driving the player.
 func withCurrentlyPlaying(t *testing.T, v video.Video, progress time.Duration) {
 	t.Helper()
 	savedV, savedP := currentlyPlaying, currentProgress
@@ -190,7 +190,7 @@ func withChatterCount(t *testing.T, n int) {
 	t.Cleanup(func() { chatterCount = saved })
 }
 
-// withReauth swaps the accountsNeedingReauth seam so the landing handler sees a
+// withReauth swaps the accountsNeedingReauth seam so the admin handler sees a
 // fixed re-auth list without depending on global in-memory token state.
 func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Helper()
@@ -199,7 +199,7 @@ func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Cleanup(func() { accountsNeedingReauth = saved })
 }
 
-func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
+func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
 
@@ -215,7 +215,7 @@ func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -234,7 +234,7 @@ func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
 	}
 }
 
-func TestLandingHandler_NoReauthPromptWhenHealthy(t *testing.T) {
+func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 
@@ -242,7 +242,7 @@ func TestLandingHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	withReauth(t, nil) // all tokens healthy
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if strings.Contains(rec.Body.String(), "re-authenticate") {
 		t.Errorf("re-auth prompt should be hidden when no account needs re-auth")

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -40,23 +40,23 @@ func SetVersion(v string) {
 // twitchConnected reports whether the bot currently has its Twitch IRC
 // connection. It deliberately does NOT gate the readiness probe: /health/ready
 // is always 200 once the HTTP server is up (see httpmw.ReadinessHandler), so
-// the landing page, /auth/init and /auth/callback stay reachable through the
+// the admin panel, /auth/init and /auth/callback stay reachable through the
 // Ingress even when the bot is offline — otherwise the very page used to
 // re-auth a disconnected bot would 503. Instead this flag drives the
-// landing-page status row and the tripbot_twitch_connected gauge, so "up but
+// admin-panel status row and the tripbot_twitch_connected gauge, so "up but
 // not in chat" is surfaced without pulling the pod out of the Service.
 // cmd/tripbot flips it via SetTwitchConnected on IRC connect / disconnect.
 var twitchConnected atomic.Bool
 
 // SetTwitchConnected updates the chat-connection signal: the in-memory flag
-// the landing page reads and the tripbot_twitch_connected gauge.
+// the admin panel reads and the tripbot_twitch_connected gauge.
 func SetTwitchConnected(connected bool) {
 	twitchConnected.Store(connected)
 	instrumentation.TwitchConnection.Set(connected)
 }
 
 // TwitchConnected reports the last-known chat-connection state, for the
-// landing page's status row.
+// admin panel's status row.
 func TwitchConnected() bool {
 	return twitchConnected.Load()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,10 +46,10 @@ func Start(ctx context.Context) {
 	// healthcheck endpoints
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
 	hp.Handle("/live", tagged("/health/live", httpmw.LivenessHandler()))
-	// /ready runs no checks: tripbot's HTTP surface (landing page, /auth/init,
+	// /ready runs no checks: tripbot's HTTP surface (admin panel, /auth/init,
 	// /auth/callback, /metrics) doesn't depend on the Twitch connection, so the
 	// pod must stay routable even when the bot is offline. Chat-connection is
-	// surfaced via the landing page + the tripbot_twitch_connected gauge.
+	// surfaced via the admin panel + the tripbot_twitch_connected gauge.
 	hp.Handle("/ready", tagged("/health/ready", httpmw.ReadinessHandler()))
 
 	// version endpoint — returns build metadata as JSON
@@ -66,8 +66,8 @@ func Start(ctx context.Context) {
 	// prometheus metrics endpoint
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
-	// landing page (status overview + links) on the root path
-	r.Handle("/", tagged("/", landingHandler)).Methods("GET", "HEAD")
+	// admin panel (status overview + links) on the root path
+	r.Handle("/", tagged("/", adminHandler)).Methods("GET", "HEAD")
 
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -290,7 +290,7 @@ func BroadcasterUserAccessToken() string {
 }
 
 // AccountReauth describes an account whose in-memory token is missing or
-// expired and therefore needs operator re-auth. The landing page renders one
+// expired and therefore needs operator re-auth. The admin panel renders one
 // "Sign in as <LoginAs>" link per entry, pointing at InitURL.
 type AccountReauth struct {
 	Account string // "bot" | "broadcaster" — the /auth/init account selector
@@ -314,7 +314,7 @@ func tokenReason(t oauthtokens.Token) string {
 }
 
 // AccountsNeedingReauth returns the bot and/or broadcaster accounts whose
-// in-memory token is missing or expired, so the landing page can prompt for
+// in-memory token is missing or expired, so the admin panel can prompt for
 // re-auth. Returns nil when everything's healthy. The broadcaster is only
 // considered when a distinct broadcaster identity exists (ChannelName set and
 // != BotUsername) — otherwise there's no separate row to re-auth.
@@ -496,7 +496,7 @@ func RefreshUserAccessToken(ctx context.Context) {
 // auth-bootstrap flow (or by another tripbot's refresh) without a process
 // restart. When neither yields a usable token — e.g. a DB-restored row whose
 // refresh_token is also revoked — the in-memory slot is left blanked and the
-// reauth link is logged; the landing page's re-auth prompt then covers it.
+// reauth link is logged; the admin panel's re-auth prompt then covers it.
 func Reauth(ctx context.Context, account string) {
 	username := c.Conf.BotUsername
 	apply := applyBotToken


### PR DESCRIPTION
## Summary
- First sub-step of repurposing the page at `/` from a passive status surface into an admin/ops panel. This PR is the naming pass only — no behavior change. URL route stays `/`, HTML template body unchanged.
- File renames via `git mv` (blame preserved): `pkg/server/landing.go` → `admin.go`, `landing_test.go` → `admin_test.go`.
- Go symbol renames in `admin.go`: `landingHandler` → `adminHandler`, `landingTmpl` → `adminTmpl`, `landingData` → `adminData`, `template.New("landing")` → `template.New("admin")`.
- Test function renames: `TestLandingHandler_*` → `TestAdminHandler_*`.
- Comment sweep across `server.go`, `handlers.go`, `httpmw/health.go`, `instrumentation/tripbot.go`, `cmd/tripbot/tripbot.go`, `twitch/authentication.go`.
- Future sub-items (auth gating, OBS stream toggle, reboot buttons, Sentry, etc.) land separately.

## Test plan
- [x] `task test:macos` green (including `pkg/server`)
- [x] `git grep -nE 'landing|Landing' -- pkg/ cmd/` clean
- [ ] Visit `/` on a running tripbot; confirm the page renders identically