### PR TITLE
obs: demote GetStreamStatus transient errors to slog.Warn

### DIFF
--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -65,7 +65,10 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 		case <-ticker.C:
 			resp, err := client.Stream.GetStreamStatus()
 			if err != nil {
-				slog.ErrorContext(ctx, "obs GetStreamStatus error", "err", err)
+				// Transient: OBS pod restart, network blip, websocket drop.
+				// The outer loop reconnects after 10s and OBSStreaming
+				// is the alertable signal — keep this off Sentry.
+				slog.WarnContext(ctx, "obs GetStreamStatus error", "err", err)
 				instrumentation.OBSStreaming.Set(false)
 				return // trigger reconnect
 			}


### PR DESCRIPTION
## Summary

- OBS websocket disconnects in `PollStreamingActive` (OBS pod restart, network blip) are self-healing — the outer loop reconnects after 10s and the `obs_streaming_active` gauge accurately flips to `false` during the gap.
- Demote the per-tick `GetStreamStatus` error log from `slog.ErrorContext` to `slog.WarnContext` so transient drops stop paging Sentry. The gauge remains the alertable signal; warn-level still writes to stderr + Loki for debugging.
- Surfaces as Sentry [VLC-SERVER-8](https://a-dana-life.sentry.io/issues/VLC-SERVER-8) — currently 18 events firing across prod-1 / stage-1 / dev. Will spike on the first `task obs:prod:stream:on` once streaming is on by default; pre-empting the noise.

## Test plan

- [x] `task test:macos` green
- [ ] Verify after rollout: a deliberate OBS websocket interruption produces a Loki `WARN` line + the `obs_streaming_active` gauge dropping, with no new Sentry event