### PR TITLE
admin: per-service uptime in /version + Sentry env-link

### DIFF
--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -190,13 +190,15 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag (threaded through Config{Version} into the Server);
 // sha + built_at are read from the binary's embedded VCS info (Go's
-// automatic -buildvcs).
+// automatic -buildvcs). started_at is when the process began so callers
+// can derive uptime themselves.
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: s.Version}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: s.Version, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, set := range info.Settings {
@@ -214,6 +216,10 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "couldn't encode version response", "err", err)
 	}
 }
+
+// startedAt marks process start so /version can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
 // (via otelhttp.Labeler) and traces (via the active span), and overrides

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -54,6 +55,9 @@ const (
 	// lands straight in that namespace's flow view instead of Hubble's "choose
 	// a namespace" page — see hubbleNamespace.
 	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
+	// sentryURL is the org's issue list. gatherLinks appends ?environment=<env>
+	// so the link lands pre-filtered to this env's issues — see sentryEnv.
+	sentryURL = "https://a-dana-life.sentry.io/issues/"
 )
 
 // serviceStatus is one row in the admin panel's status table.
@@ -63,12 +67,14 @@ type serviceStatus struct {
 	Detail     string
 	Version    string // optional build tag (e.g. vlc-server's, from /version)
 	VersionURL string // changelog link (at the build's sha) for Version
+	Uptime     string // human-readable "up Xh"; empty when the service is unreachable
 }
 
 // versionInfo is the subset of a service's /version JSON the page uses.
 type versionInfo struct {
-	Tag string `json:"tag"`
-	Sha string `json:"sha"`
+	Tag       string `json:"tag"`
+	Sha       string `json:"sha"`
+	StartedAt string `json:"started_at"` // RFC3339; used to derive uptime locally
 }
 
 // nowPlaying is the current-video summary shown when vlc-server is healthy.
@@ -142,6 +148,7 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		OK:         twitchConnected.Load(),
 		Version:    versionTag,
 		VersionURL: changelogURL(sha),
+		Uptime:     uptimeSince(startedAt),
 	}
 	if tripbot.OK {
 		tripbot.Detail = "in chat"
@@ -158,9 +165,18 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		vlc.Detail = "healthy"
 		vlc.Version = vlcVer.Tag
 		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
+		if t, err := time.Parse(time.RFC3339, vlcVer.StartedAt); err == nil {
+			vlc.Uptime = uptimeSince(t)
+		}
 	}
 
 	return []serviceStatus{tripbot, vlc}
+}
+
+// uptimeSince formats a "since" duration as the short Go duration string
+// rounded to the second — matches the meta-line uptime format.
+func uptimeSince(t time.Time) string {
+	return time.Since(t).Round(time.Second).String()
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -244,8 +260,21 @@ func gatherLinks() []navLink {
 		navLink{Label: "grafana", URL: grafanaURL},
 		navLink{Label: "traefik", URL: traefikURL},
 		navLink{Label: "hubble", URL: hubbleBaseURL + "?namespace=" + hubbleNamespace()},
+		navLink{Label: "sentry", URL: sentryURL + "?environment=" + sentryEnv()},
 	)
 	return links
+}
+
+// sentryEnv returns the environment tag Sentry events carry, so the admin
+// panel's "sentry" link lands pre-filtered to this env's issues. Reads
+// SENTRY_ENVIRONMENT (what the sentry-go SDK uses) so the link tag stays
+// in sync with the events. Falls back to ENV for cases (tests, unset envs)
+// where SENTRY_ENVIRONMENT isn't set.
+func sentryEnv() string {
+	if v := os.Getenv("SENTRY_ENVIRONMENT"); v != "" {
+		return v
+	}
+	return c.Conf.Environment
 }
 
 // hubbleNamespace returns the Kubernetes namespace to deep-link the Hubble flow
@@ -316,6 +345,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   ul { list-style:none; margin:0; padding:0; }
   .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
   .row .name { flex:1; }
+  .row .uptime { font-size:.85em; color:#666; }
   .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
   /* status hugs the far right and right-aligns so it forms a clean column,
      aligned whether or not the row carries a version */
@@ -365,6 +395,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     <li class="row">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
+      {{if .Uptime}}<span class="uptime">up {{.Uptime}}</span>{{end}}
       {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
       <span class="status">{{.Detail}}</span>
     </li>

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sync/atomic"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -63,13 +64,15 @@ func TwitchConnected() bool {
 
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag; sha + built_at are read from the binary's embedded
-// VCS info (Go's automatic -buildvcs).
+// VCS info (Go's automatic -buildvcs). started_at is when the process
+// began (admin.startedAt) so callers can derive uptime themselves.
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: versionTag}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/mux"
@@ -49,17 +50,19 @@ func (s *Server) rtspHealthHandler(w http.ResponseWriter, r *http.Request) {
 // versionHandler returns build metadata as JSON. The tag comes from
 // Server.Version (injected via Config at construction time); sha +
 // built_at are read from the binary's embedded VCS info (Go's automatic
-// -buildvcs).
+// -buildvcs). started_at is when the process began so callers can derive
+// uptime themselves.
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	tag := s.Version
 	if tag == "" {
 		tag = "dev"
 	}
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: tag}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: tag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, st := range info.Settings {
@@ -77,6 +80,10 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "couldn't encode version response", "err", err)
 	}
 }
+
+// startedAt marks process start so /version can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
 
 func (s *Server) vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {
 	// return the currently-playing file


### PR DESCRIPTION
**Stacked on #651 (admin panel rename).** Merge #651 first; this PR re-targets `develop` automatically.

## Summary
- Each `/version` JSON response gains `started_at` (RFC3339) so callers can derive uptime locally — added to tripbot, vlc-server, and onscreens-server.
- Admin panel renders an "up Xh" pill on every service row, between name and version. tripbot reads its own `startedAt`; vlc-server's comes through `/version`.
- Sentry joins the dashboard link strip, pre-filtered to this env's issues via `?environment=<SENTRY_ENVIRONMENT>` — the same tag the sentry-go SDK already stamps on every event (set per-env in the k8s manifests: `prod-1` / `stage-1` / `development`).

OBS uptime is deferred — OBS doesn't have an HTTP /version surface; vlc-server polls it for the streaming gauge, so a future "OBS connected since" pull-through would be the path there.

## Test plan
- [x] `task test:macos` green
- [ ] Hit `/version` on running tripbot + vlc-server + onscreens-server; confirm `started_at` present
- [ ] Visit `/` on running tripbot; confirm uptime pills render on tripbot + vlc-server rows
- [ ] Click "sentry" link; confirm it lands at `a-dana-life.sentry.io/issues/?environment=prod-1` (or the right env)