### PR TITLE
admin: OBS stream toggle (molly switch) + pkg/obs control surface

### DIFF
--- a/pkg/obs/control.go
+++ b/pkg/obs/control.go
@@ -1,0 +1,84 @@
+package obs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	goobs "github.com/andreykaipov/goobs"
+)
+
+// dial opens a fresh OBS WebSocket connection using the same env vars
+// PollStreamingActive reads. Callers are responsible for client.Disconnect().
+// Returns an error if either OBS is unreachable or the password is rejected;
+// caller logs at the appropriate level for its context.
+func dial(_ context.Context) (*goobs.Client, error) {
+	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
+	if addr == "" {
+		addr = "obs:4455"
+	}
+	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
+	if passwd == "" {
+		passwd = "adanalife"
+	}
+	return goobs.New(addr, goobs.WithPassword(passwd))
+}
+
+// StartStream tells OBS to begin streaming. Opens a fresh connection per
+// call — toggle clicks are rare, so a long-lived shared client isn't worth
+// the coordination cost.
+func StartStream(ctx context.Context) error {
+	client, err := dial(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	_, err = client.Stream.StartStream()
+	return err
+}
+
+// StopStream tells OBS to stop streaming. Symmetric to StartStream.
+func StopStream(ctx context.Context) error {
+	client, err := dial(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	_, err = client.Stream.StopStream()
+	return err
+}
+
+// ErrUnreachable is returned by GetStreamStatus when OBS itself can't be
+// reached — distinguishes "OBS is down" from "OBS replied 'not streaming'".
+// Callers can render a different UX for the unreachable case.
+var ErrUnreachable = errors.New("obs websocket unreachable")
+
+// GetStreamStatus reports whether OBS is currently streaming. Returns
+// ErrUnreachable wrapped with the underlying dial error when OBS itself
+// can't be reached, so the admin panel can render "OBS unreachable"
+// rather than a misleading "not streaming."
+func GetStreamStatus(ctx context.Context) (bool, error) {
+	client, err := dial(ctx)
+	if err != nil {
+		return false, errors.Join(ErrUnreachable, err)
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	resp, err := client.Stream.GetStreamStatus()
+	if err != nil {
+		return false, err
+	}
+	return resp.OutputActive, nil
+}

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -190,13 +190,15 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag (threaded through Config{Version} into the Server);
 // sha + built_at are read from the binary's embedded VCS info (Go's
-// automatic -buildvcs).
+// automatic -buildvcs). started_at is when the process began so callers
+// can derive uptime themselves.
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: s.Version}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: s.Version, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, set := range info.Settings {
@@ -214,6 +216,10 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "couldn't encode version response", "err", err)
 	}
 }
+
+// startedAt marks process start so /version can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
 // (via otelhttp.Labeler) and traces (via the active span), and overrides

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/obs"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
+	"github.com/gorilla/mux"
 )
 
 // startedAt marks process start so the admin panel can report uptime. Set at
@@ -38,6 +40,14 @@ var (
 	// token; the admin panel renders a re-auth prompt for each. Overridable in
 	// tests. Reads in-memory token state — no DB or network call.
 	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
+	// obsStreamStatus reports whether OBS is currently streaming. Function-seam
+	// so handler tests can stub without opening a real OBS WebSocket. Default
+	// hits OBS via pkg/obs (fresh connection per call — see obs.GetStreamStatus).
+	obsStreamStatus = obs.GetStreamStatus
+	// obsStartStream / obsStopStream send the toggle commands to OBS. Function
+	// seams for the same reason. Default to pkg/obs.
+	obsStartStream = obs.StartStream
+	obsStopStream  = obs.StopStream
 )
 
 const (
@@ -84,6 +94,16 @@ type nowPlaying struct {
 	Progress string
 }
 
+// streamControl drives the OBS stream toggle widget. Reachable=false hides
+// the action button (we don't want to offer "Start" when OBS is unreachable
+// — the click would just fail). When Reachable=true, Active selects the
+// button label/style: "Stop stream" (red) when active, "Start stream"
+// (green) when idle.
+type streamControl struct {
+	Reachable bool
+	Active    bool
+}
+
 // navLink is one entry in the admin panel's links list.
 type navLink struct {
 	Label string
@@ -99,6 +119,7 @@ type adminData struct {
 	Chatters int // users currently in chat
 	Services []serviceStatus
 	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Stream   streamControl
 	Links    []navLink
 	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
@@ -126,6 +147,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Chatters: chatterCount(),
 		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
 		Now:      currentVideo(vlcOK),
+		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
 	}
@@ -177,6 +199,44 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 // rounded to the second — matches the meta-line uptime format.
 func uptimeSince(t time.Time) string {
 	return time.Since(t).Round(time.Second).String()
+}
+
+// gatherStream asks OBS for the current streaming state. A reachability
+// failure (OBS down, password wrong) returns Reachable=false so the panel
+// hides the toggle button rather than offering an action that would just
+// fail. The OBS WebSocket connection is opened + closed inside obs.GetStreamStatus.
+func gatherStream(ctx context.Context) streamControl {
+	active, err := obsStreamStatus(ctx)
+	if err != nil {
+		// Reachability failure is a normal "OBS not running" condition on
+		// dev clusters — log at debug, render as unreachable, move on.
+		slog.DebugContext(ctx, "obs stream status unavailable", "err", err)
+		return streamControl{Reachable: false}
+	}
+	return streamControl{Reachable: true, Active: active}
+}
+
+// obsStreamActionHandler handles POST /admin/obs/stream/{action} (action =
+// "start" or "stop") from the admin panel's toggle form. Calls into pkg/obs
+// to flip OBS's streaming state, then 303-redirects to "/" so the panel
+// reflects the new state on reload. Errors log + still redirect — the
+// refreshed panel will show the actual state, which is the source of truth.
+func obsStreamActionHandler(w http.ResponseWriter, r *http.Request) {
+	action := mux.Vars(r)["action"]
+	var err error
+	switch action {
+	case "start":
+		err = obsStartStream(r.Context())
+	case "stop":
+		err = obsStopStream(r.Context())
+	default:
+		http.Error(w, "unknown action", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		slog.ErrorContext(r.Context(), "obs stream toggle failed", "action", action, "err", err)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -367,6 +427,16 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .reauth a.btn { display:inline-block; background:#ffb454; color:#1a1100; font-weight:600; padding:8px 14px; border-radius:6px; }
   .reauth a.btn:hover { background:#ffc578; color:#1a1100; }
   .reauth .why { font-family:var(--mono); font-size:.85em; opacity:.85; }
+  /* stream toggle — start (green) or stop (red), with a molly-switch two-click confirm */
+  .stream-form { margin:8px 0 12px; }
+  button.stream { font:inherit; font-weight:600; padding:9px 18px; border-radius:6px; border:none; cursor:pointer; transition:background .15s, color .15s; }
+  button.stream.start { background:#1f6f3e; color:#e8f7ec; }
+  button.stream.start:hover { background:#2a8a4d; }
+  button.stream.stop  { background:#6a1e1e; color:#fbe6e6; }
+  button.stream.stop:hover  { background:#852828; }
+  /* armed = first click landed; second click within 5s actually fires */
+  button.stream.armed { background:#f85149; color:#fff; box-shadow:0 0 0 2px #f8514980; }
+  .stream-unreachable { color:#666; font-size:.9em; font-style:italic; margin:6px 0 0; }
 </style>
 </head>
 <body>
@@ -402,6 +472,21 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{end}}
   </ul>
 
+  <h2>stream</h2>
+  {{if .Stream.Reachable}}
+    {{if .Stream.Active}}
+    <form class="stream-form" method="post" action="/admin/obs/stream/stop">
+      <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armStream(this)">stop stream</button>
+    </form>
+    {{else}}
+    <form class="stream-form" method="post" action="/admin/obs/stream/start">
+      <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armStream(this)">start stream</button>
+    </form>
+    {{end}}
+  {{else}}
+  <p class="stream-unreachable">OBS unreachable</p>
+  {{end}}
+
   {{with .Now}}
   <h2>now playing</h2>
   <p class="now">
@@ -416,5 +501,29 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>
 </main>
+<script>
+// Molly switch: first click arms the button (relabel + redden, 5s window);
+// second click within the window lets the form submit. Click-away or timeout
+// disarms. No deps — vanilla DOM only.
+function armStream(btn) {
+  if (btn.dataset.armed === '1') {
+    return true; // confirm — let the form submit
+  }
+  btn.dataset.armed = '1';
+  btn.classList.add('armed');
+  btn.textContent = btn.dataset.armLabel;
+  const disarm = () => {
+    btn.dataset.armed = '';
+    btn.classList.remove('armed');
+    btn.textContent = btn.dataset.originalLabel;
+    document.removeEventListener('click', outsideClick, true);
+  };
+  const outsideClick = (e) => { if (e.target !== btn) disarm(); };
+  setTimeout(disarm, 5000);
+  // capture-phase listener so clicks anywhere else disarm before they bubble
+  setTimeout(() => document.addEventListener('click', outsideClick, true), 0);
+  return false; // suppress this submit
+}
+</script>
 </body>
 </html>`))

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -54,6 +55,9 @@ const (
 	// lands straight in that namespace's flow view instead of Hubble's "choose
 	// a namespace" page — see hubbleNamespace.
 	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
+	// sentryURL is the org's issue list. gatherLinks appends ?environment=<env>
+	// so the link lands pre-filtered to this env's issues — see sentryEnv.
+	sentryURL = "https://a-dana-life.sentry.io/issues/"
 )
 
 // serviceStatus is one row in the admin panel's status table.
@@ -63,12 +67,14 @@ type serviceStatus struct {
 	Detail     string
 	Version    string // optional build tag (e.g. vlc-server's, from /version)
 	VersionURL string // changelog link (at the build's sha) for Version
+	Uptime     string // human-readable "up Xh"; empty when the service is unreachable
 }
 
 // versionInfo is the subset of a service's /version JSON the page uses.
 type versionInfo struct {
-	Tag string `json:"tag"`
-	Sha string `json:"sha"`
+	Tag       string `json:"tag"`
+	Sha       string `json:"sha"`
+	StartedAt string `json:"started_at"` // RFC3339; used to derive uptime locally
 }
 
 // nowPlaying is the current-video summary shown when vlc-server is healthy.
@@ -142,6 +148,7 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		OK:         twitchConnected.Load(),
 		Version:    versionTag,
 		VersionURL: changelogURL(sha),
+		Uptime:     uptimeSince(startedAt),
 	}
 	if tripbot.OK {
 		tripbot.Detail = "in chat"
@@ -158,9 +165,18 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		vlc.Detail = "healthy"
 		vlc.Version = vlcVer.Tag
 		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
+		if t, err := time.Parse(time.RFC3339, vlcVer.StartedAt); err == nil {
+			vlc.Uptime = uptimeSince(t)
+		}
 	}
 
 	return []serviceStatus{tripbot, vlc}
+}
+
+// uptimeSince formats a "since" duration as the short Go duration string
+// rounded to the second — matches the meta-line uptime format.
+func uptimeSince(t time.Time) string {
+	return time.Since(t).Round(time.Second).String()
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -244,8 +260,21 @@ func gatherLinks() []navLink {
 		navLink{Label: "grafana", URL: grafanaURL},
 		navLink{Label: "traefik", URL: traefikURL},
 		navLink{Label: "hubble", URL: hubbleBaseURL + "?namespace=" + hubbleNamespace()},
+		navLink{Label: "sentry", URL: sentryURL + "?environment=" + sentryEnv()},
 	)
 	return links
+}
+
+// sentryEnv returns the environment tag Sentry events carry, so the admin
+// panel's "sentry" link lands pre-filtered to this env's issues. Reads
+// SENTRY_ENVIRONMENT (what the sentry-go SDK uses) so the link tag stays
+// in sync with the events. Falls back to ENV for cases (tests, unset envs)
+// where SENTRY_ENVIRONMENT isn't set.
+func sentryEnv() string {
+	if v := os.Getenv("SENTRY_ENVIRONMENT"); v != "" {
+		return v
+	}
+	return c.Conf.Environment
 }
 
 // hubbleNamespace returns the Kubernetes namespace to deep-link the Hubble flow
@@ -316,6 +345,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   ul { list-style:none; margin:0; padding:0; }
   .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
   .row .name { flex:1; }
+  .row .uptime { font-size:.85em; color:#666; }
   .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
   /* status hugs the far right and right-aligns so it forms a clean column,
      aligned whether or not the row carries a version */
@@ -365,6 +395,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     <li class="row">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
+      {{if .Uptime}}<span class="uptime">up {{.Uptime}}</span>{{end}}
       {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
       <span class="status">{{.Detail}}</span>
     </li>

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +12,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
+	"github.com/gorilla/mux"
 )
 
 func TestSiblingURL(t *testing.T) {
@@ -52,6 +55,96 @@ func TestChangelogURL(t *testing.T) {
 		t.Errorf("changelogURL(\"\") = %q, want %q", got, want)
 	}
 }
+
+// withObsStream swaps the obsStartStream / obsStopStream / obsStreamStatus
+// seams to test fakes so we can exercise the handler without an OBS
+// WebSocket. Returns the captured invocation counts.
+func withObsStream(t *testing.T, startErr, stopErr error) (started, stopped *int) {
+	t.Helper()
+	savedStart, savedStop := obsStartStream, obsStopStream
+	t.Cleanup(func() { obsStartStream, obsStopStream = savedStart, savedStop })
+	started, stopped = new(int), new(int)
+	obsStartStream = func(context.Context) error { *started++; return startErr }
+	obsStopStream = func(context.Context) error { *stopped++; return stopErr }
+	return started, stopped
+}
+
+func TestObsStreamActionHandler_StartRedirectsAndCalls(t *testing.T) {
+	started, _ := withObsStream(t, nil, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if got := rec.Header().Get("Location"); got != "/" {
+		t.Fatalf("got Location %q, want /", got)
+	}
+	if *started != 1 {
+		t.Fatalf("obsStartStream called %d times, want 1", *started)
+	}
+}
+
+func TestObsStreamActionHandler_StopRedirectsAndCalls(t *testing.T) {
+	_, stopped := withObsStream(t, nil, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/stop", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if *stopped != 1 {
+		t.Fatalf("obsStopStream called %d times, want 1", *stopped)
+	}
+}
+
+func TestObsStreamActionHandler_UnknownActionIs400(t *testing.T) {
+	withObsStream(t, nil, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/bogus", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestObsStreamActionHandler_RedirectsEvenOnError(t *testing.T) {
+	// State is the source of truth — refreshed panel will show the actual
+	// state. Surfacing the error in flash UI isn't worth the complexity for
+	// a tailnet-only solo-operator panel.
+	started, _ := withObsStream(t, errFakeOBS, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if *started != 1 {
+		t.Fatalf("obsStartStream called %d times, want 1", *started)
+	}
+}
+
+var errFakeOBS = errors.New("fake OBS error")
 
 func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sync/atomic"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -63,13 +64,15 @@ func TwitchConnected() bool {
 
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag; sha + built_at are read from the binary's embedded
-// VCS info (Go's automatic -buildvcs).
+// VCS info (Go's automatic -buildvcs). started_at is when the process
+// began (admin.startedAt) so callers can derive uptime themselves.
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: versionTag}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,11 @@ func Start(ctx context.Context) {
 	// admin panel (status overview + links) on the root path
 	r.Handle("/", tagged("/", adminHandler)).Methods("GET", "HEAD")
 
+	// admin actions — tailnet-only by virtue of where the Ingress is
+	// exposed; no app-layer auth gate (see CLAUDE.md / vault decisions).
+	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
+	admin.Handle("/obs/stream/{action}", tagged("/admin/obs/stream/{action}", obsStreamActionHandler))
+
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)
 

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/mux"
@@ -49,17 +50,19 @@ func (s *Server) rtspHealthHandler(w http.ResponseWriter, r *http.Request) {
 // versionHandler returns build metadata as JSON. The tag comes from
 // Server.Version (injected via Config at construction time); sha +
 // built_at are read from the binary's embedded VCS info (Go's automatic
-// -buildvcs).
+// -buildvcs). started_at is when the process began so callers can derive
+// uptime themselves.
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	tag := s.Version
 	if tag == "" {
 		tag = "dev"
 	}
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: tag}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: tag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, st := range info.Settings {
@@ -77,6 +80,10 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "couldn't encode version response", "err", err)
 	}
 }
+
+// startedAt marks process start so /version can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
 
 func (s *Server) vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {
 	// return the currently-playing file


### PR DESCRIPTION
**Heads-up:** PR #653 (per-service uptime + Sentry link) merged into `feature/admin-panel-rename` but its content didn't reach `develop` (only #651's rename squashed in). This PR now carries #653's commits forward — 4 logical pieces total:

1. **`version: include started_at in /version JSON`** — original #653 commit. Each `/version` response gains `started_at` (RFC3339) so callers can derive uptime locally. Adds it to tripbot, vlc-server, onscreens-server.
2. **`admin: render per-service uptime + add Sentry env-link`** — original #653 commit. Each service row gets an "up Xh" pill; Sentry joins the dashboard link strip pre-filtered to this env via `SENTRY_ENVIRONMENT`.
3. **`obs: add StartStream / StopStream / GetStreamStatus to pkg/obs`** — new control surface, fresh OBS WebSocket connection per call. `ErrUnreachable` distinguishes "OBS down" from "not streaming".
4. **`admin: OBS stream toggle with molly-switch confirm`** — new "stream" section on the admin panel. Single button: red "stop stream" when active, green "start stream" when idle, "OBS unreachable" when OBS is down. Molly switch: first click arms (relabel + redden, 5s timer), second click within window submits. ~20 lines of vanilla JS, no deps. `POST /admin/obs/stream/{start,stop}` → 303 to `/`. Tailnet-only by Ingress; no app-layer auth.

## Test plan
- [x] `task test:macos` green (handler tests cover start, stop, unknown-action 400, redirect-on-error)
- [ ] Visit `/` on a running tripbot; confirm uptime pills + Sentry link + stream toggle render
- [ ] Click button; confirm it arms with new label + red; click again; confirm OBS state flips
- [ ] Click button + click somewhere else; confirm disarm within 5s
- [ ] Hit each `/version` (tripbot, vlc-server, onscreens-server); confirm `started_at` present