### PR TITLE
Release v2.15.2: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.15.2] — 2026-05-24
+
+Patch release. The landing page graduates into an admin panel: renamed throughout, with a clickable logo, per-service uptime pills, an env-aware Sentry deep-link, and a stream on/off toggle with a two-click molly switch. Small chatbot + onscreens polish on the side: `!song` no longer attributes SomaFM as the source (Twitch policy hedge), `!somafm` credit command added, and the `!timewarp` cover now reliably spans the inter-clip cut.
+
+### admin panel (formerly "landing page")
+
+- **Rename "landing page" → "admin panel" throughout.** File `pkg/server/landing.go` → `admin.go` (paired test file too), Go symbols (`landingHandler`/`landingTmpl`/`landingData` → `admin*`), test names, and comment references across server / httpmw / instrumentation / cmd / twitch. URL route stays `/`. First sub-step of repurposing the page from a passive status surface into an admin/ops panel — actual admin features land in this release too (see below). ([#651])
+- **Logo is a refresh button.** Wraps the A Dana Life mark in `<a href="/">` so clicking it reloads the page. Cheap dynamic-feel UX since the panel refreshes its data per request anyway. ([#650])
+- **Per-service uptime pills.** Each row on the status table now carries an "up Xh" pill between name and version. Powered by a new `started_at` (RFC3339) field on each binary's `/version` response — tripbot, vlc-server, and onscreens-server — that callers can derive uptime from locally. ([#654])
+- **Sentry env-link.** Sentry joins the dashboard link strip, pre-filtered to this env's issues via `?environment=<SENTRY_ENVIRONMENT>` (the same tag the sentry-go SDK already stamps on every event). ([#654])
+- **OBS stream on/off toggle with molly-switch confirm.** New "stream" section on the panel with a single button reflecting the inverse of OBS's current state: red "stop stream" when active, green "start stream" when idle, "OBS unreachable" when OBS is down. **Molly switch:** first click arms the button (relabel + redden, 5s timer); second click within the window submits. Click-away or timeout disarms. ~20 lines of vanilla JS, no deps. `POST /admin/obs/stream/{start,stop}` calls into the new `pkg/obs` control surface directly — no HTTP hop through vlc-server. Tailnet-only by virtue of the Ingress; no app-layer auth gate. ([#654])
+
+### chatbot
+
+- **`!song` drops the SomaFM/Groove Salad attribution.** Replies with just the track now ("&lt;artist&gt; — &lt;title&gt;") instead of naming the source service — keeps the Twitch music-policy surface smaller while VOD-free playback continues. Adds a separate `!somafm` command that responds with a SomaFM credit + link, so the attribution stays available on demand. ([#648])
+
+### onscreens
+
+- **`!timewarp` cover spans the cut.** Bumped the cover animation another 200ms so it stays opaque through the H.264 discontinuity reliably, not just usually. Server-side hide timer bumped to match. ([#649])
+
+### obs / pkg
+
+- **`pkg/obs` gets a control surface.** New `obs.StartStream(ctx)`, `obs.StopStream(ctx)`, `obs.GetStreamStatus(ctx) (active bool, err error)` package-level functions that each open + close a fresh OBS WebSocket connection. Toggle clicks are rare, so a long-lived shared client isn't worth the coordination cost; `PollStreamingActive`'s existing connection stays as-is for the metrics path. `obs.ErrUnreachable` distinguishes "OBS down" from "OBS replied 'not streaming'", so the admin panel can render a different UX for each. ([#654])
+- **`obs.GetStreamStatus` transient errors demoted to `slog.Warn`.** Polling failures that recover within the reconnect window were spamming the error log + Sentry; warn-level keeps them in Loki without the noise. ([#652])
+
+[#648]: https://github.com/adanalife/tripbot/pull/648
+[#649]: https://github.com/adanalife/tripbot/pull/649
+[#650]: https://github.com/adanalife/tripbot/pull/650
+[#651]: https://github.com/adanalife/tripbot/pull/651
+[#652]: https://github.com/adanalife/tripbot/pull/652
+[#654]: https://github.com/adanalife/tripbot/pull/654
+
 ## [v2.15.1] — 2026-05-24
 
 Patch release. Closes two operational gaps surfaced in the launch cutover: viewer `!report` chat reports now POST to a Discord webhook (with the existing slog/Sentry path kept as audit trail), and vlc-server gains an in-process RTSP DESCRIBE watchdog that self-heals the silent "OPTIONS 200 / DESCRIBE 500 / OBS sees nothing" failure mode confirmed on both stage-1 and prod-1 over the past few days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Patch release. The landing page graduates into an admin panel: renamed throughou
 - **Rename "landing page" → "admin panel" throughout.** File `pkg/server/landing.go` → `admin.go` (paired test file too), Go symbols (`landingHandler`/`landingTmpl`/`landingData` → `admin*`), test names, and comment references across server / httpmw / instrumentation / cmd / twitch. URL route stays `/`. First sub-step of repurposing the page from a passive status surface into an admin/ops panel — actual admin features land in this release too (see below). ([#651])
 - **Logo is a refresh button.** Wraps the A Dana Life mark in `<a href="/">` so clicking it reloads the page. Cheap dynamic-feel UX since the panel refreshes its data per request anyway. ([#650])
 - **Per-service uptime pills.** Each row on the status table now carries an "up Xh" pill between name and version. Powered by a new `started_at` (RFC3339) field on each binary's `/version` response — tripbot, vlc-server, and onscreens-server — that callers can derive uptime from locally. ([#654])
+- **onscreens-server in the status table.** Third row alongside tripbot and vlc-server, probed via the existing `ONSCREENS_SERVER_HOST` env var (same `/health/ready` + `/version` shape vlc uses). Refactor extracts a `siblingStatus(name, host)` helper so future services drop in as one line. ([#656])
 - **Sentry env-link.** Sentry joins the dashboard link strip, pre-filtered to this env's issues via `?environment=<SENTRY_ENVIRONMENT>` (the same tag the sentry-go SDK already stamps on every event). ([#654])
 - **OBS stream on/off toggle with molly-switch confirm.** New "stream" section on the panel with a single button reflecting the inverse of OBS's current state: red "stop stream" when active, green "start stream" when idle, "OBS unreachable" when OBS is down. **Molly switch:** first click arms the button (relabel + redden, 5s timer); second click within the window submits. Click-away or timeout disarms. ~20 lines of vanilla JS, no deps. `POST /admin/obs/stream/{start,stop}` calls into the new `pkg/obs` control surface directly — no HTTP hop through vlc-server. Tailnet-only by virtue of the Ingress; no app-layer auth gate. ([#654])
 
@@ -36,6 +37,7 @@ Patch release. The landing page graduates into an admin panel: renamed throughou
 [#651]: https://github.com/adanalife/tripbot/pull/651
 [#652]: https://github.com/adanalife/tripbot/pull/652
 [#654]: https://github.com/adanalife/tripbot/pull/654
+[#656]: https://github.com/adanalife/tripbot/pull/656
 
 ## [v2.15.1] — 2026-05-24
 

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -199,8 +199,8 @@ func startCron() {
 // token lands — rather than crashlooping. A crashing pod after a wipe also
 // raced the DB restore's migrate init (see the 2026-05-20 convergence-wipe
 // notes); staying up avoids that. The pod stays Ready throughout (readiness
-// no longer gates on Twitch) so the landing page + /auth/init are reachable
-// to re-auth; "not in chat" is surfaced via the landing page + the
+// no longer gates on Twitch) so the admin panel + /auth/init are reachable
+// to re-auth; "not in chat" is surfaced via the admin panel + the
 // tripbot_twitch_connected gauge instead.
 func loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
@@ -282,9 +282,9 @@ func connectToTwitch() {
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
 	// Mark the bot connected to chat once the IRC connection is established.
-	// This drives the landing-page status row + the tripbot_twitch_connected
+	// This drives the admin-panel status row + the tripbot_twitch_connected
 	// gauge — it does NOT gate /health/ready, which stays 200 so the pod keeps
-	// serving the landing page + /auth/* even while the bot is offline.
+	// serving the admin panel + /auth/* even while the bot is offline.
 	client.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
 		server.SetTwitchConnected(true)
@@ -295,7 +295,7 @@ func connectToTwitch() {
 	for {
 		slog.Info("initializing connection to Twitch")
 		// Connect blocks while connected and returns when the connection
-		// drops; mark not-in-chat so the landing page + gauge reflect the gap
+		// drops; mark not-in-chat so the admin panel + gauge reflect the gap
 		// until the next OnConnect fires.
 		err := client.Connect()
 		server.SetTwitchConnected(false)
@@ -314,7 +314,7 @@ func connectToTwitch() {
 				} else {
 					// Reauth couldn't produce a token (refresh_token revoked and
 					// no fresh row in the DB yet). Surface the re-bootstrap link
-					// so re-auth is a click; the landing page shows it too.
+					// so re-auth is a click; the admin panel shows it too.
 					slog.Error("IRC auth failed and no valid token after reauth; re-bootstrap needed", "login_as", c.Conf.BotUsername, "reauth_url", mytwitch.AuthInitURL("bot"))
 				}
 			}

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -209,6 +209,12 @@ func (a *App) buildRegistry() []Command {
 			Aliases: []string{"!music"},
 			Handler: a.songCmd,
 		},
+		{
+			Trigger: "!somafm",
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Stream music by SomaFM — https://somafm.com")
+			},
+		},
 	}
 }
 

--- a/pkg/chatbot/song.go
+++ b/pkg/chatbot/song.go
@@ -102,8 +102,8 @@ func (a *App) songCmd(ctx context.Context, user *users.User, _ []string) {
 	artist, title, err := a.NowPlaying.Current(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "now-playing fetch failed", "err", err)
-		a.IRC.Say("Couldn't reach SomaFM for the current track, sorry!")
+		a.IRC.Say("Couldn't reach the music source for the current track, sorry!")
 		return
 	}
-	a.IRC.Say(fmt.Sprintf("♪ Now playing on SomaFM Groove Salad Classic: %s — %s", title, artist))
+	a.IRC.Say(fmt.Sprintf("♪ Now playing: %s — %s", title, artist))
 }

--- a/pkg/httpmw/health.go
+++ b/pkg/httpmw/health.go
@@ -39,7 +39,7 @@ func LivenessHandler() http.HandlerFunc {
 // status so a failing probe is debuggable from `kubectl describe pod`'s
 // probe output. With no checks, the handler always reports 200 —
 // equivalent to LivenessHandler but distinguishable on the URL. tripbot
-// registers it with no checks on purpose: its HTTP surface (landing page,
+// registers it with no checks on purpose: its HTTP surface (admin panel,
 // /auth/init, /auth/callback, /metrics) doesn't depend on the Twitch
 // connection, so the pod must stay in the Service even when the bot is
 // offline — otherwise the very page used to re-auth would 503.

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -71,7 +71,7 @@ var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followe
 // TwitchConnection exposes the chat-connection gauge. Set(true) on IRC
 // connect, Set(false) on disconnect. Readiness no longer gates on the Twitch
 // connection (the pod stays in the Service so the re-auth page is reachable),
-// so this gauge — alongside the landing-page status row — is what surfaces
+// so this gauge — alongside the admin-panel status row — is what surfaces
 // "up but not in chat" to dashboards and alerts.
 var TwitchConnection = twitchConnectionIface{gauge: twitchConnected}
 

--- a/pkg/obs/control.go
+++ b/pkg/obs/control.go
@@ -1,0 +1,84 @@
+package obs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	goobs "github.com/andreykaipov/goobs"
+)
+
+// dial opens a fresh OBS WebSocket connection using the same env vars
+// PollStreamingActive reads. Callers are responsible for client.Disconnect().
+// Returns an error if either OBS is unreachable or the password is rejected;
+// caller logs at the appropriate level for its context.
+func dial(_ context.Context) (*goobs.Client, error) {
+	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
+	if addr == "" {
+		addr = "obs:4455"
+	}
+	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
+	if passwd == "" {
+		passwd = "adanalife"
+	}
+	return goobs.New(addr, goobs.WithPassword(passwd))
+}
+
+// StartStream tells OBS to begin streaming. Opens a fresh connection per
+// call — toggle clicks are rare, so a long-lived shared client isn't worth
+// the coordination cost.
+func StartStream(ctx context.Context) error {
+	client, err := dial(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	_, err = client.Stream.StartStream()
+	return err
+}
+
+// StopStream tells OBS to stop streaming. Symmetric to StartStream.
+func StopStream(ctx context.Context) error {
+	client, err := dial(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	_, err = client.Stream.StopStream()
+	return err
+}
+
+// ErrUnreachable is returned by GetStreamStatus when OBS itself can't be
+// reached — distinguishes "OBS is down" from "OBS replied 'not streaming'".
+// Callers can render a different UX for the unreachable case.
+var ErrUnreachable = errors.New("obs websocket unreachable")
+
+// GetStreamStatus reports whether OBS is currently streaming. Returns
+// ErrUnreachable wrapped with the underlying dial error when OBS itself
+// can't be reached, so the admin panel can render "OBS unreachable"
+// rather than a misleading "not streaming."
+func GetStreamStatus(ctx context.Context) (bool, error) {
+	client, err := dial(ctx)
+	if err != nil {
+		return false, errors.Join(ErrUnreachable, err)
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	resp, err := client.Stream.GetStreamStatus()
+	if err != nil {
+		return false, err
+	}
+	return resp.OutputActive, nil
+}

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -65,7 +65,10 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 		case <-ticker.C:
 			resp, err := client.Stream.GetStreamStatus()
 			if err != nil {
-				slog.ErrorContext(ctx, "obs GetStreamStatus error", "err", err)
+				// Transient: OBS pod restart, network blip, websocket drop.
+				// The outer loop reconnects after 10s and OBSStreaming
+				// is the alertable signal — keep this off Sentry.
+				slog.WarnContext(ctx, "obs GetStreamStatus error", "err", err)
 				instrumentation.OBSStreaming.Set(false)
 				return // trigger reconnect
 			}

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -190,13 +190,15 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag (threaded through Config{Version} into the Server);
 // sha + built_at are read from the binary's embedded VCS info (Go's
-// automatic -buildvcs).
+// automatic -buildvcs). started_at is when the process began so callers
+// can derive uptime themselves.
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: s.Version}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: s.Version, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, set := range info.Settings {
@@ -214,6 +216,10 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "couldn't encode version response", "err", err)
 	}
 }
+
+// startedAt marks process start so /version can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
 
 // tagged wraps a HandlerFunc so the http.route attribute is set on metrics
 // (via otelhttp.Labeler) and traces (via the active span), and overrides

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -32,10 +32,10 @@
     text-shadow: 0 0 22px rgba(180, 200, 230, 0.55), 0 4px 14px rgba(0, 0, 0, 0.6);
   }
   /* the .play class (added on the showing rising-edge) drives all the timing */
-  #warp.play .cover     { animation: tw-cover 3.8s ease-in-out forwards; }
+  #warp.play .cover     { animation: tw-cover 4.0s ease-in-out forwards; }
   #warp.play .streaks i { animation: tw-streak 1s linear infinite; }
-  #warp.play .tw        { animation: tw-text 3.8s cubic-bezier(.16, .8, .3, 1) forwards; }
-  /* cover: slam opaque (0->0.4s), hold through the gap, fade out to reveal (~3.05-3.7s) */
+  #warp.play .tw        { animation: tw-text 4.0s cubic-bezier(.16, .8, .3, 1) forwards; }
+  /* cover: slam opaque (0->0.44s), hold through the gap, fade out to reveal (~3.2-3.88s) */
   @keyframes tw-cover { 0% { opacity: 0; } 11% { opacity: 1; } 80% { opacity: 1; } 97% { opacity: 0; } 100% { opacity: 0; } }
   @keyframes tw-streak {
     0%   { transform: rotate(var(--a)) translateY(0) scaleY(0.15); opacity: 0; }

--- a/pkg/onscreens-server/timewarp.go
+++ b/pkg/onscreens-server/timewarp.go
@@ -7,9 +7,9 @@ import (
 
 // timewarpDuration controls how long a !timewarp render stays "showing" before
 // the background expiry sweeper hides it. It spans the full-screen warp
-// animation in the browser source (~3.8s) with a little headroom so the cover
+// animation in the browser source (~4.0s) with a little headroom so the cover
 // is still up while the new clip's first frames decode.
-var timewarpDuration = time.Duration(4400 * time.Millisecond)
+var timewarpDuration = time.Duration(4600 * time.Millisecond)
 
 // newTimewarp constructs the timewarp *Onscreen. It checks for expiry more
 // often than the default so the onscreen flips back to hidden soon after the

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -7,13 +7,16 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime/debug"
 	"strings"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/obs"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
+	"github.com/gorilla/mux"
 )
 
 // startedAt marks process start so the admin panel can report uptime. Set at
@@ -37,6 +40,14 @@ var (
 	// token; the admin panel renders a re-auth prompt for each. Overridable in
 	// tests. Reads in-memory token state — no DB or network call.
 	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
+	// obsStreamStatus reports whether OBS is currently streaming. Function-seam
+	// so handler tests can stub without opening a real OBS WebSocket. Default
+	// hits OBS via pkg/obs (fresh connection per call — see obs.GetStreamStatus).
+	obsStreamStatus = obs.GetStreamStatus
+	// obsStartStream / obsStopStream send the toggle commands to OBS. Function
+	// seams for the same reason. Default to pkg/obs.
+	obsStartStream = obs.StartStream
+	obsStopStream  = obs.StopStream
 )
 
 const (
@@ -54,6 +65,9 @@ const (
 	// lands straight in that namespace's flow view instead of Hubble's "choose
 	// a namespace" page — see hubbleNamespace.
 	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
+	// sentryURL is the org's issue list. gatherLinks appends ?environment=<env>
+	// so the link lands pre-filtered to this env's issues — see sentryEnv.
+	sentryURL = "https://a-dana-life.sentry.io/issues/"
 )
 
 // serviceStatus is one row in the admin panel's status table.
@@ -63,12 +77,14 @@ type serviceStatus struct {
 	Detail     string
 	Version    string // optional build tag (e.g. vlc-server's, from /version)
 	VersionURL string // changelog link (at the build's sha) for Version
+	Uptime     string // human-readable "up Xh"; empty when the service is unreachable
 }
 
 // versionInfo is the subset of a service's /version JSON the page uses.
 type versionInfo struct {
-	Tag string `json:"tag"`
-	Sha string `json:"sha"`
+	Tag       string `json:"tag"`
+	Sha       string `json:"sha"`
+	StartedAt string `json:"started_at"` // RFC3339; used to derive uptime locally
 }
 
 // nowPlaying is the current-video summary shown when vlc-server is healthy.
@@ -76,6 +92,16 @@ type nowPlaying struct {
 	File     string
 	State    string
 	Progress string
+}
+
+// streamControl drives the OBS stream toggle widget. Reachable=false hides
+// the action button (we don't want to offer "Start" when OBS is unreachable
+// — the click would just fail). When Reachable=true, Active selects the
+// button label/style: "Stop stream" (red) when active, "Start stream"
+// (green) when idle.
+type streamControl struct {
+	Reachable bool
+	Active    bool
 }
 
 // navLink is one entry in the admin panel's links list.
@@ -93,6 +119,7 @@ type adminData struct {
 	Chatters int // users currently in chat
 	Services []serviceStatus
 	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Stream   streamControl
 	Links    []navLink
 	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
@@ -120,6 +147,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Chatters: chatterCount(),
 		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
 		Now:      currentVideo(vlcOK),
+		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
 	}
@@ -142,6 +170,7 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		OK:         twitchConnected.Load(),
 		Version:    versionTag,
 		VersionURL: changelogURL(sha),
+		Uptime:     uptimeSince(startedAt),
 	}
 	if tripbot.OK {
 		tripbot.Detail = "in chat"
@@ -158,9 +187,56 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		vlc.Detail = "healthy"
 		vlc.Version = vlcVer.Tag
 		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
+		if t, err := time.Parse(time.RFC3339, vlcVer.StartedAt); err == nil {
+			vlc.Uptime = uptimeSince(t)
+		}
 	}
 
 	return []serviceStatus{tripbot, vlc}
+}
+
+// uptimeSince formats a "since" duration as the short Go duration string
+// rounded to the second — matches the meta-line uptime format.
+func uptimeSince(t time.Time) string {
+	return time.Since(t).Round(time.Second).String()
+}
+
+// gatherStream asks OBS for the current streaming state. A reachability
+// failure (OBS down, password wrong) returns Reachable=false so the panel
+// hides the toggle button rather than offering an action that would just
+// fail. The OBS WebSocket connection is opened + closed inside obs.GetStreamStatus.
+func gatherStream(ctx context.Context) streamControl {
+	active, err := obsStreamStatus(ctx)
+	if err != nil {
+		// Reachability failure is a normal "OBS not running" condition on
+		// dev clusters — log at debug, render as unreachable, move on.
+		slog.DebugContext(ctx, "obs stream status unavailable", "err", err)
+		return streamControl{Reachable: false}
+	}
+	return streamControl{Reachable: true, Active: active}
+}
+
+// obsStreamActionHandler handles POST /admin/obs/stream/{action} (action =
+// "start" or "stop") from the admin panel's toggle form. Calls into pkg/obs
+// to flip OBS's streaming state, then 303-redirects to "/" so the panel
+// reflects the new state on reload. Errors log + still redirect — the
+// refreshed panel will show the actual state, which is the source of truth.
+func obsStreamActionHandler(w http.ResponseWriter, r *http.Request) {
+	action := mux.Vars(r)["action"]
+	var err error
+	switch action {
+	case "start":
+		err = obsStartStream(r.Context())
+	case "stop":
+		err = obsStopStream(r.Context())
+	default:
+		http.Error(w, "unknown action", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		slog.ErrorContext(r.Context(), "obs stream toggle failed", "action", action, "err", err)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -244,8 +320,21 @@ func gatherLinks() []navLink {
 		navLink{Label: "grafana", URL: grafanaURL},
 		navLink{Label: "traefik", URL: traefikURL},
 		navLink{Label: "hubble", URL: hubbleBaseURL + "?namespace=" + hubbleNamespace()},
+		navLink{Label: "sentry", URL: sentryURL + "?environment=" + sentryEnv()},
 	)
 	return links
+}
+
+// sentryEnv returns the environment tag Sentry events carry, so the admin
+// panel's "sentry" link lands pre-filtered to this env's issues. Reads
+// SENTRY_ENVIRONMENT (what the sentry-go SDK uses) so the link tag stays
+// in sync with the events. Falls back to ENV for cases (tests, unset envs)
+// where SENTRY_ENVIRONMENT isn't set.
+func sentryEnv() string {
+	if v := os.Getenv("SENTRY_ENVIRONMENT"); v != "" {
+		return v
+	}
+	return c.Conf.Environment
 }
 
 // hubbleNamespace returns the Kubernetes namespace to deep-link the Hubble flow
@@ -316,6 +405,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   ul { list-style:none; margin:0; padding:0; }
   .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
   .row .name { flex:1; }
+  .row .uptime { font-size:.85em; color:#666; }
   .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
   /* status hugs the far right and right-aligns so it forms a clean column,
      aligned whether or not the row carries a version */
@@ -337,6 +427,16 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .reauth a.btn { display:inline-block; background:#ffb454; color:#1a1100; font-weight:600; padding:8px 14px; border-radius:6px; }
   .reauth a.btn:hover { background:#ffc578; color:#1a1100; }
   .reauth .why { font-family:var(--mono); font-size:.85em; opacity:.85; }
+  /* stream toggle — start (green) or stop (red), with a molly-switch two-click confirm */
+  .stream-form { margin:8px 0 12px; }
+  button.stream { font:inherit; font-weight:600; padding:9px 18px; border-radius:6px; border:none; cursor:pointer; transition:background .15s, color .15s; }
+  button.stream.start { background:#1f6f3e; color:#e8f7ec; }
+  button.stream.start:hover { background:#2a8a4d; }
+  button.stream.stop  { background:#6a1e1e; color:#fbe6e6; }
+  button.stream.stop:hover  { background:#852828; }
+  /* armed = first click landed; second click within 5s actually fires */
+  button.stream.armed { background:#f85149; color:#fff; box-shadow:0 0 0 2px #f8514980; }
+  .stream-unreachable { color:#666; font-size:.9em; font-style:italic; margin:6px 0 0; }
 </style>
 </head>
 <body>
@@ -365,11 +465,27 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     <li class="row">
       <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
       <span class="name">{{.Name}}</span>
+      {{if .Uptime}}<span class="uptime">up {{.Uptime}}</span>{{end}}
       {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
       <span class="status">{{.Detail}}</span>
     </li>
     {{end}}
   </ul>
+
+  <h2>stream</h2>
+  {{if .Stream.Reachable}}
+    {{if .Stream.Active}}
+    <form class="stream-form" method="post" action="/admin/obs/stream/stop">
+      <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armStream(this)">stop stream</button>
+    </form>
+    {{else}}
+    <form class="stream-form" method="post" action="/admin/obs/stream/start">
+      <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armStream(this)">start stream</button>
+    </form>
+    {{end}}
+  {{else}}
+  <p class="stream-unreachable">OBS unreachable</p>
+  {{end}}
 
   {{with .Now}}
   <h2>now playing</h2>
@@ -385,5 +501,29 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>
 </main>
+<script>
+// Molly switch: first click arms the button (relabel + redden, 5s window);
+// second click within the window lets the form submit. Click-away or timeout
+// disarms. No deps — vanilla DOM only.
+function armStream(btn) {
+  if (btn.dataset.armed === '1') {
+    return true; // confirm — let the form submit
+  }
+  btn.dataset.armed = '1';
+  btn.classList.add('armed');
+  btn.textContent = btn.dataset.armLabel;
+  const disarm = () => {
+    btn.dataset.armed = '';
+    btn.classList.remove('armed');
+    btn.textContent = btn.dataset.originalLabel;
+    document.removeEventListener('click', outsideClick, true);
+  };
+  const outsideClick = (e) => { if (e.target !== btn) disarm(); };
+  setTimeout(disarm, 5000);
+  // capture-phase listener so clicks anywhere else disarm before they bubble
+  setTimeout(() => document.addEventListener('click', outsideClick, true), 0);
+  return false; // suppress this submit
+}
+</script>
 </body>
 </html>`))

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -16,17 +16,17 @@ import (
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
-// startedAt marks process start so the landing page can report uptime. Set at
+// startedAt marks process start so the admin panel can report uptime. Set at
 // package load; close enough to process start for a human-readable "up Xh".
 var startedAt = time.Now()
 
 // healthClient is the short-timeout client used for the sibling-service status
-// ping. 2s keeps a slow or hung vlc-server from stalling the landing render.
+// ping. 2s keeps a slow or hung vlc-server from stalling the panel render.
 var healthClient = &http.Client{Timeout: 2 * time.Second}
 
 // currentlyPlaying / currentProgress are overridable in tests; by default they
 // read pkg/video's in-process state (refreshed by a 60s cron tick), so the
-// landing page costs nothing to show "now playing".
+// admin panel costs nothing to show "now playing".
 var (
 	currentlyPlaying = video.CurrentlyPlaying
 	currentProgress  = video.CurrentProgress
@@ -34,7 +34,7 @@ var (
 	// the UpdateSession cron. Overridable in tests.
 	chatterCount = mytwitch.ChatterCount
 	// accountsNeedingReauth reports which Twitch accounts have a missing/expired
-	// token; the landing page renders a re-auth prompt for each. Overridable in
+	// token; the admin panel renders a re-auth prompt for each. Overridable in
 	// tests. Reads in-memory token state — no DB or network call.
 	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
 )
@@ -56,7 +56,7 @@ const (
 	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
 )
 
-// serviceStatus is one row in the landing page's status table.
+// serviceStatus is one row in the admin panel's status table.
 type serviceStatus struct {
 	Name       string
 	OK         bool
@@ -78,14 +78,14 @@ type nowPlaying struct {
 	Progress string
 }
 
-// navLink is one entry in the landing page's links list.
+// navLink is one entry in the admin panel's links list.
 type navLink struct {
 	Label string
 	URL   string
 }
 
-// landingData is the template payload.
-type landingData struct {
+// adminData is the template payload.
+type adminData struct {
 	Channel  string // broadcaster Twitch username
 	Bot      string // bot Twitch username
 	Env      string
@@ -97,12 +97,12 @@ type landingData struct {
 	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
-// landingHandler serves the human-facing root page on the tripbot Ingress: a
+// adminHandler serves the human-facing root page on the tripbot Ingress: a
 // lightweight status overview (tripbot's own readiness + a live vlc-server
 // ping, each version linking to its changelog), the currently-playing video
 // when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
 // / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
-func landingHandler(w http.ResponseWriter, r *http.Request) {
+func adminHandler(w http.ResponseWriter, r *http.Request) {
 	vlcOK := c.Conf.VlcServerHost != "" &&
 		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
 
@@ -112,7 +112,7 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
 	}
 
-	data := landingData{
+	data := adminData{
 		Channel:  c.Conf.ChannelName,
 		Bot:      c.Conf.BotUsername,
 		Env:      c.Conf.Environment,
@@ -125,8 +125,8 @@ func landingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := landingTmpl.Execute(w, data); err != nil {
-		slog.ErrorContext(r.Context(), "couldn't render landing page", "err", err)
+	if err := adminTmpl.Execute(w, data); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't render admin panel", "err", err)
 	}
 }
 
@@ -289,7 +289,7 @@ func siblingURL(externalURL, service string) string {
 	return u.String()
 }
 
-var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
+var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -125,19 +125,13 @@ type adminData struct {
 }
 
 // adminHandler serves the human-facing root page on the tripbot Ingress: a
-// lightweight status overview (tripbot's own readiness + a live vlc-server
-// ping, each version linking to its changelog), the currently-playing video
+// lightweight status overview (tripbot's own readiness + live sibling-service
+// pings, each version linking to its changelog), the currently-playing video
 // when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
 // / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
 func adminHandler(w http.ResponseWriter, r *http.Request) {
-	vlcOK := c.Conf.VlcServerHost != "" &&
-		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
-
-	// vlc-server's build info — one extra in-cluster GET, only when it's up.
-	var vlcVer versionInfo
-	if vlcOK {
-		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
-	}
+	vlc := siblingStatus(r.Context(), "vlc-server", c.Conf.VlcServerHost)
+	onscreens := siblingStatus(r.Context(), "onscreens-server", c.Conf.OnscreensServerHost)
 
 	data := adminData{
 		Channel:  c.Conf.ChannelName,
@@ -145,8 +139,8 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Env:      c.Conf.Environment,
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
 		Chatters: chatterCount(),
-		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
-		Now:      currentVideo(vlcOK),
+		Services: gatherStatus(buildSHA(), vlc, onscreens),
+		Now:      currentVideo(vlc.OK),
 		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
@@ -159,12 +153,9 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
-// the already-computed vlc-server health. Each row carries its build tag in a
-// version column linking to that build's changelog: tripbot's own tag (at sha,
-// the running binary's VCS revision) and vlc-server's (from its /version). The
-// vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as not-OK
-// rather than erroring the page.
-func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
+// the already-probed sibling-service rows. Each row carries its build tag in a
+// version column linking to that build's changelog at the deployed sha.
+func gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
 		OK:         twitchConnected.Load(),
@@ -182,17 +173,31 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		tripbot.Detail = "not in chat"
 	}
 
-	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}
-	if vlcOK {
-		vlc.Detail = "healthy"
-		vlc.Version = vlcVer.Tag
-		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
-		if t, err := time.Parse(time.RFC3339, vlcVer.StartedAt); err == nil {
-			vlc.Uptime = uptimeSince(t)
-		}
-	}
+	return append([]serviceStatus{tripbot}, siblings...)
+}
 
-	return []serviceStatus{tripbot, vlc}
+// siblingStatus probes a sibling HTTP service (vlc-server, onscreens-server)
+// and returns its row for the status table. Best-effort: an empty host or any
+// readiness failure (DNS, timeout, non-2xx) renders as unreachable rather than
+// erroring the page. When the probe succeeds, also fetches /version to fill in
+// the build tag (linked to its changelog at the deployed sha) and uptime.
+func siblingStatus(ctx context.Context, name, host string) serviceStatus {
+	s := serviceStatus{Name: name, Detail: "unreachable"}
+	if host == "" {
+		return s
+	}
+	if !pingHealthy(ctx, "http://"+host+"/health/ready") {
+		return s
+	}
+	s.OK = true
+	s.Detail = "healthy"
+	ver := fetchVersion(ctx, host)
+	s.Version = ver.Tag
+	s.VersionURL = changelogURL(ver.Sha) // same repo as tripbot
+	if t, err := time.Parse(time.RFC3339, ver.StartedAt); err == nil {
+		s.Uptime = uptimeSince(t)
+	}
+	return s
 }
 
 // uptimeSince formats a "since" duration as the short Go duration string

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -165,8 +165,23 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}))
 	defer vlc.Close()
 
+	// stand in for onscreens-server: same /health/ready + /version surface
+	onscreens := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health/ready":
+			w.WriteHeader(http.StatusOK)
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag":"v8.8.8-osc","sha":"feedfacecafe"}`))
+		default:
+			t.Errorf("unexpected onscreens request %q", r.URL.Path)
+		}
+	}))
+	defer onscreens.Close()
+
 	withConf(t, func() {
 		c.Conf.VlcServerHost = strings.TrimPrefix(vlc.URL, "http://")
+		c.Conf.OnscreensServerHost = strings.TrimPrefix(onscreens.URL, "http://")
 		c.Conf.ChannelName = "adanalife_"
 		c.Conf.BotUsername = "tripbot4000"
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
@@ -190,9 +205,12 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
 		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
 		"in chat",                   // tripbot chat-connection status
-		"healthy",                   // vlc status
+		"healthy",                   // vlc status (onscreens row also asserts "healthy" via the version-link check below)
 		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
 		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
+		`<a href="https://github.com/adanalife/tripbot/blob/feedfacecafe/CHANGELOG.md">v8.8.8-osc</a>`, // onscreens version → changelog@sha
+		">vlc-server<",       // vlc row label
+		">onscreens-server<", // onscreens row label
 		"12 in chat",                          // chatter count
 		`<code class="env">production</code>`, // env in monospace chip
 		"now playing",                         // now-playing section shown when vlc healthy
@@ -252,11 +270,12 @@ func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 // mutate them for the test, and restores them afterward.
 func withConf(t *testing.T, set func()) {
 	t.Helper()
-	saved := struct{ vlc, channel, bot, external, env string }{
-		c.Conf.VlcServerHost, c.Conf.ChannelName, c.Conf.BotUsername, c.Conf.ExternalURL, c.Conf.Environment,
+	saved := struct{ vlc, onscreens, channel, bot, external, env string }{
+		c.Conf.VlcServerHost, c.Conf.OnscreensServerHost, c.Conf.ChannelName, c.Conf.BotUsername, c.Conf.ExternalURL, c.Conf.Environment,
 	}
 	t.Cleanup(func() {
 		c.Conf.VlcServerHost = saved.vlc
+		c.Conf.OnscreensServerHost = saved.onscreens
 		c.Conf.ChannelName = saved.channel
 		c.Conf.BotUsername = saved.bot
 		c.Conf.ExternalURL = saved.external

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -53,7 +53,7 @@ func TestChangelogURL(t *testing.T) {
 	}
 }
 
-func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
+func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
@@ -87,7 +87,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	SetVersion("v1.2.3")
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -122,7 +122,7 @@ func TestLandingHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}
 }
 
-func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
+func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
 	withReauth(t, nil)
@@ -138,7 +138,7 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -155,7 +155,7 @@ func TestLandingHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	}
 }
 
-// withConf snapshots the config fields the landing handler reads, runs set to
+// withConf snapshots the config fields the admin handler reads, runs set to
 // mutate them for the test, and restores them afterward.
 func withConf(t *testing.T, set func()) {
 	t.Helper()
@@ -173,7 +173,7 @@ func withConf(t *testing.T, set func()) {
 }
 
 // withCurrentlyPlaying swaps the currentlyPlaying / currentProgress seams so
-// the landing handler sees a fixed video + progress without driving the player.
+// the admin handler sees a fixed video + progress without driving the player.
 func withCurrentlyPlaying(t *testing.T, v video.Video, progress time.Duration) {
 	t.Helper()
 	savedV, savedP := currentlyPlaying, currentProgress
@@ -190,7 +190,7 @@ func withChatterCount(t *testing.T, n int) {
 	t.Cleanup(func() { chatterCount = saved })
 }
 
-// withReauth swaps the accountsNeedingReauth seam so the landing handler sees a
+// withReauth swaps the accountsNeedingReauth seam so the admin handler sees a
 // fixed re-auth list without depending on global in-memory token state.
 func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Helper()
@@ -199,7 +199,7 @@ func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Cleanup(func() { accountsNeedingReauth = saved })
 }
 
-func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
+func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
 
@@ -215,7 +215,7 @@ func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -234,7 +234,7 @@ func TestLandingHandler_RendersReauthPrompt(t *testing.T) {
 	}
 }
 
-func TestLandingHandler_NoReauthPromptWhenHealthy(t *testing.T) {
+func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 
@@ -242,7 +242,7 @@ func TestLandingHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	withReauth(t, nil) // all tokens healthy
 
 	rec := httptest.NewRecorder()
-	landingHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if strings.Contains(rec.Body.String(), "re-authenticate") {
 		t.Errorf("re-auth prompt should be hidden when no account needs re-auth")

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +12,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
+	"github.com/gorilla/mux"
 )
 
 func TestSiblingURL(t *testing.T) {
@@ -52,6 +55,96 @@ func TestChangelogURL(t *testing.T) {
 		t.Errorf("changelogURL(\"\") = %q, want %q", got, want)
 	}
 }
+
+// withObsStream swaps the obsStartStream / obsStopStream / obsStreamStatus
+// seams to test fakes so we can exercise the handler without an OBS
+// WebSocket. Returns the captured invocation counts.
+func withObsStream(t *testing.T, startErr, stopErr error) (started, stopped *int) {
+	t.Helper()
+	savedStart, savedStop := obsStartStream, obsStopStream
+	t.Cleanup(func() { obsStartStream, obsStopStream = savedStart, savedStop })
+	started, stopped = new(int), new(int)
+	obsStartStream = func(context.Context) error { *started++; return startErr }
+	obsStopStream = func(context.Context) error { *stopped++; return stopErr }
+	return started, stopped
+}
+
+func TestObsStreamActionHandler_StartRedirectsAndCalls(t *testing.T) {
+	started, _ := withObsStream(t, nil, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if got := rec.Header().Get("Location"); got != "/" {
+		t.Fatalf("got Location %q, want /", got)
+	}
+	if *started != 1 {
+		t.Fatalf("obsStartStream called %d times, want 1", *started)
+	}
+}
+
+func TestObsStreamActionHandler_StopRedirectsAndCalls(t *testing.T) {
+	_, stopped := withObsStream(t, nil, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/stop", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if *stopped != 1 {
+		t.Fatalf("obsStopStream called %d times, want 1", *stopped)
+	}
+}
+
+func TestObsStreamActionHandler_UnknownActionIs400(t *testing.T) {
+	withObsStream(t, nil, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/bogus", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestObsStreamActionHandler_RedirectsEvenOnError(t *testing.T) {
+	// State is the source of truth — refreshed panel will show the actual
+	// state. Surfacing the error in flash UI isn't worth the complexity for
+	// a tailnet-only solo-operator panel.
+	started, _ := withObsStream(t, errFakeOBS, nil)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/obs/stream/{action}", http.HandlerFunc(obsStreamActionHandler)).Methods("POST")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/obs/stream/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if *started != 1 {
+		t.Fatalf("obsStartStream called %d times, want 1", *started)
+	}
+}
+
+var errFakeOBS = errors.New("fake OBS error")
 
 func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sync/atomic"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -63,13 +64,15 @@ func TwitchConnected() bool {
 
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag; sha + built_at are read from the binary's embedded
-// VCS info (Go's automatic -buildvcs).
+// VCS info (Go's automatic -buildvcs). started_at is when the process
+// began (admin.startedAt) so callers can derive uptime themselves.
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: versionTag}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -40,23 +40,23 @@ func SetVersion(v string) {
 // twitchConnected reports whether the bot currently has its Twitch IRC
 // connection. It deliberately does NOT gate the readiness probe: /health/ready
 // is always 200 once the HTTP server is up (see httpmw.ReadinessHandler), so
-// the landing page, /auth/init and /auth/callback stay reachable through the
+// the admin panel, /auth/init and /auth/callback stay reachable through the
 // Ingress even when the bot is offline — otherwise the very page used to
 // re-auth a disconnected bot would 503. Instead this flag drives the
-// landing-page status row and the tripbot_twitch_connected gauge, so "up but
+// admin-panel status row and the tripbot_twitch_connected gauge, so "up but
 // not in chat" is surfaced without pulling the pod out of the Service.
 // cmd/tripbot flips it via SetTwitchConnected on IRC connect / disconnect.
 var twitchConnected atomic.Bool
 
 // SetTwitchConnected updates the chat-connection signal: the in-memory flag
-// the landing page reads and the tripbot_twitch_connected gauge.
+// the admin panel reads and the tripbot_twitch_connected gauge.
 func SetTwitchConnected(connected bool) {
 	twitchConnected.Store(connected)
 	instrumentation.TwitchConnection.Set(connected)
 }
 
 // TwitchConnected reports the last-known chat-connection state, for the
-// landing page's status row.
+// admin panel's status row.
 func TwitchConnected() bool {
 	return twitchConnected.Load()
 }

--- a/pkg/server/landing.go
+++ b/pkg/server/landing.go
@@ -306,6 +306,8 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
   main { width:min(92vw,520px); padding:clamp(24px,4vw,48px); }
   /* logo is the monochrome black mark; invert to white on the dark bg */
   .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(1); opacity:.92; display:block; margin:0 0 16px; }
+  .logo-link { display:inline-block; }
+  .logo-link:hover .logo { opacity:1; }
   h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 4px; letter-spacing:.02em; }
   .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:2px 7px; border-radius:5px; font-size:.5em; font-weight:normal; letter-spacing:0; vertical-align:middle; }
   .meta { color:#888; margin:0 0 2px; font-size:.92em; }
@@ -340,8 +342,9 @@ var landingTmpl = template.Must(template.New("landing").Parse(`<!doctype html>
 <body>
 <main>
   <!-- A Dana Life mark, referenced from the website (the single owner of brand
-       assets) rather than copied in — see vault general/logo.md. -->
-  <img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44">
+       assets) rather than copied in — see vault general/logo.md. The anchor
+       wraps the mark so clicking it refreshes the page. -->
+  <a class="logo-link" href="/" title="refresh"><img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44"></a>
   <h1>tripbot <code class="env">{{.Env}}</code></h1>
   <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,11 @@ func Start(ctx context.Context) {
 	// admin panel (status overview + links) on the root path
 	r.Handle("/", tagged("/", adminHandler)).Methods("GET", "HEAD")
 
+	// admin actions — tailnet-only by virtue of where the Ingress is
+	// exposed; no app-layer auth gate (see CLAUDE.md / vault decisions).
+	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
+	admin.Handle("/obs/stream/{action}", tagged("/admin/obs/stream/{action}", obsStreamActionHandler))
+
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,10 +46,10 @@ func Start(ctx context.Context) {
 	// healthcheck endpoints
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
 	hp.Handle("/live", tagged("/health/live", httpmw.LivenessHandler()))
-	// /ready runs no checks: tripbot's HTTP surface (landing page, /auth/init,
+	// /ready runs no checks: tripbot's HTTP surface (admin panel, /auth/init,
 	// /auth/callback, /metrics) doesn't depend on the Twitch connection, so the
 	// pod must stay routable even when the bot is offline. Chat-connection is
-	// surfaced via the landing page + the tripbot_twitch_connected gauge.
+	// surfaced via the admin panel + the tripbot_twitch_connected gauge.
 	hp.Handle("/ready", tagged("/health/ready", httpmw.ReadinessHandler()))
 
 	// version endpoint — returns build metadata as JSON
@@ -66,8 +66,8 @@ func Start(ctx context.Context) {
 	// prometheus metrics endpoint
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
-	// landing page (status overview + links) on the root path
-	r.Handle("/", tagged("/", landingHandler)).Methods("GET", "HEAD")
+	// admin panel (status overview + links) on the root path
+	r.Handle("/", tagged("/", adminHandler)).Methods("GET", "HEAD")
 
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -290,7 +290,7 @@ func BroadcasterUserAccessToken() string {
 }
 
 // AccountReauth describes an account whose in-memory token is missing or
-// expired and therefore needs operator re-auth. The landing page renders one
+// expired and therefore needs operator re-auth. The admin panel renders one
 // "Sign in as <LoginAs>" link per entry, pointing at InitURL.
 type AccountReauth struct {
 	Account string // "bot" | "broadcaster" — the /auth/init account selector
@@ -314,7 +314,7 @@ func tokenReason(t oauthtokens.Token) string {
 }
 
 // AccountsNeedingReauth returns the bot and/or broadcaster accounts whose
-// in-memory token is missing or expired, so the landing page can prompt for
+// in-memory token is missing or expired, so the admin panel can prompt for
 // re-auth. Returns nil when everything's healthy. The broadcaster is only
 // considered when a distinct broadcaster identity exists (ChannelName set and
 // != BotUsername) — otherwise there's no separate row to re-auth.
@@ -496,7 +496,7 @@ func RefreshUserAccessToken(ctx context.Context) {
 // auth-bootstrap flow (or by another tripbot's refresh) without a process
 // restart. When neither yields a usable token — e.g. a DB-restored row whose
 // refresh_token is also revoked — the in-memory slot is left blanked and the
-// reauth link is logged; the landing page's re-auth prompt then covers it.
+// reauth link is logged; the admin panel's re-auth prompt then covers it.
 func Reauth(ctx context.Context, account string) {
 	username := c.Conf.BotUsername
 	apply := applyBotToken

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/mux"
@@ -49,17 +50,19 @@ func (s *Server) rtspHealthHandler(w http.ResponseWriter, r *http.Request) {
 // versionHandler returns build metadata as JSON. The tag comes from
 // Server.Version (injected via Config at construction time); sha +
 // built_at are read from the binary's embedded VCS info (Go's automatic
-// -buildvcs).
+// -buildvcs). started_at is when the process began so callers can derive
+// uptime themselves.
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	tag := s.Version
 	if tag == "" {
 		tag = "dev"
 	}
 	resp := struct {
-		Tag     string `json:"tag"`
-		Sha     string `json:"sha"`
-		BuiltAt string `json:"built_at"`
-	}{Tag: tag}
+		Tag       string `json:"tag"`
+		Sha       string `json:"sha"`
+		BuiltAt   string `json:"built_at"`
+		StartedAt string `json:"started_at"`
+	}{Tag: tag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, st := range info.Settings {
@@ -77,6 +80,10 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(r.Context(), "couldn't encode version response", "err", err)
 	}
 }
+
+// startedAt marks process start so /version can report uptime. Set at
+// package load; close enough to process start for a human-readable "up Xh".
+var startedAt = time.Now()
 
 func (s *Server) vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {
 	// return the currently-playing file


### PR DESCRIPTION
## Summary

Patch release. The landing page graduates into an admin panel: renamed throughout, with a clickable logo, per-service uptime pills (now including onscreens-server), an env-aware Sentry deep-link, and a stream on/off toggle with a two-click molly switch. Small chatbot + onscreens polish on the side.

### admin panel (formerly "landing page")
- Rename "landing page" → "admin panel" throughout — file, symbols, tests, comments. URL stays `/`. ([#651])
- Logo is a refresh button. ([#650])
- Per-service uptime pills, powered by `started_at` (RFC3339) on each binary's `/version`. ([#654])
- onscreens-server in the status table; `siblingStatus(name, host)` refactor so future services drop in as one line. ([#656])
- Sentry env-link in the dashboard strip, pre-filtered to `?environment=<env>`. ([#654])
- OBS stream on/off toggle with molly-switch confirm; "OBS unreachable" when OBS is down; tailnet-only by Ingress. ([#654])

### chatbot
- `!song` drops the SomaFM attribution; new `!somafm` credit command. ([#648])

### onscreens
- `!timewarp` cover spans the cut reliably (+200ms). ([#649])

### obs / pkg
- `pkg/obs` gets `StartStream` / `StopStream` / `GetStreamStatus`; `ErrUnreachable` distinguishes OBS-down from not-streaming. ([#654])
- `obs.GetStreamStatus` transient errors demoted to slog.Warn. ([#652])

## Test plan
- [ ] Auto-tag fires v2.15.2 on merge (no `#minor`/`#major` keyword → patch default)
- [ ] Multi-arch image manifests build for tripbot/vlc/obs
- [ ] Discord notification posts on release
- [ ] After image rolls in prod-1: visit `/`, confirm uptime pills + onscreens-server row + Sentry link render; click logo (reload); arm + click stream toggle to confirm flip; verify Sentry deep-link lands on `?environment=prod-1`

[#648]: https://github.com/adanalife/tripbot/pull/648
[#649]: https://github.com/adanalife/tripbot/pull/649
[#650]: https://github.com/adanalife/tripbot/pull/650
[#651]: https://github.com/adanalife/tripbot/pull/651
[#652]: https://github.com/adanalife/tripbot/pull/652
[#654]: https://github.com/adanalife/tripbot/pull/654
[#656]: https://github.com/adanalife/tripbot/pull/656