### PR TITLE
admin: add onscreens-server to the status table

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -125,19 +125,13 @@ type adminData struct {
 }
 
 // adminHandler serves the human-facing root page on the tripbot Ingress: a
-// lightweight status overview (tripbot's own readiness + a live vlc-server
-// ping, each version linking to its changelog), the currently-playing video
+// lightweight status overview (tripbot's own readiness + live sibling-service
+// pings, each version linking to its changelog), the currently-playing video
 // when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
 // / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
 func adminHandler(w http.ResponseWriter, r *http.Request) {
-	vlcOK := c.Conf.VlcServerHost != "" &&
-		pingHealthy(r.Context(), "http://"+c.Conf.VlcServerHost+"/health/ready")
-
-	// vlc-server's build info — one extra in-cluster GET, only when it's up.
-	var vlcVer versionInfo
-	if vlcOK {
-		vlcVer = fetchVersion(r.Context(), c.Conf.VlcServerHost)
-	}
+	vlc := siblingStatus(r.Context(), "vlc-server", c.Conf.VlcServerHost)
+	onscreens := siblingStatus(r.Context(), "onscreens-server", c.Conf.OnscreensServerHost)
 
 	data := adminData{
 		Channel:  c.Conf.ChannelName,
@@ -145,8 +139,8 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Env:      c.Conf.Environment,
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
 		Chatters: chatterCount(),
-		Services: gatherStatus(vlcOK, vlcVer, buildSHA()),
-		Now:      currentVideo(vlcOK),
+		Services: gatherStatus(buildSHA(), vlc, onscreens),
+		Now:      currentVideo(vlc.OK),
 		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
@@ -159,12 +153,9 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
-// the already-computed vlc-server health. Each row carries its build tag in a
-// version column linking to that build's changelog: tripbot's own tag (at sha,
-// the running binary's VCS revision) and vlc-server's (from its /version). The
-// vlc ping is best-effort: any failure (DNS, timeout, non-2xx) renders as not-OK
-// rather than erroring the page.
-func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
+// the already-probed sibling-service rows. Each row carries its build tag in a
+// version column linking to that build's changelog at the deployed sha.
+func gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
 		OK:         twitchConnected.Load(),
@@ -182,17 +173,31 @@ func gatherStatus(vlcOK bool, vlcVer versionInfo, sha string) []serviceStatus {
 		tripbot.Detail = "not in chat"
 	}
 
-	vlc := serviceStatus{Name: "vlc-server", OK: vlcOK, Detail: "unreachable"}
-	if vlcOK {
-		vlc.Detail = "healthy"
-		vlc.Version = vlcVer.Tag
-		vlc.VersionURL = changelogURL(vlcVer.Sha) // same repo as tripbot
-		if t, err := time.Parse(time.RFC3339, vlcVer.StartedAt); err == nil {
-			vlc.Uptime = uptimeSince(t)
-		}
-	}
+	return append([]serviceStatus{tripbot}, siblings...)
+}
 
-	return []serviceStatus{tripbot, vlc}
+// siblingStatus probes a sibling HTTP service (vlc-server, onscreens-server)
+// and returns its row for the status table. Best-effort: an empty host or any
+// readiness failure (DNS, timeout, non-2xx) renders as unreachable rather than
+// erroring the page. When the probe succeeds, also fetches /version to fill in
+// the build tag (linked to its changelog at the deployed sha) and uptime.
+func siblingStatus(ctx context.Context, name, host string) serviceStatus {
+	s := serviceStatus{Name: name, Detail: "unreachable"}
+	if host == "" {
+		return s
+	}
+	if !pingHealthy(ctx, "http://"+host+"/health/ready") {
+		return s
+	}
+	s.OK = true
+	s.Detail = "healthy"
+	ver := fetchVersion(ctx, host)
+	s.Version = ver.Tag
+	s.VersionURL = changelogURL(ver.Sha) // same repo as tripbot
+	if t, err := time.Parse(time.RFC3339, ver.StartedAt); err == nil {
+		s.Uptime = uptimeSince(t)
+	}
+	return s
 }
 
 // uptimeSince formats a "since" duration as the short Go duration string

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -165,8 +165,23 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	}))
 	defer vlc.Close()
 
+	// stand in for onscreens-server: same /health/ready + /version surface
+	onscreens := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health/ready":
+			w.WriteHeader(http.StatusOK)
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag":"v8.8.8-osc","sha":"feedfacecafe"}`))
+		default:
+			t.Errorf("unexpected onscreens request %q", r.URL.Path)
+		}
+	}))
+	defer onscreens.Close()
+
 	withConf(t, func() {
 		c.Conf.VlcServerHost = strings.TrimPrefix(vlc.URL, "http://")
+		c.Conf.OnscreensServerHost = strings.TrimPrefix(onscreens.URL, "http://")
 		c.Conf.ChannelName = "adanalife_"
 		c.Conf.BotUsername = "tripbot4000"
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
@@ -190,9 +205,12 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`<a href="https://twitch.tv/adanalife_">adanalife_</a>`,   // broadcaster profile
 		`<a href="https://twitch.tv/tripbot4000">tripbot4000</a>`, // bot profile
 		"in chat",                   // tripbot chat-connection status
-		"healthy",                   // vlc status
+		"healthy",                   // vlc status (onscreens row also asserts "healthy" via the version-link check below)
 		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
 		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
+		`<a href="https://github.com/adanalife/tripbot/blob/feedfacecafe/CHANGELOG.md">v8.8.8-osc</a>`, // onscreens version → changelog@sha
+		">vlc-server<",       // vlc row label
+		">onscreens-server<", // onscreens row label
 		"12 in chat",                          // chatter count
 		`<code class="env">production</code>`, // env in monospace chip
 		"now playing",                         // now-playing section shown when vlc healthy
@@ -252,11 +270,12 @@ func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 // mutate them for the test, and restores them afterward.
 func withConf(t *testing.T, set func()) {
 	t.Helper()
-	saved := struct{ vlc, channel, bot, external, env string }{
-		c.Conf.VlcServerHost, c.Conf.ChannelName, c.Conf.BotUsername, c.Conf.ExternalURL, c.Conf.Environment,
+	saved := struct{ vlc, onscreens, channel, bot, external, env string }{
+		c.Conf.VlcServerHost, c.Conf.OnscreensServerHost, c.Conf.ChannelName, c.Conf.BotUsername, c.Conf.ExternalURL, c.Conf.Environment,
 	}
 	t.Cleanup(func() {
 		c.Conf.VlcServerHost = saved.vlc
+		c.Conf.OnscreensServerHost = saved.onscreens
 		c.Conf.ChannelName = saved.channel
 		c.Conf.BotUsername = saved.bot
 		c.Conf.ExternalURL = saved.external


### PR DESCRIPTION
## Summary

The admin panel had rows for tripbot itself + vlc-server; adds a third row for **onscreens-server** so it shows up next to its siblings — green/red dot, build tag linked to the changelog at the deployed sha, uptime.

## Notes

- onscreens-server has its own HTTP listener (default `:8081`) with the exact same `/health/ready` + `/version` surface vlc-server uses (`pkg/onscreens-server/server.go`). The panel probes that listener directly via the existing `ONSCREENS_SERVER_HOST` env var — independent of vlc-server, even though today the two share a pod/Service (`vlc-server:8080` for vlc, `vlc-server:8081` for onscreens). When the processes get split, the env var alone changes and the panel code keeps working.
- Refactor: extracts `siblingStatus(name, host)` from the inline vlc block (second duplicate of the pattern); `gatherStatus` becomes variadic over sibling rows so future services drop in as one line.

## Test plan

- [x] `task test:macos -- ./pkg/server/...` green locally
- [ ] CI green
- [ ] After merge to develop + deploy to stage, hit the panel and confirm the onscreens row is present and "healthy"