### PR TITLE
chatbot: add a 500ms lead-in before the !timewarp overlay

### DIFF
--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -20,6 +20,12 @@ import (
 // plus it's also used to reset peoples lastLocation time
 var lastTimewarpTime time.Time
 
+// timewarpOverlayLeadIn is how long we wait after the "Here we go...!" chat
+// message before bringing up the warp overlay. Lets the audience register the
+// chat beat before the cover slams in, so the takeover feels intentional
+// rather than instantaneous.
+var timewarpOverlayLeadIn = 500 * time.Millisecond
+
 // timewarpCoverDelay is how long we wait after triggering the full-screen warp
 // overlay before actually jumping the playhead. The overlay is driven by a
 // browser source that polls for state, so it needs a beat to bring the opaque
@@ -29,6 +35,9 @@ var timewarpCoverDelay = 800 * time.Millisecond
 
 // timewarp jumps the playhead to a random video in the loop
 func (a *App) timewarp(ctx context.Context) {
+	// give the chat message a beat to land before the visual takeover
+	time.Sleep(timewarpOverlayLeadIn)
+
 	// bring up the full-screen warp overlay, then give the browser source a
 	// beat to render the opaque cover before we hard-cut to a new clip
 	a.Onscreens.ShowTimewarp(ctx)


### PR DESCRIPTION
## Summary

Inserts a 500ms pause after the \`Here we go...!\` chat message and before the full-screen warp overlay fires. Today the cover slams in essentially instantaneously after the chat cue; this gives viewers a beat of normal stream so the takeover feels intentional rather than abrupt.

The existing 800ms cover-delay (overlay → playhead jump) is unchanged — the cover still has its full beat to render before the hard cut. End-to-end timeline:

| Before              | After               |
|---------------------|---------------------|
| t=0 \"Here we go...!\" + overlay | t=0 \"Here we go...!\" |
| t=800ms hard cut    | t=500ms overlay     |
|                     | t=1300ms hard cut   |

## Test plan

- [x] \`task test:macos -- ./pkg/chatbot/...\` green locally
- [ ] CI green
- [ ] After merge + deploy, run \`!timewarp\` on stage and confirm the chat-to-overlay gap feels right