### PR TITLE
admin: shared POST /admin/shutdown across all three Go servers

### DIFF
--- a/pkg/httpmw/shutdown.go
+++ b/pkg/httpmw/shutdown.go
@@ -1,0 +1,48 @@
+package httpmw
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+// ShutdownSignal sends SIGTERM to the current process. Exposed as a package
+// variable so tests can swap it for a no-op fake. The default lands the
+// signal on the same handler each cmd/* main wires via signal.NotifyContext,
+// which runs the graceful shutdown chain (HTTP drain, telemetry flush,
+// Sentry flush) and exits 0. k8s's restartPolicy: Always brings the pod
+// back — the admin panel's "restart" surface, no kube-API needed.
+var ShutdownSignal = func() error {
+	return syscall.Kill(os.Getpid(), syscall.SIGTERM)
+}
+
+// ShutdownDelay is the gap between responding 202 and firing the signal.
+// The response needs to leave the wire before the process starts dying;
+// shutting down inline would error the in-flight write before the client
+// sees the 202. Exposed so tests don't sleep half a second per case.
+var ShutdownDelay = 500 * time.Millisecond
+
+// ShutdownHandler returns the POST /admin/shutdown handler shared across
+// tripbot's Go servers (tripbot, vlc-server, onscreens-server). Responds
+// 202 + a short body, then schedules SIGTERM after ShutdownDelay.
+//
+// The handler is intentionally minimal: no body parsing, no auth check
+// (tailnet-only by Ingress per the admin-panel discussion in CLAUDE.md +
+// vault/decisions). If/when the panel reaches beyond the tailnet, the
+// auth gate goes on the route registration, not here.
+func ShutdownHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slog.WarnContext(r.Context(), "admin shutdown requested — SIGTERMing self", "delay", ShutdownDelay)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("shutting down\n"))
+
+		go func() {
+			time.Sleep(ShutdownDelay)
+			if err := ShutdownSignal(); err != nil {
+				slog.ErrorContext(r.Context(), "admin shutdown signal failed", "err", err)
+			}
+		}()
+	}
+}

--- a/pkg/httpmw/shutdown_test.go
+++ b/pkg/httpmw/shutdown_test.go
@@ -1,0 +1,33 @@
+package httpmw
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestShutdownHandler_Responds202AndFiresSignal(t *testing.T) {
+	savedSignal, savedDelay := ShutdownSignal, ShutdownDelay
+	t.Cleanup(func() { ShutdownSignal, ShutdownDelay = savedSignal, savedDelay })
+
+	fired := make(chan struct{}, 1)
+	ShutdownSignal = func() error {
+		fired <- struct{}{}
+		return nil
+	}
+	ShutdownDelay = 5 * time.Millisecond
+
+	rec := httptest.NewRecorder()
+	ShutdownHandler()(rec, httptest.NewRequest(http.MethodPost, "/admin/shutdown", nil))
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusAccepted)
+	}
+
+	select {
+	case <-fired:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("shutdown signal was not fired within timeout")
+	}
+}

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -110,6 +110,13 @@ func (s *Server) Start(ctx context.Context) error {
 	osc.Handle("/render/{name}", tagged("/onscreens/render/{name}", s.onscreensRenderHandler))
 	osc.Handle("/asset/{name}", tagged("/onscreens/asset/{name}", s.onscreensAssetHandler))
 
+	// admin actions — tailnet-only by virtue of where the Ingress is exposed;
+	// no app-layer auth gate. /admin/shutdown is the admin panel's "restart
+	// onscreens-server" surface; the shared handler SIGTERMs the process and
+	// k8s restartPolicy: Always brings the pod back.
+	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
+	admin.Handle("/shutdown", tagged("/admin/shutdown", httpmw.ShutdownHandler()))
+
 	// prometheus metrics endpoint
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,6 +73,7 @@ func Start(ctx context.Context) {
 	// exposed; no app-layer auth gate (see CLAUDE.md / vault decisions).
 	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
 	admin.Handle("/obs/stream/{action}", tagged("/admin/obs/stream/{action}", obsStreamActionHandler))
+	admin.Handle("/shutdown", tagged("/admin/shutdown", httpmw.ShutdownHandler()))
 
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -119,6 +119,13 @@ func (s *Server) Start(ctx context.Context) {
 	// separate port). vlc-server no longer serves /onscreens/* — clients
 	// (chatbot, OBS browser sources) hit ONSCREENS_SERVER_HOST directly.
 
+	// admin actions — tailnet-only by virtue of where the Ingress is exposed;
+	// no app-layer auth gate. /admin/shutdown is the admin panel's "restart
+	// vlc-server" surface; the shared handler SIGTERMs the process and k8s
+	// restartPolicy: Always brings the pod back.
+	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
+	admin.Handle("/shutdown", tagged("/admin/shutdown", httpmw.ShutdownHandler()))
+
 	// prometheus metrics endpoint
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 


### PR DESCRIPTION
**PR A of a three-PR sequence.** The admin panel grows restart-via-shutdown rather than going through the kube-API:

- **A (this)**: shared `httpmw.ShutdownHandler()` registered on each Go server's admin subrouter — 202 response, then async SIGTERM, graceful shutdown chain, k8s respawns via \`restartPolicy: Always\`.
- **B (next)**: tiny Flask shim baked into the OBS image at the same \`/admin/shutdown\` shape — so OBS looks identical from the admin panel's perspective.
- **C (after B)**: admin panel lists OBS in the status table + adds per-service restart buttons (molly switch) that POST to each service's shutdown endpoint.

No kube-API, no ServiceAccount, no client-go — and the same endpoints work whether the admin console is in-tripbot or external (direct detach prep per the architectural-awareness TODO in \`vault/tripbot/tripbot/TODO.md\`).

## Summary

Single shared implementation in **pkg/httpmw** alongside the existing \`LivenessHandler\` / \`ReadinessHandler\` that all three servers already use. \`httpmw.ShutdownHandler()\` returns the \`http.HandlerFunc\`; each server registers it under its admin subrouter with one line.

- **Handler shape**: responds 202 + writes "shutting down\\n", then a goroutine waits \`ShutdownDelay\` (default 500ms) and calls \`ShutdownSignal()\` (default: SIGTERM self). The existing \`signal.NotifyContext\` handler in each \`cmd/*\` main catches the signal and runs the graceful shutdown chain (HTTP drain, telemetry flush, Sentry flush).
- **Test seams**: \`ShutdownSignal\` + \`ShutdownDelay\` are exported package vars so tests can swap them; one shared test in \`pkg/httpmw\` covers all three servers (they all dispatch into the same handler).
- **Why async**: shutting down inline would error the in-flight write before the client sees the 202.
- **Route registrations**: 1 line per server. All three pick up future improvements to the shared handler for free.

\`\`\`
 pkg/httpmw/shutdown.go         | new (~50 LOC)
 pkg/httpmw/shutdown_test.go    | new (~30 LOC)
 pkg/server/server.go           | +1
 pkg/vlc-server/server.go       | +7 (new admin subrouter)
 pkg/onscreens-server/server.go | +7 (new admin subrouter)
\`\`\`

## Test plan
- [x] \`task test:macos\` green (pkg/httpmw test exercises the shared handler; the three servers stay green via existing tests since the only change is route wire-up)
- [ ] After deploy: \`curl -X POST <svc>/admin/shutdown\` on each service in stage — confirm pod restarts cleanly (graceful shutdown logs, not a kill -9), no in-flight requests dropped
- [ ] Verify each cmd/*'s existing signal-handler chain (sentry.Flush, telemetry flush, etc.) runs end-to-end on the SIGTERM