### PR TITLE
admin: OBS row in status table + per-service restart buttons

### DIFF
--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -39,6 +39,13 @@ type TripbotConfig struct {
 	// API (state.json, render/, asset/, plus the show/hide endpoints the
 	// chatbot drives).
 	OnscreensServerHost string `required:"true" envconfig:"ONSCREENS_SERVER_HOST"`
+	// ObsServerHost is the host:port of obs-server — the Flask process
+	// baked into the OBS image that exposes /health/ready, /version,
+	// and POST /admin/shutdown on the same shape the Go services use.
+	// Named for symmetry with vlc-server / onscreens-server. The admin
+	// panel probes it for the OBS row + posts to its /admin/shutdown
+	// for the "restart obs" button. Optional — blank skips the OBS row.
+	ObsServerHost string `envconfig:"OBS_SERVER_HOST"`
 
 	// DiscordAlertsWebhook is the Discord webhook URL that !report posts
 	// viewer reports to. Optional — when unset, !report falls through to

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/obs"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
@@ -132,6 +134,7 @@ type adminData struct {
 func adminHandler(w http.ResponseWriter, r *http.Request) {
 	vlc := siblingStatus(r.Context(), "vlc-server", c.Conf.VlcServerHost)
 	onscreens := siblingStatus(r.Context(), "onscreens-server", c.Conf.OnscreensServerHost)
+	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
 
 	data := adminData{
 		Channel:  c.Conf.ChannelName,
@@ -139,7 +142,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Env:      c.Conf.Environment,
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
 		Chatters: chatterCount(),
-		Services: gatherStatus(buildSHA(), vlc, onscreens),
+		Services: gatherStatus(buildSHA(), vlc, onscreens, obs),
 		Now:      currentVideo(vlc.OK),
 		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
@@ -219,6 +222,73 @@ func gatherStream(ctx context.Context) streamControl {
 		return streamControl{Reachable: false}
 	}
 	return streamControl{Reachable: true, Active: active}
+}
+
+// restartHosts maps the {service} path variable to the host:port of that
+// service's admin-shutdown endpoint. "tripbot" is the special case: routing
+// to localhost would hit the SAME server, so we call httpmw.ShutdownHandler's
+// signal seam directly (in-process) — no HTTP hop. Function-pointer seams
+// for the proxy + in-process paths so tests don't open real sockets.
+var (
+	restartProxyShutdown = func(ctx context.Context, host string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+host+"/admin/shutdown", nil)
+		if err != nil {
+			return err
+		}
+		resp, err := healthClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("shutdown returned %d", resp.StatusCode)
+		}
+		return nil
+	}
+	// restartSelf SIGTERMs tripbot itself by reusing httpmw's shared signal
+	// seam. Same path the local /admin/shutdown handler uses — the only
+	// difference is the trigger came from a button on the same page.
+	restartSelf = func() error {
+		go func() {
+			time.Sleep(httpmw.ShutdownDelay)
+			if err := httpmw.ShutdownSignal(); err != nil {
+				slog.Error("admin restart-self signal failed", "err", err)
+			}
+		}()
+		return nil
+	}
+)
+
+// restartActionHandler handles POST /admin/restart/{service}. For tripbot it
+// triggers an in-process self-shutdown (same shape as /admin/shutdown — the
+// existing signal handler chain runs). For sibling services it proxies to
+// their /admin/shutdown endpoint. Always 303-redirects to "/" so the panel
+// reflects the new state on reload (tripbot's self-restart redirect resolves
+// once the new pod is serving; until then the browser sees a brief gap).
+func restartActionHandler(w http.ResponseWriter, r *http.Request) {
+	service := mux.Vars(r)["service"]
+	var err error
+	switch service {
+	case "tripbot":
+		err = restartSelf()
+	case "vlc-server":
+		err = restartProxyShutdown(r.Context(), c.Conf.VlcServerHost)
+	case "onscreens-server":
+		err = restartProxyShutdown(r.Context(), c.Conf.OnscreensServerHost)
+	case "obs":
+		if c.Conf.ObsServerHost == "" {
+			http.Error(w, "OBS_SERVER_HOST not configured", http.StatusBadRequest)
+			return
+		}
+		err = restartProxyShutdown(r.Context(), c.Conf.ObsServerHost)
+	default:
+		http.Error(w, "unknown service", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		slog.ErrorContext(r.Context(), "admin restart failed", "service", service, "err", err)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
 // obsStreamActionHandler handles POST /admin/obs/stream/{action} (action =
@@ -442,6 +512,11 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   /* armed = first click landed; second click within 5s actually fires */
   button.stream.armed { background:#f85149; color:#fff; box-shadow:0 0 0 2px #f8514980; }
   .stream-unreachable { color:#666; font-size:.9em; font-style:italic; margin:6px 0 0; }
+  /* per-service restart — small, unobtrusive, lives at the end of each row */
+  .row .restart-form { margin:0; }
+  button.restart { font:inherit; font-size:.8em; padding:3px 9px; border-radius:4px; border:1px solid #2a2a2a; background:#1a1a1a; color:#888; cursor:pointer; transition:background .15s, color .15s, border-color .15s; }
+  button.restart:hover { background:#252525; color:#ccc; border-color:#3a3a3a; }
+  button.restart.armed { background:#f85149; color:#fff; border-color:#f85149; box-shadow:0 0 0 2px #f8514980; }
 </style>
 </head>
 <body>
@@ -473,6 +548,9 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
       {{if .Uptime}}<span class="uptime">up {{.Uptime}}</span>{{end}}
       {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
       <span class="status">{{.Detail}}</span>
+      <form class="restart-form" method="post" action="/admin/restart/{{.Name}}">
+        <button type="submit" class="restart" data-arm-label="confirm restart" data-original-label="restart" onclick="return armConfirm(this)">restart</button>
+      </form>
     </li>
     {{end}}
   </ul>
@@ -481,11 +559,11 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   {{if .Stream.Reachable}}
     {{if .Stream.Active}}
     <form class="stream-form" method="post" action="/admin/obs/stream/stop">
-      <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armStream(this)">stop stream</button>
+      <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armConfirm(this)">stop stream</button>
     </form>
     {{else}}
     <form class="stream-form" method="post" action="/admin/obs/stream/start">
-      <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armStream(this)">start stream</button>
+      <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armConfirm(this)">start stream</button>
     </form>
     {{end}}
   {{else}}
@@ -510,7 +588,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
 // Molly switch: first click arms the button (relabel + redden, 5s window);
 // second click within the window lets the form submit. Click-away or timeout
 // disarms. No deps — vanilla DOM only.
-function armStream(btn) {
+function armConfirm(btn) {
   if (btn.dataset.armed === '1') {
     return true; // confirm — let the form submit
   }

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -146,6 +146,97 @@ func TestObsStreamActionHandler_RedirectsEvenOnError(t *testing.T) {
 
 var errFakeOBS = errors.New("fake OBS error")
 
+// withRestart swaps the restart seams so handler tests don't open real
+// sockets or SIGTERM the test process. Returns the captured invocation
+// records for assertion.
+func withRestart(t *testing.T) (selfCalls *int, proxyHosts *[]string) {
+	t.Helper()
+	savedSelf, savedProxy := restartSelf, restartProxyShutdown
+	t.Cleanup(func() { restartSelf, restartProxyShutdown = savedSelf, savedProxy })
+
+	selfCalls, proxyHosts = new(int), new([]string)
+	restartSelf = func() error { *selfCalls++; return nil }
+	restartProxyShutdown = func(_ context.Context, host string) error {
+		*proxyHosts = append(*proxyHosts, host)
+		return nil
+	}
+	return selfCalls, proxyHosts
+}
+
+func TestRestartActionHandler_TripbotCallsSelf(t *testing.T) {
+	selfCalls, proxyHosts := withRestart(t)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/restart/{service}", http.HandlerFunc(restartActionHandler)).Methods("POST")
+	req := httptest.NewRequest(http.MethodPost, "/admin/restart/tripbot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if *selfCalls != 1 {
+		t.Fatalf("restartSelf called %d times, want 1", *selfCalls)
+	}
+	if len(*proxyHosts) != 0 {
+		t.Fatalf("expected no proxy calls, got %v", *proxyHosts)
+	}
+}
+
+func TestRestartActionHandler_VlcProxiesToVlcServerHost(t *testing.T) {
+	savedHost := c.Conf.VlcServerHost
+	t.Cleanup(func() { c.Conf.VlcServerHost = savedHost })
+	c.Conf.VlcServerHost = "vlc-server.example:8080"
+	selfCalls, proxyHosts := withRestart(t)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/restart/{service}", http.HandlerFunc(restartActionHandler)).Methods("POST")
+	req := httptest.NewRequest(http.MethodPost, "/admin/restart/vlc-server", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if *selfCalls != 0 {
+		t.Fatalf("restartSelf called %d times, want 0", *selfCalls)
+	}
+	if got, want := *proxyHosts, []string{"vlc-server.example:8080"}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("got proxy hosts %v, want %v", got, want)
+	}
+}
+
+func TestRestartActionHandler_ObsRequiresAdminHost(t *testing.T) {
+	savedHost := c.Conf.ObsServerHost
+	t.Cleanup(func() { c.Conf.ObsServerHost = savedHost })
+	c.Conf.ObsServerHost = "" // not configured
+	withRestart(t)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/restart/{service}", http.HandlerFunc(restartActionHandler)).Methods("POST")
+	req := httptest.NewRequest(http.MethodPost, "/admin/restart/obs", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRestartActionHandler_UnknownServiceIs400(t *testing.T) {
+	withRestart(t)
+
+	r := mux.NewRouter()
+	r.Handle("/admin/restart/{service}", http.HandlerFunc(restartActionHandler)).Methods("POST")
+	req := httptest.NewRequest(http.MethodPost, "/admin/restart/bogus", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
 func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -74,6 +74,7 @@ func Start(ctx context.Context) {
 	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
 	admin.Handle("/obs/stream/{action}", tagged("/admin/obs/stream/{action}", obsStreamActionHandler))
 	admin.Handle("/shutdown", tagged("/admin/shutdown", httpmw.ShutdownHandler()))
+	admin.Handle("/restart/{service}", tagged("/admin/restart/{service}", restartActionHandler))
 
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)


### PR DESCRIPTION
**PR C of three.** Consumes the shim from #659 and the env wiring from [adanalife/infra#573](https://github.com/adanalife/infra/pull/573/changes).

## OBS in the status table

Same shape as vlc-server and onscreens-server — the existing \`siblingStatus(name, host)\` helper handles probe + version + uptime; just one more call wired into \`adminHandler\` and the gatherStatus aggregation. Pulls the host from a new \`OBS_ADMIN_HOST\` env (optional — blank skips the OBS row).

## Per-service restart buttons

Small "restart" button at the end of every service row. Molly switch via the shared inline JS (renamed \`armStream\` → \`armConfirm\` so the same function reads right for both the stream toggle and the new restart buttons).

\`POST /admin/restart/{service}\` proxies the action:

- **tripbot** — special case: triggers an in-process self-shutdown via \`httpmw.ShutdownSignal\` directly (no HTTP self-hop). After the 303 redirect the browser sees a brief gap until the new pod is up and the panel renders again.
- **vlc-server / onscreens-server / obs** — proxies to the service's \`/admin/shutdown\` endpoint over HTTP.
- **obs** when \`OBS_ADMIN_HOST\` isn't set — 400.

Function-pointer seams for \`restartSelf\` + \`restartProxyShutdown\` so tests stay hermetic.

## Files

\`\`\`
 pkg/config/tripbot/type.go | +6  (ObsAdminHost env)
 pkg/server/admin.go        | +90 (handler, seams, OBS row, template, CSS, JS rename)
 pkg/server/admin_test.go   | +85 (4 new handler tests + withRestart helper)
 pkg/server/server.go       | +1  (route registration)
\`\`\`

## Test plan
- [x] \`task test:macos\` green (new tests cover tripbot-self, vlc-server proxy, obs-empty-host 400, unknown-service 400)
- [ ] After this + infra#573 + a tripbot release: visit \`/\` on prod-1, confirm 4-service table with restart button per row
- [ ] Click restart on vlc-server → arm → confirm → vlc-server pod restarts; panel reloads and shows fresh uptime
- [ ] Click restart on tripbot → arm → confirm → tripbot pod restarts; panel briefly unreachable then back
- [ ] Click restart on obs → arm → confirm → OBS container exits + respawns

## Dependencies

- ✅ [tripbot#659](https://github.com/adanalife/tripbot/pull/659/changes) (merged) — OBS Flask shim
- ⏳ [adanalife/infra#573](https://github.com/adanalife/infra/pull/573/changes) (open) — Service port + \`OBS_ADMIN_HOST\` env
- ⏳ Next tripbot release picks up #659's image build

This PR's code is correct without infra#573 — the OBS row just renders "unreachable" until that env lands and OBS:8080 is exposed.

## Followups already in the vault

- \`vault/tripbot/tripbot/TODO.md\`: collapsible-controls section (default closed) → restart buttons could move there once it exists
- \`vault/tripbot/obs/TODO.md\`: deep-check \`/health/ready\` in the OBS shim + migrate k8s livenessProbe to httpGet