### PR TITLE
obs: rename admin-shim → obs-server for symmetry with vlc-server / onscreens-server

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -94,11 +94,11 @@ RUN mkdir -p /etc/tripbot \
 EXPOSE 5900
 EXPOSE 4455
 EXPOSE 6080
-# admin-shim: Flask app exposing /health/ready, /version, POST /admin/shutdown
-# so the admin panel can treat OBS like any other service. Port 8080 matches
-# the "primary HTTP listener" convention from tripbot and vlc-server (the OBS
-# pod has no other Go HTTP server, so 8080 is free here). Lives in the shared
-# /opt/obs/venv; supervised by admin-shim.conf.
+# obs-server: Flask app exposing /health/ready, /version, POST /admin/shutdown
+# so the admin panel can treat OBS like vlc-server / onscreens-server. Port
+# 8080 matches their "primary HTTP listener" convention (the OBS pod has no
+# other Go HTTP server, so 8080 is free here). Lives in the shared
+# /opt/obs/venv; supervised by obs-server.conf.
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD /opt/obs/healthcheck.sh

--- a/infra/docker/obs/script/obs_server.py
+++ b/infra/docker/obs/script/obs_server.py
@@ -1,11 +1,12 @@
-"""Tiny admin-shim for the OBS container.
+"""obs-server: tiny HTTP listener bridging OBS to the admin panel.
 
 OBS itself doesn't expose an HTTP surface (only obs-websocket on :4455).
-The admin panel needs three things from OBS that the other Go services
-expose natively via their own HTTP listeners — health, version, and a
-shutdown endpoint that triggers a pod restart. This shim provides them
-in the same shape so the admin panel can treat OBS like any other
-service in the status table.
+The admin panel needs three things from OBS that vlc-server and
+onscreens-server expose natively via their own HTTP listeners — health,
+version, and a shutdown endpoint that triggers a pod restart. obs-server
+provides them in the same shape, so the admin panel can treat OBS like
+its sibling backend services in the status table. Named for symmetry
+with vlc-server / onscreens-server.
 
 Flask was picked over stdlib http.server because the route DSL reads
 obvious and we already have a Python venv in the image for obsws-python

--- a/infra/docker/obs/script/start-obs-server.sh
+++ b/infra/docker/obs/script/start-obs-server.sh
@@ -7,4 +7,4 @@
 # Lives in the shared /opt/obs/venv (obsws-python + websockify + flask).
 set -euo pipefail
 
-exec /opt/obs/venv/bin/python /opt/obs/script/admin_shim.py
+exec /opt/obs/venv/bin/python /opt/obs/script/obs_server.py

--- a/infra/docker/obs/supervisor/obs-server.conf
+++ b/infra/docker/obs/supervisor/obs-server.conf
@@ -1,5 +1,5 @@
-[program:admin-shim]
-command=/opt/obs/script/start-admin-shim.sh
+[program:obs-server]
+command=/opt/obs/script/start-obs-server.sh
 priority=10
 autostart=true
 # The shim is a single-page Flask app — Restarting it from a crash is


### PR DESCRIPTION
Follow-up to #659 (which landed the OBS Flask shim under "admin-shim" naming) — renames everything to **obs-server** so it matches the existing \`vlc-server\` / \`onscreens-server\` pattern, and stops overloading "admin" with the \`/admin/*\` route prefix on every server.

## Renames

- \`infra/docker/obs/script/admin_shim.py\` → \`obs_server.py\` (git mv preserves blame)
- \`infra/docker/obs/script/start-admin-shim.sh\` → \`start-obs-server.sh\`
- \`infra/docker/obs/supervisor/admin-shim.conf\` → \`obs-server.conf\`
- supervisord \`[program:admin-shim]\` → \`[program:obs-server]\`
- Dockerfile + Python docstring comments updated

## Paired changes (open)

- [adanalife/infra#573](https://github.com/adanalife/infra/pull/573/changes) — env var \`OBS_ADMIN_HOST\` → \`OBS_SERVER_HOST\`, k8s port name \`admin\` → \`obs-server\`
- [adanalife/tripbot#660](https://github.com/adanalife/tripbot/pull/660/changes) — config field \`ObsAdminHost\` → \`ObsServerHost\`

## Test plan
- [x] \`python3 -m py_compile obs_server.py\` clean
- [ ] CI builds the OBS image with the new file paths + supervisor program name
- [ ] After deploy: \`supervisorctl status\` shows \`obs-server\` (not \`admin-shim\`); endpoints unchanged (\`/health/ready\`, \`/version\`, \`POST /admin/shutdown\` — the \`/admin/*\` route prefix is intentional, that's the per-server "operator actions" namespace)

No behavior change — just naming.