### PR TITLE
obs-server: fix /admin/shutdown 500 — use threading.Timer not SIGALRM

### DIFF
--- a/infra/docker/obs/script/obs_server.py
+++ b/infra/docker/obs/script/obs_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import signal
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -100,22 +101,22 @@ def shutdown():
     shutdown brings down all children, container exits, k8s respawns
     the pod.
 
-    Flask's built-in scheduler is hand-rolled; we use signal.setitimer
-    to fire SIGALRM after the delay, then handle it by SIGTERMing pid 1.
-    This avoids spawning a threading.Timer in the request path (cleaner
-    teardown — the in-flight response finishes, then the timer fires).
+    threading.Timer (not signal.setitimer + SIGALRM): Flask's dev server
+    is multi-threaded, so request handlers don't run in the main thread —
+    and Python's signal.* APIs raise from non-main threads. A Timer runs
+    in a background thread, fires after the delay, and SIGTERMs pid 1
+    without that constraint.
     """
     app.logger.warning(
         "admin shutdown requested — SIGTERMing supervisord (pid %d) in %.1fs",
         SUPERVISORD_PID,
         SHUTDOWN_DELAY_SECONDS,
     )
-    signal.signal(signal.SIGALRM, _fire_shutdown)
-    signal.setitimer(signal.ITIMER_REAL, SHUTDOWN_DELAY_SECONDS)
+    threading.Timer(SHUTDOWN_DELAY_SECONDS, _fire_shutdown).start()
     return make_response(("shutting down\n", 202))
 
 
-def _fire_shutdown(_signum, _frame):
+def _fire_shutdown():
     try:
         os.kill(SUPERVISORD_PID, signal.SIGTERM)
     except OSError as exc:  # supervisord already dead, or PID mapping odd


### PR DESCRIPTION
Found live on prod-1 after rolling v2.15.3. \`POST /admin/shutdown\` against obs-server returns 500. Root cause: Flask's dev server runs request handlers in worker threads, and Python's \`signal.signal()\` / \`signal.setitimer()\` raise \`ValueError\` when called from any thread that isn't the main interpreter thread.

Concrete repro:
\`\`\`
$ kubectl exec -n prod-1 tripbot-... -- curl -sv -X POST http://obs:8080/admin/shutdown
< HTTP/1.1 500 INTERNAL SERVER ERROR
\`\`\`

## Fix

Swap the \`signal.setitimer(ITIMER_REAL, ...)\` + \`SIGALRM\` handler approach for \`threading.Timer\` — runs in a background thread, fires after the delay, SIGTERMs supervisord (pid 1). No main-thread requirement. ~8 lines changed.

## Test plan
- [x] \`python3 -m py_compile obs_server.py\` clean
- [ ] After this release ships: \`curl -X POST http://obs:8080/admin/shutdown\` returns 202; OBS container exits within ~1s; k8s respawns; new pod's \`/version\` reports a fresh \`started_at\`
- [ ] Click the OBS restart button in the admin panel; same outcome from the UI side

## Followup (not blocking)

This is a class-of-bug the v2.15.3 release-smoke missed because we don't actually exercise \`POST /admin/shutdown\` end-to-end in CI. The Go services' tests stub the signal seam so they don't hit it either. Probably worth a vault TODO for "smoke-test the full restart path on each release" — I'll add one in a separate commit.

Patch release worth cutting after this lands.