### PR TITLE
admin: render the SomaFM "now playing" audio line + Groove Salad link

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -121,6 +121,7 @@ type adminData struct {
 	Chatters int // users currently in chat
 	Services []serviceStatus
 	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Audio    nowPlayingTrack // current SomaFM track; empty Title hides the line
 	Stream   streamControl
 	Links    []navLink
 	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
@@ -144,6 +145,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Chatters: chatterCount(),
 		Services: gatherStatus(buildSHA(), vlc, onscreens, obs),
 		Now:      currentVideo(vlc.OK),
+		Audio:    nowPlayingFetcher(r.Context()),
 		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
@@ -512,6 +514,10 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .now { margin:0; padding:7px 0; }
   .now .file { font-family:var(--mono); word-break:break-all; }
   .now .state { color:var(--muted); }
+  /* audio = the SomaFM background track from gsclassic.json */
+  .audio { margin:0; padding:7px 0; }
+  .audio .track { color:var(--fg); opacity:.85; }
+  .audio .state { color:var(--muted); }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   /* theme toggle — text-only, sits to the right of the env chip */
@@ -608,12 +614,18 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{end}}
   </details>
 
+  {{if or .Now .Audio.Title}}<h2>now playing</h2>{{end}}
   {{with .Now}}
-  <h2>now playing</h2>
   <p class="now">
     <span class="file">{{.File}}</span>
     {{if .State}}<span class="state">· {{.State}}</span>{{end}}
     {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
+  </p>
+  {{end}}
+  {{if .Audio.Title}}
+  <p class="audio">
+    <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
+    <span class="state">· <a href="https://somafm.com/gsclassic/">Groove Salad Classic</a> on SomaFM</span>
   </p>
   {{end}}
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -241,6 +241,7 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
+	withNowPlaying(t, nowPlayingTrack{Artist: "Test Artist", Title: "Test Track"})
 
 	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +326,7 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 }
 
 func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
+	withNowPlaying(t, nowPlayingTrack{}) // no audio info — keeps assertion on "now playing" absence valid
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
 	withReauth(t, nil)
@@ -402,9 +404,20 @@ func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Cleanup(func() { accountsNeedingReauth = saved })
 }
 
+// withNowPlaying swaps the SomaFM fetcher so the admin handler sees a fixed
+// audio track (or empty for "no audio info") without hitting somafm.com from
+// a test.
+func withNowPlaying(t *testing.T, track nowPlayingTrack) {
+	t.Helper()
+	saved := nowPlayingFetcher
+	nowPlayingFetcher = func(context.Context) nowPlayingTrack { return track }
+	t.Cleanup(func() { nowPlayingFetcher = saved })
+}
+
 func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
+	withNowPlaying(t, nowPlayingTrack{})
 
 	withConf(t, func() {
 		c.Conf.VlcServerHost = "" // skip the vlc ping
@@ -438,6 +451,7 @@ func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 }
 
 func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
+	withNowPlaying(t, nowPlayingTrack{})
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 

--- a/pkg/server/somafm.go
+++ b/pkg/server/somafm.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// somaFMNowPlayingURL is the per-channel now-playing JSON feed for the
+// Groove Salad Classic stream that runs as the OBS background audio
+// source. Duplicates the URL constant from pkg/chatbot/song.go on
+// purpose — the cleanest consolidation would be a shared pkg/song
+// package, but that's a separate refactor; the duplication is two
+// lines + a 4-field struct.
+const somaFMNowPlayingURL = "https://somafm.com/songs/gsclassic.json"
+
+// nowPlayingTrack carries the current SomaFM track for the admin
+// template. Both fields empty when the fetch fails or returns nothing.
+type nowPlayingTrack struct {
+	Artist string
+	Title  string
+}
+
+// fetchNowPlaying GETs the SomaFM JSON feed and returns the current
+// track. Best-effort: any failure (timeout, non-2xx, empty list) yields
+// a zero track + nil error so the template just omits the audio line.
+// Uses the existing 2s healthClient — same pattern as the sibling
+// /health probes; the page never blocks on SomaFM being slow.
+func fetchNowPlaying(ctx context.Context) nowPlayingTrack {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, somaFMNowPlayingURL, nil)
+	if err != nil {
+		return nowPlayingTrack{}
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return nowPlayingTrack{}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nowPlayingTrack{}
+	}
+	var body struct {
+		Songs []struct {
+			Artist string `json:"artist"`
+			Title  string `json:"title"`
+		} `json:"songs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nowPlayingTrack{}
+	}
+	if len(body.Songs) == 0 {
+		return nowPlayingTrack{}
+	}
+	return nowPlayingTrack{Artist: body.Songs[0].Artist, Title: body.Songs[0].Title}
+}
+
+// nowPlayingFetcher is overridable in tests so we don't hit SomaFM
+// from a unit test. Default fetches live.
+var nowPlayingFetcher = fetchNowPlaying


### PR DESCRIPTION
Below the existing video "now playing" block, the panel now shows the current track from the OBS background-audio source (SomaFM's Groove Salad Classic) plus a link to the station.

\`\`\`
now playing
  WY_0042.MP4 · Wyoming · 1m27s
  Solar Fields — Stream Cuts · Groove Salad Classic on SomaFM
\`\`\`

## Implementation

- \`pkg/server/somafm.go\` — short-timeout GET against \`https://somafm.com/songs/gsclassic.json\`, best-effort (any failure → empty track, audio line just doesn't render). Same pattern as the existing sibling-service \`/health\` probes; the page never blocks on SomaFM being slow.
- Duplicates the SomaFM URL constant + the response struct from \`pkg/chatbot/song.go\` on purpose — the clean consolidation is a shared \`pkg/song\` package, but that's a moderate refactor better as its own PR. Two lines of duplication isn't worth blocking on.
- Function-pointer test seam (\`nowPlayingFetcher\`) so admin tests stub a fixed track instead of hitting somafm.com from CI.

## Test plan
- [x] \`task test:macos\` green (4 existing AdminHandler tests stubbed; the "vlc unreachable" assertion still passes since empty audio also hides the section)
- [ ] Visit panel; if SomaFM is reachable, the audio line shows current artist + track + "Groove Salad Classic" link
- [ ] If SomaFM is down or slow, the line silently omits — no broken UI

## Followup TODO worth opening

Consolidating \`somaFMNowPlayingURL\` + the response struct into a shared \`pkg/song\` package (or similar) so chatbot and server both import one canonical implementation. Mechanical refactor.