### PR TITLE
admin: collapsible stream-preview with lazy-loaded Twitch embed

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -114,17 +115,18 @@ type navLink struct {
 
 // adminData is the template payload.
 type adminData struct {
-	Channel  string // broadcaster Twitch username
-	Bot      string // bot Twitch username
-	Env      string
-	Uptime   string
-	Chatters int // users currently in chat
-	Services []serviceStatus
-	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
-	Audio    nowPlayingTrack // current SomaFM track; empty Title hides the line
-	Stream   streamControl
-	Links    []navLink
-	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
+	Channel   string // broadcaster Twitch username
+	Bot       string // bot Twitch username
+	Env       string
+	Uptime    string
+	Chatters  int // users currently in chat
+	Services  []serviceStatus
+	Now       *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Audio     nowPlayingTrack // current SomaFM track; empty Title hides the line
+	Stream    streamControl
+	PanelHost string // host the panel was reached at; the Twitch embed needs it as parent=
+	Links     []navLink
+	Reauth    []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
 // adminHandler serves the human-facing root page on the tripbot Ingress: a
@@ -147,6 +149,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Now:      currentVideo(vlc.OK),
 		Audio:    nowPlayingFetcher(r.Context()),
 		Stream:   gatherStream(r.Context()),
+		PanelHost: panelHost(r),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
 	}
@@ -461,6 +464,23 @@ func siblingURL(externalURL, service string) string {
 	return u.String()
 }
 
+// panelHost returns the hostname the panel was reached at, for use as the
+// Twitch embed's parent= parameter. Read from r.Host (the request's Host
+// header) so it matches whatever the browser used — Tailscale's tail*.ts.net
+// hostname when the panel is reached via the operator's tailnet, the public
+// FQDN when reached through the Ingress. Strips any port suffix. Returns ""
+// when r.Host is empty (unusual; template hides the stream-preview block).
+func panelHost(r *http.Request) string {
+	h := r.Host
+	if h == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		return host
+	}
+	return h
+}
+
 var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -524,6 +544,17 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .audio { margin:0; padding:7px 0; }
   .audio .track { color:var(--fg); opacity:.85; }
   .audio .state { color:var(--muted); }
+  /* stream-preview disclosure — same shape as .controls, just a different
+     summary label. iframe is lazy-loaded by the inline JS so the ~2MB
+     Twitch player isn't fetched on every panel render. */
+  details.stream-preview { margin:24px 0 0; }
+  details.stream-preview > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); cursor:pointer; padding:8px 0; border-top:1px solid var(--divider); list-style:none; }
+  details.stream-preview > summary::-webkit-details-marker { display:none; }
+  details.stream-preview > summary::before { content:"▸ "; color:var(--dim); display:inline-block; }
+  details.stream-preview[open] > summary::before { content:"▾ "; }
+  details.stream-preview > summary:hover { color:var(--fg); }
+  .stream-frame { aspect-ratio:16 / 9; width:100%; margin-top:10px; background:#000; border-radius:6px; overflow:hidden; }
+  .stream-frame iframe { width:100%; height:100%; border:none; display:block; }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   /* theme toggle — text-only, sits to the right of the env chip */
@@ -635,12 +666,41 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   </p>
   {{end}}
 
+  {{if and .Channel .PanelHost}}
+  <details class="stream-preview" id="stream-preview">
+    <summary>stream preview</summary>
+    <div class="stream-frame">
+      <iframe data-src="https://player.twitch.tv/?channel={{.Channel}}&parent={{.PanelHost}}&muted=true&autoplay=true"
+              allowfullscreen
+              title="Twitch stream preview"></iframe>
+    </div>
+  </details>
+  {{end}}
+
   <h2>dashboards</h2>
   <nav class="links">
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>
 </main>
 <script>
+// Stream-preview lazy-load. The Twitch player iframe is ~2MB; we don't want
+// to fetch it on every panel render, only when the operator actually expands
+// the disclosure. On collapse we point it at about:blank so the player stops
+// (otherwise audio + bandwidth keep going even when the section's hidden).
+(function() {
+  const details = document.getElementById('stream-preview');
+  if (!details) return;
+  const iframe = details.querySelector('iframe');
+  if (!iframe) return;
+  details.addEventListener('toggle', () => {
+    if (details.open) {
+      iframe.src = iframe.dataset.src;
+    } else {
+      iframe.src = 'about:blank';
+    }
+  });
+})();
+
 // Theme toggle. Reads localStorage for an explicit user override; otherwise
 // the @media(prefers-color-scheme: light) CSS rule applies. Setting
 // data-theme on <html> overrides the media query in either direction.

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/gorilla/mux"
 )
 
+func TestPanelHost(t *testing.T) {
+	cases := []struct {
+		host, want string
+	}{
+		{"tripbot.prod.whereisdana.today", "tripbot.prod.whereisdana.today"},
+		{"tripbot.prod.whereisdana.today:8080", "tripbot.prod.whereisdana.today"},
+		{"localhost:8080", "localhost"},
+		{"adanalife-minipc.tail020deb.ts.net", "adanalife-minipc.tail020deb.ts.net"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Host = tc.host
+		if got := panelHost(req); got != tc.want {
+			t.Errorf("panelHost(Host=%q) = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}
+
 func TestSiblingURL(t *testing.T) {
 	cases := []struct {
 		in, service, want string


### PR DESCRIPTION
New \`<details>\` section between "now playing" and "dashboards", default closed. Summary "stream preview"; on expand, an iframe loads the Twitch player for the broadcaster channel.

\`\`\`
[▸ stream preview]    ← default state, no iframe loaded
[▾ stream preview]    ← expanded
  ┌───────────────────────┐
  │                       │
  │   <Twitch player>     │   16:9 aspect, muted, autoplay
  │                       │
  └───────────────────────┘
\`\`\`

## Why lazy-load

The Twitch player iframe is ~2MB on first paint. Loading it on every panel render burns bandwidth even when the operator just wants to glance at status. Inline JS listens for the \`toggle\` event:

- **Open** → set \`iframe.src\` from \`data-src\`; player loads
- **Close** → set \`iframe.src = 'about:blank'\`; player stops (otherwise audio + bandwidth keep going hidden)

## Why r.Host for parent=

Twitch's embed requires \`parent=<hostname>\` matching the page's actual host (security check). The panel is reachable two ways: via the public Ingress FQDN (\`tripbot.prod.whereisdana.today\`) and via the operator's tailnet (\`tail*.ts.net\` if the tailscale-operator path is in use). \`r.Host\` reflects whichever the browser actually used, so \`parent=\` always matches. Strips any port suffix with \`net.SplitHostPort\`.

Section renders only when both \`Channel\` and \`PanelHost\` are set, so dev/local contexts where neither resolves cleanly just hide the section.

## Test plan
- [x] \`task test:macos\` green (new \`TestPanelHost\` covers FQDN, host:port, tailnet name, empty)
- [ ] Visit prod-1 panel; stream-preview disclosure renders closed by default
- [ ] Click summary; iframe loads the live stream (muted)
- [ ] Click summary again; iframe stops (about:blank), no lingering audio
- [ ] Visit via tailnet hostname; iframe also loads (parent= matches)