### PR TITLE
Release v2.15.4: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.15.4] — 2026-05-25
+
+Patch release. Admin panel polish — the page grows a collapsible stream-preview, picks up system-aware light/dark, learns to refresh itself on iOS Home Screen reopens, and shows what's playing on the SomaFM background-audio source. Also fixes a real bug: obs-server's `POST /admin/shutdown` was returning 500 because Flask's worker-thread request handlers can't call `signal.setitimer()` — the "restart OBS" button now actually works.
+
+### admin panel
+
+- **Collapsible stream-preview with lazy-loaded Twitch embed.** New `<details>` between "now playing" and "dashboards", default closed. On expand, an iframe loads the Twitch player muted; on collapse, the iframe points at `about:blank` so the player stops and bandwidth doesn't keep flowing. The embed's `parent=` parameter is derived from `r.Host` so it matches whichever way the operator reached the panel (public Ingress FQDN or tail*.ts.net via the tailnet). ([#669])
+- **Light/dark mode toggle.** CSS custom properties for the foundational palette; `@media (prefers-color-scheme: light)` activates a Tufte-ish off-white palette automatically for OS-light users. A small "◐" text button next to the env chip flips between light/dark and persists the choice in localStorage. Semantic colors (re-auth amber, stream green/red, restart muted, dot up/down) stay hardcoded — they're status signals that should read the same in either theme. ([#667])
+- **Collapsible "controls" disclosure (default closed).** The stream toggle moves into a `<details>` element so the page reads calm at-a-glance and the action surfaces hide behind one click. Native browser element, no JS. Restart buttons stay inline in service rows for now; if row clutter grows, they can move into the disclosure later. ([#665])
+- **Stop-stream button shrunk + muted.** The old big-red button was sized to dominate when the dangerous action is rarely the right click. Renders muted by default — dark-red background, small border, less padding — and the molly-switch arms it bright red on first click, which is when the visual weight should peak. ([#666])
+- **"now playing" audio line.** Below the existing video block, the panel now shows the current track from the SomaFM Groove Salad Classic stream (the OBS background audio source) + a link to the station. Best-effort fetch with a short timeout; quietly omits when SomaFM is slow/down. ([#668])
+- **Refresh when iOS Home Screen app returns to focus.** Two-part fix for Dana's stale-on-reopen frustration: `Cache-Control: no-store` headers so Safari doesn't serve a cached page, plus a `visibilitychange` JS listener that reloads when the tab transitions hidden → visible after ≥10s (avoids reload-spam on quick app-switches). ([#664])
+
+### obs
+
+- **obs-server: fix `POST /admin/shutdown` 500.** Confirmed live on prod-1 after v2.15.3 rolled. Flask's dev server runs request handlers in worker threads, and Python's `signal.signal()` / `signal.setitimer()` raise `ValueError` from any thread that isn't the main interpreter thread — so the SIGALRM-based shutdown schedule blew up before sending the kill. Swap to `threading.Timer`: runs in a background thread, fires after the delay, SIGTERMs supervisord. The "restart OBS" button in the admin panel now actually works. ([#663])
+
+[#663]: https://github.com/adanalife/tripbot/pull/663
+[#664]: https://github.com/adanalife/tripbot/pull/664
+[#665]: https://github.com/adanalife/tripbot/pull/665
+[#666]: https://github.com/adanalife/tripbot/pull/666
+[#667]: https://github.com/adanalife/tripbot/pull/667
+[#668]: https://github.com/adanalife/tripbot/pull/668
+[#669]: https://github.com/adanalife/tripbot/pull/669
+
 ## [v2.15.3] — 2026-05-24
 
 Patch release. The admin panel grows a restart surface: every backend service exposes `POST /admin/shutdown` that gracefully exits the process so k8s respawns the pod, and the panel itself learns a "restart" button per service with a molly-switch two-click confirm. OBS joins the panel's status table for the first time — a tiny Flask process named `obs-server` (paired with `vlc-server` / `onscreens-server`) runs alongside OBS in the same pod and exposes the same `/health/ready` + `/version` + `/admin/shutdown` shape the Go services use. Small chatbot polish on the side: `!timewarp` gets a 500ms lead-in before the overlay fires so the cover starts opaque on the right frame.

--- a/infra/docker/obs/script/obs_server.py
+++ b/infra/docker/obs/script/obs_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import signal
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -100,22 +101,22 @@ def shutdown():
     shutdown brings down all children, container exits, k8s respawns
     the pod.
 
-    Flask's built-in scheduler is hand-rolled; we use signal.setitimer
-    to fire SIGALRM after the delay, then handle it by SIGTERMing pid 1.
-    This avoids spawning a threading.Timer in the request path (cleaner
-    teardown — the in-flight response finishes, then the timer fires).
+    threading.Timer (not signal.setitimer + SIGALRM): Flask's dev server
+    is multi-threaded, so request handlers don't run in the main thread —
+    and Python's signal.* APIs raise from non-main threads. A Timer runs
+    in a background thread, fires after the delay, and SIGTERMs pid 1
+    without that constraint.
     """
     app.logger.warning(
         "admin shutdown requested — SIGTERMing supervisord (pid %d) in %.1fs",
         SUPERVISORD_PID,
         SHUTDOWN_DELAY_SECONDS,
     )
-    signal.signal(signal.SIGALRM, _fire_shutdown)
-    signal.setitimer(signal.ITIMER_REAL, SHUTDOWN_DELAY_SECONDS)
+    threading.Timer(SHUTDOWN_DELAY_SECONDS, _fire_shutdown).start()
     return make_response(("shutting down\n", 202))
 
 
-def _fire_shutdown(_signum, _frame):
+def _fire_shutdown():
     try:
         os.kill(SUPERVISORD_PID, signal.SIGTERM)
     except OSError as exc:  # supervisord already dead, or PID mapping odd

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -121,6 +121,7 @@ type adminData struct {
 	Chatters int // users currently in chat
 	Services []serviceStatus
 	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Audio    nowPlayingTrack // current SomaFM track; empty Title hides the line
 	Stream   streamControl
 	Links    []navLink
 	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
@@ -144,6 +145,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Chatters: chatterCount(),
 		Services: gatherStatus(buildSHA(), vlc, onscreens, obs),
 		Now:      currentVideo(vlc.OK),
+		Audio:    nowPlayingFetcher(r.Context()),
 		Stream:   gatherStream(r.Context()),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
@@ -512,6 +514,10 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .now { margin:0; padding:7px 0; }
   .now .file { font-family:var(--mono); word-break:break-all; }
   .now .state { color:var(--muted); }
+  /* audio = the SomaFM background track from gsclassic.json */
+  .audio { margin:0; padding:7px 0; }
+  .audio .track { color:var(--fg); opacity:.85; }
+  .audio .state { color:var(--muted); }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   /* theme toggle — text-only, sits to the right of the env chip */
@@ -608,12 +614,18 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{end}}
   </details>
 
+  {{if or .Now .Audio.Title}}<h2>now playing</h2>{{end}}
   {{with .Now}}
-  <h2>now playing</h2>
   <p class="now">
     <span class="file">{{.File}}</span>
     {{if .State}}<span class="state">· {{.State}}</span>{{end}}
     {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
+  </p>
+  {{end}}
+  {{if .Audio.Title}}
+  <p class="audio">
+    <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
+    <span class="state">· <a href="https://somafm.com/gsclassic/">Groove Salad Classic</a> on SomaFM</span>
   </p>
   {{end}}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -114,17 +115,18 @@ type navLink struct {
 
 // adminData is the template payload.
 type adminData struct {
-	Channel  string // broadcaster Twitch username
-	Bot      string // bot Twitch username
-	Env      string
-	Uptime   string
-	Chatters int // users currently in chat
-	Services []serviceStatus
-	Now      *nowPlaying // nil when vlc is unhealthy or nothing is playing
-	Audio    nowPlayingTrack // current SomaFM track; empty Title hides the line
-	Stream   streamControl
-	Links    []navLink
-	Reauth   []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
+	Channel   string // broadcaster Twitch username
+	Bot       string // bot Twitch username
+	Env       string
+	Uptime    string
+	Chatters  int // users currently in chat
+	Services  []serviceStatus
+	Now       *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Audio     nowPlayingTrack // current SomaFM track; empty Title hides the line
+	Stream    streamControl
+	PanelHost string // host the panel was reached at; the Twitch embed needs it as parent=
+	Links     []navLink
+	Reauth    []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
 // adminHandler serves the human-facing root page on the tripbot Ingress: a
@@ -147,6 +149,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Now:      currentVideo(vlc.OK),
 		Audio:    nowPlayingFetcher(r.Context()),
 		Stream:   gatherStream(r.Context()),
+		PanelHost: panelHost(r),
 		Links:    gatherLinks(),
 		Reauth:   accountsNeedingReauth(),
 	}
@@ -461,6 +464,23 @@ func siblingURL(externalURL, service string) string {
 	return u.String()
 }
 
+// panelHost returns the hostname the panel was reached at, for use as the
+// Twitch embed's parent= parameter. Read from r.Host (the request's Host
+// header) so it matches whatever the browser used — Tailscale's tail*.ts.net
+// hostname when the panel is reached via the operator's tailnet, the public
+// FQDN when reached through the Ingress. Strips any port suffix. Returns ""
+// when r.Host is empty (unusual; template hides the stream-preview block).
+func panelHost(r *http.Request) string {
+	h := r.Host
+	if h == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		return host
+	}
+	return h
+}
+
 var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -524,6 +544,17 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .audio { margin:0; padding:7px 0; }
   .audio .track { color:var(--fg); opacity:.85; }
   .audio .state { color:var(--muted); }
+  /* stream-preview disclosure — same shape as .controls, just a different
+     summary label. iframe is lazy-loaded by the inline JS so the ~2MB
+     Twitch player isn't fetched on every panel render. */
+  details.stream-preview { margin:24px 0 0; }
+  details.stream-preview > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); cursor:pointer; padding:8px 0; border-top:1px solid var(--divider); list-style:none; }
+  details.stream-preview > summary::-webkit-details-marker { display:none; }
+  details.stream-preview > summary::before { content:"▸ "; color:var(--dim); display:inline-block; }
+  details.stream-preview[open] > summary::before { content:"▾ "; }
+  details.stream-preview > summary:hover { color:var(--fg); }
+  .stream-frame { aspect-ratio:16 / 9; width:100%; margin-top:10px; background:#000; border-radius:6px; overflow:hidden; }
+  .stream-frame iframe { width:100%; height:100%; border:none; display:block; }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   /* theme toggle — text-only, sits to the right of the env chip */
@@ -635,12 +666,41 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   </p>
   {{end}}
 
+  {{if and .Channel .PanelHost}}
+  <details class="stream-preview" id="stream-preview">
+    <summary>stream preview</summary>
+    <div class="stream-frame">
+      <iframe data-src="https://player.twitch.tv/?channel={{.Channel}}&parent={{.PanelHost}}&muted=true&autoplay=true"
+              allowfullscreen
+              title="Twitch stream preview"></iframe>
+    </div>
+  </details>
+  {{end}}
+
   <h2>dashboards</h2>
   <nav class="links">
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>
 </main>
 <script>
+// Stream-preview lazy-load. The Twitch player iframe is ~2MB; we don't want
+// to fetch it on every panel render, only when the operator actually expands
+// the disclosure. On collapse we point it at about:blank so the player stops
+// (otherwise audio + bandwidth keep going even when the section's hidden).
+(function() {
+  const details = document.getElementById('stream-preview');
+  if (!details) return;
+  const iframe = details.querySelector('iframe');
+  if (!iframe) return;
+  details.addEventListener('toggle', () => {
+    if (details.open) {
+      iframe.src = iframe.dataset.src;
+    } else {
+      iframe.src = 'about:blank';
+    }
+  });
+})();
+
 // Theme toggle. Reads localStorage for an explicit user override; otherwise
 // the @media(prefers-color-scheme: light) CSS rule applies. Setting
 // data-theme on <html> overrides the media query in either direction.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -528,11 +528,13 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   .reauth .why { font-family:var(--mono); font-size:.85em; opacity:.85; }
   /* stream toggle — start (green) or stop (red), with a molly-switch two-click confirm */
   .stream-form { margin:8px 0 12px; }
-  button.stream { font:inherit; font-weight:600; padding:9px 18px; border-radius:6px; border:none; cursor:pointer; transition:background .15s, color .15s; }
-  button.stream.start { background:#1f6f3e; color:#e8f7ec; }
+  button.stream { font:inherit; font-size:.9em; padding:6px 14px; border-radius:5px; border:none; cursor:pointer; transition:background .15s, color .15s; }
+  button.stream.start { background:#1f6f3e; color:#e8f7ec; font-weight:600; }
   button.stream.start:hover { background:#2a8a4d; }
-  button.stream.stop  { background:#6a1e1e; color:#fbe6e6; }
-  button.stream.stop:hover  { background:#852828; }
+  /* "stop stream" is the less-likely-correct click — render it muted so
+     it doesn't dominate. The molly-switch arms it red on first click. */
+  button.stream.stop  { background:#2a1a1a; color:#c89696; border:1px solid #4a2a2a; }
+  button.stream.stop:hover  { background:#3a2020; color:#e8b0b0; }
   /* armed = first click landed; second click within 5s actually fires */
   button.stream.armed { background:#f85149; color:#fff; box-shadow:0 0 0 2px #f8514980; }
   .stream-unreachable { color:#666; font-size:.9em; font-style:italic; margin:6px 0 0; }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -152,6 +152,12 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// iOS Safari aggressively caches pages saved as Home Screen apps —
+	// without this, reopening the icon shows stale state until the user
+	// hard-refreshes. no-store forces a fresh fetch every time; the
+	// page is tiny so the cost is trivial.
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
 	if err := adminTmpl.Execute(w, data); err != nil {
 		slog.ErrorContext(r.Context(), "couldn't render admin panel", "err", err)
 	}
@@ -649,6 +655,21 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     const next = cur === 'light' ? 'dark' : 'light';
     root.setAttribute('data-theme', next);
     localStorage.setItem('admin-theme', next);
+  });
+})();
+
+// iOS Home Screen apps return to a stale cached page on reopen — even with
+// no-store headers, Safari sometimes serves the old paint. Reload when the
+// tab becomes visible after being hidden ≥10s, so quick app-switches don't
+// reload-spam but a return-from-Home-Screen does.
+(function() {
+  let hiddenAt = 0;
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      hiddenAt = Date.now();
+    } else if (hiddenAt && Date.now() - hiddenAt >= 10000) {
+      location.reload();
+    }
   });
 })();
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -465,34 +465,58 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
 <link rel="icon" type="image/png" sizes="16x16" href="https://www.dana.lol/assets/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="https://www.dana.lol/assets/apple-touch-icon.png">
 <style>
-  :root { color-scheme: dark; --mono: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
-  body { background:#0a0a0a; color:#eee; font:clamp(14px,0.5vw + 11px,18px)/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
+  :root {
+    color-scheme: dark light;
+    --mono: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    /* Dark palette (default + user-override) */
+    --bg:#0a0a0a; --fg:#eee; --muted:#888; --dim:#666; --faint:#cdd;
+    --chip-bg:#1a1a1a; --chip-border:#262626;
+    --divider:#1c1c1c; --logo-invert:1;
+  }
+  @media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]) {
+      color-scheme: light;
+      --bg:#fafaf7; --fg:#111; --muted:#666; --dim:#888; --faint:#444;
+      --chip-bg:#ececea; --chip-border:#d8d8d4;
+      --divider:#e2e2de; --logo-invert:0;
+    }
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --bg:#fafaf7; --fg:#111; --muted:#666; --dim:#888; --faint:#444;
+    --chip-bg:#ececea; --chip-border:#d8d8d4;
+    --divider:#e2e2de; --logo-invert:0;
+  }
+  body { background:var(--bg); color:var(--fg); font:clamp(14px,0.5vw + 11px,18px)/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; margin:0; display:flex; min-height:100vh; align-items:center; justify-content:center; }
   main { width:min(92vw,520px); padding:clamp(24px,4vw,48px); }
-  /* logo is the monochrome black mark; invert to white on the dark bg */
-  .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(1); opacity:.92; display:block; margin:0 0 16px; }
+  /* logo is the monochrome black mark; invert to white on dark bg, leave as-is on light */
+  .logo { width:clamp(44px,5vw,60px); height:auto; filter:invert(var(--logo-invert)); opacity:.92; display:block; margin:0 0 16px; }
   .logo-link { display:inline-block; }
   .logo-link:hover .logo { opacity:1; }
   h1 { font-size:clamp(20px,1.2vw + 15px,28px); margin:0 0 4px; letter-spacing:.02em; }
-  .env { font-family:var(--mono); background:#1a1a1a; border:1px solid #262626; color:#cdd; padding:2px 7px; border-radius:5px; font-size:.5em; font-weight:normal; letter-spacing:0; vertical-align:middle; }
-  .meta { color:#888; margin:0 0 2px; font-size:.92em; }
-  .accounts { color:#666; margin:0 0 24px; font-size:.85em; }
-  h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:24px 0 8px; }
+  .env { font-family:var(--mono); background:var(--chip-bg); border:1px solid var(--chip-border); color:var(--faint); padding:2px 7px; border-radius:5px; font-size:.5em; font-weight:normal; letter-spacing:0; vertical-align:middle; }
+  .meta { color:var(--muted); margin:0 0 2px; font-size:.92em; }
+  .accounts { color:var(--dim); margin:0 0 24px; font-size:.85em; }
+  h2 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); margin:24px 0 8px; }
   ul { list-style:none; margin:0; padding:0; }
-  .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid #1c1c1c; }
+  .row { display:flex; align-items:center; gap:12px; padding:7px 0; border-bottom:1px solid var(--divider); }
   .row .name { flex:1; }
-  .row .uptime { font-size:.85em; color:#666; }
-  .row .ver { font-family:var(--mono); font-size:.85em; color:#777; }
+  .row .uptime { font-size:.85em; color:var(--dim); }
+  .row .ver { font-family:var(--mono); font-size:.85em; color:var(--dim); }
   /* status hugs the far right and right-aligns so it forms a clean column,
      aligned whether or not the row carries a version */
-  .row .status { color:#888; font-size:.92em; text-align:right; min-width:5.5em; }
+  .row .status { color:var(--muted); font-size:.92em; text-align:right; min-width:5.5em; }
   .dot { width:9px; height:9px; border-radius:50%; flex:0 0 auto; }
   .up { background:#3fb950; box-shadow:0 0 6px #3fb95080; }
   .down { background:#f85149; box-shadow:0 0 6px #f8514980; }
   .now { margin:0; padding:7px 0; }
   .now .file { font-family:var(--mono); word-break:break-all; }
-  .now .state { color:#888; }
+  .now .state { color:var(--muted); }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
+  /* theme toggle — text-only, sits to the right of the env chip */
+  .theme-toggle { background:none; border:none; color:var(--dim); font:inherit; font-size:.85em; cursor:pointer; padding:2px 6px; margin-left:6px; vertical-align:middle; }
+  .theme-toggle:hover { color:var(--fg); }
   .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
   /* re-auth callout: only rendered when a token is missing/expired */
   .reauth { background:#3a1d00; border:1px solid #6b3b00; border-radius:8px; padding:14px 16px; margin:0 0 24px; }
@@ -525,7 +549,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
        assets) rather than copied in — see vault general/logo.md. The anchor
        wraps the mark so clicking it refreshes the page. -->
   <a class="logo-link" href="/" title="refresh"><img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44"></a>
-  <h1>tripbot <code class="env">{{.Env}}</code></h1>
+  <h1>tripbot <code class="env">{{.Env}}</code><button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐</button></h1>
   <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
 
@@ -585,6 +609,23 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   </nav>
 </main>
 <script>
+// Theme toggle. Reads localStorage for an explicit user override; otherwise
+// the @media(prefers-color-scheme: light) CSS rule applies. Setting
+// data-theme on <html> overrides the media query in either direction.
+(function() {
+  const root = document.documentElement;
+  const saved = localStorage.getItem('admin-theme'); // "light" | "dark" | null
+  if (saved) root.setAttribute('data-theme', saved);
+  const btn = document.getElementById('theme-toggle');
+  if (btn) btn.addEventListener('click', () => {
+    // Effective theme: the resolved color-scheme (after CSS + override).
+    const cur = getComputedStyle(root).colorScheme.includes('light') ? 'light' : 'dark';
+    const next = cur === 'light' ? 'dark' : 'light';
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('admin-theme', next);
+  });
+})();
+
 // Molly switch: first click arms the button (relabel + redden, 5s window);
 // second click within the window lets the form submit. Click-away or timeout
 // disarms. No deps — vanilla DOM only.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -538,6 +538,15 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   /* armed = first click landed; second click within 5s actually fires */
   button.stream.armed { background:#f85149; color:#fff; box-shadow:0 0 0 2px #f8514980; }
   .stream-unreachable { color:#666; font-size:.9em; font-style:italic; margin:6px 0 0; }
+  /* Collapsible "controls" disclosure — defaults closed so the page stays
+     calm; click "controls" to reveal stream toggle + future control widgets. */
+  details.controls { margin:24px 0 0; }
+  details.controls > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; cursor:pointer; padding:8px 0; border-top:1px solid #1c1c1c; list-style:none; }
+  details.controls > summary::-webkit-details-marker { display:none; }
+  details.controls > summary::before { content:"▸ "; color:#666; transition:transform .15s ease; display:inline-block; }
+  details.controls[open] > summary::before { content:"▾ "; }
+  details.controls > summary:hover { color:#ccc; }
+  details.controls h3 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:14px 0 6px; }
   /* per-service restart — small, unobtrusive, lives at the end of each row */
   .row .restart-form { margin:0; }
   button.restart { font:inherit; font-size:.8em; padding:3px 9px; border-radius:4px; border:1px solid #2a2a2a; background:#1a1a1a; color:#888; cursor:pointer; transition:background .15s, color .15s, border-color .15s; }
@@ -581,20 +590,23 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{end}}
   </ul>
 
-  <h2>stream</h2>
-  {{if .Stream.Reachable}}
-    {{if .Stream.Active}}
-    <form class="stream-form" method="post" action="/admin/obs/stream/stop">
-      <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armConfirm(this)">stop stream</button>
-    </form>
+  <details class="controls">
+    <summary>controls</summary>
+    <h3>stream</h3>
+    {{if .Stream.Reachable}}
+      {{if .Stream.Active}}
+      <form class="stream-form" method="post" action="/admin/obs/stream/stop">
+        <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armConfirm(this)">stop stream</button>
+      </form>
+      {{else}}
+      <form class="stream-form" method="post" action="/admin/obs/stream/start">
+        <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armConfirm(this)">start stream</button>
+      </form>
+      {{end}}
     {{else}}
-    <form class="stream-form" method="post" action="/admin/obs/stream/start">
-      <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armConfirm(this)">start stream</button>
-    </form>
+    <p class="stream-unreachable">OBS unreachable</p>
     {{end}}
-  {{else}}
-  <p class="stream-unreachable">OBS unreachable</p>
-  {{end}}
+  </details>
 
   {{with .Now}}
   <h2>now playing</h2>

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -241,6 +241,7 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
+	withNowPlaying(t, nowPlayingTrack{Artist: "Test Artist", Title: "Test Track"})
 
 	// stand in for vlc-server: readiness ping + version endpoint
 	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +326,7 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 }
 
 func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
+	withNowPlaying(t, nowPlayingTrack{}) // no audio info — keeps assertion on "now playing" absence valid
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
 	withReauth(t, nil)
@@ -402,9 +404,20 @@ func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Cleanup(func() { accountsNeedingReauth = saved })
 }
 
+// withNowPlaying swaps the SomaFM fetcher so the admin handler sees a fixed
+// audio track (or empty for "no audio info") without hitting somafm.com from
+// a test.
+func withNowPlaying(t *testing.T, track nowPlayingTrack) {
+	t.Helper()
+	saved := nowPlayingFetcher
+	nowPlayingFetcher = func(context.Context) nowPlayingTrack { return track }
+	t.Cleanup(func() { nowPlayingFetcher = saved })
+}
+
 func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(false)
+	withNowPlaying(t, nowPlayingTrack{})
 
 	withConf(t, func() {
 		c.Conf.VlcServerHost = "" // skip the vlc ping
@@ -438,6 +451,7 @@ func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 }
 
 func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
+	withNowPlaying(t, nowPlayingTrack{})
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/gorilla/mux"
 )
 
+func TestPanelHost(t *testing.T) {
+	cases := []struct {
+		host, want string
+	}{
+		{"tripbot.prod.whereisdana.today", "tripbot.prod.whereisdana.today"},
+		{"tripbot.prod.whereisdana.today:8080", "tripbot.prod.whereisdana.today"},
+		{"localhost:8080", "localhost"},
+		{"adanalife-minipc.tail020deb.ts.net", "adanalife-minipc.tail020deb.ts.net"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Host = tc.host
+		if got := panelHost(req); got != tc.want {
+			t.Errorf("panelHost(Host=%q) = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}
+
 func TestSiblingURL(t *testing.T) {
 	cases := []struct {
 		in, service, want string

--- a/pkg/server/somafm.go
+++ b/pkg/server/somafm.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// somaFMNowPlayingURL is the per-channel now-playing JSON feed for the
+// Groove Salad Classic stream that runs as the OBS background audio
+// source. Duplicates the URL constant from pkg/chatbot/song.go on
+// purpose — the cleanest consolidation would be a shared pkg/song
+// package, but that's a separate refactor; the duplication is two
+// lines + a 4-field struct.
+const somaFMNowPlayingURL = "https://somafm.com/songs/gsclassic.json"
+
+// nowPlayingTrack carries the current SomaFM track for the admin
+// template. Both fields empty when the fetch fails or returns nothing.
+type nowPlayingTrack struct {
+	Artist string
+	Title  string
+}
+
+// fetchNowPlaying GETs the SomaFM JSON feed and returns the current
+// track. Best-effort: any failure (timeout, non-2xx, empty list) yields
+// a zero track + nil error so the template just omits the audio line.
+// Uses the existing 2s healthClient — same pattern as the sibling
+// /health probes; the page never blocks on SomaFM being slow.
+func fetchNowPlaying(ctx context.Context) nowPlayingTrack {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, somaFMNowPlayingURL, nil)
+	if err != nil {
+		return nowPlayingTrack{}
+	}
+	resp, err := healthClient.Do(req)
+	if err != nil {
+		return nowPlayingTrack{}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nowPlayingTrack{}
+	}
+	var body struct {
+		Songs []struct {
+			Artist string `json:"artist"`
+			Title  string `json:"title"`
+		} `json:"songs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nowPlayingTrack{}
+	}
+	if len(body.Songs) == 0 {
+		return nowPlayingTrack{}
+	}
+	return nowPlayingTrack{Artist: body.Songs[0].Artist, Title: body.Songs[0].Title}
+}
+
+// nowPlayingFetcher is overridable in tests so we don't hit SomaFM
+// from a unit test. Default fetches live.
+var nowPlayingFetcher = fetchNowPlaying


### PR DESCRIPTION
## Summary

Patch release. Admin panel polish + one real bug fix on obs-server.

### admin panel
- Collapsible stream-preview with lazy-loaded Twitch embed. ([#669])
- Light/dark mode toggle (system pref default + persisted override). ([#667])
- Collapsible "controls" disclosure (default closed). ([#665])
- "stop stream" button shrunk + muted. ([#666])
- "now playing" audio line with Groove Salad link. ([#668])
- Refresh when iOS Home Screen app returns to focus. ([#664])

### obs
- Fix \`obs-server\` \`POST /admin/shutdown\` 500 — Flask worker thread couldn't call \`signal.setitimer()\`; swap to \`threading.Timer\`. The "restart OBS" button in the admin panel now actually works. ([#663])

## Test plan
- [ ] Auto-tag fires v2.15.4 on merge (no \`#minor\`/\`#major\` keyword → patch)
- [ ] Multi-arch images build for tripbot/vlc/obs (the obs image picks up the threading.Timer fix)
- [ ] After image rolls: \`curl -X POST http://obs:8080/admin/shutdown\` returns 202, OBS container exits + respawns
- [ ] Visit panel: stream-preview disclosure works; theme toggle persists; "now playing" audio line shows SomaFM track; iOS Home Screen app refreshes on reopen

[#663]: https://github.com/adanalife/tripbot/pull/663
[#664]: https://github.com/adanalife/tripbot/pull/664
[#665]: https://github.com/adanalife/tripbot/pull/665
[#666]: https://github.com/adanalife/tripbot/pull/666
[#667]: https://github.com/adanalife/tripbot/pull/667
[#668]: https://github.com/adanalife/tripbot/pull/668
[#669]: https://github.com/adanalife/tripbot/pull/669