### PR TITLE
admin: panel layout polish — drop audio link, collapse now-playing, footer toggles

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -547,12 +547,15 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   /* stream-preview disclosure — same shape as .controls, just a different
      summary label. iframe is lazy-loaded by the inline JS so the ~2MB
      Twitch player isn't fetched on every panel render. */
-  details.stream-preview { margin:24px 0 0; }
-  details.stream-preview > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); cursor:pointer; padding:8px 0; border-top:1px solid var(--divider); list-style:none; }
-  details.stream-preview > summary::-webkit-details-marker { display:none; }
-  details.stream-preview > summary::before { content:"▸ "; color:var(--dim); display:inline-block; }
-  details.stream-preview[open] > summary::before { content:"▾ "; }
-  details.stream-preview > summary:hover { color:var(--fg); }
+  /* Shared disclosure-row styling — controls / now-playing / stream-preview
+     all default closed and reveal on click. Same look, just different
+     summary labels. */
+  details.stream-preview, details.now-playing { margin:24px 0 0; }
+  details.stream-preview > summary, details.now-playing > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); cursor:pointer; padding:8px 0; border-top:1px solid var(--divider); list-style:none; }
+  details.stream-preview > summary::-webkit-details-marker, details.now-playing > summary::-webkit-details-marker { display:none; }
+  details.stream-preview > summary::before, details.now-playing > summary::before { content:"▸ "; color:var(--dim); display:inline-block; }
+  details.stream-preview[open] > summary::before, details.now-playing[open] > summary::before { content:"▾ "; }
+  details.stream-preview > summary:hover, details.now-playing > summary:hover { color:var(--fg); }
   .stream-frame { aspect-ratio:16 / 9; width:100%; margin-top:10px; background:#000; border-radius:6px; overflow:hidden; }
   .stream-frame iframe { width:100%; height:100%; border:none; display:block; }
   a { color:#58a6ff; text-decoration:none; }
@@ -651,18 +654,22 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{end}}
   </details>
 
-  {{if or .Now .Audio.Title}}<h2>now playing</h2>{{end}}
-  {{with .Now}}
-  <p class="now">
-    <span class="file">{{.File}}</span>
-    {{if .State}}<span class="state">· {{.State}}</span>{{end}}
-    {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
-  </p>
-  {{end}}
-  {{if .Audio.Title}}
-  <p class="audio">
-    <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
-  </p>
+  {{if or .Now .Audio.Title}}
+  <details class="now-playing">
+    <summary>now playing</summary>
+    {{with .Now}}
+    <p class="now">
+      <span class="file">{{.File}}</span>
+      {{if .State}}<span class="state">· {{.State}}</span>{{end}}
+      {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
+    </p>
+    {{end}}
+    {{if .Audio.Title}}
+    <p class="audio">
+      <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
+    </p>
+    {{end}}
+  </details>
   {{end}}
 
   {{if and .Channel .PanelHost}}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -690,6 +690,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   </nav>
 
   <div class="panel-footer">
+    <button id="toggle-all" class="theme-toggle" type="button" title="expand or collapse all sections">▾ expand all</button>
     <button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐ theme</button>
   </div>
 </main>
@@ -710,6 +711,30 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
       iframe.src = 'about:blank';
     }
   });
+})();
+
+// Expand/collapse all <details> on the page. If any section is closed, the
+// click opens them all; if all are already open, it closes them all. Button
+// label flips to match the next action. The stream-preview's toggle listener
+// (see above) lazy-loads/unloads the iframe on each open/close, so this
+// reuses that path correctly.
+(function() {
+  const btn = document.getElementById('toggle-all');
+  if (!btn) return;
+  const sync = () => {
+    const all = document.querySelectorAll('main details');
+    const anyClosed = Array.from(all).some(d => !d.open);
+    btn.textContent = anyClosed ? '▾ expand all' : '▸ collapse all';
+  };
+  btn.addEventListener('click', () => {
+    const all = document.querySelectorAll('main details');
+    const anyClosed = Array.from(all).some(d => !d.open);
+    all.forEach(d => { d.open = anyClosed; });
+    sync();
+  });
+  // Keep the label honest if the operator toggles individual sections.
+  document.querySelectorAll('main details').forEach(d => d.addEventListener('toggle', sync));
+  sync();
 })();
 
 // Theme toggle. Reads localStorage for an explicit user override; otherwise

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -662,7 +662,6 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   {{if .Audio.Title}}
   <p class="audio">
     <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
-    <span class="state">· <a href="https://somafm.com/gsclassic/">Groove Salad Classic</a> on SomaFM</span>
   </p>
   {{end}}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -561,7 +561,8 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   /* theme toggle — text-only, sits to the right of the env chip */
-  .theme-toggle { background:none; border:none; color:var(--dim); font:inherit; font-size:.85em; cursor:pointer; padding:2px 6px; margin-left:6px; vertical-align:middle; }
+  .panel-footer { margin-top:32px; padding-top:14px; border-top:1px solid var(--divider); display:flex; gap:10px; align-items:center; }
+  .theme-toggle { background:none; border:none; color:var(--dim); font:inherit; font-size:.85em; cursor:pointer; padding:2px 6px; }
   .theme-toggle:hover { color:var(--fg); }
   .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
   /* re-auth callout: only rendered when a token is missing/expired */
@@ -606,7 +607,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
        assets) rather than copied in — see vault general/logo.md. The anchor
        wraps the mark so clicking it refreshes the page. -->
   <a class="logo-link" href="/" title="refresh"><img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44"></a>
-  <h1>tripbot <code class="env">{{.Env}}</code><button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐</button></h1>
+  <h1>tripbot <code class="env">{{.Env}}</code></h1>
   <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
 
@@ -687,6 +688,10 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   <nav class="links">
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>
+
+  <div class="panel-footer">
+    <button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐ theme</button>
+  </div>
 </main>
 <script>
 // Stream-preview lazy-load. The Twitch player iframe is ~2MB; we don't want


### PR DESCRIPTION
Four small UX polish commits, each atomic:

1. **Drop the Groove Salad link from the audio line.** It wrapped awkwardly when the artist + title was long. The \`!somafm\` chat command already carries the credit + link; the panel doesn't need it.
2. **Wrap "now playing" in a collapsed \`<details>\`.** Same disclosure shape as controls + stream-preview. Status table stays visible; video/audio details hide behind a click. Reuses the existing rules via a shared multi-selector.
3. **Move the ◐ theme toggle to a panel footer.** Was crowding the env chip in the header. New "panel footer" below the dashboards links holds the theme button + the new toggle-all button, separated by a divider rule.
4. **Add an "expand/collapse all" button in the footer.** Single click opens every \`<main details>\` if any are closed, or closes them all if they're all open. Label flips to match the next action.

## End-state layout

\`\`\`
logo
tripbot prod-1
up 4m12s · 3 in chat
broadcaster adanalife_ · bot tripbot4000

status
  ● tripbot           ...
  ● vlc-server        ...
  ● onscreens-server  ...
  ● obs               ...

▸ controls
▸ now playing
▸ stream preview

dashboards: obs · grafana · traefik · hubble · sentry
─────────────────────────────────────
▾ expand all   ◐ theme
\`\`\`

## Test plan
- [x] \`task test:macos\` green
- [ ] Visit panel; now-playing closed by default, opens on click
- [ ] Click "expand all" → all disclosures open; label flips to "collapse all"; click again closes them
- [ ] Open one disclosure manually; label updates to reflect the new mixed state
- [ ] Theme toggle still works from the new footer location