### PR TITLE
Release v2.15.5: develop → master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 All notable changes to TripBot. Format follows [Keep a Changelog](https://keepachangelog.com); versioning follows [Semantic Versioning](https://semver.org).
 
+## [v2.15.5] — 2026-05-25
+
+Patch release. More admin-panel polish on top of v2.15.4, plus a temporary hack for the prod stream-preview so it shows something live until the broadcasting cutover.
+
+### admin panel
+
+- **Panel layout polish.** Four small changes shipped as one PR: drop the "Groove Salad Classic on SomaFM" link from the audio line (wrapped awkwardly when artist + title was long); wrap "now playing" in a collapsed `<details>` matching the controls / stream-preview shape; move the theme toggle to a new panel footer at the bottom (was crowding the env chip); add an "expand/collapse all" button next to the theme toggle in that footer. ([#671])
+
+### temporary
+
+- **prod-1's stream-preview embeds `adanalife_staging` until the broadcasting cutover.** `previewChannel()` returns `adanalife_staging` when `c.Conf.IsProduction()`, else `ChannelName`. Pure code-side hack — no infra/env-var change. The broadcaster link in the accounts line still uses `Channel` (= `adanalife_`) so click-through goes to the right Twitch page; only the iframe diverges. **Revert at cutover** by deleting the if-block in `pkg/server/admin.go`'s `previewChannel()`. ([#672])
+
+[#671]: https://github.com/adanalife/tripbot/pull/671
+[#672]: https://github.com/adanalife/tripbot/pull/672
+
 ## [v2.15.4] — 2026-05-25
 
 Patch release. Admin panel polish — the page grows a collapsible stream-preview, picks up system-aware light/dark, learns to refresh itself on iOS Home Screen reopens, and shows what's playing on the SomaFM background-audio source. Also fixes a real bug: obs-server's `POST /admin/shutdown` was returning 500 because Flask's worker-thread request handlers can't call `signal.setitimer()` — the "restart OBS" button now actually works.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -547,18 +547,22 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   /* stream-preview disclosure — same shape as .controls, just a different
      summary label. iframe is lazy-loaded by the inline JS so the ~2MB
      Twitch player isn't fetched on every panel render. */
-  details.stream-preview { margin:24px 0 0; }
-  details.stream-preview > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); cursor:pointer; padding:8px 0; border-top:1px solid var(--divider); list-style:none; }
-  details.stream-preview > summary::-webkit-details-marker { display:none; }
-  details.stream-preview > summary::before { content:"▸ "; color:var(--dim); display:inline-block; }
-  details.stream-preview[open] > summary::before { content:"▾ "; }
-  details.stream-preview > summary:hover { color:var(--fg); }
+  /* Shared disclosure-row styling — controls / now-playing / stream-preview
+     all default closed and reveal on click. Same look, just different
+     summary labels. */
+  details.stream-preview, details.now-playing { margin:24px 0 0; }
+  details.stream-preview > summary, details.now-playing > summary { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); cursor:pointer; padding:8px 0; border-top:1px solid var(--divider); list-style:none; }
+  details.stream-preview > summary::-webkit-details-marker, details.now-playing > summary::-webkit-details-marker { display:none; }
+  details.stream-preview > summary::before, details.now-playing > summary::before { content:"▸ "; color:var(--dim); display:inline-block; }
+  details.stream-preview[open] > summary::before, details.now-playing[open] > summary::before { content:"▾ "; }
+  details.stream-preview > summary:hover, details.now-playing > summary:hover { color:var(--fg); }
   .stream-frame { aspect-ratio:16 / 9; width:100%; margin-top:10px; background:#000; border-radius:6px; overflow:hidden; }
   .stream-frame iframe { width:100%; height:100%; border:none; display:block; }
   a { color:#58a6ff; text-decoration:none; }
   a:hover { color:#9cf; }
   /* theme toggle — text-only, sits to the right of the env chip */
-  .theme-toggle { background:none; border:none; color:var(--dim); font:inherit; font-size:.85em; cursor:pointer; padding:2px 6px; margin-left:6px; vertical-align:middle; }
+  .panel-footer { margin-top:32px; padding-top:14px; border-top:1px solid var(--divider); display:flex; gap:10px; align-items:center; }
+  .theme-toggle { background:none; border:none; color:var(--dim); font:inherit; font-size:.85em; cursor:pointer; padding:2px 6px; }
   .theme-toggle:hover { color:var(--fg); }
   .links { display:flex; flex-wrap:wrap; gap:18px; margin-top:10px; }
   /* re-auth callout: only rendered when a token is missing/expired */
@@ -603,7 +607,7 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
        assets) rather than copied in — see vault general/logo.md. The anchor
        wraps the mark so clicking it refreshes the page. -->
   <a class="logo-link" href="/" title="refresh"><img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44"></a>
-  <h1>tripbot <code class="env">{{.Env}}</code><button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐</button></h1>
+  <h1>tripbot <code class="env">{{.Env}}</code></h1>
   <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
 
@@ -651,19 +655,22 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
     {{end}}
   </details>
 
-  {{if or .Now .Audio.Title}}<h2>now playing</h2>{{end}}
-  {{with .Now}}
-  <p class="now">
-    <span class="file">{{.File}}</span>
-    {{if .State}}<span class="state">· {{.State}}</span>{{end}}
-    {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
-  </p>
-  {{end}}
-  {{if .Audio.Title}}
-  <p class="audio">
-    <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
-    <span class="state">· <a href="https://somafm.com/gsclassic/">Groove Salad Classic</a> on SomaFM</span>
-  </p>
+  {{if or .Now .Audio.Title}}
+  <details class="now-playing">
+    <summary>now playing</summary>
+    {{with .Now}}
+    <p class="now">
+      <span class="file">{{.File}}</span>
+      {{if .State}}<span class="state">· {{.State}}</span>{{end}}
+      {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
+    </p>
+    {{end}}
+    {{if .Audio.Title}}
+    <p class="audio">
+      <span class="track">{{.Audio.Artist}} — {{.Audio.Title}}</span>
+    </p>
+    {{end}}
+  </details>
   {{end}}
 
   {{if and .Channel .PanelHost}}
@@ -681,6 +688,11 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   <nav class="links">
     {{range .Links}}<a href="{{.URL}}">{{.Label}}</a>{{end}}
   </nav>
+
+  <div class="panel-footer">
+    <button id="toggle-all" class="theme-toggle" type="button" title="expand or collapse all sections">▾ expand all</button>
+    <button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐ theme</button>
+  </div>
 </main>
 <script>
 // Stream-preview lazy-load. The Twitch player iframe is ~2MB; we don't want
@@ -699,6 +711,30 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
       iframe.src = 'about:blank';
     }
   });
+})();
+
+// Expand/collapse all <details> on the page. If any section is closed, the
+// click opens them all; if all are already open, it closes them all. Button
+// label flips to match the next action. The stream-preview's toggle listener
+// (see above) lazy-loads/unloads the iframe on each open/close, so this
+// reuses that path correctly.
+(function() {
+  const btn = document.getElementById('toggle-all');
+  if (!btn) return;
+  const sync = () => {
+    const all = document.querySelectorAll('main details');
+    const anyClosed = Array.from(all).some(d => !d.open);
+    btn.textContent = anyClosed ? '▾ expand all' : '▸ collapse all';
+  };
+  btn.addEventListener('click', () => {
+    const all = document.querySelectorAll('main details');
+    const anyClosed = Array.from(all).some(d => !d.open);
+    all.forEach(d => { d.open = anyClosed; });
+    sync();
+  });
+  // Keep the label honest if the operator toggles individual sections.
+  document.querySelectorAll('main details').forEach(d => d.addEventListener('toggle', sync));
+  sync();
 })();
 
 // Theme toggle. Reads localStorage for an explicit user override; otherwise

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -115,18 +115,19 @@ type navLink struct {
 
 // adminData is the template payload.
 type adminData struct {
-	Channel   string // broadcaster Twitch username
-	Bot       string // bot Twitch username
-	Env       string
-	Uptime    string
-	Chatters  int // users currently in chat
-	Services  []serviceStatus
-	Now       *nowPlaying // nil when vlc is unhealthy or nothing is playing
-	Audio     nowPlayingTrack // current SomaFM track; empty Title hides the line
-	Stream    streamControl
-	PanelHost string // host the panel was reached at; the Twitch embed needs it as parent=
-	Links     []navLink
-	Reauth    []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
+	Channel        string // broadcaster Twitch username; renders as text + broadcaster link
+	PreviewChannel string // Twitch channel the stream-preview embed loads; usually == Channel
+	Bot            string // bot Twitch username
+	Env            string
+	Uptime         string
+	Chatters       int // users currently in chat
+	Services       []serviceStatus
+	Now            *nowPlaying // nil when vlc is unhealthy or nothing is playing
+	Audio          nowPlayingTrack // current SomaFM track; empty Title hides the line
+	Stream         streamControl
+	PanelHost      string // host the panel was reached at; the Twitch embed needs it as parent=
+	Links          []navLink
+	Reauth         []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
 }
 
 // adminHandler serves the human-facing root page on the tripbot Ingress: a
@@ -140,8 +141,9 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
 
 	data := adminData{
-		Channel:  c.Conf.ChannelName,
-		Bot:      c.Conf.BotUsername,
+		Channel:        c.Conf.ChannelName,
+		PreviewChannel: previewChannel(),
+		Bot:            c.Conf.BotUsername,
 		Env:      c.Conf.Environment,
 		Uptime:   time.Since(startedAt).Round(time.Second).String(),
 		Chatters: chatterCount(),
@@ -464,6 +466,19 @@ func siblingURL(externalURL, service string) string {
 	return u.String()
 }
 
+// previewChannel returns the Twitch channel name the stream-preview embed
+// should load. Normally == ChannelName, but on prod-1 we temporarily point
+// it at adanalife_staging because prod isn't broadcasting yet — the embed
+// would render a "stream offline" placeholder otherwise. REVERT THIS at the
+// streaming cutover: just delete the if-block so the prod panel embeds
+// adanalife_ like every other env.
+func previewChannel() string {
+	if c.Conf.IsProduction() {
+		return "adanalife_staging"
+	}
+	return c.Conf.ChannelName
+}
+
 // panelHost returns the hostname the panel was reached at, for use as the
 // Twitch embed's parent= parameter. Read from r.Host (the request's Host
 // header) so it matches whatever the browser used — Tailscale's tail*.ts.net
@@ -673,11 +688,11 @@ var adminTmpl = template.Must(template.New("admin").Parse(`<!doctype html>
   </details>
   {{end}}
 
-  {{if and .Channel .PanelHost}}
+  {{if and .PreviewChannel .PanelHost}}
   <details class="stream-preview" id="stream-preview">
     <summary>stream preview</summary>
     <div class="stream-frame">
-      <iframe data-src="https://player.twitch.tv/?channel={{.Channel}}&parent={{.PanelHost}}&muted=true&autoplay=true"
+      <iframe data-src="https://player.twitch.tv/?channel={{.PreviewChannel}}&parent={{.PanelHost}}&muted=true&autoplay=true"
               allowfullscreen
               title="Twitch stream preview"></iframe>
     </div>


### PR DESCRIPTION
## Summary

Patch release. More admin-panel polish on top of v2.15.4, plus a temporary hack for the prod stream-preview.

### admin panel
- Panel layout polish (4 atomic commits): drop Groove Salad link, collapse "now playing", move theme toggle to a footer, add expand/collapse-all button. ([#671])

### temporary
- prod-1's stream-preview embeds \`adanalife_staging\` until the broadcasting cutover. Code-side hack, no infra change. Revert by deleting the if-block in \`previewChannel()\`. ([#672])

## Test plan
- [ ] Auto-tag fires v2.15.5 (patch default)
- [ ] Multi-arch image manifests build
- [ ] After deploy: prod panel embed shows the staging stream live; broadcaster link still goes to \`twitch.tv/adanalife_\`
- [ ] now-playing renders collapsed; expand/collapse-all + theme toggle both work in the footer

## Followups
- The "revert previewChannel() if-block at cutover" reminder is captured in the launch-plan cutover checklist (this session).

[#671]: https://github.com/adanalife/tripbot/pull/671
[#672]: https://github.com/adanalife/tripbot/pull/672