### PR TITLE
chatbot: add !makebot / !unbot admin commands

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -24,6 +25,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
 	"github.com/hako/durafmt"
+	"gorm.io/gorm"
 )
 
 // lastHelloTime is used to rate-limit the hello command
@@ -549,4 +551,35 @@ func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) 
 	slog.InfoContext(ctx, "setting middle text", "text", text)
 
 	a.Onscreens.ShowMiddleText(ctx, text)
+}
+
+func (a *App) makeBotCmd(ctx context.Context, user *users.User, params []string) {
+	a.setBotFlag(ctx, user, params, true, "!makebot")
+}
+
+func (a *App) unBotCmd(ctx context.Context, user *users.User, params []string) {
+	a.setBotFlag(ctx, user, params, false, "!unbot")
+}
+
+// setBotFlag is the shared body of !makebot and !unbot. Admin-only, silent
+// in chat, logs the outcome for ops visibility.
+func (a *App) setBotFlag(ctx context.Context, user *users.User, params []string, isBot bool, trigger string) {
+	slog.InfoContext(ctx, "ran "+trigger, "username", user.Username)
+	if !c.UserIsAdmin(user.Username) {
+		return
+	}
+	if len(params) == 0 {
+		slog.WarnContext(ctx, trigger+" called with no target", "username", user.Username)
+		return
+	}
+	target := strings.ToLower(strings.TrimPrefix(params[0], "@"))
+	if err := a.Sessions.SetBot(ctx, target, isBot); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			slog.WarnContext(ctx, trigger+": target user not found", "target", target)
+			return
+		}
+		slog.ErrorContext(ctx, trigger+" failed", "target", target, "err", err)
+		return
+	}
+	slog.InfoContext(ctx, trigger+": flipped is_bot", "target", target, "is_bot", isBot)
 }

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
+	"gorm.io/gorm"
 )
 
 // captureSay swaps sayFn for a recorder and returns helpers to read the
@@ -1218,5 +1219,96 @@ func TestMilesCmd_OtherUser_StripsAtSign(t *testing.T) {
 	}
 	if len(rec.Calls) != 1 || rec.Calls[0] != `Find("ghost")` {
 		t.Errorf("expected Sessions.Find(\"ghost\") with @ stripped, got %v", rec.Calls)
+	}
+}
+
+// --- makeBotCmd / unBotCmd ---
+
+func TestMakeBotCmd_NonAdmin_DoesNotCallSetBot(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{}
+	app.Sessions = rec
+
+	app.makeBotCmd(context.Background(), newTestUser("viewer1"), []string{"target"})
+
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected no Sessions calls for non-admin, got %v", rec.Calls)
+	}
+}
+
+func TestMakeBotCmd_Admin_NoParams_DoesNotCallSetBot(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{}
+	app.Sessions = rec
+
+	app.makeBotCmd(context.Background(), newTestUser(adminUser), nil)
+
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected no Sessions calls without target, got %v", rec.Calls)
+	}
+}
+
+func TestMakeBotCmd_Admin_FlipsToTrue(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{FindResult: users.User{ID: 7, Username: "tripbot4000"}}
+	app.Sessions = rec
+
+	app.makeBotCmd(context.Background(), newTestUser(adminUser), []string{"tripbot4000"})
+
+	want := `SetBot("tripbot4000", true)`
+	if len(rec.Calls) != 1 || rec.Calls[0] != want {
+		t.Errorf("expected %s, got %v", want, rec.Calls)
+	}
+}
+
+func TestMakeBotCmd_Admin_StripsAtAndLowercases(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{}
+	app.Sessions = rec
+
+	app.makeBotCmd(context.Background(), newTestUser(adminUser), []string{"@TripBot4000"})
+
+	want := `SetBot("tripbot4000", true)`
+	if len(rec.Calls) != 1 || rec.Calls[0] != want {
+		t.Errorf("expected %s, got %v", want, rec.Calls)
+	}
+}
+
+func TestMakeBotCmd_UnknownUser_SwallowsError(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{SetBotErr: gorm.ErrRecordNotFound}
+	app.Sessions = rec
+
+	// Must not panic — the handler logs and returns.
+	app.makeBotCmd(context.Background(), newTestUser(adminUser), []string{"ghost"})
+
+	want := `SetBot("ghost", true)`
+	if len(rec.Calls) != 1 || rec.Calls[0] != want {
+		t.Errorf("expected one SetBot call, got %v", rec.Calls)
+	}
+}
+
+func TestUnBotCmd_Admin_FlipsToFalse(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{FindResult: users.User{ID: 7, Username: "innocent"}}
+	app.Sessions = rec
+
+	app.unBotCmd(context.Background(), newTestUser(adminUser), []string{"innocent"})
+
+	want := `SetBot("innocent", false)`
+	if len(rec.Calls) != 1 || rec.Calls[0] != want {
+		t.Errorf("expected %s, got %v", want, rec.Calls)
+	}
+}
+
+func TestUnBotCmd_NonAdmin_DoesNotCallSetBot(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingSessions{}
+	app.Sessions = rec
+
+	app.unBotCmd(context.Background(), newTestUser("viewer1"), []string{"target"})
+
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected no Sessions calls for non-admin, got %v", rec.Calls)
 	}
 }

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -163,6 +163,14 @@ func (a *App) buildRegistry() []Command {
 			Handler: a.middleCmd,
 		},
 		{
+			Trigger: "!makebot",
+			Handler: a.makeBotCmd,
+		},
+		{
+			Trigger: "!unbot",
+			Handler: a.unBotCmd,
+		},
+		{
 			Trigger:        "!miles",
 			Aliases:        []string{"!points"},
 			Handler:        a.milesCmd,

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -29,6 +29,9 @@ type Sessions interface {
 	// Shutdown logs out every in-memory session, flushing each user's
 	// state to the DB. Called by !shutdown before the process exits.
 	Shutdown(ctx context.Context)
+	// SetBot flips users.is_bot for a username. Returns
+	// gorm.ErrRecordNotFound if the user doesn't exist.
+	SetBot(ctx context.Context, username string, isBot bool) error
 }
 
 // realSessions delegates to pkg/users.
@@ -44,4 +47,8 @@ func (realSessions) LifetimeLeaderboard() [][]string {
 
 func (realSessions) Shutdown(ctx context.Context) {
 	users.Shutdown(ctx)
+}
+
+func (realSessions) SetBot(ctx context.Context, username string, isBot bool) error {
+	return users.SetBot(ctx, username, isBot)
 }

--- a/pkg/chatbot/sessions_test.go
+++ b/pkg/chatbot/sessions_test.go
@@ -12,9 +12,10 @@ import (
 // reads as empty, and Shutdown is a no-op.
 type noopSessions struct{}
 
-func (noopSessions) Find(_ context.Context, _ string) users.User { return users.User{} }
-func (noopSessions) LifetimeLeaderboard() [][]string             { return nil }
-func (noopSessions) Shutdown(_ context.Context)                  {}
+func (noopSessions) Find(_ context.Context, _ string) users.User           { return users.User{} }
+func (noopSessions) LifetimeLeaderboard() [][]string                       { return nil }
+func (noopSessions) Shutdown(_ context.Context)                            {}
+func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error      { return nil }
 
 // recordingSessions captures every call made to it so tests can assert
 // the chatbot queried the expected user / leaderboard surfaces.
@@ -25,6 +26,8 @@ type recordingSessions struct {
 	Calls       []string
 	FindResult  users.User
 	Leaderboard [][]string
+	// SetBotErr is the error SetBot will return for every call.
+	SetBotErr error
 }
 
 func (r *recordingSessions) Find(_ context.Context, username string) users.User {
@@ -39,4 +42,9 @@ func (r *recordingSessions) LifetimeLeaderboard() [][]string {
 
 func (r *recordingSessions) Shutdown(_ context.Context) {
 	r.Calls = append(r.Calls, "Shutdown()")
+}
+
+func (r *recordingSessions) SetBot(_ context.Context, username string, isBot bool) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("SetBot(%q, %t)", username, isBot))
+	return r.SetBotErr
 }


### PR DESCRIPTION
## Summary

Manual curation surface for `users.is_bot`. Pairs with the dropped hardcoded ignore-list (PR #674); without that list, this is how Dana flips a misclassified user from chat without a redeploy.

- `!makebot <username>` → sets `is_bot=true`, persists, reflects in the in-memory `LoggedIn` map.
- `!unbot <username>` → sets `is_bot=false`, same path.
- Admin-only (silent for non-admins, matching `!middle` / `!secretinfo`).
- **Silent in chat** by Dana's preference — outcome logs at slog Info / Warn for ops visibility.
- A leading `@` is stripped and the target is lowercased before the lookup.
- Underlying call goes through a new `App.Sessions.SetBot` seam, with `recordingSessions` covering the path end-to-end.

Stacked on PR #674 (which drops the hardcoded `IgnoredUsers` list and adds the `users.SetBot` helper).

## Test plan

- [x] `task test:macos` — all packages green
- [ ] After merging both PRs: from the admin account, `!makebot tripbot4000`; verify the bot disappears from `!totalleaderboard` once `users.InitLeaderboard` re-runs (or after a restart)
- [ ] `!makebot @random-target` — confirm the `@` is stripped before the DB lookup
- [ ] `!unbot` on a non-existent user — confirm it doesn't panic and logs a warn