### PR TITLE
tests: add Go fuzz targets for chatbot + helpers parsers

### DIFF
--- a/pkg/chatbot/fuzz_test.go
+++ b/pkg/chatbot/fuzz_test.go
@@ -1,0 +1,143 @@
+package chatbot
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// splitFuzzParams mirrors how findCommand constructs params from a chat
+// message: strings.Split(msg, " ") after trimming the command word. It
+// preserves empty elements (so "a  b" yields ["a","","b"]) the same way the
+// production path does, which is the surface we want fuzz to exercise.
+func splitFuzzParams(s string) []string {
+	return strings.Split(s, " ")
+}
+
+// newFuzzApp returns a test App whose IRC is a recording fake (not noopIRC,
+// which delegates to the package-level sayFn and would dereference the nil
+// twitch client during fuzz runs).
+func newFuzzApp(vid video.Video) *App {
+	app := newTestApp(vid)
+	app.IRC = &recordingIRC{}
+	return app
+}
+
+// FuzzFindCommand asserts the chat-message parser never panics on arbitrary
+// input. Anything that gets typed into Twitch chat (including the invisible
+// Chatterino dup-suppression rune \U000e0000, inverted-bang aliases, multi-
+// word aliases, and arbitrary UTF-8) flows through findCommand.
+func FuzzFindCommand(f *testing.F) {
+	seeds := []string{
+		"",
+		" ",
+		"!help",
+		"!",
+		"! help",
+		"!miles @dana",
+		"¡miles",
+		"hi",
+		"no audio",
+		"frozen since yesterday",
+		"!help \U000e0000",
+		"!help\t",
+		"\x00",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		_, _ = findCommand(s)
+	})
+}
+
+// FuzzGuessCmd fuzzes the !guess argument parser. The video's State is set
+// to a sentinel string no realistic chat input can match, so fuzz stays on
+// the wrong-guess path (no DB writes). The handful of inputs that happen to
+// match are skipped to avoid the AddToScore path's sqlmock requirement.
+func FuzzGuessCmd(f *testing.F) {
+	const unguessableState = "\x00ZZ_FUZZ_SENTINEL_ZZ\x00"
+
+	seeds := []string{"", " ", "CA", "ca", "California", "@CA", "CA ZZ", "\x00", "  CA  "}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		app := newFuzzApp(newTestVideo(unguessableState, 0, 0, time.Time{}))
+		params := splitFuzzParams(s)
+		// guessCmd's correct-guess branch lower-cases both sides and the
+		// 2-letter form gets expanded via helpers.StateAbbrevToState; bail
+		// if either form matches the sentinel (essentially impossible).
+		guess := strings.Join(params, " ")
+		if strings.ToLower(guess) == strings.ToLower(unguessableState) {
+			t.Skip("fuzz hit the sentinel state")
+		}
+		app.guessCmd(context.Background(), newTestUser("viewer1"), params)
+	})
+}
+
+// FuzzMilesCmd exercises the other-user lookup path, which calls
+// helpers.StripAtSign(params[0]). The noopSessions fake returns a zero-value
+// user so milesCmd short-circuits before any DB-backed mileage lookup.
+func FuzzMilesCmd(f *testing.F) {
+	seeds := []string{"@dana", "dana", "", "@", " ", "@dana extra", "\x00", "@@dana"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		app := newFuzzApp(video.Video{})
+		params := splitFuzzParams(s)
+		if len(params) == 0 {
+			t.Skip("empty params hits the self path which reads CurrentMiles")
+		}
+		app.milesCmd(context.Background(), newTestUser("viewer1"), params)
+	})
+}
+
+// FuzzFollowageCmd covers the StripAtSign-on-params[0] path for !followage.
+// mytwitch.FollowedAt short-circuits when the broadcaster token isn't loaded
+// (the test-env default), so no HTTP fires.
+func FuzzFollowageCmd(f *testing.F) {
+	seeds := []string{"@dana", "dana", "", "@", " ", "@dana extra", "\x00"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		app := newFuzzApp(video.Video{})
+		app.middleCmd(context.Background(), newTestUser("viewer1"), splitFuzzParams(s))
+		app.followageCmd(context.Background(), newTestUser("viewer1"), splitFuzzParams(s))
+	})
+}
+
+// FuzzMiddleCmd covers the admin-gated "hide" branch (single-param case-
+// insensitive match) and the show-text branch (params joined by space). The
+// recordingOnscreens fake swallows the overlay calls.
+func FuzzMiddleCmd(f *testing.F) {
+	seeds := []string{"hide", "HIDE", "Hide", "hello world", "", "  ", "hide me", "\x00", "@hide"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		app := newFuzzApp(video.Video{})
+		params := splitFuzzParams(s)
+		app.middleCmd(context.Background(), newTestUser(adminUser), params)
+	})
+}
+
+// FuzzSetBotFlag covers the !makebot / !unbot argument handling: lowercase
+// + TrimPrefix("@") on params[0], then the noopSessions.SetBot call.
+func FuzzSetBotFlag(f *testing.F) {
+	seeds := []string{"@dana", "dana", "DANA", "@", "", " ", "@@dana", "@dana extra", "\x00"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		app := newFuzzApp(video.Video{})
+		params := splitFuzzParams(s)
+		app.makeBotCmd(context.Background(), newTestUser(adminUser), params)
+		app.unBotCmd(context.Background(), newTestUser(adminUser), params)
+	})
+}

--- a/pkg/helpers/fuzz_test.go
+++ b/pkg/helpers/fuzz_test.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzStripAtSign asserts the @-prefix stripper never panics on arbitrary
+// input and is idempotent on its own output.
+func FuzzStripAtSign(f *testing.F) {
+	seeds := []string{"", "@", "@dana", "dana", "da@na", "@@dana", "\x00"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		got := StripAtSign(s)
+		// At most one leading @ should be removed. Either the input had no
+		// leading @ and the result is unchanged, or the input had one and
+		// the result is the input minus its first byte.
+		if strings.HasPrefix(s, "@") {
+			if got != s[1:] {
+				t.Fatalf("StripAtSign(%q) = %q; want %q", s, got, s[1:])
+			}
+		} else if got != s {
+			t.Fatalf("StripAtSign(%q) = %q; want unchanged", s, got)
+		}
+	})
+}
+
+// FuzzStateAbbrevToState asserts random input never panics and that the
+// non-empty-result case round-trips back to the original (uppercased) abbrev.
+func FuzzStateAbbrevToState(f *testing.F) {
+	seeds := []string{"", "CA", "ca", "Ny", "ZZ", "  ", "\x00", "California", "AE"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		name := StateAbbrevToState(s)
+		if name == "" {
+			return
+		}
+		// When the lookup hit, the returned name should map back to the
+		// original uppercased two-letter abbrev.
+		back := StateToStateAbbrev(name)
+		if back != strings.ToUpper(s) {
+			t.Fatalf("StateAbbrevToState(%q) = %q; reverse %q != %q", s, name, back, strings.ToUpper(s))
+		}
+	})
+}
+
+// FuzzTitlecaseState asserts the convenience wrapper never panics on arbitrary
+// input. It accepts either a two-letter abbrev or a full state name.
+func FuzzTitlecaseState(f *testing.F) {
+	seeds := []string{"", "CA", "california", "New york", "  ", "ZZ", "\x00"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = TitlecaseState(s)
+	})
+}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -298,9 +298,5 @@ func Base64Decode(str string) (string, error) {
 }
 
 func StripAtSign(username string) string {
-	if username[0] == []byte("@")[0] {
-		// strip the @ sign
-		username = username[1:]
-	}
-	return username
+	return strings.TrimPrefix(username, "@")
 }

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -174,6 +174,7 @@ func TestStripAtSign(t *testing.T) {
 		{"without @ prefix", "dana", "dana"},
 		{"@ in middle is preserved", "da@na", "da@na"},
 		{"only @ sign", "@", ""},
+		{"empty string", "", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/helpers/states.go
+++ b/pkg/helpers/states.go
@@ -11,13 +11,16 @@ func StateAbbrevToState(abbrev string) string {
 }
 
 func StateToStateAbbrev(state string) string {
-	// capitalize the first letter of the state
-	state = strings.Title(strings.ToLower(state))
-	val, ok := InvertMap(stateAbbrevs)[state]
-	if !ok {
-		return ""
+	// Case-insensitive lookup so names like "district of columbia" still
+	// resolve. strings.Title was previously used but mis-capitalised the
+	// internal "of"/"and" words in multi-word names.
+	want := strings.ToLower(state)
+	for abbrev, name := range stateAbbrevs {
+		if strings.ToLower(name) == want {
+			return abbrev
+		}
 	}
-	return val
+	return ""
 }
 
 //TODO: this doesn't handle the case where the state is invalid


### PR DESCRIPTION
## Summary

Adopts Go's built-in `go test -fuzz` (Go 1.18+) for parser-shaped code in `pkg/helpers` and `pkg/chatbot`. Closes the "Adopt Go's built-in fuzz testing for chat commands and parser-shaped code" TODO and the older "use go-fuzz or gofuzz to test chat commands" entry.

### Fuzz targets

- `pkg/helpers/fuzz_test.go`: `FuzzStripAtSign`, `FuzzStateAbbrevToState` (round-trip), `FuzzTitlecaseState`.
- `pkg/chatbot/fuzz_test.go`: `FuzzFindCommand` (the message parser), plus per-command coverage for `guessCmd`, `milesCmd`, `followageCmd`, `middleCmd`, and `setBotFlag` (the `params`-splitting bodies).

Each ran clean for 10–15s in dev (50k–400k execs/sec depending on target).

### Bugs surfaced by the targets

Caught in <1 min of fuzzing — fixed in their own commits ahead of the harness:

1. `helpers.StripAtSign("")` panicked at `username[0]` before the length check. Replaced with `strings.TrimPrefix`.
2. `helpers.StateToStateAbbrev("District of Columbia")` returned `""` — `strings.Title` mis-capitalised the internal "of". Lookup now case-insensitive across the map values.

Both bugs were latent (the existing callers don't currently hit them), but the fixes are cheap and the fuzz targets are the regression nets.

### Test scaffolding note

Chatbot fuzz targets use a small `newFuzzApp` wrapper that swaps `noopIRC` for `recordingIRC` — `noopIRC.Say` still delegates to the package-level `sayFn` during the App.IRC migration ([per the chatbot-app-injection-pattern ADR](https://github.com/adanalife/tripbot/blob/develop/CLAUDE.md)), and that path dereferences a nil twitch client under fuzz load.

## Test plan

- [x] `task test:macos` — full suite green
- [x] Each fuzz target run with `-fuzz=^X$ -fuzztime=10s` (helpers + chatbot)
- [ ] CI green on the PR