### PR TITLE
ci: add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,21 @@
+name: govulncheck
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # libvlc-dev is required because pkg/vlc-{client,server} pull in
+      # libvlc-go/v3 (cgo); govulncheck has to build the package graph
+      # to do its symbolic call-site analysis.
+      - run: sudo apt-get update -qq && sudo apt-get install -y libvlc-dev
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,10 +11,13 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
       # libvlc-dev is required because pkg/vlc-{client,server} pull in
       # libvlc-go/v3 (cgo); govulncheck has to build the package graph
-      # to do its symbolic call-site analysis.
+      # to do its symbolic call-site analysis. apt-get install doesn't
+      # need the repo on disk, so no outer checkout — the action does
+      # its own checkout + setup-go (an outer actions/checkout@v6 here
+      # leaves credentials around that collide with the action's pinned
+      # v4 checkout, yielding a duplicate-Authorization 400 on fetch).
       - run: sudo apt-get update -qq && sudo apt-get install -y libvlc-dev
       - uses: golang/govulncheck-action@v1
         with:


### PR DESCRIPTION
## Summary

Adds [`golang/govulncheck-action@v1`](https://github.com/golang/govulncheck-action) as a CI gate on PRs + pushes to develop/master. Scans go.mod **and the imported call graph** against [vuln.go.dev](https://pkg.go.dev/vuln/), so it only fails when a known vulnerability is actually reachable from our code — much tighter signal than CodeQL or raw Dependabot alerts.

Runs alongside the existing testing.yml / linting.yml / super-linter.yml — doesn't replace any of them.

Picks at the "survey modern Go tooling worth adopting" TODO in `vault/tripbot/TODO.md:38` — govulncheck was one of the named candidates. `go test -fuzz` landed in #676; this is the second item in that survey.

## Dry-run results (on develop, today)

`govulncheck ./...` locally:

> No vulnerabilities found.
>
> Your code is affected by 0 vulnerabilities. This scan also found 1 vulnerability in packages you import and 5 vulnerabilities in modules you require, but your code doesn't appear to call these vulnerabilities.

All 6 latent ones are in `golang.org/x/net` — none reachable from tripbot's call sites. So this should land green; the CI gate will start catching new ones as they're disclosed.

## Test plan

- [ ] govulncheck workflow runs green on this PR
- [ ] Verify the action name shows up in the PR checks UI