### PR TITLE
admin: revert pre-cutover stream-preview staging hack

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -467,15 +467,8 @@ func siblingURL(externalURL, service string) string {
 }
 
 // previewChannel returns the Twitch channel name the stream-preview embed
-// should load. Normally == ChannelName, but on prod-1 we temporarily point
-// it at adanalife_staging because prod isn't broadcasting yet — the embed
-// would render a "stream offline" placeholder otherwise. REVERT THIS at the
-// streaming cutover: just delete the if-block so the prod panel embeds
-// adanalife_ like every other env.
+// should load.
 func previewChannel() string {
-	if c.Conf.IsProduction() {
-		return "adanalife_staging"
-	}
 	return c.Conf.ChannelName
 }
 


### PR DESCRIPTION
## Summary

Drops the `IsProduction()` if-block in `previewChannel()` (`pkg/server/admin.go`) that was returning `"adanalife_staging"` on prod-1 so the admin panel's stream-preview embed showed the live staging stream until prod was actually broadcasting. Originally landed in [#672](https://github.com/adanalife/tripbot/pull/672/changes), shipped via v2.15.5.

After the streaming cutover the panel embed should show whatever channel the env is configured for — `adanalife_` on prod, like every other env. The helper collapses to a one-liner returning `c.Conf.ChannelName`.

## Sequencing

**Merge in the cutover window** — sequence:
1. Stream-key flip (`aws secretsmanager put-secret-value` for the real `adanalife_` key)
2. Wait for `twitch.tv/adanalife_` to be visibly live
3. Merge this PR + cut a tripbot release + rollout

Pairs with [infra#577](https://github.com/adanalife/infra/pull/577/changes) (sibling cleanup of the same pre-cutover placeholder-state references in the OBS prod-1 overlay + Taskfile).

## Test plan

- [x] `task test:macos -- ./pkg/server/...` — `pkg/server` tests pass
- [ ] Post-cutover: visit `https://tripbot.prod.whereisdana.today/` in a browser, confirm the stream-preview embed loads `twitch.tv/adanalife_` (not `_staging`)