### PR TITLE
Disable follower-gating for launch

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -80,6 +80,11 @@ var helpIndex = rand.Intn(len(c.HelpMessages))
 const followerMsg = "Right now only followers of the channel can run unlimited commands :)"
 const subscriberMsg = "You must be a subscriber to run that command :)"
 
+// followerGatingEnabled toggles the RequiresFollow access check in
+// checkAccess. Disabled for launch so first-time viewers aren't told to
+// follow before they can try commands. Flip back to true to re-enable.
+var followerGatingEnabled = false
+
 // Initialize returns a Twitch client struct with all of the various configuration in place.
 func Initialize() *twitch.Client {
 	var err error

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -43,7 +43,7 @@ type chatUser interface {
 // checkAccess returns true when the user is allowed to run cmd.
 // It calls sayFn with the appropriate denial message when access is denied.
 func (cmd *Command) checkAccess(ctx context.Context, user chatUser, sayFn func(string)) bool {
-	if cmd.RequiresFollow && !user.HasCommandAvailable(ctx) {
+	if followerGatingEnabled && cmd.RequiresFollow && !user.HasCommandAvailable(ctx) {
 		sayFn(followerMsg)
 		return false
 	}

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -204,6 +204,10 @@ func TestCheckAccess_NoRestrictions(t *testing.T) {
 }
 
 func TestCheckAccess_RequiresFollow_NonFollower(t *testing.T) {
+	prev := followerGatingEnabled
+	followerGatingEnabled = true
+	t.Cleanup(func() { followerGatingEnabled = prev })
+
 	cmd := &Command{Trigger: "!test", RequiresFollow: true}
 	var said string
 	if cmd.checkAccess(context.Background(), &fakeUser{follower: false}, func(msg string) { said = msg }) {
@@ -215,6 +219,10 @@ func TestCheckAccess_RequiresFollow_NonFollower(t *testing.T) {
 }
 
 func TestCheckAccess_RequiresFollow_Follower(t *testing.T) {
+	prev := followerGatingEnabled
+	followerGatingEnabled = true
+	t.Cleanup(func() { followerGatingEnabled = prev })
+
 	cmd := &Command{Trigger: "!test", RequiresFollow: true}
 	var said string
 	if !cmd.checkAccess(context.Background(), &fakeUser{follower: true}, func(msg string) { said = msg }) {
@@ -222,6 +230,21 @@ func TestCheckAccess_RequiresFollow_Follower(t *testing.T) {
 	}
 	if said != "" {
 		t.Errorf("expected no message, got %q", said)
+	}
+}
+
+func TestCheckAccess_RequiresFollow_GatingDisabled(t *testing.T) {
+	prev := followerGatingEnabled
+	followerGatingEnabled = false
+	t.Cleanup(func() { followerGatingEnabled = prev })
+
+	cmd := &Command{Trigger: "!test", RequiresFollow: true}
+	var said string
+	if !cmd.checkAccess(context.Background(), &fakeUser{follower: false}, func(msg string) { said = msg }) {
+		t.Error("expected true for non-follower when gating disabled")
+	}
+	if said != "" {
+		t.Errorf("expected no message when gating disabled, got %q", said)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a `followerGatingEnabled` kill switch (default `false`) wrapping the `RequiresFollow` check in `checkAccess` so launch-day viewers don't get told to follow before running commands
- Leave the 17 `RequiresFollow: true` entries in `registry.go` intact — re-enabling is a one-line flip of the var back to `true`
- Update the two existing follower-gating tests to set the flag explicitly, and add a `_GatingDisabled` test that proves the kill switch works

## Test plan
- [ ] `task test:macos` green (verified locally)
- [ ] After deploy, run a `RequiresFollow` command (e.g. `!miles`, `!location`) from a non-follower account and confirm no "only followers" message and the command runs
- [ ] Confirm `!report` and other non-gated commands still behave as before