### PR TITLE
quiet "OCRing coords skipped!" log to debug

### DIFF
--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -102,7 +102,7 @@ func (v Video) save(ctx context.Context) error {
 
 	if lat == 0 || lng == 0 {
 		//TODO: this is where we used to run ocrCoords()
-		slog.ErrorContext(ctx, "OCRing coords skipped!")
+		slog.DebugContext(ctx, "OCRing coords skipped!")
 		flagged = true
 	}
 


### PR DESCRIPTION
## Summary

`pkg/video/db.go:105` logs `OCRing coords skipped!` at Error level every time a video is saved without coords. Since `ocrCoords()` was removed, that's the expected steady state for any video without lat/lng — so this fires constantly, spamming Loki and sending a Sentry exception per save.

Dropped to Debug. The TODO comment above it remains as the marker that OCR used to live there.

## Test plan

- [ ] Confirm the log line stops appearing in Grafana at default levels
- [ ] Confirm Sentry stops receiving exceptions for this site