### PR TITLE
quiet the VLC / onscreens client error cascade

### DIFF
--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -128,21 +128,26 @@ func (c *Client) HideGPSImage(ctx context.Context) error {
 }
 
 //TODO: move this to a common location
+//
+// Transport-layer errors log at Debug, not Error: each wrapper above this
+// (HideMiddleText, ShowGPSImage, …) logs the operation-specific failure at
+// Error with the same underlying err. Logging here too would double-count
+// every onscreens outage in Loki and Sentry.
 func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.ErrorContext(ctx, "error building request to onscreens server", "err", err)
+		slog.DebugContext(ctx, "error building request to onscreens server", "err", err)
 		return "", err
 	}
 	response, err := c.httpClient.Do(req)
 	if err != nil {
-		slog.ErrorContext(ctx, "error connecting to onscreens server", "err", err)
+		slog.DebugContext(ctx, "error connecting to onscreens server", "err", err)
 		return "", err
 	}
 	defer response.Body.Close()
 	contents, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		slog.ErrorContext(ctx, "error reading response from onscreens server", "err", err)
+		slog.DebugContext(ctx, "error reading response from onscreens server", "err", err)
 		return "", err
 	}
 	// make note of non-200 status codes

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -68,7 +68,10 @@ func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 		// share the Video with the system
 		p.CurrentlyPlaying, err = LoadOrCreate(ctx, p.curVid)
 		if err != nil {
-			slog.ErrorContext(ctx, "unable to create Video", "err", err, "file", p.curVid)
+			// Downstream of vlc.CurrentlyPlaying; the wrapper there already
+			// logged the root cause at Error. Debug-level keeps the breadcrumb
+			// without double-counting in Sentry.
+			slog.DebugContext(ctx, "unable to create Video", "err", err, "file", p.curVid)
 		}
 
 		slog.InfoContext(ctx, "now playing",

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -89,21 +89,26 @@ func (c *Client) Back(ctx context.Context, n int) error {
 }
 
 //TODO: move this to a common location
+//
+// Transport-layer errors log at Debug, not Error: each wrapper above this
+// (CurrentlyPlaying, PlayRandom, …) logs the operation-specific failure at
+// Error with the same underlying err. Logging here too would triple-count
+// every VLC outage in Loki and Sentry.
 func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		slog.ErrorContext(ctx, "error building request to VLC server", "err", err)
+		slog.DebugContext(ctx, "error building request to VLC server", "err", err)
 		return "", err
 	}
 	response, err := c.httpClient.Do(req)
 	if err != nil {
-		slog.ErrorContext(ctx, "error connecting to VLC server", "err", err)
+		slog.DebugContext(ctx, "error connecting to VLC server", "err", err)
 		return "", err
 	}
 	defer response.Body.Close()
 	contents, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		slog.ErrorContext(ctx, "error reading response from VLC server", "err", err)
+		slog.DebugContext(ctx, "error reading response from VLC server", "err", err)
 		return "", err
 	}
 	return string(contents), nil


### PR DESCRIPTION
## Summary

A single "no route to host" from `vlc-server` was producing **5 ERROR records (and 5 Sentry exceptions) on one trace_id**:

- `pkg/vlc-client/vlc-client.go:100` — `error connecting to VLC server` (transport)
- `pkg/vlc-client/vlc-client.go:38` — `unable to determine current video` (wrapper, same err)
- `pkg/video/video.go:71` — `unable to create Video` err=`no file provided` (downstream symptom)
- `pkg/onscreens-client/onscreens-client.go:139` — `error connecting to onscreens server` (transport)
- `pkg/onscreens-client/onscreens-client.go:124` — `error hiding gps onscreen` (wrapper, same err)

Demoted the transport-layer helpers (`get()` in both clients) and the downstream `unable to create Video` to Debug. The wrappers above retain their meaningful operation-named Error logs, so we still get one good record per failure instead of five.

Follows the [[slog-attribute-keys]] convention — Error events should map ~1:1 to a meaningful Sentry exception, not duplicate the same root cause at every stack layer.

## Test plan

- [x] `task test:macos` passes
- [ ] After deploy, confirm one VLC-server outage produces one Error per affected operation (not 3+)
- [ ] Confirm Sentry stops receiving 5x duplicates per outage