### PR TITLE
obs: shim xdg-screensaver to silence per-cycle warnings

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -71,6 +71,16 @@ RUN curl -fsSL "https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSIO
     && mv "/opt/noVNC-${NOVNC_VERSION}" /opt/novnc \
     && printf '%s\n' '<!doctype html><title>OBS noVNC</title><meta http-equiv="refresh" content="0; url=vnc.html?resize=scale&amp;autoconnect=true&amp;reconnect=true">' > /opt/novnc/index.html
 
+# OBS calls `xdg-screensaver suspend` every 30s while streaming to inhibit
+# the desktop screensaver. In a headless container there is no supported
+# screensaver backend (no X11 $DISPLAY, no GNOME/KDE session), so the
+# freedesktop script exits 2 and OBS logs `Failed to create xdg-screensaver`
+# every cycle — ~120 wasted fork+exec per pod per hour, all spamming Loki at
+# warn level. Shim it to a no-op so OBS gets exit 0 and stops complaining.
+# /usr/local/bin is ahead of /usr/bin in PATH so this wins.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/xdg-screensaver \
+    && chmod +x /usr/local/bin/xdg-screensaver
+
 COPY infra/docker/obs/config/ /opt/obs/config/
 COPY infra/docker/obs/script/ /opt/obs/script/
 COPY infra/docker/obs/entrypoint.sh /opt/obs/entrypoint.sh

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -92,6 +92,16 @@ RUN ldconfig
 # (logged by OBS as `Webpage has crashed unexpectedly! Reason: '9'`).
 RUN find /usr/local -name chrome-sandbox -exec chmod 4755 {} +
 
+# OBS calls `xdg-screensaver suspend` every 30s while streaming to inhibit
+# the desktop screensaver. In a headless container there is no supported
+# screensaver backend (no X11 $DISPLAY, no GNOME/KDE session), so the
+# freedesktop script exits 2 and OBS logs `Failed to create xdg-screensaver`
+# every cycle — ~120 wasted fork+exec per pod per hour, all spamming Loki at
+# warn level. Shim it to a no-op so OBS gets exit 0 and stops complaining.
+# /usr/local/bin is ahead of /usr/bin in PATH so this wins.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/xdg-screensaver \
+    && chmod +x /usr/local/bin/xdg-screensaver
+
 COPY infra/docker/obs/config/ /opt/obs/config/
 COPY infra/docker/obs/script/ /opt/obs/script/
 COPY infra/docker/obs/entrypoint.sh /opt/obs/entrypoint.sh


### PR DESCRIPTION
## Summary

OBS calls `xdg-screensaver suspend $window_id` every 30s while streaming to inhibit the desktop screensaver. The freedesktop script can't find a backend in a headless container (no `\$DISPLAY`, no GNOME/KDE session) and exits 2 — OBS then logs `Failed to create xdg-screensaver: 2` at warn level on every cycle:

```
warning: Failed to create xdg-screensaver: 2
warning: Failed to create xdg-screensaver: 2
warning: Failed to create xdg-screensaver: 2
...
```

About **120 wasted fork+exec per pod per hour**, all hitting Loki.

Drop a no-op shim at `/usr/local/bin/xdg-screensaver` (ahead of `/usr/bin` in PATH) so OBS gets exit 0 and stops trying. Cleaner than a Loki-side drop filter — the noise never enters the log stream and OBS does no work it doesn't need to. Applied to both Dockerfile (amd64) and Dockerfile.arm64.

## Test plan

- [ ] After deploy, confirm `xdg-screensaver: 2` warnings stop in Loki
- [ ] Confirm OBS still streams normally (the shim only suppresses the screensaver inhibition; there's no screensaver to suppress anyway)