### PR TITLE
admin panel: route outbound links over the tailnet

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -8,10 +8,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -59,15 +57,24 @@ const (
 	grafanaURL = "https://adanalife.grafana.net/dashboards/f/fflhs4m586io0e"
 	// githubURL is the tripbot source repo (vlc-server + obs live here too).
 	githubURL = "https://github.com/adanalife/tripbot"
-	// traefikURL / hubbleURL are the cluster's platform dashboards. They live
-	// in kube-system as a single prod-zone install shared across envs, so
-	// (unlike OBS) they aren't derived per-environment.
-	traefikURL = "https://traefik.prod.whereisdana.today"
-	// hubbleBaseURL is the single prod-zone Hubble install on the mini-PC
-	// cluster. gatherLinks appends ?namespace=<env's namespace> so the link
-	// lands straight in that namespace's flow view instead of Hubble's "choose
-	// a namespace" page — see hubbleNamespace.
-	hubbleBaseURL = "https://hubble.prod.whereisdana.today/"
+	// tailnetBase is Dana's tailnet MagicDNS suffix. App UIs are exposed by
+	// the Tailscale K8s operator at <service>-<env>.<tailnetBase>, e.g.
+	// tripbot-prod.tail020deb.ts.net. We prefer these over the LAN-IP-backed
+	// *.whereisdana.today URLs because the latter silently fail on client
+	// networks that share the home LAN's 192.168.1.0/24 range — the operator
+	// names are CGNAT (100.x), so they never collide. See vault
+	// decisions/tailscale-access-model.md.
+	tailnetBase = "tail020deb.ts.net"
+	// traefikURL / hubbleBaseURL are the cluster's platform dashboards. They
+	// live in kube-system as a single prod-zone install shared across envs
+	// (see vault decisions/stage-prod-cotenancy.md), so the host is always
+	// -prod regardless of which env's panel is rendering the link.
+	traefikURL = "https://traefik-prod." + tailnetBase
+	// hubbleBaseURL is the prod-zone Hubble install. gatherLinks appends
+	// ?namespace=<env's namespace> so the link lands straight in that
+	// namespace's flow view instead of Hubble's "choose a namespace" page —
+	// see hubbleNamespace.
+	hubbleBaseURL = "https://hubble-prod." + tailnetBase + "/"
 	// sentryURL is the org's issue list. gatherLinks appends ?environment=<env>
 	// so the link lands pre-filtered to this env's issues — see sentryEnv.
 	sentryURL = "https://a-dana-life.sentry.io/issues/"
@@ -401,7 +408,7 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 // neither appears here. Entries whose URL can't be derived are dropped.
 func gatherLinks() []navLink {
 	links := []navLink{}
-	if obs := siblingURL(c.Conf.ExternalURL, "obs"); obs != "" {
+	if obs := tailnetServiceURL("obs"); obs != "" {
 		links = append(links, navLink{Label: "obs", URL: obs})
 	}
 	links = append(links,
@@ -449,21 +456,25 @@ func changelogURL(sha string) string {
 	return githubURL + "/blob/" + ref + "/CHANGELOG.md"
 }
 
-// siblingURL rewrites externalURL's leading hostname label to service, e.g.
-// https://tripbot.prod.whereisdana.today -> https://obs.prod.whereisdana.today.
-// Returns "" when externalURL isn't a multi-label FQDN (e.g. localhost), since
-// there's no sibling Ingress to point at in that case.
-func siblingURL(externalURL, service string) string {
-	u, err := url.Parse(externalURL)
-	if err != nil || u.Hostname() == "" {
+// tailnetServiceURL returns the Tailscale K8s-operator URL for a sibling
+// service in this env's namespace, e.g. obs-prod.tail020deb.ts.net for
+// production. Tailnet (CGNAT 100.x) URLs are preferred over the LAN-IP-backed
+// *.whereisdana.today URLs because the latter silently fail on client
+// networks that overlap the home LAN's 192.168.1.0/24 range. Returns "" for
+// environments not served by the operator (dev/local/testing run on a
+// separate cluster), which hides the link rather than rendering one that
+// won't reach anything.
+func tailnetServiceURL(service string) string {
+	var env string
+	switch {
+	case c.Conf.IsProduction():
+		env = "prod"
+	case c.Conf.IsStaging():
+		env = "stage"
+	default:
 		return ""
 	}
-	_, rest, found := strings.Cut(u.Hostname(), ".")
-	if !found {
-		return ""
-	}
-	u.Host = service + "." + rest
-	return u.String()
+	return "https://" + service + "-" + env + "." + tailnetBase
 }
 
 // previewChannel returns the Twitch channel name the stream-preview embed

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -34,18 +34,22 @@ func TestPanelHost(t *testing.T) {
 	}
 }
 
-func TestSiblingURL(t *testing.T) {
+func TestTailnetServiceURL(t *testing.T) {
+	saved := c.Conf.Environment
+	t.Cleanup(func() { c.Conf.Environment = saved })
 	cases := []struct {
-		in, service, want string
+		env, service, want string
 	}{
-		{"https://tripbot.prod.whereisdana.today", "obs", "https://obs.prod.whereisdana.today"},
-		{"https://tripbot.stage.whereisdana.today", "obs", "https://obs.stage.whereisdana.today"},
-		{"http://localhost:8080", "obs", ""}, // not an FQDN — no sibling Ingress
-		{"", "obs", ""},
+		{"production", "obs", "https://obs-prod.tail020deb.ts.net"},
+		{"production", "vlc-server", "https://vlc-server-prod.tail020deb.ts.net"},
+		{"staging", "obs", "https://obs-stage.tail020deb.ts.net"},
+		{"development", "obs", ""}, // not served by the operator
+		{"testing", "obs", ""},
 	}
 	for _, tc := range cases {
-		if got := siblingURL(tc.in, tc.service); got != tc.want {
-			t.Errorf("siblingURL(%q, %q) = %q, want %q", tc.in, tc.service, got, tc.want)
+		c.Conf.Environment = tc.env
+		if got := tailnetServiceURL(tc.service); got != tc.want {
+			t.Errorf("tailnetServiceURL(%q) with ENV=%q = %q, want %q", tc.service, tc.env, got, tc.want)
 		}
 	}
 }
@@ -332,11 +336,11 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`>grafana</a>`,                        // one-word grafana link
 		`>traefik</a>`,                        // one-word traefik link
 		`>hubble</a>`,                         // one-word hubble link
-		"https://obs.prod.whereisdana.today",  // derived OBS href
+		"https://obs-prod.tail020deb.ts.net",  // tailnet OBS href
 		grafanaURL,                            // grafana href
 		traefikURL,                            // traefik href
 		// Environment is "production" above → hubble link carries ?namespace=prod-1
-		"https://hubble.prod.whereisdana.today/?namespace=prod-1",
+		"https://hubble-prod.tail020deb.ts.net/?namespace=prod-1",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)


### PR DESCRIPTION
## Summary

- Switch the admin panel's outbound dashboard + sibling-service links from `*.whereisdana.today` to the Tailscale K8s operator's `*-{prod,stage}.tail020deb.ts.net` names. The whereisdana hosts resolve to the home LAN IP `192.168.1.200` and silently dead-end on client networks that share `192.168.1.0/24`; the operator names are CGNAT (`100.x`) and don't collide.
- Replaces `siblingURL` (label-rewrite of `EXTERNAL_URL`) with `tailnetServiceURL`, which derives `-prod` / `-stage` from `c.Conf` and returns `""` for dev/local/testing so the link hides on clusters the operator doesn't cover.
- Affected links: `traefik`, `hubble`, derived `obs`. `grafana` and `sentry` were already env-independent. The auth re-init URLs still use `c.Conf.ExternalURL` because that's the Twitch OAuth `redirect_uri` host — moving them is a bigger change that needs the Twitch app allowlist updated, and is left as a follow-up.
- The `tailnetBase` const will become an env var when the tailnet rename lands — tracked in vault `tripbot/tripbot/TODO.md`.

## Test plan

- [x] `go vet ./pkg/server/...`
- [x] `task test:macos` (full suite green)
- [x] Eyeball the admin panel on stage/prod once deployed: `obs`, `traefik`, `hubble` links should resolve to `*-{prod,stage}.tail020deb.ts.net`