### PR TITLE
chatbot: reorder !socialmedia output to modern priority

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -70,7 +70,7 @@ func (a *App) buildRegistry() []Command {
 			Trigger: "!socialmedia",
 			Aliases: []string{"!social", "!socials"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Find me outside of Twitch: !twitter, !instagram, !facebook, !youtube")
+				sayFn("Find me outside of Twitch: !instagram, !youtube, !twitter, !facebook")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Reorder `!socialmedia` output: Instagram, YouTube, Twitter, Facebook
- Per-platform commands (`!twitter`/`!instagram`/`!facebook`/`!youtube`) themselves are unchanged

## Test plan
- [x] `task test:macos` passes locally (pkg/chatbot included)
- [ ] On Twitch, run `!socialmedia` and confirm new order