### PR TITLE
httpmw: demote /onscreens/state.json + other poll-rate log noise to debug

### DIFF
--- a/pkg/httpmw/slog_logger.go
+++ b/pkg/httpmw/slog_logger.go
@@ -10,13 +10,16 @@ import (
 	"github.com/urfave/negroni/v3"
 )
 
-// healthPaths are logged at Debug instead of Info so kubelet's liveness
-// and readiness probes don't dominate the default log stream. Other
+// debugPaths are logged at Debug instead of Info because they're polled
+// often enough to dominate the default log stream. Kubelet's liveness and
+// readiness probes hit /health/{live,ready} every few seconds; OBS's CEF
+// browser sources poll /onscreens/state.json at ~14 req/sec idle. Other
 // frequent paths (e.g. /metrics) stay at Info — add them here if they
 // become noisy.
-var healthPaths = map[string]bool{
-	"/health/live":  true,
-	"/health/ready": true,
+var debugPaths = map[string]bool{
+	"/health/live":          true,
+	"/health/ready":         true,
+	"/onscreens/state.json": true,
 }
 
 // SlogLogger is a negroni-compatible middleware that emits one slog
@@ -41,7 +44,7 @@ func (l *SlogLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 	}
 
 	level := slog.LevelInfo
-	if healthPaths[r.URL.Path] {
+	if debugPaths[r.URL.Path] {
 		level = slog.LevelDebug
 	}
 	slog.LogAttrs(r.Context(), level, "http request",

--- a/pkg/httpmw/slog_logger_test.go
+++ b/pkg/httpmw/slog_logger_test.go
@@ -20,8 +20,10 @@ func TestSlogLoggerLevelByPath(t *testing.T) {
 	}{
 		{path: "/health/live", wantLvl: "DEBUG", notLevel: "INFO"},
 		{path: "/health/ready", wantLvl: "DEBUG", notLevel: "INFO"},
+		{path: "/onscreens/state.json", wantLvl: "DEBUG", notLevel: "INFO"},
 		{path: "/anything-else", wantLvl: "INFO", notLevel: "DEBUG"},
 		{path: "/health/", wantLvl: "INFO", notLevel: "DEBUG"},
+		{path: "/onscreens/state", wantLvl: "INFO", notLevel: "DEBUG"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Demote `/onscreens/state.json` access logs from INFO to DEBUG. OBS's CEF browser sources poll this endpoint at ~14 req/sec idle, which dominates the default INFO log stream.
- Extends the existing health-probe debug-path allowlist from [#583](https://github.com/adanalife/tripbot/pull/583/changes) (which demoted `/health/live` + `/health/ready` for the same reason).
- Renames `healthPaths` -> `debugPaths` to reflect the broader purpose.

Broader audit of `pkg/vlc-server` + `pkg/onscreens-server` `slog.Info*` calls turned up nothing else worth demoting — all remaining Info-level calls fire once at startup, once per shutdown, or once per state transition (rotator/middle-text creation, watchdog start, RTSP recovery, shutdown). The `404 GET` lines in both `catchAllHandler`s are also infrequent enough to stay Info.

Pairs with the OBS `text_ft2_source` migration item, which would eliminate the polling entirely (after which this becomes redundant).

## Test plan

- [x] `task test:macos` passes (incl. updated `TestSlogLoggerLevelByPath` with `/onscreens/state.json` -> DEBUG + `/onscreens/state` -> INFO negative case)
- [ ] Tail vlc-server / onscreens-server logs at INFO level and confirm `/onscreens/state.json` no longer appears
- [ ] DEBUG-level tailing still surfaces the lines for diagnostics