### PR TITLE
scoreboards: monthly guess leaderboard polish (align, filter zero, hide empty)

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -296,30 +296,35 @@ func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, 
 	size := 10
 	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
 
-	// special message if the leaderboard is empty
-	if len(leaderboard) == 0 {
-		a.IRC.Say("No one is on that leaderboard yet!")
-		return
-	}
-
 	// truncate the leaderboard if necessary
 	if size > len(leaderboard) {
 		size = len(leaderboard)
 	}
 	leaderboard = leaderboard[:size]
 
+	// Filter zero-scorers (AddToScoreByName uses FirstOrCreate, so every
+	// user who's ever guessed has a row — many at 0 early in the month).
 	var intLeaderboard [][]string
 	for _, leaderPair := range leaderboard {
 		// guesses are ints not floats, so remove the decimal place
 		intVersion := strings.Split(leaderPair[1], ".")[0]
+		if intVersion == "0" || intVersion == "" {
+			continue
+		}
 		intLeaderboard = append(intLeaderboard, []string{leaderPair[0], intVersion})
+	}
+
+	// special message if no one has any correct guesses yet
+	if len(intLeaderboard) == 0 {
+		a.IRC.Say("No one is on that leaderboard yet!")
+		return
 	}
 
 	// display leaderboard on screen
 	a.Onscreens.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 
 	// build a message to send to chat
-	msg := fmt.Sprintf("Top %d correct guesses this month: ", size)
+	msg := fmt.Sprintf("Top %d correct guesses this month: ", len(intLeaderboard))
 	for i, leaderPair := range intLeaderboard {
 		msg += fmt.Sprintf("%d. %s (%s)", i+1, leaderPair[0], leaderPair[1])
 		if i+1 != len(intLeaderboard) {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -1064,6 +1064,76 @@ func TestMonthlyGuessLeaderboardCmd_WithGuesses_StripsDecimals(t *testing.T) {
 	}
 }
 
+// Zero-scorers (rows present because AddToScoreByName FirstOrCreate seeds 0)
+// should be filtered out of both the overlay and the chat message.
+func TestMonthlyGuessLeaderboardCmd_FiltersZeroScorers(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	rows := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 5.0).
+		AddRow("viewer2", 0.0).
+		AddRow("viewer3", 2.0).
+		AddRow("viewer4", 0.0)
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(rows)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.monthlyGuessLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
+
+	msg := out()
+	if strings.Contains(msg, "viewer2") || strings.Contains(msg, "viewer4") {
+		t.Errorf("expected zero-scorers filtered from chat message, got %q", msg)
+	}
+	if !strings.Contains(msg, "viewer1") || !strings.Contains(msg, "viewer3") {
+		t.Errorf("expected non-zero scorers retained, got %q", msg)
+	}
+	if !strings.Contains(msg, "Top 2 correct guesses") {
+		t.Errorf("expected count to reflect filtered length (2), got %q", msg)
+	}
+	if len(rec.Calls) != 1 {
+		t.Fatalf("expected one overlay call, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// When every scoreboard row is a zero-scorer (start of a new month), the
+// command should fall back to the "no one yet" chat message and skip the
+// overlay entirely — same shape as the truly-empty query result.
+func TestMonthlyGuessLeaderboardCmd_AllZero_SaysNoneYetAndSkipsOverlay(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	rows := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 0.0).
+		AddRow("viewer2", 0.0)
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(rows)
+
+	out, restore := captureSay(t)
+	defer restore()
+
+	app.monthlyGuessLeaderboardCmd(context.Background(), newTestUser("caller"), nil)
+
+	if !strings.Contains(out(), "No one is on that leaderboard yet") {
+		t.Errorf("expected empty-leaderboard message when all zero, got %q", out())
+	}
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected no overlay call when all zero, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
 // --- milesCmd ---
 //
 // Self-lookup (no params) and other-user lookup (with params) both end up

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -75,11 +75,20 @@ func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
 	}
 	leaderboard = leaderboard[:size]
 
+	// Filter zero-scorers (AddToScoreByName uses FirstOrCreate, so every
+	// user who's ever guessed has a row — many at 0 early in the month).
+	// If the filtered list is empty, skip the overlay entirely.
 	var intLeaderboard [][]string
 	for _, leaderPair := range leaderboard {
 		// guesses are ints not floats, so remove the decimal place
 		intVersion := strings.Split(leaderPair[1], ".")[0]
+		if intVersion == "0" || intVersion == "" {
+			continue
+		}
 		intLeaderboard = append(intLeaderboard, []string{leaderPair[0], intVersion})
+	}
+	if len(intLeaderboard) == 0 {
+		return
 	}
 
 	// display leaderboard on screen

--- a/pkg/onscreens-server/browser.go
+++ b/pkg/onscreens-server/browser.go
@@ -63,7 +63,10 @@ var onscreenRegistry = map[string]onscreenStyle{
 		Name: SlugMiddleText, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",
 	},
 	SlugLeaderboard: {
-		Name: SlugLeaderboard, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",
+		// Monospace font so the space-padded score column in
+		// users.LeaderboardContent renders as a true visual column —
+		// proportional fonts make padding-space alignment unreliable.
+		Name: SlugLeaderboard, FontCSS: `"Menlo", "Consolas", "Courier New", monospace`, FontSizePx: 18, ColorCSS: "#ffffff",
 	},
 	SlugLeftMessage: {
 		Name: SlugLeftMessage, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, MinFontSizePx: 18, ColorCSS: "#ffffff",

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -105,7 +105,11 @@ func printLeaderboard() {
 	}
 }
 
-// LeaderboardContent creates the content for the leaderboard onscreen
+// LeaderboardContent creates the content for the leaderboard onscreen.
+// The score column is left-aligned to the width of the longest score so
+// usernames line up cleanly across rows with mixed 1/2/3-digit scores.
+// Requires a monospace font on the onscreen for the padding to render
+// as a true column — see onscreens-server's onscreenRegistry.
 func LeaderboardContent(title string, leaderboard [][]string) string {
 	var output string
 	output = strings.Title(title) + "\n"
@@ -116,8 +120,16 @@ func LeaderboardContent(title string, leaderboard [][]string) string {
 	}
 	leaderboard = leaderboard[:size]
 
+	// width of the longest score field, for left-aligning the score column
+	scoreWidth := 0
+	for _, pair := range leaderboard {
+		if len(pair[1]) > scoreWidth {
+			scoreWidth = len(pair[1])
+		}
+	}
+
 	for _, score := range leaderboard {
-		output = output + fmt.Sprintf("%s (%s)\n", score[1], score[0])
+		output = output + fmt.Sprintf("%-*s (%s)\n", scoreWidth, score[1], score[0])
 	}
 
 	return output

--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -82,6 +82,45 @@ func TestLeaderboardContentEmpty(t *testing.T) {
 	}
 }
 
+// Mixed 1/2/3-digit scores should pad to the longest width so the (username)
+// column starts at the same offset on every row — relies on a monospace font
+// on the leaderboard onscreen for the spacing to render visually.
+func TestLeaderboardContentLeftAlignsScores(t *testing.T) {
+	board := [][]string{
+		{"alice", "123"},
+		{"bob", "15"},
+		{"carol", "7"},
+	}
+	got := LeaderboardContent("guesses", board)
+
+	wantLines := []string{
+		"123 (alice)",
+		"15  (bob)",
+		"7   (carol)",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(got, line) {
+			t.Fatalf("expected line %q in output, got %q", line, got)
+		}
+	}
+}
+
+// Single-width score column should not introduce trailing padding spaces.
+func TestLeaderboardContentSingleWidthNoExcessPadding(t *testing.T) {
+	board := [][]string{
+		{"alice", "5"},
+		{"bob", "3"},
+	}
+	got := LeaderboardContent("guesses", board)
+
+	if !strings.Contains(got, "5 (alice)") {
+		t.Fatalf("expected '5 (alice)' (no padding), got %q", got)
+	}
+	if strings.Contains(got, "5  (alice)") {
+		t.Fatalf("did not expect double-space padding with uniform width, got %q", got)
+	}
+}
+
 // snapshotLeaderboard saves the global LifetimeMilesLeaderboard and returns a
 // restore func. Use with defer to keep tests from contaminating each other.
 func snapshotLeaderboard() func() {


### PR DESCRIPTION
## Summary
- Filter out users with 0 correct guesses from the monthly guess leaderboard (both the periodic overlay and the `!guessleaderboard` chat command). `AddToScoreByName` does `FirstOrCreate`, so every user who's ever attempted a guess has a row at value=0; those were appearing on the overlay early in each month.
- Skip rendering the overlay entirely if every row is filtered out (start-of-month case). The chat command falls back to its existing "No one is on that leaderboard yet!" message.
- Left-align the score column in `LeaderboardContent` by padding to the longest score's width via `%-*s`, so usernames start at the same offset across rows with mixed 1/2/3-digit scores.
- Switch the leaderboard onscreen's font from `"Trebuchet MS"` to a monospace stack so the padding renders as a true visual column (proportional fonts can't reliably align padding spaces with digit widths).

### Scope notes
- The zero-scorer filter is scoped to the **guess** leaderboard surfaces only (not miles), since (a) the TODO specifically calls out monthly guesses, and (b) lifetime miles already filters `miles != 0` upstream, and (c) monthly miles values are fractional in the noise floor — `0.008` is "logged in for 30s," which is not the same as "did nothing."
- The score-column padding *is* in the shared `LeaderboardContent` path, so monthly miles + lifetime miles overlays also benefit visually. No behavior change there.
- Empty-list handoff: the overlay caller (`ShowGuessLeaderboard`) was the only thing rendering the overlay on the cron — early-return there means no overlay push, no empty-box. The chatbot command already had an empty-state code path; just moved the check to after the filter.

## Test plan
- [x] New unit tests pass: `task test:macos` green (`./pkg/users/...`, `./pkg/chatbot/...`)
- [x] `TestLeaderboardContentLeftAlignsScores` — mixed 1/2/3-digit scores produce padding to the longest width
- [x] `TestMonthlyGuessLeaderboardCmd_FiltersZeroScorers` — zero-value rows excluded from both overlay + chat
- [x] `TestMonthlyGuessLeaderboardCmd_AllZero_SaysNoneYetAndSkipsOverlay` — all-zero result falls back to "no one yet" and skips the overlay
- [ ] Watch the stream early in a month with no correct guesses — overlay should not render on the 5-min cron
- [ ] Verify aligned scores when scores span 1/2/3 digits at end-of-month
- [ ] Confirm monospace font reads OK alongside other onscreens at the leaderboard's 18px size