### PR TITLE
chatbot: add !bluesky + !tiktok; update !socialmedia listing

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -107,6 +107,12 @@ func (a *App) buildRegistry() []Command {
 			},
 		},
 		{
+			Trigger: "!tiktok",
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Follow on TikTok: https://tiktok.com/@adanalife")
+			},
+		},
+		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -70,7 +70,7 @@ func (a *App) buildRegistry() []Command {
 			Trigger: "!socialmedia",
 			Aliases: []string{"!social", "!socials"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Find me outside of Twitch: !twitter, !instagram, !facebook, !youtube")
+				sayFn("Find me outside of Twitch: !youtube, !tiktok, !instagram, !bluesky")
 			},
 		},
 		{

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -113,6 +113,13 @@ func (a *App) buildRegistry() []Command {
 			},
 		},
 		{
+			Trigger: "!bluesky",
+			Aliases: []string{"!bsky"},
+			Handler: func(_ context.Context, _ *users.User, _ []string) {
+				sayFn("Follow on Bluesky: https://bsky.app/profile/dana.lol")
+			},
+		},
+		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {


### PR DESCRIPTION
## Summary

Adds two new per-platform chat commands and updates the `!socialmedia` summary to reflect the post-launch social presence (Twitter being demoted in favor of Bluesky; Facebook dropped from surface; TikTok added).

### New commands

- `!bluesky` (alias `!bsky`) → posts the Bluesky profile URL (handle: `@dana.lol`)
- `!tiktok` → posts the TikTok profile URL (handle: `@adanalife`)

### Updated commands

- `!socialmedia` listing now: `!youtube, !tiktok, !instagram, !bluesky` (was `!twitter, !instagram, !facebook, !youtube`).
- `!twitter` and `!facebook` commands **remain registered** — no breaking change for anyone who types them, just removed from the summary listing.

## Test plan

- [x] `task test:macos` passes (pkg/chatbot + the whole suite)
- [ ] On Twitch, run `!bluesky` and `!tiktok` — confirm correct URLs in chat
- [ ] Run `!socialmedia` — confirm new listing
- [ ] Confirm `!twitter` and `!facebook` still respond