### PR TITLE
dockerignore: cleaner pattern for the infra/docker/obs exception

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,14 @@
 .env.*
-infra
-!infra/docker/obs
-!infra/docker/vlc/config
-!infra/docker/bin
+
+# infra/: exclude the bits that have nothing to do with image builds.
+# Everything under infra/docker/{obs,vlc,bin,tripbot} is in by default;
+# the COPY directives in those Dockerfiles pull from there.
+infra/certs
+infra/windows
+infra/README.md
+infra/docker/docker-compose*.yml
+infra/docker/env.docker
+infra/docker/test
+
 assets/video
 log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,12 @@
 .env.*
 
-# infra/: exclude the bits that have nothing to do with image builds.
-# Everything under infra/docker/{obs,vlc,bin,tripbot} is in by default;
-# the COPY directives in those Dockerfiles pull from there.
-infra/certs
-infra/windows
-infra/README.md
-infra/docker/docker-compose*.yml
-infra/docker/env.docker
-infra/docker/test
+# Exclude all of infra/ from the build context, then re-include the
+# specific subtrees Dockerfiles COPY from. Keeps the build context
+# minimal without enumerating every infra/ subdir we don't care about.
+infra
+!infra/docker/obs
+!infra/docker/vlc/config
+!infra/docker/bin
 
 assets/video
 log


### PR DESCRIPTION
## Summary

Keep the pre-PR `.dockerignore` shape (broad `infra` ignore + targeted `!infra/docker/{obs,vlc/config,bin}` re-includes) and add a comment block explaining what the pattern does and why.

## Rationale

The earlier approach (enumerating every infra subdir we *don't* care about) is more explicit but longer and grows as new subdirs land under `infra/`. The broad-ignore + re-include pattern is tidier in the file and self-narrating once the comment is there.

## Test plan

- [x] CI Docker build passes (validates .dockerignore behavior)
- [x] Pre-commit passes
- [ ] Functionally equivalent to pre-PR state — should be a no-op for build context