### PR TITLE
obs: lower default SomaFM volume to -18.3 dB

### DIFF
--- a/infra/docker/obs/config/Tripbot.json.tmpl
+++ b/infra/docker/obs/config/Tripbot.json.tmpl
@@ -340,7 +340,7 @@
       },
       "sync": 0,
       "versioned_id": "ffmpeg_source",
-      "volume": 1
+      "volume": 0.121619
     },
     {
       "balance": 0.5,


### PR DESCRIPTION
## Summary

- Sets the `Groove Salad Classic` ffmpeg_source `volume` in the seed scene config from `1` (0 dB / full) to `0.121619` (-18.3 dB linear mul) so the level Dana dialled in live on launch night survives pod restarts / image rebuilds.
- The runtime tweak was via the OBS noVNC mixer — ephemeral; the seed JSON is the persistent home.

`-18.3 dB` → `10^(-18.3/20)` ≈ `0.121619` mul. OBS scene JSON expresses `volume` as linear (matches the existing `volume: 1` on every other source).

## Test plan

- [ ] Pod rolls cleanly on the new image (scene loads, no JSON parse errors in OBS startup logs)
- [ ] OBS audio mixer shows the Groove Salad source at ~-18.3 dB after a fresh start
- [ ] Track 1 meter peaks in green/yellow during a sound check (per `vault/twitch/live-stream-verification.md` §3 target zone of -20 to -10 dB)