### PR TITLE
ci: release-development workflow publishes :develop images on push

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -1,0 +1,293 @@
+# Publishes :develop multi-arch images on push to develop, gated by
+# per-image path filters. Stage pulls :develop; prod stays on :latest
+# (release.yml). Mirrors release.yml's matrix-on-native-runners +
+# manifest-list shape (see vault/decisions/multi-arch-release-pattern.md).
+name: Release Development
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  # Per-image path filters. tripbot and vlc rebuild on any Go change to
+  # their respective code surfaces; obs only rebuilds when its Dockerfile
+  # context changes (the arm64 CEF compile is ~30 min, so skipping it on
+  # Go-only merges is the load-bearing reason this job exists).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tripbot: ${{ steps.filter.outputs.tripbot }}
+      vlc: ${{ steps.filter.outputs.vlc }}
+      obs: ${{ steps.filter.outputs.obs }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            tripbot:
+              - 'cmd/tripbot/**'
+              - 'pkg/**'
+              - 'infra/docker/tripbot/**'
+              - 'go.mod'
+              - 'go.sum'
+              - '.dockerignore'
+              - '.github/workflows/release-development.yml'
+            vlc:
+              - 'cmd/vlc-server/**'
+              - 'cmd/onscreens-server/**'
+              - 'pkg/vlc-server/**'
+              - 'pkg/onscreens-server/**'
+              - 'pkg/vlc-client/**'
+              - 'pkg/onscreens-client/**'
+              - 'infra/docker/vlc/**'
+              - 'go.mod'
+              - 'go.sum'
+              - '.dockerignore'
+              - '.github/workflows/release-development.yml'
+            obs:
+              - 'infra/docker/obs/**'
+              - '.github/workflows/release-development.yml'
+
+  tripbot-build:
+    needs: changes
+    if: needs.changes.outputs.tripbot == 'true'
+    name: tripbot-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve develop version
+        id: ver
+        run: echo "value=develop-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: adanalife/tripbot
+          flavor: |
+            latest=false
+            suffix=-${{ matrix.arch }}
+          tags: |
+            type=raw,value=develop
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/tripbot/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          build-args: |
+            VERSION=${{ steps.ver.outputs.value }}
+            SHA=${{ github.sha }}
+          cache-from: type=gha,scope=tripbot-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=tripbot-${{ matrix.arch }}
+
+      - name: Verify version stamping
+        run: |
+          IMAGE="adanalife/tripbot:develop-${{ matrix.arch }}"
+          .github/scripts/verify-stamped-image.sh "$IMAGE" \
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
+
+  tripbot-manifest:
+    needs: tripbot-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest list
+        run: |
+          docker buildx imagetools create \
+            -t adanalife/tripbot:develop \
+            adanalife/tripbot:develop-amd64 \
+            adanalife/tripbot:develop-arm64
+
+  vlc-build:
+    needs: changes
+    if: needs.changes.outputs.vlc == 'true'
+    name: vlc-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve develop version
+        id: ver
+        run: echo "value=develop-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: adanalife/vlc
+          flavor: |
+            latest=false
+            suffix=-${{ matrix.arch }}
+          tags: |
+            type=raw,value=develop
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/vlc/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          build-args: |
+            VERSION=${{ steps.ver.outputs.value }}
+            SHA=${{ github.sha }}
+          cache-from: type=gha,scope=vlc-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=vlc-${{ matrix.arch }}
+
+      - name: Verify version stamping
+        run: |
+          IMAGE="adanalife/vlc:develop-${{ matrix.arch }}"
+          .github/scripts/verify-stamped-image.sh "$IMAGE" \
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
+
+  vlc-manifest:
+    needs: vlc-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest list
+        run: |
+          docker buildx imagetools create \
+            -t adanalife/vlc:develop \
+            adanalife/vlc:develop-amd64 \
+            adanalife/vlc:develop-arm64
+
+  obs-build:
+    needs: changes
+    if: needs.changes.outputs.obs == 'true'
+    name: obs-build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            dockerfile: infra/docker/obs/Dockerfile
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            dockerfile: infra/docker/obs/Dockerfile.arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve develop version
+        id: ver
+        run: echo "value=develop-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: adanalife/obs
+          flavor: |
+            latest=false
+            suffix=-${{ matrix.arch }}
+          tags: |
+            type=raw,value=develop
+
+      - name: Build & push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          build-args: |
+            VERSION=${{ steps.ver.outputs.value }}
+            SHA=${{ github.sha }}
+          cache-from: type=gha,scope=obs-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=obs-${{ matrix.arch }}
+
+      - name: Verify version stamping
+        run: |
+          IMAGE="adanalife/obs:develop-${{ matrix.arch }}"
+          .github/scripts/verify-stamped-image.sh "$IMAGE" \
+            "${{ steps.ver.outputs.value }}" "${{ github.sha }}"
+
+  obs-manifest:
+    needs: obs-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest list
+        run: |
+          docker buildx imagetools create \
+            -t adanalife/obs:develop \
+            adanalife/obs:develop-amd64 \
+            adanalife/obs:develop-arm64


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release-development.yml`, a tag-publish workflow that fires on every push to `develop` and publishes `:develop` multi-arch images to Docker Hub. Mirrors `release.yml`'s matrix-on-native-runners + manifest-list shape per the multi-arch-release-pattern ADR.

End-state loop for stage:

```
merge PR → release-development.yml republishes :develop
         → kubectl rollout restart deploy/<x> -n stage-1
         → stage runs the new code
```

Prod is untouched: it stays on the base's `:latest`, which only moves when `release.yml` fires from a `v*` tag push.

### Path filters

dorny/paths-filter@v4 gates each image's build:

- **tripbot** — `cmd/tripbot/`, `pkg/`, `infra/docker/tripbot/`, `go.mod`, `go.sum`, `.dockerignore`
- **vlc** — `cmd/{vlc-server,onscreens-server}/`, `pkg/{vlc-server,vlc-client,onscreens-server,onscreens-client}/`, `infra/docker/vlc/`, `go.mod`, `go.sum`, `.dockerignore`
- **obs** — `infra/docker/obs/` only

The OBS filter is the load-bearing reason this gating job exists — the arm64 leg's CEF compile runs ~30 min, so skipping it on Go-only merges is meaningful CI savings. tripbot + vlc filters are broader (any `pkg/` change rebuilds both) because their build cost is low and false-positive rebuilds are cheaper than missing a real dependency.

Each filter also includes the workflow file itself, so editing it forces a republish — useful when iterating.

### Tag scheme

- per-arch: `adanalife/<img>:develop-amd64`, `adanalife/<img>:develop-arm64`
- manifest list: `adanalife/<img>:develop`
- no `latest=` flag (prod's `:latest` stays release-tag-driven)

`VERSION` build-arg stamps as `develop-<short-sha>` so the `/version` endpoint on a running stage pod identifies which commit it's from. `verify-stamped-image.sh` runs per-arch as the corruption check, same as `release.yml`.

No Discord notification (release.yml has one but develop merges would be too noisy).

### Companion infra PR

[adanalife/infra#594](https://github.com/adanalife/infra/pull/594/changes) points the `stage-1` + `development` overlays at `:develop`. This PR alone publishes the tag but nothing consumes it until that one lands too.

## Test plan

- [ ] Merge → confirm `release-development.yml` fires + all three images push manifest lists for `:develop`
- [ ] Make a no-op edit under `infra/docker/obs/` → confirm OBS builds (both arches)
- [ ] Make a Go-only edit (no OBS change) → confirm OBS build is skipped, tripbot + vlc build
- [ ] After infra companion lands: stage rollout pulls `adanalife/tripbot:develop` with the expected `develop-<sha>` baked into `/version`