### PR TITLE
vlc-server: tell ffmpeg the output muxer for the first-frame extract

### DIFF
--- a/pkg/vlc-server/firstframe.go
+++ b/pkg/vlc-server/firstframe.go
@@ -38,7 +38,10 @@ func NextFrameCachePath() string {
 // -ss 0 before -i for fast seek; -frames:v 1 to grab one frame; -q:v 3
 // is a sane JPEG quality (2-5 range); -nostdin so a stalled ffmpeg can't
 // read from vlc-server's stdin; -y to overwrite the .tmp from any prior
-// interrupted extraction.
+// interrupted extraction. -f image2 -update 1 selects the muxer
+// explicitly and says "single image, not a sequence" so ffmpeg doesn't
+// try to infer the muxer from the .tmp file extension or treat the path
+// as a numbered-sequence pattern.
 func ExtractFirstFrame(ctx context.Context, videoPath, outPath string) error {
 	tmpPath := outPath + ".tmp"
 	defer os.Remove(tmpPath) // best-effort; harmless after a successful rename
@@ -50,6 +53,7 @@ func ExtractFirstFrame(ctx context.Context, videoPath, outPath string) error {
 		"ffmpeg", "-nostdin", "-y",
 		"-ss", "0", "-i", videoPath,
 		"-frames:v", "1", "-q:v", "3",
+		"-f", "image2", "-update", "1",
 		tmpPath,
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary

Follow-up to [#695](https://github.com/adanalife/tripbot/pull/695). Stage logs after that PR shipped show every first-frame extraction failing:

\`\`\`
Error initializing the muxer for /opt/data/run/next-frame.jpg.tmp: Invalid argument
Error opening output file /opt/data/run/next-frame.jpg.tmp.
\`\`\`

ffmpeg infers the output muxer from the file extension, and \`.tmp\` (our atomic-write sibling path) isn't a recognized image format. Adds \`-f image2 -update 1\` to make the muxer + single-image semantics explicit so the extension on the tmp path stops mattering.

Verified locally against the default test video — clean JPEG, no warnings.

## Test plan

- [ ] CI builds \`:develop\`
- [ ] Stage vlc-server picks up the new image
- [ ] \`curl -sI https://vlc.stage.whereisdana.today/next-frame.jpg\` returns 200 image/jpeg within ~10s of a playlist advance
- [ ] Pod logs show \`refreshed next-frame cover\` info lines, not the prior \`failed to extract next-frame\` warnings