### PR TITLE
twitch: widen refresh window from 30m to 45m

### DIFF
--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -547,11 +547,11 @@ func applyBroadcasterToken(tok oauthtokens.Token) {
 }
 
 // refreshOne rotates a single (provider="twitch", username) row if within
-// 30 minutes of expiry. applyInMemory writes the rotated token into the
+// 45 minutes of expiry. applyInMemory writes the rotated token into the
 // matching in-memory slot — also called on the empty-token path so the
 // caller's slot gets blanked (forcing reconnect / re-bootstrap signalling).
 //
-// force skips the 30-minute pre-expiry window: the hourly cron passes false
+// force skips the 45-minute pre-expiry window: the hourly cron passes false
 // (only rotate when close to expiry), while Reauth passes true to rotate
 // immediately after an auth failure regardless of the stored ExpiresAt (which
 // is unreliable after a DB restore — the dump's expiry says "valid" but Twitch
@@ -585,7 +585,12 @@ func refreshOne(ctx context.Context, username string, applyInMemory func(oauthto
 		return
 	}
 
-	if !force && time.Until(t.ExpiresAt) > 30*time.Minute {
+	// 45 min, not 30: Twitch's actual enforcement runs a few minutes early
+	// of the published ExpiresAt — the hourly cron at 30 min was missing the
+	// window and producing one self-healed 401 per 4h-ish token cycle (one
+	// Sentry event each). 45 min gives the cron 15 min of headroom before
+	// Twitch's variable enforcement kicks in.
+	if !force && time.Until(t.ExpiresAt) > 45*time.Minute {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Bump `time.Until(t.ExpiresAt) > 30*time.Minute` to `> 45*time.Minute` in `refreshOne`.
- Updates the two doc-comment "30 minutes" references in the same block.

## Why

The hourly cron at 30 min was missing Twitch's variable-early enforcement, producing one self-healed 401 per ~4h token cycle per identity (≈12/day across bot + broadcaster).

Concrete example from prod earlier today:

```
19:33:45  bot token issued      → ExpiresAt T+~4h ≈ 23:33
22:33     hourly cron: 60m left → skip
23:26:39  GetChannelChatChatters returned 401  ← Twitch enforced ~7m early
23:26:40  refreshed user access token tripbot4000  ← #636 self-heal, 248ms
```

The 401 fires `checkHelixResp` → `Reauth(ctx, "bot")` → `refreshOne(force=true)` → fresh token. Recovery is sub-second; the service stays healthy. But the ERROR-level slog line ships to Sentry via samber/slog-sentry, and one Sentry event per identity per 4h cycle looks alarming when it's actually proof the self-heal is working.

## The math

Hourly cron with a 30-min window: exactly one cron fire per cycle lands in `[T+3h30m, T+4h]`. Twitch enforces around `T+3h50m` (variable). If the cron fires at `T+3h35m`, it sees 25m left and skips — and the next fire is past Twitch's enforcement.

Widening to 45 min raises the floor: any cron fire in `[T+3h15m, T+4h]` refreshes proactively, comfortably ahead of Twitch's variable cutoff.

## Test plan
- [x] `task test:macos` — pkg/twitch green.
- [ ] On prod: after rollout, observe one full 4h token cycle without a `helix * returned 401` log line. Sentry's TRIPBOT-7Q issue should stop accumulating events.
- [ ] If the floor is still too tight (Twitch enforces even earlier on some calls), bump again — but 45m is a reasonable starting point given the observed ~7-10 min variance.

## Companion to
- #698 (refresh-on-startup + expiry gauge)
- #636 (helix self-heal — this PR just spares it from firing on the routine cycle)