### PR TITLE
leaderboard: align scores via CSS grid, drop monospace requirement

### DIFF
--- a/pkg/onscreens-server/browser.go
+++ b/pkg/onscreens-server/browser.go
@@ -56,6 +56,7 @@ type onscreenStyle struct {
 	DropShadow    bool         // text-shadow on/off
 	AnchorXPx     int          // center-x within the browser-source viewport (0 = use flex-center fallback)
 	FitWidthPx    int          // single-line width budget for shrink-to-fit (0 = no fit pass)
+	RenderAsHTML  bool         // inject content via innerHTML instead of textContent (server emits HTML for this onscreen)
 }
 
 var onscreenRegistry = map[string]onscreenStyle{
@@ -63,10 +64,11 @@ var onscreenRegistry = map[string]onscreenStyle{
 		Name: SlugMiddleText, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",
 	},
 	SlugLeaderboard: {
-		// Monospace font so the space-padded score column in
-		// users.LeaderboardContent renders as a true visual column —
-		// proportional fonts make padding-space alignment unreliable.
-		Name: SlugLeaderboard, FontCSS: `"Menlo", "Consolas", "Courier New", monospace`, FontSizePx: 18, ColorCSS: "#ffffff",
+		// Server emits an HTML grid (see users.LeaderboardContent) so the
+		// score column aligns via CSS rather than space-padding — any font
+		// works.
+		Name: SlugLeaderboard, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",
+		RenderAsHTML: true,
 	},
 	SlugLeftMessage: {
 		Name: SlugLeftMessage, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, MinFontSizePx: 18, ColorCSS: "#ffffff",

--- a/pkg/onscreens-server/handlers_test.go
+++ b/pkg/onscreens-server/handlers_test.go
@@ -3,6 +3,7 @@ package onscreensServer
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -78,5 +79,49 @@ func TestOnscreensFlagHandlerUnknownActionReturns417(t *testing.T) {
 
 	if rec.Code != http.StatusExpectationFailed {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusExpectationFailed)
+	}
+}
+
+// The leaderboard onscreen is registered with RenderAsHTML, so its render
+// HTML must opt the JS into innerHTML (data-html="true") and ship the
+// .lb-grid CSS.
+func TestRenderLeaderboardEmitsHTMLMode(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/onscreens/render/leaderboard", nil)
+	req = mux.SetURLVars(req, map[string]string{"name": SlugLeaderboard})
+	rec := httptest.NewRecorder()
+
+	s.onscreensRenderHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `data-html="true"`) {
+		t.Fatalf("expected data-html=\"true\" on leaderboard root, got body:\n%s", body)
+	}
+	if !strings.Contains(body, ".lb-grid") {
+		t.Fatalf("expected .lb-grid CSS in leaderboard render, got body:\n%s", body)
+	}
+}
+
+// A non-HTML onscreen should keep the legacy textContent path
+// (data-html="false") so middle-text et al. don't suddenly start parsing
+// chat content as HTML.
+func TestRenderMiddleTextStaysTextContent(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/onscreens/render/middle-text", nil)
+	req = mux.SetURLVars(req, map[string]string{"name": SlugMiddleText})
+	rec := httptest.NewRecorder()
+
+	s.onscreensRenderHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `data-html="false"`) {
+		t.Fatalf("expected data-html=\"false\" on middle-text root, got body:\n%s", rec.Body.String())
 	}
 }

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -87,6 +87,22 @@
   {{end}}
   #root.image { width: 100%; height: 100%; }
   #root.image img { width: 100%; height: 100%; object-fit: contain; display: block; }
+  /* Leaderboard onscreen (RenderAsHTML): CSS grid auto-sizes the score
+     column to the widest entry, so digits align across rows in any font.
+     LeaderboardContent in pkg/users emits the matching markup. */
+  .lb-grid {
+    display: inline-grid;
+    grid-template-columns: auto auto;
+    column-gap: 0.4em;
+    row-gap: 0.05em;
+    text-align: left;
+  }
+  .lb-title {
+    grid-column: 1 / -1;
+    text-align: center;
+    margin-bottom: 0.15em;
+  }
+  .lb-score, .lb-user { white-space: nowrap; }
 {{end}}
 </style>
 </head>
@@ -145,9 +161,9 @@
 {{if .IsImage}}
 <div id="root" class="image hidden" data-name="{{.Name}}" data-image="true"><img src="/onscreens/asset/{{.Name}}" alt=""></div>
 {{else if gt .FitWidthPx 0}}
-<div id="root" class="text hidden" data-name="{{.Name}}" data-image="false" data-anchored="true"><span class="content"></span></div>
+<div id="root" class="text hidden" data-name="{{.Name}}" data-image="false" data-anchored="true" data-html="{{.RenderAsHTML}}"><span class="content"></span></div>
 {{else}}
-<div id="root" class="text hidden" data-name="{{.Name}}" data-image="false"></div>
+<div id="root" class="text hidden" data-name="{{.Name}}" data-image="false" data-html="{{.RenderAsHTML}}"></div>
 {{end}}
 <script>
 (function () {
@@ -155,6 +171,7 @@
   var name = root.dataset.name;
   var isImage = root.dataset.image === 'true';
   var isAnchored = root.dataset.anchored === 'true';
+  var isHTML = root.dataset.html === 'true';
   var content = isAnchored ? root.querySelector('.content') : root;
 
   var MAX_FONT_PX = {{.FontSizePx}};
@@ -185,7 +202,11 @@
     }
     root.classList.remove('hidden');
     if (!isImage) {
-      content.textContent = snap.content || '';
+      if (isHTML) {
+        content.innerHTML = snap.content || '';
+      } else {
+        content.textContent = snap.content || '';
+      }
       fitText();
     }
   }

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"fmt"
+	"html"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -105,32 +106,29 @@ func printLeaderboard() {
 	}
 }
 
-// LeaderboardContent creates the content for the leaderboard onscreen.
-// The score column is left-aligned to the width of the longest score so
-// usernames line up cleanly across rows with mixed 1/2/3-digit scores.
-// Requires a monospace font on the onscreen for the padding to render
-// as a true column — see onscreens-server's onscreenRegistry.
+// LeaderboardContent renders the leaderboard onscreen as a CSS-grid HTML
+// fragment. The score column auto-sizes to the widest entry via
+// grid-template-columns, so digits line up across rows regardless of font.
+// The onscreen is registered with RenderAsHTML in onscreenRegistry so the
+// browser-source template injects this via innerHTML.
 func LeaderboardContent(title string, leaderboard [][]string) string {
-	var output string
-	output = strings.Title(title) + "\n"
-
 	size := 5
 	if len(leaderboard) < size {
 		size = len(leaderboard)
 	}
 	leaderboard = leaderboard[:size]
 
-	// width of the longest score field, for left-aligning the score column
-	scoreWidth := 0
-	for _, pair := range leaderboard {
-		if len(pair[1]) > scoreWidth {
-			scoreWidth = len(pair[1])
-		}
+	var b strings.Builder
+	b.WriteString(`<div class="lb-grid">`)
+	fmt.Fprintf(&b, `<div class="lb-title">%s</div>`, html.EscapeString(strings.Title(title)))
+	for _, row := range leaderboard {
+		fmt.Fprintf(
+			&b,
+			`<span class="lb-score">%s</span><span class="lb-user">(%s)</span>`,
+			html.EscapeString(row[1]),
+			html.EscapeString(row[0]),
+		)
 	}
-
-	for _, score := range leaderboard {
-		output = output + fmt.Sprintf("%-*s (%s)\n", scoreWidth, score[1], score[0])
-	}
-
-	return output
+	b.WriteString(`</div>`)
+	return b.String()
 }

--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -34,16 +34,16 @@ func TestLeaderboardContent(t *testing.T) {
 	}
 	got := LeaderboardContent("monthly miles", board)
 
-	if !strings.HasPrefix(got, "Monthly Miles\n") {
+	if !strings.Contains(got, `<div class="lb-title">Monthly Miles</div>`) {
 		t.Fatalf("expected title-cased header, got %q", got)
 	}
 	for _, name := range []string{"alice", "bob", "carol"} {
-		if !strings.Contains(got, name) {
-			t.Fatalf("expected %q in output, got %q", name, got)
+		if !strings.Contains(got, `<span class="lb-user">(`+name+`)</span>`) {
+			t.Fatalf("expected user span for %q, got %q", name, got)
 		}
 	}
-	if !strings.Contains(got, "100.5 (alice)") {
-		t.Fatalf("expected '100.5 (alice)' format, got %q", got)
+	if !strings.Contains(got, `<span class="lb-score">100.5</span><span class="lb-user">(alice)</span>`) {
+		t.Fatalf("expected adjacent score+user spans for alice, got %q", got)
 	}
 }
 
@@ -77,15 +77,15 @@ func TestLeaderboardContentSmallerThanFive(t *testing.T) {
 
 func TestLeaderboardContentEmpty(t *testing.T) {
 	got := LeaderboardContent("nobody", nil)
-	if got != "Nobody\n" {
-		t.Fatalf("got %q, want %q", got, "Nobody\n")
+	want := `<div class="lb-grid"><div class="lb-title">Nobody</div></div>`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }
 
-// Mixed 1/2/3-digit scores should pad to the longest width so the (username)
-// column starts at the same offset on every row — relies on a monospace font
-// on the leaderboard onscreen for the spacing to render visually.
-func TestLeaderboardContentLeftAlignsScores(t *testing.T) {
+// Scores render in their own span (no space-padding) so the CSS grid can
+// auto-size the column.
+func TestLeaderboardContentNoSpacePadding(t *testing.T) {
 	board := [][]string{
 		{"alice", "123"},
 		{"bob", "15"},
@@ -93,31 +93,34 @@ func TestLeaderboardContentLeftAlignsScores(t *testing.T) {
 	}
 	got := LeaderboardContent("guesses", board)
 
-	wantLines := []string{
-		"123 (alice)",
-		"15  (bob)",
-		"7   (carol)",
+	wantSpans := []string{
+		`<span class="lb-score">123</span><span class="lb-user">(alice)</span>`,
+		`<span class="lb-score">15</span><span class="lb-user">(bob)</span>`,
+		`<span class="lb-score">7</span><span class="lb-user">(carol)</span>`,
 	}
-	for _, line := range wantLines {
-		if !strings.Contains(got, line) {
-			t.Fatalf("expected line %q in output, got %q", line, got)
+	for _, want := range wantSpans {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in output, got %q", want, got)
 		}
+	}
+	// No padding spaces between score and user spans.
+	if strings.Contains(got, "</span> <span") {
+		t.Fatalf("did not expect padding space between score/user spans, got %q", got)
 	}
 }
 
-// Single-width score column should not introduce trailing padding spaces.
-func TestLeaderboardContentSingleWidthNoExcessPadding(t *testing.T) {
+// Defensive: usernames are normally [a-zA-Z0-9_] from Twitch, but the
+// renderer escapes anything that would break out of the surrounding HTML.
+func TestLeaderboardContentEscapesHTML(t *testing.T) {
 	board := [][]string{
-		{"alice", "5"},
-		{"bob", "3"},
+		{"<script>", "1"},
 	}
-	got := LeaderboardContent("guesses", board)
-
-	if !strings.Contains(got, "5 (alice)") {
-		t.Fatalf("expected '5 (alice)' (no padding), got %q", got)
+	got := LeaderboardContent("xss", board)
+	if strings.Contains(got, "<script>") {
+		t.Fatalf("expected HTML-escaped username, got %q", got)
 	}
-	if strings.Contains(got, "5  (alice)") {
-		t.Fatalf("did not expect double-space padding with uniform width, got %q", got)
+	if !strings.Contains(got, "&lt;script&gt;") {
+		t.Fatalf("expected &lt;script&gt; escape, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the [vault TODO](https://github.com/adanalife/tripbot) for *Leaderboard formatting — align numbers via CSS, not monospace* (flagged 2026-05-26 after [#689](https://github.com/adanalife/tripbot/pull/689/changes) didn't quite land).

[#689](https://github.com/adanalife/tripbot/pull/689/changes) left scores `%-*s`-padded and forced the leaderboard onscreen to a monospace stack so the spaces would render as a column. In practice the monospace swap didn't take post-launch — Dana: *"the leaderboard formatting changes we made didnt work — do we have to use a monospace font? can't we have css or something make it left-aligned?"*

This switches the leaderboard to an HTML CSS grid:

- `pkg/users.LeaderboardContent` now emits `<div class="lb-grid"><div class="lb-title">…</div><span class="lb-score">…</span><span class="lb-user">(user)</span>…</div>` instead of space-padded plaintext.
- Each onscreen registers a new `RenderAsHTML bool` in `onscreenRegistry`. The leaderboard sets it; the rest stay on the legacy `textContent` path (no surface-area change for middle-text, rotators, etc.).
- `templates/onscreen.html.tmpl` carries the matching CSS (`display: inline-grid`, `grid-template-columns: auto auto`) and reads `data-html` off `#root` to pick `innerHTML` vs `textContent`.
- Font reverts from `"Menlo", "Consolas", "Courier New", monospace` → `"Trebuchet MS", sans-serif` to match the other onscreens.
- Defensive `html.EscapeString` of title / score / user — Twitch usernames are `[a-zA-Z0-9_]`, but the renderer holds the line on callers.

The grid auto-sizes the score column to its widest entry, so digits left-align across rows in any font — `5`, `12`, `123` all start at the same x. Usernames end up aligned too (free side-benefit of the fixed-width column), even though Dana said he didn't care about that.

## Test plan

- [x] `task test:macos -- ./pkg/users/... ./pkg/onscreens-server/...` green
- [x] New `TestLeaderboardContentNoSpacePadding` / `TestLeaderboardContentEscapesHTML` cover the HTML output shape
- [x] New `TestRenderLeaderboardEmitsHTMLMode` / `TestRenderMiddleTextStaysTextContent` cover the template branching
- [ ] Trigger `!leaderboard` / `!totalleaderboard` / `!guessleaderboard` on stage and confirm scores align under Trebuchet MS at end-of-month with mixed 1/2/3-digit values
- [ ] Confirm other onscreens (middle-text, rotators, GPS, flag) still render unchanged