### PR TITLE
obs: silent-disconnect watchdog (Twitch live-status cross-check)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/eventsub"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/adanalife/tripbot/pkg/obs"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -104,7 +105,17 @@ func main() {
 	getCurrentUsers()
 	startEventSub(shutdownCtx)
 	startDiscord(shutdownCtx)
+	startSilentDisconnectWatchdog(shutdownCtx)
 	connectToTwitch()
+}
+
+// startSilentDisconnectWatchdog launches the goroutine that detects the
+// half-open RTMP state where OBS reports outputActive=true but Twitch's
+// API shows the channel offline, and force-restarts the stream after
+// 3 consecutive minute-spaced misalignments. First seen in prod on
+// 2026-05-27, ~30h into an OBS session.
+func startSilentDisconnectWatchdog(ctx context.Context) {
+	go obs.WatchSilentDisconnect(ctx, obs.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
 }
 
 // startDiscord brings up the bot's Discord slash-command session when

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -29,6 +29,9 @@ var (
 	twitchConnected   = mustGauge("tripbot_twitch_connected", "1 when the bot is connected to Twitch chat (IRC), 0 otherwise")
 	twitchTokenExpiry = mustGauge("tripbot_twitch_token_expires_at_seconds", "Unix timestamp of the in-memory Twitch user-access-token's ExpiresAt, labeled by account (bot|broadcaster). 0 when the account has no loaded token.")
 	twitchHelixErrors = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
+	twitchChannelLive = mustGauge("tripbot_twitch_channel_live", "1 when Helix GetStreams reports the configured channel as live, 0 when offline. Driven by the OBS silent-disconnect watchdog's Helix poll.")
+
+	obsSilentDisconnectRestarts = mustCounter("tripbot_obs_silent_disconnect_restarts_total", "Total times the OBS silent-disconnect watchdog forced a StopStream+StartStream because OBS reported outputActive=true while Twitch reported the channel offline")
 
 	twitchHelixRateRemaining = mustGauge("twitch_helix_rate_limit_remaining", "Last-seen Ratelimit-Remaining header from Twitch Helix responses (per app-access bearer)")
 	twitchHelixRateLimit     = mustGauge("twitch_helix_rate_limit_total", "Last-seen Ratelimit-Limit header from Twitch Helix responses (per app-access bearer)")
@@ -87,6 +90,20 @@ var TwitchTokenExpiry = twitchTokenExpiryIface{gauge: twitchTokenExpiry}
 // TwitchHelixErrors.Inc(endpoint, statusCode). Endpoint is a short label
 // like "GetUsers"; statusCode is the HTTP status reported by Twitch.
 var TwitchHelixErrors = twitchHelixErrorsIface{counter: twitchHelixErrors}
+
+// TwitchChannelLive exposes the per-tick Twitch live-status gauge written
+// by the OBS silent-disconnect watchdog. Set(true) on every successful
+// Helix poll that reports the channel as live, Set(false) when GetStreams
+// returns empty. Paired with OBSStreaming in an alert: divergence
+// (OBS=1 / Twitch=0) is the silent half-open RTMP signal.
+var TwitchChannelLive = twitchChannelLiveIface{gauge: twitchChannelLive}
+
+// OBSSilentDisconnectRestarts exposes the watchdog's force-restart counter.
+// Inc() is called after a successful StopStream+StartStream sequence.
+// Any non-zero rate is alertable — the watchdog only fires after a
+// 3-minute debounce, so even one increment means we saw a real silent
+// disconnect in prod.
+var OBSSilentDisconnectRestarts = obsSilentDisconnectRestartsIface{counter: obsSilentDisconnectRestarts}
 
 // TwitchHelixRateLimit exposes the per-bearer Helix rate-budget gauges.
 // SetRemaining + SetLimit are called by the response-recording transport
@@ -174,6 +191,22 @@ func (h twitchHelixErrorsIface) Inc(endpoint string, statusCode int) {
 		attribute.String("endpoint", endpoint),
 		attribute.Int("status_code", statusCode),
 	))
+}
+
+type twitchChannelLiveIface struct{ gauge metric.Int64Gauge }
+
+func (t twitchChannelLiveIface) Set(live bool) {
+	var v int64
+	if live {
+		v = 1
+	}
+	t.gauge.Record(context.Background(), v)
+}
+
+type obsSilentDisconnectRestartsIface struct{ counter metric.Int64Counter }
+
+func (o obsSilentDisconnectRestartsIface) Inc() {
+	o.counter.Add(context.Background(), 1)
 }
 
 type twitchHelixRateLimitIface struct {

--- a/pkg/obs/silent_disconnect_watchdog.go
+++ b/pkg/obs/silent_disconnect_watchdog.go
@@ -1,0 +1,123 @@
+package obs
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// WatchdogDeps are the OBS+Twitch+restart hooks the silent-disconnect
+// watchdog calls. Injectable so the loop can be unit-tested without a real
+// OBS WebSocket or live Helix client. DefaultWatchdogDeps wires the
+// production implementations.
+type WatchdogDeps struct {
+	OBSActive  func(context.Context) (bool, error)
+	TwitchLive func(context.Context) (bool, error)
+	Restart    func(context.Context) error
+}
+
+// DefaultWatchdogDeps wires WatchSilentDisconnect's hooks to the real OBS
+// WebSocket + Helix client + StopStream/StartStream sequence.
+func DefaultWatchdogDeps() WatchdogDeps {
+	return WatchdogDeps{
+		OBSActive: GetStreamStatus,
+		TwitchLive: func(ctx context.Context) (bool, error) {
+			return twitch.IsChannelLive(ctx, c.Conf.ChannelName)
+		},
+		Restart: defaultRestart,
+	}
+}
+
+// defaultRestart stops then starts the OBS stream with a small gap to let
+// the RTMP teardown settle before OBS opens a fresh connection. Matches
+// the manual recovery sequence we ran by hand the first time the silent
+// half-open hit prod (see the 2026-05-27 incident).
+func defaultRestart(ctx context.Context) error {
+	if err := StopStream(ctx); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(3 * time.Second):
+	}
+	return StartStream(ctx)
+}
+
+// WatchSilentDisconnect detects the silent half-open RTMP state where OBS
+// reports outputActive=true but Twitch's API reports the channel offline,
+// and force-restarts the stream after `threshold` consecutive
+// misalignments. `cooldown` bounds how often a restart can fire so a
+// flapping Twitch API can't put us in a restart loop.
+//
+// Background: when Twitch's ingest server closes the RTMP session without
+// the FIN/RST making it back to OBS (e.g. an idle middlebox dropping the
+// connection, or some Twitch-side terminations), OBS's write socket stays
+// open and its built-in reconnect never fires — it keeps writing into the
+// void. The fix is to detect the divergence from outside OBS and force a
+// fresh RTMP connection.
+func WatchSilentDisconnect(ctx context.Context, deps WatchdogDeps, interval time.Duration, threshold int, cooldown time.Duration) {
+	misses := 0
+	var lastRestart time.Time
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	slog.InfoContext(ctx, "obs silent-disconnect watchdog started",
+		"interval", interval, "threshold", threshold, "cooldown", cooldown)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			obsActive, err := deps.OBSActive(ctx)
+			if err != nil {
+				// OBS unreachable — let PollStreamingActive's gauge be the
+				// alert signal. Reset misses so a transient OBS blip doesn't
+				// race with a real Twitch-side drop.
+				slog.WarnContext(ctx, "watchdog: obs status unavailable", "err", err)
+				misses = 0
+				continue
+			}
+			if !obsActive {
+				// OBS itself isn't streaming — nothing for the watchdog to
+				// do. The operator-driven "start streaming" gesture is
+				// outside our scope.
+				misses = 0
+				continue
+			}
+			twitchLive, err := deps.TwitchLive(ctx)
+			if err != nil {
+				slog.WarnContext(ctx, "watchdog: helix status unavailable", "err", err)
+				misses = 0
+				continue
+			}
+			if twitchLive {
+				misses = 0
+				continue
+			}
+			misses++
+			slog.WarnContext(ctx, "watchdog: silent-disconnect suspected",
+				"misses", misses, "threshold", threshold)
+			if misses < threshold {
+				continue
+			}
+			if since := time.Since(lastRestart); since < cooldown {
+				slog.WarnContext(ctx, "watchdog: restart suppressed by cooldown",
+					"since_last_restart", since, "cooldown", cooldown)
+				continue
+			}
+			slog.ErrorContext(ctx, "watchdog: forcing stream restart",
+				"consecutive_misses", misses)
+			if err := deps.Restart(ctx); err != nil {
+				slog.ErrorContext(ctx, "watchdog: restart failed", "err", err)
+				continue
+			}
+			lastRestart = time.Now()
+			misses = 0
+		}
+	}
+}

--- a/pkg/obs/silent_disconnect_watchdog.go
+++ b/pkg/obs/silent_disconnect_watchdog.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/twitch"
 )
 
@@ -25,7 +26,11 @@ func DefaultWatchdogDeps() WatchdogDeps {
 	return WatchdogDeps{
 		OBSActive: GetStreamStatus,
 		TwitchLive: func(ctx context.Context) (bool, error) {
-			return twitch.IsChannelLive(ctx, c.Conf.ChannelName)
+			live, err := twitch.IsChannelLive(ctx, c.Conf.ChannelName)
+			if err == nil {
+				instrumentation.TwitchChannelLive.Set(live)
+			}
+			return live, err
 		},
 		Restart: defaultRestart,
 	}
@@ -116,6 +121,7 @@ func WatchSilentDisconnect(ctx context.Context, deps WatchdogDeps, interval time
 				slog.ErrorContext(ctx, "watchdog: restart failed", "err", err)
 				continue
 			}
+			instrumentation.OBSSilentDisconnectRestarts.Inc()
 			lastRestart = time.Now()
 			misses = 0
 		}

--- a/pkg/obs/silent_disconnect_watchdog_test.go
+++ b/pkg/obs/silent_disconnect_watchdog_test.go
@@ -1,0 +1,169 @@
+package obs
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeDeps drives the watchdog with scripted (obs, twitch) responses,
+// counts restarts, and signals when the script is exhausted so the test
+// can cleanly tear down the loop. OBSActive advances the script (it's
+// called every tick) and stashes the current pair; TwitchLive reads from
+// that stash. Holds the final pair after exhaustion to avoid racing
+// shutdown.
+type fakeDeps struct {
+	mu       sync.Mutex
+	script   [][2]bool
+	idx      int
+	current  [2]bool
+	restarts atomic.Int32
+	doneCh   chan struct{}
+	doneOnce sync.Once
+}
+
+func newFakeDeps(script [][2]bool) *fakeDeps {
+	return &fakeDeps{script: script, doneCh: make(chan struct{})}
+}
+
+func (f *fakeDeps) deps() WatchdogDeps {
+	return WatchdogDeps{
+		OBSActive: func(context.Context) (bool, error) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			if f.idx >= len(f.script) {
+				f.doneOnce.Do(func() { close(f.doneCh) })
+				if len(f.script) > 0 {
+					f.current = f.script[len(f.script)-1]
+				}
+			} else {
+				f.current = f.script[f.idx]
+				f.idx++
+			}
+			return f.current[0], nil
+		},
+		TwitchLive: func(context.Context) (bool, error) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			return f.current[1], nil
+		},
+		Restart: func(context.Context) error {
+			f.restarts.Add(1)
+			return nil
+		},
+	}
+}
+
+func runUntilExhausted(t *testing.T, deps *fakeDeps, threshold int, cooldown time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go WatchSilentDisconnect(ctx, deps.deps(), 2*time.Millisecond, threshold, cooldown)
+	select {
+	case <-deps.doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("script not exhausted")
+	}
+	cancel()
+	// Give the loop a beat to exit so racing restarts don't bleed past the assertion.
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestWatchSilentDisconnect_FiresAfterThresholdMisses(t *testing.T) {
+	deps := newFakeDeps([][2]bool{
+		{true, false}, // miss 1
+		{true, false}, // miss 2
+		{true, false}, // miss 3 → restart (resets misses, sets lastRestart)
+		{true, true},  // healthy
+	})
+	runUntilExhausted(t, deps, 3, time.Minute)
+	if got := deps.restarts.Load(); got != 1 {
+		t.Fatalf("restart count: want 1, got %d", got)
+	}
+}
+
+func TestWatchSilentDisconnect_TransientMissDoesNotFire(t *testing.T) {
+	deps := newFakeDeps([][2]bool{
+		{true, false}, // miss 1
+		{true, false}, // miss 2
+		{true, true},  // recovered — reset
+		{true, false}, // miss 1 (counter reset)
+		{true, true},
+	})
+	runUntilExhausted(t, deps, 3, time.Minute)
+	if got := deps.restarts.Load(); got != 0 {
+		t.Fatalf("restart count: want 0, got %d", got)
+	}
+}
+
+func TestWatchSilentDisconnect_CooldownSuppressesRapidRestarts(t *testing.T) {
+	deps := newFakeDeps([][2]bool{
+		{true, false}, {true, false}, {true, false}, // → restart 1
+		{true, false}, {true, false}, {true, false}, // cooldown blocks
+		{true, false}, {true, false}, {true, false},
+	})
+	runUntilExhausted(t, deps, 3, time.Hour)
+	if got := deps.restarts.Load(); got != 1 {
+		t.Fatalf("restart count: want 1 (cooldown suppresses retries), got %d", got)
+	}
+}
+
+func TestWatchSilentDisconnect_ObsInactiveSkips(t *testing.T) {
+	deps := newFakeDeps([][2]bool{
+		{false, false}, {false, false}, {false, false}, {false, false},
+	})
+	runUntilExhausted(t, deps, 3, time.Minute)
+	if got := deps.restarts.Load(); got != 0 {
+		t.Fatalf("restart count: want 0 (OBS not streaming), got %d", got)
+	}
+}
+
+func TestWatchSilentDisconnect_HelixErrorResetsMisses(t *testing.T) {
+	var tickCount atomic.Int32
+	var restarts atomic.Int32
+	done := make(chan struct{})
+	var doneOnce sync.Once
+
+	deps := WatchdogDeps{
+		OBSActive: func(context.Context) (bool, error) {
+			return true, nil
+		},
+		TwitchLive: func(context.Context) (bool, error) {
+			n := tickCount.Add(1)
+			switch n {
+			case 1, 2:
+				return false, nil // miss 1, miss 2
+			case 3:
+				return false, errors.New("helix transient") // resets misses
+			case 4, 5:
+				return false, nil // miss 1, miss 2 (no third → no restart)
+			default:
+				doneOnce.Do(func() { close(done) })
+				return true, nil
+			}
+		},
+		Restart: func(context.Context) error {
+			restarts.Add(1)
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go WatchSilentDisconnect(ctx, deps, 2*time.Millisecond, 3, time.Minute)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test loop did not advance")
+	}
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	if got := restarts.Load(); got != 0 {
+		t.Fatalf("restart count: want 0 (helix error reset misses before threshold), got %d", got)
+	}
+}

--- a/pkg/twitch/streams.go
+++ b/pkg/twitch/streams.go
@@ -1,0 +1,38 @@
+package twitch
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/nicklaw5/helix/v2"
+)
+
+// IsChannelLive returns true when the given Twitch login currently has an
+// active stream per Helix GetStreams. Used by the OBS silent-disconnect
+// watchdog to detect the half-open RTMP state where OBS thinks it's
+// streaming but Twitch has dropped the broadcast.
+//
+// Authorizes against the app-access-token — GetStreams is public and does
+// not need a user token.
+func IsChannelLive(ctx context.Context, login string) (bool, error) {
+	if login == "" {
+		return false, fmt.Errorf("IsChannelLive: empty login")
+	}
+	client, err := Client()
+	if err != nil {
+		return false, fmt.Errorf("twitch API client unavailable: %w", err)
+	}
+	resp, err := client.GetStreams(&helix.StreamsParams{
+		UserLogins: []string{login},
+	})
+	if err != nil {
+		return false, fmt.Errorf("GetStreams: %w", err)
+	}
+	if checkHelixResp(ctx, "GetStreams", "", &resp.ResponseCommon) {
+		return false, fmt.Errorf("GetStreams returned %d", resp.StatusCode)
+	}
+	live := len(resp.Data.Streams) > 0
+	slog.DebugContext(ctx, "twitch live check", "login", login, "live", live)
+	return live, nil
+}


### PR DESCRIPTION
## Summary

- Add `pkg/obs/silent_disconnect_watchdog.go` — long-running goroutine that polls OBS `GetStreamStatus.outputActive` against Helix `GetStreams`, and force-restarts the OBS stream after N consecutive misalignments.
- Add `pkg/twitch/streams.go` with `IsChannelLive(ctx, login)` — thin wrapper around Helix `GetStreams` using the app-access-token client.
- Wire `startSilentDisconnectWatchdog` into `cmd/tripbot/tripbot.go`: 60s poll, 3-miss debounce (3 min), 10 min cooldown between forced restarts.
- Add metrics: `tripbot_twitch_channel_live` gauge + `tripbot_obs_silent_disconnect_restarts_total` counter. Read by the matching Grafana alert in [adanalife/infra#611](https://github.com/adanalife/infra/pull/611/changes).

## Why

OBS's built-in reconnect only fires on a *detected* RTMP drop. When Twitch's ingest server closes the session without the FIN/RST making it back to OBS (an idle middlebox eating it, or some Twitch-side terminations), the write socket stays half-open, OBS reports `outputActive: true / outputCongestion: 0.0 / outputReconnecting: false`, and frames keep getting written into the void. Twitch shows offline.

Hit prod on 2026-05-27, ~30h into a session: manual recovery was `StopStream` + `StartStream` via OBS WebSocket. That immediate fix is the same sequence this watchdog automates.

## Design

Hooks are injectable (`WatchdogDeps`) so the loop can be unit-tested without a real OBS WebSocket or live Helix client. `DefaultWatchdogDeps()` wires production: `obs.GetStreamStatus` + `twitch.IsChannelLive(ctx, c.Conf.ChannelName)` + a `StopStream → 3s sleep → StartStream` restart sequence (matches the manual recovery sequence).

Failure modes intentionally fail safe:
- OBS unreachable → reset misses, log, skip (let `PollStreamingActive`'s gauge be the alert).
- OBS not active → no-op (operator-driven start gesture is outside scope).
- Helix transient error → reset misses, log, skip.
- Twitch flapping → 10 min cooldown bounds restart frequency.

## Paired PR

[adanalife/infra#611](https://github.com/adanalife/infra/pull/611/changes) — adds the Grafana alert rules that read the metrics this PR exposes:

- **critical**: `obs_streaming_active=1 AND tripbot_twitch_channel_live=0` for 3m → page (the #1 stream-health alert)
- **warning**: any increment of the restart counter → "we auto-recovered, FYI"

## Test plan

- [x] `task test:macos` passes — 5 watchdog table tests cover: fires after threshold, transient miss doesn't fire, cooldown suppresses, OBS-inactive skips, Helix error resets misses
- [ ] Deploy to stage-1, verify `WatchSilentDisconnect started` log line at boot + steady WARN-free state when stream is healthy
- [ ] Stage synthetic test: temporarily swap `CHANNEL_NAME` (or the watchdog's `TwitchLive` hook) to a known-offline channel; confirm detection, restart sequence, and stream recovery
- [ ] On prod, watch first 24h for false-positive restarts in `tripbot` logs