### PR TITLE
discord: log every gateway interaction (debug)

### DIFF
--- a/pkg/discord/commands.go
+++ b/pkg/discord/commands.go
@@ -52,11 +52,20 @@ func commandDefinitions() []*discordgo.ApplicationCommand {
 // invocations. Unknown command names get an ephemeral reply rather
 // than silently no-op'ing.
 func (s *Session) handleInteraction(sess *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx := context.Background()
+	// Diagnostic breadcrumb — confirms the gateway is delivering
+	// INTERACTION_CREATE events to this handler. Logs every interaction
+	// regardless of type so we see ping/autocomplete/etc. too.
+	slog.InfoContext(ctx, "discord interaction received",
+		"interaction_type", int(i.Type),
+		"guild_id", i.GuildID,
+		"channel_id", i.ChannelID,
+	)
 	if i.Type != discordgo.InteractionApplicationCommand {
 		return
 	}
-	ctx := context.Background()
 	name := i.ApplicationCommandData().Name
+	slog.InfoContext(ctx, "discord command invoked", "command", name)
 
 	switch name {
 	case "leaderboard":

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -56,6 +56,10 @@ func New(token, guildID string) (*Session, error) {
 	// Slash commands don't need any privileged intents, and we don't
 	// consume normal message events.
 	s.Identify.Intents = discordgo.IntentsNone
+	// Diagnostic: log gateway-level events so we can see whether
+	// INTERACTION_CREATE is reaching us. Bump to LogDebug if even
+	// informational chatter doesn't surface the interaction dispatch.
+	s.LogLevel = discordgo.LogInformational
 	return &Session{s: s, guildID: guildID}, nil
 }
 


### PR DESCRIPTION
## Summary

Diagnostic instrumentation for an unexplained behavior on stage: \`/leaderboard\` autocompletes in Discord and Discord shows "is thinking…", but no \`INTERACTION_CREATE\` event ever surfaces in tripbot logs. Verified ruled out so far:

- Bot in guild, online, gateway connected (12h+ uptime no restarts)
- Guild commands registered (4 of them) — confirmed via \`GET /applications/{app_id}/guilds/{guild_id}/commands\`
- \`interactions_endpoint_url\` is \`null\` (no HTTP hijack)
- Permissions = \`18432\` (Send Messages + Embed Links) on the install link
- Token rotated + pod restarted to invalidate any other session holding the gateway lock — still nothing

Two cheap diagnostics added:

- \`handleInteraction\` logs every interaction it receives (type + guild_id + channel_id) before any type filter, so successful invocations stop being silent
- \`discordgo.Session.LogLevel = LogInformational\` so the library's own gateway chatter (HELLO, READY, dispatched events) surfaces in logs

Will tell us cleanly whether the gateway is even delivering \`INTERACTION_CREATE\` events. If yes, the bug is downstream (handler dispatch or response edit). If no, it's a Discord-side routing issue we'll need a different angle on.

Plan: merge, let stage roll the develop image, restart the pod, retry \`/commands\` in #tripbot-staging, check logs.

## Test plan

- [x] \`task test:macos\` passes
- [x] \`go build ./pkg/discord/... ./cmd/tripbot/...\` clean
- [ ] After deploy: log "discord interaction received" appears when a slash command is invoked, OR the log is still silent — either way we learn something