### PR TITLE
discord: don't delete commands on shutdown + log /commands reply timing

### DIFF
--- a/pkg/discord/commands.go
+++ b/pkg/discord/commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 
@@ -143,6 +144,7 @@ func (s *Session) runCommands(ctx context.Context, i *discordgo.InteractionCreat
 		Description: body,
 		Color:       0xff7a00,
 	}
+	start := time.Now()
 	err := s.s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
@@ -150,9 +152,12 @@ func (s *Session) runCommands(ctx context.Context, i *discordgo.InteractionCreat
 			Flags:  discordgo.MessageFlagsEphemeral,
 		},
 	})
+	elapsed := time.Since(start)
 	if err != nil {
-		slog.ErrorContext(ctx, "discord /commands reply failed", "err", err)
+		slog.ErrorContext(ctx, "discord /commands reply failed", "err", err, "elapsed", elapsed.String())
+		return
 	}
+	slog.InfoContext(ctx, "discord /commands reply ok", "elapsed", elapsed.String())
 }
 
 // deferReply tells Discord "I'll respond shortly" — gives us the full

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -107,18 +107,19 @@ func (s *Session) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop deregisters the per-guild slash commands and closes the gateway
-// connection. Safe to call multiple times.
+// Stop closes the gateway connection. Safe to call multiple times.
+//
+// Deliberately does NOT deregister commands: ApplicationCommandBulkOverwrite
+// matches commands by name and updates them in-place, so the new pod's
+// registered command IDs are identical to the old pod's. Deleting on shutdown
+// would wipe out the just-registered commands of the incoming pod on every
+// rollout restart — leaving zero commands in Discord even though both pods
+// successfully called register. Commands persisting across pod cycles is the
+// correct shape; the next Start() reconciles them via BulkOverwrite.
 func (s *Session) Stop() error {
 	if s == nil || s.s == nil {
 		return nil
 	}
-	for _, cmd := range s.registeredCmds {
-		if err := s.s.ApplicationCommandDelete(s.s.State.User.ID, s.guildID, cmd.ID); err != nil {
-			slog.Warn("discord command deregister failed", "command", cmd.Name, "err", err)
-		}
-	}
-	s.registeredCmds = nil
 	if err := s.s.Close(); err != nil {
 		return fmt.Errorf("discord close: %w", err)
 	}


### PR DESCRIPTION
## Summary

Two follow-ups to [#707](https://github.com/adanalife/tripbot/pull/707/changes) that landed as separate commits on that branch but didn't make it into the squash merge.

### Commit 1 — Stop() no longer deletes commands on shutdown

Found by watching a stage rollout-restart sequence: commands disappear from the Discord client autocomplete even though both old and new pod logs show successful registration. The race is on shared command IDs:

1. New pod runs \`ApplicationCommandBulkOverwrite\`. Discord matches the four command names against existing entries and updates them in place — IDs A1..A4 stay the same.
2. New pod stores A1..A4 in \`s.registeredCmds\` (its "own" registration from its POV, but actually the same IDs the old pod registered).
3. Old pod receives SIGTERM, \`gracefulShutdown\` calls \`Stop()\`, \`Stop\` loops over its \`registeredCmds\` and calls \`ApplicationCommandDelete\` for A1..A4 — the IDs the new pod is now relying on.
4. End state: zero commands in Discord, despite both pods believing registration succeeded.

Fix: \`Stop()\` only closes the gateway. \`BulkOverwrite\` is the right reconciliation primitive across pod cycles — it doesn't need a paired teardown.

### Commit 2 — Time + log /commands reply outcome

After [#707](https://github.com/adanalife/tripbot/pull/707/changes) instrumented \`handleInteraction\`, we confirmed the gateway delivers interactions and our handler dispatches. But a "thinking → no response" symptom in stage with NO error log suggests \`InteractionRespond\` may be silently slow (exceeding Discord's 3s response window) but eventually returning nil. Add a duration measurement around the call and a success log so we can see both the latency and the outcome explicitly.

## Test plan

- [x] \`go build ./pkg/discord/... ./cmd/tripbot/...\` clean
- [ ] After merge: rollout restart stage, run \`/commands\`, expect either \`discord /commands reply ok elapsed=Xms\` or \`discord /commands reply failed err="..."\`
- [ ] Same again — verify commands persist across the restart (Stop() fix)