### PR TITLE
obs: watchdog skips misses when OBS already knows it's reconnecting

### DIFF
--- a/pkg/obs/control.go
+++ b/pkg/obs/control.go
@@ -82,3 +82,29 @@ func GetStreamStatus(ctx context.Context) (bool, error) {
 	}
 	return resp.OutputActive, nil
 }
+
+// GetStreamActiveSteady reports whether OBS is in steady-state streaming —
+// outputActive=true AND outputReconnecting=false. The silent-disconnect
+// watchdog uses this rather than GetStreamStatus because OBS's known-
+// failure reconnect loop also reports outputActive=true; only the "OBS
+// doesn't know it failed" state (reconnecting=false) is the silent half-
+// open the watchdog exists to catch. Without this guard, an OBS-detected
+// disconnect that takes longer than the watchdog's debounce to recover
+// would also force a Stop+Start — harmless but redundant work that races
+// OBS's own reconnect.
+func GetStreamActiveSteady(ctx context.Context) (bool, error) {
+	client, err := dial(ctx)
+	if err != nil {
+		return false, errors.Join(ErrUnreachable, err)
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+	resp, err := client.Stream.GetStreamStatus()
+	if err != nil {
+		return false, err
+	}
+	return resp.OutputActive && !resp.OutputReconnecting, nil
+}

--- a/pkg/obs/silent_disconnect_watchdog.go
+++ b/pkg/obs/silent_disconnect_watchdog.go
@@ -22,9 +22,16 @@ type WatchdogDeps struct {
 
 // DefaultWatchdogDeps wires WatchSilentDisconnect's hooks to the real OBS
 // WebSocket + Helix client + StopStream/StartStream sequence.
+//
+// OBSActive uses GetStreamActiveSteady (not GetStreamStatus) so the
+// watchdog skips counting misses when OBS already knows the stream is
+// failing — outputReconnecting=true means OBS will handle recovery
+// itself, and a watchdog-forced restart there would just race OBS's
+// reconnect. Only the truly silent half-open (outputActive=true AND
+// outputReconnecting=false AND Twitch offline) needs intervention.
 func DefaultWatchdogDeps() WatchdogDeps {
 	return WatchdogDeps{
-		OBSActive: GetStreamStatus,
+		OBSActive: GetStreamActiveSteady,
 		TwitchLive: func(ctx context.Context) (bool, error) {
 			live, err := twitch.IsChannelLive(ctx, c.Conf.ChannelName)
 			if err == nil {


### PR DESCRIPTION
## Summary

Adds `GetStreamActiveSteady` (`outputActive=true AND outputReconnecting=false`) and points `DefaultWatchdogDeps.OBSActive` at it. The admin panel keeps using the simpler `GetStreamStatus`.

## Why

Stage synthetic on 2026-05-28 surfaced a false-positive surface in the watchdog. We applied a Cilium NetworkPolicy blocking RTMP egress from stage OBS:

- 15:37:27 — NetworkPolicy applied
- 15:37:43 — OBS detected dropped RTMP via TCP timeout (~16s), entered built-in reconnect loop (outputActive=true, outputReconnecting=true)
- 15:39:00, 15:40:00 — Watchdog counted misses 1 and 2 (it only checked outputActive)
- 15:40:14 — NetworkPolicy removed
- 15:40:16 — OBS's reconnect attempt succeeded with fresh session

The watchdog would have force-restarted at miss 3 even though OBS was already actively recovering. Not harmful (Stop+Start works), but it races OBS's own reconnect and adds operational noise. The truly silent half-open from the 2026-05-27 prod incident had `outputReconnecting=false` — that's the only state the watchdog exists to handle.

## Paired with

- [adanalife/tripbot#702](https://github.com/adanalife/tripbot/pull/702/changes) — the original watchdog (merged)
- [adanalife/infra#611](https://github.com/adanalife/infra/pull/611/changes) — alert rules (merged)

## Test plan

- [x] `task test:macos` passes — existing 5 watchdog tests cover the state machine; the OBSActive function is swapped underneath, semantics unchanged from the loop's perspective
- [ ] Deploy to stage, verify the same NetworkPolicy synthetic now produces zero misses (since OBS goes into reconnecting=true within ~16s, before the first watchdog tick can count it)