### PR TITLE
feature flags: schema + pkg/feature + chatbot injection

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -18,6 +18,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/discord"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/eventsub"
+	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/obs"
@@ -98,6 +99,7 @@ func main() {
 	findInitialVideo()
 	users.InitLeaderboard(context.Background())
 	startCron()
+	startFeatureFlags(shutdownCtx)
 	loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
 	refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
 	setUpTwitchClient()                    // required for the below
@@ -107,6 +109,29 @@ func main() {
 	startDiscord(shutdownCtx)
 	startSilentDisconnectWatchdog(shutdownCtx)
 	connectToTwitch()
+}
+
+// featureFlagRefreshInterval is how often the Postgres-backed flag client
+// re-reads the feature_flags table. 30s is chat-acceptable lag for
+// dark-launches and kill-switches; revisit if a use case wants instant.
+const featureFlagRefreshInterval = 30 * time.Second
+
+// startFeatureFlags brings up the Postgres-backed feature flag client and
+// installs it into the chatbot package. Non-fatal: a startup failure (DB
+// hiccup, missing migration) logs loudly and leaves chatbot's package-level
+// empty in-memory client in place — every flag evaluates to its default
+// (false) until the next restart loads cleanly. Mirrors the loadTwitchToken
+// "stay up with limited functionality" pattern.
+func startFeatureFlags(ctx context.Context) {
+	fc, err := feature.NewPostgresClient(ctx, database.GormDB(), featureFlagRefreshInterval)
+	if err != nil {
+		slog.WarnContext(ctx, "feature flag client init failed; flags will default to off",
+			"fix", "ensure migration 013_create_feature_flags has run",
+			"err", err)
+		return
+	}
+	chatbot.SetFlagClient(fc)
+	go fc.Start(ctx)
 }
 
 // startSilentDisconnectWatchdog launches the goroutine that detects the

--- a/db/migrate/013_create_feature_flags.down.sql
+++ b/db/migrate/013_create_feature_flags.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE feature_flags;

--- a/db/migrate/013_create_feature_flags.up.sql
+++ b/db/migrate/013_create_feature_flags.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE feature_flags (
+    key                   TEXT PRIMARY KEY,
+    description           TEXT NOT NULL,
+    enabled               BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled_for_usernames TEXT[] NOT NULL DEFAULT '{}',
+    enabled_for_roles     TEXT[] NOT NULL DEFAULT '{}',
+    target_removal_date   DATE NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX feature_flags_target_removal_date_idx
+    ON feature_flags (target_removal_date);

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -10,6 +10,7 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/adanalife/tripbot/pkg/feature"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
@@ -51,6 +52,11 @@ type App struct {
 	// background audio source. Tests inject a fake; production uses
 	// realNowPlaying which polls SomaFM.
 	NowPlaying NowPlaying
+	// Flags evaluates feature flag values for command-time gating. Tests
+	// inject noopFlags{} (every key false); production uses realFlags which
+	// delegates to the Postgres-backed client cmd/tripbot installs via
+	// SetFlagClient once the DB connection is up.
+	Flags feature.FlagClient
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -71,6 +77,7 @@ var defaultApp = &App{
 	IRC:        realIRC{},
 	Sessions:   realSessions{},
 	NowPlaying: newRealNowPlaying(),
+	Flags:      realFlags{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -54,6 +54,7 @@ func newTestApp(vid video.Video) *App {
 		IRC:        noopIRC{},
 		Sessions:   noopSessions{},
 		NowPlaying: noopNowPlaying{},
+		Flags:      noopFlags{},
 	}
 }
 

--- a/pkg/chatbot/flags.go
+++ b/pkg/chatbot/flags.go
@@ -1,0 +1,39 @@
+package chatbot
+
+import (
+	"context"
+	"sync"
+
+	"github.com/adanalife/tripbot/pkg/feature"
+)
+
+// realFlags is the production FlagClient adapter the App is wired with at
+// package init. Delegates to flagClient, which cmd/tripbot replaces with a
+// Postgres-backed client once the DB connection is up via SetFlagClient.
+// Mirrors the realIRC / realOnscreens shape.
+type realFlags struct{}
+
+func (realFlags) Bool(ctx context.Context, key string, evalCtx feature.EvalContext) bool {
+	flagMu.RLock()
+	c := flagClient
+	flagMu.RUnlock()
+	return c.Bool(ctx, key, evalCtx)
+}
+
+// flagClient is the FlagClient realFlags delegates to. Initialised to an
+// empty in-memory client so every key evaluates to false during the brief
+// startup window before cmd/tripbot swaps in the Postgres-backed client —
+// matches the unknown-key contract from pkg/feature.
+var (
+	flagMu     sync.RWMutex
+	flagClient feature.FlagClient = feature.NewInMemoryClient(nil)
+)
+
+// SetFlagClient installs the FlagClient that realFlags delegates to.
+// Called from cmd/tripbot once the Postgres-backed client is constructed
+// and its initial snapshot has loaded.
+func SetFlagClient(c feature.FlagClient) {
+	flagMu.Lock()
+	flagClient = c
+	flagMu.Unlock()
+}

--- a/pkg/chatbot/flags_test.go
+++ b/pkg/chatbot/flags_test.go
@@ -1,0 +1,30 @@
+package chatbot
+
+import (
+	"context"
+
+	"github.com/adanalife/tripbot/pkg/feature"
+)
+
+// noopFlags satisfies feature.FlagClient for tests that don't care which
+// flags get evaluated. Every key returns false — matches the unknown-key
+// contract from pkg/feature, so a test that doesn't pre-set a flag sees
+// the same behaviour the bot does on a fresh deploy.
+type noopFlags struct{}
+
+func (noopFlags) Bool(_ context.Context, _ string, _ feature.EvalContext) bool {
+	return false
+}
+
+// recordingFlags captures every Bool() call so tests can assert on which
+// flags a command evaluated. Set populates per-key return values; keys
+// absent from Set evaluate to false.
+type recordingFlags struct {
+	Evals []string
+	Set   map[string]bool
+}
+
+func (r *recordingFlags) Bool(_ context.Context, key string, _ feature.EvalContext) bool {
+	r.Evals = append(r.Evals, key)
+	return r.Set[key]
+}

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,0 +1,63 @@
+// Package feature evaluates boolean feature flags against per-username and
+// per-role allowlists, layered over a global default.
+//
+// The FlagClient interface is the only thing call sites should depend on;
+// implementations include an in-process map (for tests and fallback) and a
+// Postgres-backed client with a periodic refresh loop. The interface is
+// shaped to match OpenFeature's bool-evaluation surface so a future swap to
+// the OpenFeature SDK is mechanical.
+package feature
+
+import "context"
+
+// FlagClient evaluates feature flag values for the application.
+//
+// Unknown flag keys evaluate to false — a flag-gated feature stays off until
+// the flag exists in the backing store. This is a safety property: a typo
+// in a key won't accidentally expose a feature.
+type FlagClient interface {
+	Bool(ctx context.Context, key string, evalCtx EvalContext) bool
+}
+
+// EvalContext carries the targeting attributes a flag is evaluated against.
+// The App is responsible for populating it (Channel, Env from config;
+// Username and Roles from the user being acted on, if any).
+type EvalContext struct {
+	Username string   // Twitch login (lowercase). Empty for system-level evals.
+	Roles    []string // {"mod","vip","sub","regular"} — multi-valued.
+	Channel  string
+	Env      string
+}
+
+// Flag is the resolved targeting shape for one flag, as held by clients in
+// their in-memory snapshot.
+type Flag struct {
+	Key                 string
+	Enabled             bool
+	EnabledForUsernames []string
+	EnabledForRoles     []string
+}
+
+// evaluate applies the v1 targeting rule:
+//
+//	username allowlist > role allowlist > global default.
+//
+// Empty Username never matches the username allowlist (so a system eval
+// against a username-targeted flag falls through to roles/default).
+func evaluate(f Flag, ctx EvalContext) bool {
+	if ctx.Username != "" {
+		for _, u := range f.EnabledForUsernames {
+			if u == ctx.Username {
+				return true
+			}
+		}
+	}
+	for _, want := range f.EnabledForRoles {
+		for _, have := range ctx.Roles {
+			if want == have {
+				return true
+			}
+		}
+	}
+	return f.Enabled
+}

--- a/pkg/feature/feature_test.go
+++ b/pkg/feature/feature_test.go
@@ -1,0 +1,106 @@
+package feature
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name string
+		flag Flag
+		ctx  EvalContext
+		want bool
+	}{
+		{
+			name: "global default off, no targeting match",
+			flag: Flag{Enabled: false},
+			ctx:  EvalContext{Username: "dana", Roles: []string{"regular"}},
+			want: false,
+		},
+		{
+			name: "global default on, no targeting match",
+			flag: Flag{Enabled: true},
+			ctx:  EvalContext{Username: "dana", Roles: []string{"regular"}},
+			want: true,
+		},
+		{
+			name: "username allowlist beats global off",
+			flag: Flag{Enabled: false, EnabledForUsernames: []string{"dana"}},
+			ctx:  EvalContext{Username: "dana"},
+			want: true,
+		},
+		{
+			name: "role allowlist beats global off",
+			flag: Flag{Enabled: false, EnabledForRoles: []string{"mod"}},
+			ctx:  EvalContext{Username: "dana", Roles: []string{"mod", "sub"}},
+			want: true,
+		},
+		{
+			name: "username allowlist no-match falls through to role allowlist",
+			flag: Flag{
+				EnabledForUsernames: []string{"someoneElse"},
+				EnabledForRoles:     []string{"mod"},
+			},
+			ctx:  EvalContext{Username: "dana", Roles: []string{"mod"}},
+			want: true,
+		},
+		{
+			name: "empty username never matches username allowlist",
+			flag: Flag{EnabledForUsernames: []string{"", "dana"}},
+			ctx:  EvalContext{Username: ""},
+			want: false,
+		},
+		{
+			name: "role allowlist requires intersection",
+			flag: Flag{EnabledForRoles: []string{"mod"}},
+			ctx:  EvalContext{Roles: []string{"sub", "regular"}},
+			want: false,
+		},
+		{
+			name: "system-level eval (no user) honors global default",
+			flag: Flag{Enabled: true},
+			ctx:  EvalContext{Env: "prod-1"},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := evaluate(tc.flag, tc.ctx); got != tc.want {
+				t.Errorf("evaluate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInMemoryClient_UnknownKeyReturnsFalse(t *testing.T) {
+	c := NewInMemoryClient(map[string]Flag{
+		"chatbot.known": {Enabled: true},
+	})
+	if c.Bool(context.Background(), "chatbot.unknown", EvalContext{}) {
+		t.Error("unknown key should evaluate to false")
+	}
+}
+
+func TestInMemoryClient_NilMap(t *testing.T) {
+	c := NewInMemoryClient(nil)
+	if c.Bool(context.Background(), "chatbot.anything", EvalContext{}) {
+		t.Error("nil-map client should evaluate every key to false")
+	}
+}
+
+func TestInMemoryClient_DelegatesEvaluation(t *testing.T) {
+	c := NewInMemoryClient(map[string]Flag{
+		"chatbot.ascii": {
+			EnabledForRoles: []string{"mod"},
+		},
+	})
+	ctx := context.Background()
+	if !c.Bool(ctx, "chatbot.ascii", EvalContext{Roles: []string{"mod"}}) {
+		t.Error("mod role should enable the flag")
+	}
+	if c.Bool(ctx, "chatbot.ascii", EvalContext{Roles: []string{"regular"}}) {
+		t.Error("regular role should leave the flag off")
+	}
+}

--- a/pkg/feature/inmemory.go
+++ b/pkg/feature/inmemory.go
@@ -1,0 +1,28 @@
+package feature
+
+import "context"
+
+// InMemoryClient is a FlagClient backed by an in-process map. Useful for
+// unit tests and for the fallback path before a real backing store is
+// wired in. The map is set at construction and not mutated.
+type InMemoryClient struct {
+	flags map[string]Flag
+}
+
+// NewInMemoryClient builds a client serving the given snapshot. A nil map
+// is fine — it just means every key evaluates to its default (false).
+func NewInMemoryClient(flags map[string]Flag) *InMemoryClient {
+	if flags == nil {
+		flags = map[string]Flag{}
+	}
+	return &InMemoryClient{flags: flags}
+}
+
+// Bool evaluates the named flag against the given context.
+func (c *InMemoryClient) Bool(_ context.Context, key string, evalCtx EvalContext) bool {
+	f, ok := c.flags[key]
+	if !ok {
+		return false
+	}
+	return evaluate(f, evalCtx)
+}

--- a/pkg/feature/postgres.go
+++ b/pkg/feature/postgres.go
@@ -1,0 +1,132 @@
+package feature
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+// flagRow mirrors the feature_flags table for GORM. Mapped into the public
+// Flag type by toFlag; the columns we don't evaluate against (description,
+// target_removal_date, timestamps) are loaded for the admin-panel surface
+// even though Bool() only reads the targeting fields.
+type flagRow struct {
+	Key                 string         `gorm:"primaryKey;column:key"`
+	Description         string         `gorm:"column:description"`
+	Enabled             bool           `gorm:"column:enabled"`
+	EnabledForUsernames pq.StringArray `gorm:"type:text[];column:enabled_for_usernames"`
+	EnabledForRoles     pq.StringArray `gorm:"type:text[];column:enabled_for_roles"`
+	TargetRemovalDate   time.Time      `gorm:"column:target_removal_date"`
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+func (flagRow) TableName() string { return "feature_flags" }
+
+func (r flagRow) toFlag() Flag {
+	return Flag{
+		Key:                 r.Key,
+		Enabled:             r.Enabled,
+		EnabledForUsernames: []string(r.EnabledForUsernames),
+		EnabledForRoles:     []string(r.EnabledForRoles),
+	}
+}
+
+// repository is the DB-access seam for the Postgres client. Split from the
+// client itself so the cache + refresh logic can be tested independently
+// from the SQL.
+type repository struct {
+	db *gorm.DB
+}
+
+func newRepository(db *gorm.DB) *repository { return &repository{db: db} }
+
+// LoadAll fetches every flag row. The table is small (bounded by the number
+// of named flags in the codebase) so an unfiltered SELECT is fine.
+func (r *repository) LoadAll(ctx context.Context) (map[string]Flag, error) {
+	var rows []flagRow
+	if err := r.db.WithContext(ctx).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]Flag, len(rows))
+	for _, row := range rows {
+		out[row.Key] = row.toFlag()
+	}
+	return out, nil
+}
+
+// PostgresClient is a FlagClient backed by a Postgres-loaded snapshot
+// refreshed in a background goroutine. The hot path (Bool) is a map read
+// under an RWMutex — no DB hit per evaluation.
+//
+// On a refresh failure the previous snapshot is retained, so a transient DB
+// outage cannot silently flip features. Recovery happens automatically at
+// the next successful refresh tick.
+type PostgresClient struct {
+	repo     *repository
+	interval time.Duration
+
+	mu    sync.RWMutex
+	flags map[string]Flag
+}
+
+// NewPostgresClient builds a client and performs the initial load. The
+// initial load is synchronous — a startup failure surfaces here rather
+// than hiding behind a background goroutine and serving false-by-default
+// for every key.
+func NewPostgresClient(ctx context.Context, db *gorm.DB, interval time.Duration) (*PostgresClient, error) {
+	c := &PostgresClient{
+		repo:     newRepository(db),
+		interval: interval,
+		flags:    map[string]Flag{},
+	}
+	if err := c.refresh(ctx); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Start runs the refresh loop until ctx is done. Intended to be invoked
+// in a goroutine by the App.
+func (c *PostgresClient) Start(ctx context.Context) {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.refresh(ctx); err != nil {
+				slog.WarnContext(ctx, "feature flag refresh failed; retaining last-known-good",
+					"err", err)
+			}
+		}
+	}
+}
+
+func (c *PostgresClient) refresh(ctx context.Context) error {
+	next, err := c.repo.LoadAll(ctx)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.flags = next
+	c.mu.Unlock()
+	return nil
+}
+
+// Bool evaluates the named flag against the cached snapshot. Returns false
+// for unknown keys.
+func (c *PostgresClient) Bool(_ context.Context, key string, evalCtx EvalContext) bool {
+	c.mu.RLock()
+	f, ok := c.flags[key]
+	c.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	return evaluate(f, evalCtx)
+}

--- a/pkg/feature/postgres_test.go
+++ b/pkg/feature/postgres_test.go
@@ -1,0 +1,170 @@
+package feature
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// newMockDB stands up a sqlmock-backed *gorm.DB suitable for unit-testing
+// the Postgres-backed flag client without a real database.
+func newMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return gdb, mock
+}
+
+// expectFlags queues a successful SELECT on feature_flags returning the given rows.
+func expectFlags(mock sqlmock.Sqlmock, rows ...flagRow) {
+	r := sqlmock.NewRows([]string{
+		"key", "description", "enabled",
+		"enabled_for_usernames", "enabled_for_roles",
+		"target_removal_date", "created_at", "updated_at",
+	})
+	for _, row := range rows {
+		r.AddRow(
+			row.Key, row.Description, row.Enabled,
+			pqArrayLiteral(row.EnabledForUsernames),
+			pqArrayLiteral(row.EnabledForRoles),
+			row.TargetRemovalDate, time.Now(), time.Now(),
+		)
+	}
+	mock.ExpectQuery(`SELECT \* FROM "feature_flags"`).WillReturnRows(r)
+}
+
+// pqArrayLiteral renders a []string the way the postgres driver returns a
+// TEXT[] column over the wire — `{a,b,c}` form — so pq.StringArray can
+// unmarshal it in tests.
+func pqArrayLiteral(s []string) string {
+	if len(s) == 0 {
+		return "{}"
+	}
+	out := "{"
+	for i, v := range s {
+		if i > 0 {
+			out += ","
+		}
+		out += v
+	}
+	out += "}"
+	return out
+}
+
+func TestPostgresClient_InitialLoad(t *testing.T) {
+	db, mock := newMockDB(t)
+	expectFlags(mock, flagRow{
+		Key:                 "chatbot.ascii",
+		Description:         "experimental ascii command",
+		Enabled:             false,
+		EnabledForUsernames: []string{"dana"},
+		EnabledForRoles:     []string{"mod"},
+		TargetRemovalDate:   time.Now().Add(30 * 24 * time.Hour),
+	})
+
+	c, err := NewPostgresClient(context.Background(), db, time.Minute)
+	if err != nil {
+		t.Fatalf("NewPostgresClient: %v", err)
+	}
+
+	if !c.Bool(context.Background(), "chatbot.ascii", EvalContext{Username: "dana"}) {
+		t.Error("dana should be in the username allowlist")
+	}
+	if !c.Bool(context.Background(), "chatbot.ascii", EvalContext{Roles: []string{"mod"}}) {
+		t.Error("mod role should match the role allowlist")
+	}
+	if c.Bool(context.Background(), "chatbot.ascii", EvalContext{Roles: []string{"regular"}}) {
+		t.Error("regular user should not be enabled")
+	}
+	if c.Bool(context.Background(), "chatbot.unknown", EvalContext{}) {
+		t.Error("unknown key should evaluate to false")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestPostgresClient_InitialLoadError(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery(`SELECT \* FROM "feature_flags"`).
+		WillReturnError(errors.New("connection refused"))
+
+	if _, err := NewPostgresClient(context.Background(), db, time.Minute); err == nil {
+		t.Error("expected initial load to surface the DB error")
+	}
+}
+
+func TestPostgresClient_RefreshFailureRetainsCache(t *testing.T) {
+	db, mock := newMockDB(t)
+	// Initial load: one flag, globally enabled.
+	expectFlags(mock, flagRow{
+		Key:               "chatbot.report_to_discord",
+		Description:       "discord webhook for !report",
+		Enabled:           true,
+		TargetRemovalDate: time.Now().Add(30 * 24 * time.Hour),
+	})
+	c, err := NewPostgresClient(context.Background(), db, time.Minute)
+	if err != nil {
+		t.Fatalf("NewPostgresClient: %v", err)
+	}
+	if !c.Bool(context.Background(), "chatbot.report_to_discord", EvalContext{}) {
+		t.Fatal("initial load: flag should be enabled")
+	}
+
+	// Manual refresh that fails — cache should be retained.
+	mock.ExpectQuery(`SELECT \* FROM "feature_flags"`).
+		WillReturnError(errors.New("connection refused"))
+	if err := c.refresh(context.Background()); err == nil {
+		t.Error("expected refresh to surface error")
+	}
+	if !c.Bool(context.Background(), "chatbot.report_to_discord", EvalContext{}) {
+		t.Error("flag should still evaluate to enabled after a failed refresh")
+	}
+
+	// Recovery refresh: flag is now globally disabled.
+	expectFlags(mock, flagRow{
+		Key:               "chatbot.report_to_discord",
+		Description:       "discord webhook for !report",
+		Enabled:           false,
+		TargetRemovalDate: time.Now().Add(30 * 24 * time.Hour),
+	})
+	if err := c.refresh(context.Background()); err != nil {
+		t.Fatalf("recovery refresh: %v", err)
+	}
+	if c.Bool(context.Background(), "chatbot.report_to_discord", EvalContext{}) {
+		t.Error("flag should be disabled after successful refresh")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestPostgresClient_EmptyTable(t *testing.T) {
+	db, mock := newMockDB(t)
+	expectFlags(mock) // zero rows
+	c, err := NewPostgresClient(context.Background(), db, time.Minute)
+	if err != nil {
+		t.Fatalf("NewPostgresClient: %v", err)
+	}
+	if c.Bool(context.Background(), "any.key", EvalContext{}) {
+		t.Error("empty table should evaluate every key to false")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Substrate for the feature-flag rollout. Adds the storage layer, the Go package, and wires it into chatbot's App. Production behaviour unchanged — no command evaluates a flag yet.

Subsequent PRs in this stack:

3. First flag through the system (`chatbot.report_to_discord` wrapping the existing webhook)
4. Admin panel CRUD endpoints under `/admin/flags`
5. Tombstone audit + prom counter (phase B)

## Design choices (locked in)

- **Boolean flags only** for v1. Targeting: per-username allowlist > per-role allowlist > global default. No percentage rollouts, no string variants, no audit log.
- **Postgres-backed** via `feature_flags` table with a 30s in-memory cache refreshed in the background. Last-known-good is retained on DB failure — a network blip should not flip features.
- **`target_removal_date NOT NULL`** on the schema — every flag is born with a tombstone.
- **Naming**: `<area>.<feature_name>` lowercase + dotted.
- **OpenFeature SDK deferred.** The `FlagClient.Bool(ctx, key, evalCtx) bool` surface is OpenFeature-shaped; swap is one file when we have a second provider or need typed variants.
- **Unknown keys evaluate to false** — safety property against typos in flag keys.

## What this PR contains

- `db/migrate/013_create_feature_flags.{up,down}.sql` — table + index on `target_removal_date`.
- `pkg/feature/` — `FlagClient` interface, `InMemoryClient` (tests + fallback), `PostgresClient` with refresh loop, sqlmock-backed tests covering initial load, startup error propagation, cache retention on failed refresh + recovery, and empty-table behaviour.
- `pkg/chatbot/flags.go` — `realFlags` adapter delegating to a package-level FlagClient under RWMutex, swapped via `SetFlagClient`.
- `pkg/chatbot/flags_test.go` — `noopFlags` (default for `newTestApp`) and `recordingFlags` for assertions.
- `App.Flags feature.FlagClient` field on the chatbot App, wired to `realFlags{}` in `defaultApp`.
- `cmd/tripbot/tripbot.go` — `startFeatureFlags(ctx)` builds the Postgres client after `startCron` and before `chatbot.Initialize`. Non-fatal on startup failure (logs + leaves the empty default in place).

## Test plan

- [ ] `task test:macos` passes locally (verified)
- [ ] Local Postgres apply: `task db:migrate` creates the table
- [ ] In dev: tripbot boots cleanly with `feature_flags` empty (no flags inserted yet); logs show "feature flag client init failed" if migration hasn't been applied