### PR TITLE
nats phase 1: parallel-publish ShowMiddleText alongside HTTP

### DIFF
--- a/cmd/onscreens-server/onscreens-server.go
+++ b/cmd/onscreens-server/onscreens-server.go
@@ -11,6 +11,7 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/natsclient"
 	onscreensServer "github.com/adanalife/tripbot/pkg/onscreens-server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	"github.com/getsentry/sentry-go"
@@ -44,6 +45,11 @@ func main() {
 	// the app cleanup off the same signals.
 	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignals()
+
+	// Connect to NATS so Server.Start can attach subscribers. Optional —
+	// when NATS_URL is empty the conn is nil and the subscriber registration
+	// is skipped; HTTP remains the sole transport.
+	natsclient.Connect(c.Conf.NatsURL, "onscreens-server")
 
 	// construct the server — runs all per-onscreen init (singletons +
 	// background loops) up front so the HTTP routes have everything to

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -22,6 +22,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/obs"
+	"github.com/adanalife/tripbot/pkg/natsclient"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -106,6 +107,7 @@ func main() {
 	updateSubscribers()
 	getCurrentUsers()
 	startEventSub(shutdownCtx)
+	startNATS()
 	startDiscord(shutdownCtx)
 	startSilentDisconnectWatchdog(shutdownCtx)
 	connectToTwitch()
@@ -132,6 +134,15 @@ func startFeatureFlags(ctx context.Context) {
 	}
 	chatbot.SetFlagClient(fc)
 	go fc.Start(ctx)
+}
+
+// startNATS connects to the in-cluster NATS broker (phase 1 of the
+// pubsub migration). Optional — when NATS_URL is empty the connection
+// is skipped and publishes no-op silently; chatbot.realOnscreens.
+// ShowMiddleText still mirrors to NATS but the publish becomes a nil
+// check, leaving HTTP as the sole transport.
+func startNATS() {
+	natsclient.Connect(c.Conf.NatsURL, "tripbot")
 }
 
 // startSilentDisconnectWatchdog launches the goroutine that detects the

--- a/go.mod
+++ b/go.mod
@@ -77,11 +77,15 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonas-p/go-shp v0.1.1 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mmcloughlin/profile v0.1.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/nats.go v1.52.0 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/kelvins/geocoder v0.0.0-20231112130812-98d82c75e49b/go.mod h1:JaVDVP2
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -162,6 +164,12 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nathan-osman/go-sunrise v1.1.0 h1:ZqZmtmtzs8Os/DGQYi0YMHpuUqR/iRoJK+wDO0wTCw8=
 github.com/nathan-osman/go-sunrise v1.1.0/go.mod h1:RcWqhT+5ShCZDev79GuWLayetpJp78RSjSWxiDowmlM=
+github.com/nats-io/nats.go v1.52.0 h1:n3avV4VBsCgsdwh71TppsTwtv+QdPs7ntSKM8qJLGsc=
+github.com/nats-io/nats.go v1.52.0/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nicklaw5/helix/v2 v2.34.0 h1:mdio9Wm+TQIjuJ199myvcKEcAmHiqigHsZlG1fDaPIE=
 github.com/nicklaw5/helix/v2 v2.34.0/go.mod h1:KaXa2mb2kBzsDana9RbXevTgnfU95DMoSORWo2hqlWA=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -57,6 +57,11 @@ type App struct {
 	// delegates to the Postgres-backed client cmd/tripbot installs via
 	// SetFlagClient once the DB connection is up.
 	Flags feature.FlagClient
+	// NATS is the fire-and-forget pubsub surface. Tests inject a
+	// recordingNATS to assert on publishes; production uses realNATS
+	// which delegates to the pkg/natsclient singleton (no-op when
+	// NATS_URL is empty).
+	NATS NATS
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -71,13 +76,14 @@ func (a *App) db() *gorm.DB {
 
 var defaultApp = &App{
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
-	Onscreens:  realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost)},
+	Onscreens:  realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost), nats: realNATS{}, env: c.Conf.Environment},
 	VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},
 	Video:      realVideo{},
 	IRC:        realIRC{},
 	Sessions:   realSessions{},
 	NowPlaying: newRealNowPlaying(),
 	Flags:      realFlags{},
+	NATS:       realNATS{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -55,6 +55,7 @@ func newTestApp(vid video.Video) *App {
 		Sessions:   noopSessions{},
 		NowPlaying: noopNowPlaying{},
 		Flags:      noopFlags{},
+		NATS:       noopNATS{},
 	}
 }
 

--- a/pkg/chatbot/nats.go
+++ b/pkg/chatbot/nats.go
@@ -1,0 +1,37 @@
+package chatbot
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/adanalife/tripbot/pkg/natsclient"
+)
+
+// NATS is the publish surface chatbot uses for fire-and-forget pubsub
+// events. Tests inject a fake (recordingNATS / noopNATS); production
+// uses realNATS which delegates to the pkg/natsclient singleton.
+//
+// Phase 1: a single call site (realOnscreens.ShowMiddleText) publishes
+// alongside the HTTP path. Phase 2 peels more onscreens-client surface
+// onto NATS; phase 3 adds JetStream for events that need replay.
+type NATS interface {
+	// Publish sends payload on subject. Errors are logged but never
+	// returned — every chatbot publish is fire-and-forget by design.
+	// When NATS is disabled (NATS_URL empty), the call no-ops silently.
+	Publish(ctx context.Context, subject string, payload []byte)
+}
+
+// realNATS delegates to whatever *nats.Conn pkg/natsclient currently
+// holds. Lazy read on each Publish so a connection that lands after
+// chatbot init (i.e. always — main runs after package vars) is picked up.
+type realNATS struct{}
+
+func (realNATS) Publish(ctx context.Context, subject string, payload []byte) {
+	c := natsclient.Conn()
+	if c == nil {
+		return
+	}
+	if err := c.Publish(subject, payload); err != nil {
+		slog.ErrorContext(ctx, "nats publish failed", "err", err, "subject", subject)
+	}
+}

--- a/pkg/chatbot/nats_test.go
+++ b/pkg/chatbot/nats_test.go
@@ -1,0 +1,91 @@
+package chatbot
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+// noopNATS satisfies NATS for tests that don't care whether anything
+// got published.
+type noopNATS struct{}
+
+func (noopNATS) Publish(_ context.Context, _ string, _ []byte) {}
+
+// recordingNATS captures every publish call so tests can assert on the
+// subject + payload pair. Goroutine-safe so concurrent commands don't
+// race the slice.
+type recordingNATS struct {
+	mu       sync.Mutex
+	Publishes []recordedPublish
+}
+
+type recordedPublish struct {
+	Subject string
+	Payload []byte
+}
+
+func (r *recordingNATS) Publish(_ context.Context, subject string, payload []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	r.Publishes = append(r.Publishes, recordedPublish{Subject: subject, Payload: cp})
+}
+
+// TestRealOnscreens_ShowMiddleText_PublishesToNATS asserts realOnscreens
+// fires the right subject + envelope shape on every ShowMiddleText call,
+// regardless of what the HTTP path does.
+func TestRealOnscreens_ShowMiddleText_PublishesToNATS(t *testing.T) {
+	rec := &recordingNATS{}
+	r := realOnscreens{c: nil, nats: rec, env: "stage"}
+
+	// Calling with a nil HTTP client panics — but we want to assert the
+	// publish happened *before* the HTTP call. Catch the panic and proceed.
+	func() {
+		defer func() { _ = recover() }()
+		_ = r.ShowMiddleText(context.Background(), "hello world")
+	}()
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	pub := rec.Publishes[0]
+	if pub.Subject != "tripbot.stage.onscreens.middle.show" {
+		t.Errorf("subject = %q, want tripbot.stage.onscreens.middle.show", pub.Subject)
+	}
+
+	var ev middleTextEvent
+	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Msg != "hello world" {
+		t.Errorf("msg = %q, want hello world", ev.Msg)
+	}
+	if ev.EmittedAt == "" {
+		t.Errorf("emitted_at empty")
+	}
+}
+
+// TestRealOnscreens_ShowMiddleText_TopicReflectsEnv covers prod, dev,
+// any non-stage env wires through correctly.
+func TestRealOnscreens_ShowMiddleText_TopicReflectsEnv(t *testing.T) {
+	for _, env := range []string{"prod", "development", "test"} {
+		t.Run(env, func(t *testing.T) {
+			rec := &recordingNATS{}
+			r := realOnscreens{c: nil, nats: rec, env: env}
+			func() {
+				defer func() { _ = recover() }()
+				_ = r.ShowMiddleText(context.Background(), "x")
+			}()
+			if len(rec.Publishes) != 1 {
+				t.Fatalf("expected 1 publish")
+			}
+			want := "tripbot." + env + ".onscreens.middle.show"
+			if rec.Publishes[0].Subject != want {
+				t.Errorf("subject = %q, want %q", rec.Publishes[0].Subject, want)
+			}
+		})
+	}
+}

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -2,6 +2,9 @@ package chatbot
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
 	"time"
 
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
@@ -21,8 +24,14 @@ type Onscreens interface {
 // realOnscreens delegates to a constructed *onscreensClient.Client. The
 // concrete Client instance is owned by the App (wired up in defaultApp),
 // not read off a package-level global in pkg/onscreens-client.
+//
+// nats + env are used by ShowMiddleText to mirror the call to NATS
+// alongside the HTTP request — phase 1 of the pubsub migration. Other
+// methods stay HTTP-only until phase 2 peels them off.
 type realOnscreens struct {
-	c *onscreensClient.Client
+	c    *onscreensClient.Client
+	nats NATS
+	env  string
 }
 
 func (r realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
@@ -34,9 +43,32 @@ func (r realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][
 func (r realOnscreens) HideMiddleText(ctx context.Context) error {
 	return r.c.HideMiddleText(ctx)
 }
+
+// middleTextEvent is the wire format published to
+// tripbot.<env>.onscreens.middle.show. Snake_case so a future protobuf
+// schema maps 1-1.
+type middleTextEvent struct {
+	Msg        string `json:"msg"`
+	EmittedAt  string `json:"emitted_at"`
+}
+
 func (r realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
+	// Parallel publish: NATS first (cheap, fire-and-forget) so a slow
+	// HTTP call doesn't delay it. HTTP remains the source of truth for
+	// phase 1; the NATS subscriber on onscreens-server acts on the same
+	// payload but its actions are presently redundant with the HTTP path.
+	payload, err := json.Marshal(middleTextEvent{
+		Msg:       msg,
+		EmittedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal middle-text event", "err", err)
+	} else {
+		r.nats.Publish(ctx, fmt.Sprintf("tripbot.%s.onscreens.middle.show", r.env), payload)
+	}
 	return r.c.ShowMiddleText(ctx, msg)
 }
+
 func (r realOnscreens) ShowTimewarp(ctx context.Context) error {
 	return r.c.ShowTimewarp(ctx)
 }

--- a/pkg/config/onscreens-server/type.go
+++ b/pkg/config/onscreens-server/type.go
@@ -18,4 +18,10 @@ type OnscreensServerConfig struct {
 	// onscreens-server HTTP listener binds to. Defaults to :8081 so it sits
 	// adjacent to vlc-server's :8080 when they run in the same pod/container.
 	OnscreensServerBindAddress string `default:":8081" envconfig:"ONSCREENS_SERVER_BIND_ADDRESS"`
+
+	// NatsURL is the in-cluster NATS endpoint the subscriber connects to
+	// (phase 1: tripbot.<env>.onscreens.middle.show). Format:
+	// nats://nats.<env-platform-ns>.svc.cluster.local:4222. Optional —
+	// when unset, the subscriber is skipped and HTTP is the sole transport.
+	NatsURL string `envconfig:"NATS_URL"`
 }

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -47,6 +47,13 @@ type TripbotConfig struct {
 	// for the "restart obs" button. Optional — blank skips the OBS row.
 	ObsServerHost string `envconfig:"OBS_SERVER_HOST"`
 
+	// NatsURL is the in-cluster NATS endpoint used for fire-and-forget
+	// inter-component events (phase 1: ShowMiddleText alongside HTTP).
+	// Format: nats://nats.<env-platform-ns>.svc.cluster.local:4222.
+	// Optional — when unset, NATS publishes no-op and the HTTP path is
+	// the sole transport. Lets local dev / tests skip NATS entirely.
+	NatsURL string `envconfig:"NATS_URL"`
+
 	// DiscordAlertsWebhook is the Discord webhook URL that !report posts
 	// viewer reports to. Optional — when unset, !report falls through to
 	// slog/Sentry only and the bot keeps running.

--- a/pkg/natsclient/natsclient.go
+++ b/pkg/natsclient/natsclient.go
@@ -1,0 +1,62 @@
+// Package natsclient owns the process-wide *nats.Conn for tripbot and
+// onscreens-server. Mirrors the pkg/database singleton pattern: lazy on
+// first Connect, no-op when the URL is empty, swappable for tests.
+//
+// Phase 1 (vault/tripbot/TODO.md "Adopt NATS as the inter-component
+// message bus"): fire-and-forget pubsub. JetStream lands later.
+package natsclient
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/nats-io/nats.go"
+)
+
+var (
+	mu   sync.Mutex
+	conn *nats.Conn
+)
+
+// Connect dials the configured NATS endpoint and stashes the result as
+// the package singleton. When url is empty the function returns nil and
+// every downstream call no-ops — lets local dev / tests skip NATS.
+// Idempotent: a successful prior Connect short-circuits on re-entry.
+func Connect(url string, name string) *nats.Conn {
+	mu.Lock()
+	defer mu.Unlock()
+	if conn != nil {
+		return conn
+	}
+	if url == "" {
+		slog.Info("nats disabled (NATS_URL unset); pubsub publishes will no-op")
+		return nil
+	}
+	c, err := nats.Connect(url,
+		nats.Name(name),
+		nats.MaxReconnects(-1),
+	)
+	if err != nil {
+		slog.Error("nats connect failed; pubsub publishes will no-op", "err", err, "url", url)
+		return nil
+	}
+	conn = c
+	slog.Info("nats connected", "url", url, "name", name)
+	return conn
+}
+
+// Conn returns the current package-singleton *nats.Conn, or nil if
+// Connect has not yet succeeded. Callers must nil-check.
+func Conn() *nats.Conn {
+	mu.Lock()
+	defer mu.Unlock()
+	return conn
+}
+
+// SetConn swaps the singleton for tests. Pair with a nats-server test
+// fixture or a stubbed *nats.Conn.
+func SetConn(c *nats.Conn) {
+	mu.Lock()
+	defer mu.Unlock()
+	conn = c
+}

--- a/pkg/onscreens-server/nats.go
+++ b/pkg/onscreens-server/nats.go
@@ -1,0 +1,57 @@
+package onscreensServer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	"github.com/nats-io/nats.go"
+)
+
+// middleTextEvent mirrors the chatbot-side wire format for
+// tripbot.<env>.onscreens.middle.show. Mirror, not import, to keep the
+// chatbot/onscreens-server package boundary clean — the wire format
+// will live in its own pkg/events module once a second event lands.
+type middleTextEvent struct {
+	Msg       string `json:"msg"`
+	EmittedAt string `json:"emitted_at"`
+}
+
+// StartNATSSubscribers attaches the server's NATS subscriptions to the
+// package-singleton *nats.Conn (initialized by main via
+// natsclient.Connect). No-op when the conn is nil (NATS_URL unset).
+// Returns the subscription so callers can Unsubscribe on shutdown if
+// they want — phase 1 lets the process exit do that work.
+//
+// Phase 1: a single subject — tripbot.<env>.onscreens.middle.show. Phase
+// 2 peels the rest of the onscreens-client surface onto NATS.
+func (s *Server) StartNATSSubscribers(ctx context.Context) {
+	conn := natsclient.Conn()
+	if conn == nil {
+		slog.InfoContext(ctx, "nats subscriber skipped (NATS_URL unset)")
+		return
+	}
+	subject := fmt.Sprintf("tripbot.%s.onscreens.middle.show", c.Conf.Environment)
+	sub, err := conn.Subscribe(subject, s.handleMiddleTextShow)
+	if err != nil {
+		slog.ErrorContext(ctx, "nats subscribe failed", "err", err, "subject", subject)
+		return
+	}
+	slog.InfoContext(ctx, "nats subscribed", "subject", subject, "queue", sub.Queue)
+}
+
+func (s *Server) handleMiddleTextShow(m *nats.Msg) {
+	var ev middleTextEvent
+	if err := json.Unmarshal(m.Data, &ev); err != nil {
+		slog.Error("nats: decode middle-text event", "err", err, "subject", m.Subject)
+		return
+	}
+	if ev.Msg == "" {
+		slog.Warn("nats: middle-text event missing msg field", "subject", m.Subject)
+		return
+	}
+	s.MiddleText.Show(ev.Msg)
+}

--- a/pkg/onscreens-server/nats_test.go
+++ b/pkg/onscreens-server/nats_test.go
@@ -1,0 +1,62 @@
+package onscreensServer
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestHandleMiddleTextShow_DecodesAndShows asserts a well-formed NATS
+// message lands on the MiddleText overlay the same way the HTTP handler
+// would (s.MiddleText.Show is the shared path).
+func TestHandleMiddleTextShow_DecodesAndShows(t *testing.T) {
+	s := &Server{MiddleText: newMiddleText()}
+
+	msg := &nats.Msg{
+		Subject: "tripbot.test.onscreens.middle.show",
+		Data:    []byte(`{"msg":"hello from nats","emitted_at":"2026-05-28T16:00:00Z"}`),
+	}
+	s.handleMiddleTextShow(msg)
+
+	if !s.MiddleText.IsShowing {
+		t.Errorf("MiddleText.IsShowing = false, want true")
+	}
+	if s.MiddleText.Content != "hello from nats" {
+		t.Errorf("MiddleText.Content = %q, want %q", s.MiddleText.Content, "hello from nats")
+	}
+}
+
+// TestHandleMiddleTextShow_RejectsEmptyMsg covers the defensive check
+// for a malformed publisher that omits the msg field. The overlay's
+// existing Content must not change. (MiddleText starts IsShowing=true by
+// design — it carries pre-restart text — so this asserts on Content.)
+func TestHandleMiddleTextShow_RejectsEmptyMsg(t *testing.T) {
+	s := &Server{MiddleText: newMiddleText()}
+	s.MiddleText.Content = "pre-existing"
+
+	msg := &nats.Msg{
+		Subject: "tripbot.test.onscreens.middle.show",
+		Data:    []byte(`{"emitted_at":"2026-05-28T16:00:00Z"}`),
+	}
+	s.handleMiddleTextShow(msg)
+
+	if s.MiddleText.Content != "pre-existing" {
+		t.Errorf("MiddleText.Content = %q, want pre-existing (empty msg should be a no-op)", s.MiddleText.Content)
+	}
+}
+
+// TestHandleMiddleTextShow_RejectsBadJSON covers a non-JSON payload.
+func TestHandleMiddleTextShow_RejectsBadJSON(t *testing.T) {
+	s := &Server{MiddleText: newMiddleText()}
+	s.MiddleText.Content = "pre-existing"
+
+	msg := &nats.Msg{
+		Subject: "tripbot.test.onscreens.middle.show",
+		Data:    []byte(`not json at all`),
+	}
+	s.handleMiddleTextShow(msg)
+
+	if s.MiddleText.Content != "pre-existing" {
+		t.Errorf("MiddleText.Content = %q, want pre-existing (bad JSON should be a no-op)", s.MiddleText.Content)
+	}
+}

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -87,6 +87,10 @@ func New(cfg Config) *Server {
 func (s *Server) Start(ctx context.Context) error {
 	slog.InfoContext(ctx, "starting onscreens-server web server", "bind", c.Conf.OnscreensServerBindAddress)
 
+	// Attach NATS subscribers. No-op when the natsclient singleton is
+	// nil (NATS_URL unset); HTTP remains the sole transport in that case.
+	s.StartNATSSubscribers(ctx)
+
 	r := mux.NewRouter()
 
 	// healthcheck endpoints


### PR DESCRIPTION
## Summary

Phase 1 of the NATS adoption: migrate one fire-and-forget HTTP call as proof. \`ShowMiddleText\` now publishes to \`tripbot.<env>.onscreens.middle.show\` in parallel with the existing HTTP request. HTTP remains the source of truth — a NATS outage / misconfig is invisible to viewers, and the on-screen overlay always lands via at least one path.

Pairs with infra PR (to follow) that wires \`NATS_URL\` on the tripbot + onscreens-server ConfigMaps per env.

## What lands

**Producer side**
- \`pkg/natsclient\` — process-wide \`*nats.Conn\` singleton, mirroring \`pkg/database\`'s SetGormDB shape. Empty \`NATS_URL\` → conn stays nil, all publishes no-op silently.
- \`pkg/chatbot\` — \`App.NATS\` interface (one method, \`Publish\`) + \`realNATS\` adapter. \`realOnscreens\` carries a \`NATS\` + \`env\` and mirrors each \`ShowMiddleText\` call.

**Subscriber side**
- \`pkg/onscreens-server\` — \`Server.StartNATSSubscribers\` attaches to the package singleton at \`Start\`. JSON-decodes the envelope, calls \`s.MiddleText.Show(msg)\` — same path the HTTP handler takes.

**Wire format**
\`\`\`json
{ "msg": "...", "emitted_at": "2026-05-28T16:35:00Z" }
\`\`\`
snake_case so an eventual protobuf swap is a 1-1 schema mapping. Reasoning: with one message type + single language consumer (Go-only), protobuf's toolchain weight isn't earned yet; revisit when an Elixir / Python consumer lands or the topic set grows past ~3.

**Tests**
- \`chatbot\`: \`recordingNATS\` fake asserts subject + payload across \`stage\` / \`prod\` / \`development\` / \`test\` env values.
- \`onscreens-server\`: happy path + empty-\`msg\` guard + bad-JSON guard. Confirms the overlay's existing \`Content\` survives malformed events untouched.

## Test plan

- [ ] CI green
- [ ] After infra PR ships \`NATS_URL\` envs, deploy this to stage
- [ ] Stage burn-in: \`nats sub "tripbot.stage.>" \` in a terminal, fire \`!hi\` (or any command that triggers a middle-text), confirm both transports deliver the overlay
- [ ] Ship to prod once stage looks clean
- [ ] Watch \`12 — Platform Services\` dashboard \`nats\` row in prod for non-zero \`in_msgs\` rate

## What's NOT here

- No HTTP fallback peel — phase 2 work. HTTP runs in parallel until NATS is proven on both envs.
- No other onscreens-client surface migrated (\`HideMiddleText\`, \`ShowLeaderboard\`, etc.). Phase 2 batches those.
- No JetStream / durability — phase 3.
- No new alerting on \`nats_*\` series — incremental, separate PR if/when something earns it.