### PR TITLE
admin panel: default stream preview to expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### admin panel
+
+- **Stream preview defaults to expanded.** The Twitch player disclosure now opens on page load instead of needing a click. Iframe wiring keeps the existing collapse-to-pause behaviour (collapse swaps `src` to `about:blank` so audio + bandwidth stop), and re-expanding restores the player from `data-src`. Initial render bootstraps `src` directly when the disclosure starts open since the `toggle` event only fires on user interaction.
+
 ### discord
 
 - **TripBot gets a live Discord bot session — first pass.** New `pkg/discord` opens a `bwmarrin/discordgo` gateway and registers four guild-scoped slash commands in ADanaLife: `/leaderboard` (monthly miles), `/totalleaderboard` (lifetime miles), `/guessleaderboard` (correct guesses this month), and a static ephemeral `/commands` listing the others. Names mirror the existing Twitch `!leaderboard` / `!totalleaderboard` / `!guessleaderboard` triggers so muscle memory transfers. Two new optional config fields (`DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`); the bot stays disabled in any env where either is unset, empty, or still at the AWS Secrets Manager placeholder string — `pkg/discord.ShouldStart` is the single decision point that skips startup cleanly with one INFO log line. Every other failure path (auth failure, command-registration failure, gateway drop) is fail-open: tripbot's core IRC / EventSub paths are never blocked or crashed by Discord. Companion infra lands in `infra` (terraform SM containers + ESO + Deployment `envFrom`) and a setup runbook lives in the vault. Deferred to follow-up passes: OAuth Discord↔Twitch linking, `/miles <user>`, stream-state commands, retiring the existing `DISCORD_ALERTS_WEBHOOK`.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -692,7 +692,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   </ul>
 
   {{if and .PreviewChannel .PanelHost}}
-  <details class="stream-preview" id="stream-preview">
+  <details class="stream-preview" id="stream-preview" open>
     <summary>stream preview</summary>
     <div class="stream-frame">
       <iframe data-src="https://player.twitch.tv/?channel={{.PreviewChannel}}&parent={{.PanelHost}}&muted=true&autoplay=true"
@@ -749,21 +749,20 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   </div>
 </main>
 <script>
-// Stream-preview lazy-load. The Twitch player iframe is ~2MB; we don't want
-// to fetch it on every panel render, only when the operator actually expands
-// the disclosure. On collapse we point it at about:blank so the player stops
-// (otherwise audio + bandwidth keep going even when the section's hidden).
+// Stream-preview iframe wiring. The disclosure defaults to open so the
+// preview is visible on load — initial paint sets src from data-src.
+// Collapse swaps src to about:blank so the player stops cleanly (audio +
+// bandwidth would otherwise keep going), and re-expanding restores it.
 (function() {
   const details = document.getElementById('stream-preview');
   if (!details) return;
   const iframe = details.querySelector('iframe');
   if (!iframe) return;
+  const load = () => { iframe.src = iframe.dataset.src; };
+  const unload = () => { iframe.src = 'about:blank'; };
+  if (details.open) load();
   details.addEventListener('toggle', () => {
-    if (details.open) {
-      iframe.src = iframe.dataset.src;
-    } else {
-      iframe.src = 'about:blank';
-    }
+    if (details.open) load(); else unload();
   });
 })();
 


### PR DESCRIPTION
## Summary

The Twitch stream-preview disclosure on the admin panel now defaults to expanded instead of needing a click.

The existing lazy-load is preserved structurally — collapse still swaps the iframe's `src` to `about:blank` so audio + bandwidth stop, and re-expanding restores it. The only twist: the previous wiring assumed the disclosure started closed and bootstrapped `src` from the `toggle` event, which only fires on user interaction. Now that initial render starts open, the same one-liner runs synchronously if `details.open` is already true.

The "fetch the ~2MB player on every panel render" trade-off this opens up is fine in practice: the admin panel is single-viewer, LAN/tailnet-only.

## Test plan

- [x] `task test:macos ./pkg/server/...` clean
- [ ] Load admin panel: stream preview is visible immediately with the player playing
- [ ] Collapse the disclosure: player stops (audio cuts, network goes idle)
- [ ] Re-expand: player resumes from the live edge