### PR TITLE
obs: detangle silent-disconnect watchdog into its own subpackage

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -21,8 +21,8 @@ import (
 	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
-	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/natsclient"
+	"github.com/adanalife/tripbot/pkg/obs/watchdog"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -159,7 +159,7 @@ func startNATS() {
 // 3 consecutive minute-spaced misalignments. First seen in prod on
 // 2026-05-27, ~30h into an OBS session.
 func startSilentDisconnectWatchdog(ctx context.Context) {
-	go obs.WatchSilentDisconnect(ctx, obs.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
+	go watchdog.WatchSilentDisconnect(ctx, watchdog.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
 }
 
 // startDiscord brings up the bot's Discord slash-command session when

--- a/pkg/obs/watchdog/watchdog.go
+++ b/pkg/obs/watchdog/watchdog.go
@@ -1,4 +1,11 @@
-package obs
+// Package watchdog implements the silent-disconnect detector that
+// cross-checks OBS's outputActive state against Twitch's live status
+// and force-restarts the OBS stream on sustained divergence. Lives
+// here (not in the parent pkg/obs package) so binaries that only need
+// pkg/obs's WebSocket helpers — vlc-server in particular — don't drag
+// in pkg/config/tripbot or pkg/twitch transitively. cmd/tripbot is
+// the sole consumer.
+package watchdog
 
 import (
 	"context"
@@ -7,6 +14,7 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/twitch"
 )
 
@@ -31,7 +39,7 @@ type WatchdogDeps struct {
 // outputReconnecting=false AND Twitch offline) needs intervention.
 func DefaultWatchdogDeps() WatchdogDeps {
 	return WatchdogDeps{
-		OBSActive: GetStreamActiveSteady,
+		OBSActive: obs.GetStreamActiveSteady,
 		TwitchLive: func(ctx context.Context) (bool, error) {
 			live, err := twitch.IsChannelLive(ctx, c.Conf.ChannelName)
 			if err == nil {
@@ -48,7 +56,7 @@ func DefaultWatchdogDeps() WatchdogDeps {
 // the manual recovery sequence we ran by hand the first time the silent
 // half-open hit prod (see the 2026-05-27 incident).
 func defaultRestart(ctx context.Context) error {
-	if err := StopStream(ctx); err != nil {
+	if err := obs.StopStream(ctx); err != nil {
 		return err
 	}
 	select {
@@ -56,7 +64,7 @@ func defaultRestart(ctx context.Context) error {
 		return ctx.Err()
 	case <-time.After(3 * time.Second):
 	}
-	return StartStream(ctx)
+	return obs.StartStream(ctx)
 }
 
 // WatchSilentDisconnect detects the silent half-open RTMP state where OBS

--- a/pkg/obs/watchdog/watchdog_test.go
+++ b/pkg/obs/watchdog/watchdog_test.go
@@ -1,4 +1,4 @@
-package obs
+package watchdog
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

Move \`pkg/obs/silent_disconnect_watchdog.go\` + its test into a new \`pkg/obs/watchdog\` subpackage so vlc-server's binary stops dragging in tripbot-specific config + database validators.

\`\`\`
pkg/obs/                                    pkg/obs/
├── control.go                              ├── control.go
├── streaming.go                            └── streaming.go
├── silent_disconnect_watchdog.go     ──→   pkg/obs/watchdog/
└── silent_disconnect_watchdog_test.go      ├── watchdog.go
                                            └── watchdog_test.go
\`\`\`

## Why

The watchdog file imported \`pkg/config/tripbot\` (reads \`ChannelName\`) AND \`pkg/twitch\` (calls \`IsChannelLive\`) at the package level. Because all files in a Go package compile and link together, anything importing \`pkg/obs\` inherited the whole chain:

\`\`\`
cmd/vlc-server → pkg/obs (imported for one call: PollStreamingActive)
              └→ silent_disconnect_watchdog.go (sibling file)
                  ├→ pkg/config/tripbot → init() envconfig.Process →
                  │  fatals on missing CHANNEL_NAME, BOT_USERNAME,
                  │  EXTERNAL_URL, ONSCREENS_SERVER_HOST
                  └→ pkg/twitch → pkg/oauthtokens → pkg/database →
                     init() log.Fatalf on missing DATABASE_USER,
                     DATABASE_DB, DATABASE_HOST
\`\`\`

v2.17.0 — which introduced the watchdog ([#702](https://github.com/adanalife/tripbot/pull/702/changes)) — couldn't boot in prod's vlc-server pod without **9 placeholder env vars** stamped into its ConfigMap. Took prod down today; recovery was [adanalife/infra#617](https://github.com/adanalife/infra/pull/617/changes) + [#619](https://github.com/adanalife/infra/pull/619/changes) workarounds.

## What changes

- \`silent_disconnect_watchdog.go\` → \`pkg/obs/watchdog/watchdog.go\` (\`package watchdog\`)
- \`silent_disconnect_watchdog_test.go\` → \`pkg/obs/watchdog/watchdog_test.go\`
- Sibling-file calls (\`GetStreamActiveSteady\`, \`StopStream\`, \`StartStream\`) become cross-package calls (\`obs.GetStreamActiveSteady\`, etc.) — \`pkg/obs/watchdog\` imports \`pkg/obs\` to reach them.
- \`cmd/tripbot/tripbot.go\` swaps \`pkg/obs\` → \`pkg/obs/watchdog\` for its single call site (\`startSilentDisconnectWatchdog\`).
- Test file's package declaration: \`package obs\` → \`package watchdog\`.

No behavior change. The watchdog is bit-for-bit the same code; only the package path moves.

## Verification

\`\`\`
$ go list -deps ./cmd/vlc-server | grep tripbot/pkg/
github.com/adanalife/tripbot/pkg/config
github.com/adanalife/tripbot/pkg/config/vlc-server
github.com/adanalife/tripbot/pkg/errors
github.com/adanalife/tripbot/pkg/helpers
github.com/adanalife/tripbot/pkg/httpmw
github.com/adanalife/tripbot/pkg/instrumentation
github.com/adanalife/tripbot/pkg/obs
github.com/adanalife/tripbot/pkg/telemetry
github.com/adanalife/tripbot/pkg/vlc-server
\`\`\`

No \`pkg/config/tripbot\`. No \`pkg/database\`. No \`pkg/twitch\`. No \`pkg/oauthtokens\`. Same for \`./cmd/onscreens-server\`.

## Test plan

- [x] \`task test:macos\` — all packages green, including \`pkg/obs/watchdog\` (2.085s)
- [x] \`go list -deps\` audit on vlc-server + onscreens-server — clean
- [ ] After merge: cut v2.17.1 release
- [ ] After v2.17.1 ships: paired infra PR drops the placeholder env block (see follow-up in \`vault/tripbot/TODO.md\`)