### PR TITLE
release-development: broaden vlc filter to pkg/** for transitive imports

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -34,12 +34,19 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/release-development.yml'
             vlc:
+              # The vlc container builds two binaries from this repo:
+              # cmd/vlc-server and cmd/onscreens-server. Both transitively
+              # import packages outside their own cmd/pkg trees — e.g.
+              # cmd/vlc-server imports pkg/obs, pkg/instrumentation,
+              # pkg/telemetry, pkg/helpers, etc. Match anything under
+              # pkg/** so a change to any shared package triggers a vlc
+              # rebuild — same shape as the tripbot filter above. Without
+              # this, edits like the 2026-05-28 pkg/obs detangle silently
+              # ship a stale vlc image because the narrow vlc-only globs
+              # don't match pkg/obs/**.
               - 'cmd/vlc-server/**'
               - 'cmd/onscreens-server/**'
-              - 'pkg/vlc-server/**'
-              - 'pkg/onscreens-server/**'
-              - 'pkg/vlc-client/**'
-              - 'pkg/onscreens-client/**'
+              - 'pkg/**'
               - 'infra/docker/vlc/**'
               - 'go.mod'
               - 'go.sum'


### PR DESCRIPTION
## Summary

Widens the \`vlc\` paths-filter from a narrow allowlist of vlc-specific subpackages to \`pkg/**\`, matching the tripbot filter's shape.

## Why

vlc-server + onscreens-server transitively import shared packages (\`pkg/obs\`, \`pkg/instrumentation\`, \`pkg/telemetry\`, \`pkg/helpers\`, \`pkg/httpmw\`, etc.). The narrow vlc filter only matched \`pkg/{vlc,onscreens}-{server,client}/\`, so any edit to a shared package silently skipped the vlc rebuild.

Concrete miss: [tripbot#716](https://github.com/adanalife/tripbot/pull/716/changes) moved the silent-disconnect watchdog out of \`pkg/obs\` into \`pkg/obs/watchdog\`. cmd/vlc-server imports pkg/obs, so the vlc binary's behavior changes — but the filter didn't match \`pkg/obs/**\`, so the workflow run on the merge of #716 shows \`vlc-build: skipped\`. Stage's \`:develop\` vlc image would have stayed on the pre-detangle code.

\`pkg/**\` mirrors the tripbot filter above. Some changes under pkg/ don't affect vlc-server's deps (e.g. pkg/chatbot), but the native-runner vlc build is ~3-4 min — cheap insurance against shipping a stale image.

## Side effect (intentional)

Merging this PR triggers a rebuild of the vlc \`:develop\` image (the workflow file itself is in the filter list, so the merge push matches), picking up the #716 detangle. Stage can then roll vlc-server to the fresh \`:develop\` image to smoke-test the move before we cut v2.17.1 for prod.

## Test plan

- [ ] After merge: workflow run shows \`vlc-build\` running (not skipped)
- [ ] New \`adanalife/vlc:develop\` image published
- [ ] Stage vlc-server rolls cleanly when restarted to pick up the new image