### PR TITLE
Release v2.17.1: develop → master

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -34,12 +34,19 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/release-development.yml'
             vlc:
+              # The vlc container builds two binaries from this repo:
+              # cmd/vlc-server and cmd/onscreens-server. Both transitively
+              # import packages outside their own cmd/pkg trees — e.g.
+              # cmd/vlc-server imports pkg/obs, pkg/instrumentation,
+              # pkg/telemetry, pkg/helpers, etc. Match anything under
+              # pkg/** so a change to any shared package triggers a vlc
+              # rebuild — same shape as the tripbot filter above. Without
+              # this, edits like the 2026-05-28 pkg/obs detangle silently
+              # ship a stale vlc image because the narrow vlc-only globs
+              # don't match pkg/obs/**.
               - 'cmd/vlc-server/**'
               - 'cmd/onscreens-server/**'
-              - 'pkg/vlc-server/**'
-              - 'pkg/onscreens-server/**'
-              - 'pkg/vlc-client/**'
-              - 'pkg/onscreens-client/**'
+              - 'pkg/**'
               - 'infra/docker/vlc/**'
               - 'go.mod'
               - 'go.sum'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+## [v2.17.1] — 2026-05-28
+
+Patch release. Hotfix for the v2.17.0 silent-disconnect watchdog's import chain — it dragged `pkg/config/tripbot` and `pkg/database` into vlc-server's binary at link time, so the vlc-server pod refused to boot in prod without 9 placeholder env vars stamped into its ConfigMap. Took prod's dashcam playback down for 13 minutes during the rollout. Detangled by moving the watchdog into its own subpackage; companion fix broadens the `release-development.yml` vlc paths-filter so shared-package edits like this one don't silently skip the vlc rebuild.
+
+### obs
+
+- **Move the silent-disconnect watchdog out of `pkg/obs` into `pkg/obs/watchdog`.** The watchdog file imported `pkg/config/tripbot` (for `ChannelName`) and `pkg/twitch` (for `IsChannelLive`) at the package level — and `pkg/twitch` transitively imports `pkg/oauthtokens` → `pkg/database`, whose `init()` `log.Fatalf`s on missing `DATABASE_USER` / `DATABASE_DB` / `DATABASE_HOST`. Because all files in a Go package compile together, anything importing `pkg/obs` inherited the whole chain. `cmd/vlc-server/vlc-server.go` has imported `pkg/obs` for ages for one call (`obs.PollStreamingActive`), so v2.17.0's vlc-server binary refused to boot without env vars for the 6 required `pkg/config/tripbot` keys + the 3 `pkg/database` checks — even though the watchdog never runs inside vlc-server. After the move, `pkg/obs` holds only `control.go` + `streaming.go` (zero tripbot-internal imports beyond `pkg/instrumentation`), and `cmd/tripbot` is the sole consumer of the new `pkg/obs/watchdog` subpackage. Verified: `go list -deps ./cmd/vlc-server` no longer includes `pkg/config/tripbot`, `pkg/database`, `pkg/twitch`, or `pkg/oauthtokens`. Same for `./cmd/onscreens-server`. ([#716])
+
+### ci
+
+- **Broaden the `release-development.yml` vlc paths-filter to `pkg/**`.** The narrow vlc filter (only `pkg/{vlc,onscreens}-{server,client}/`) meant any change to a shared package — `pkg/obs`, `pkg/instrumentation`, `pkg/telemetry`, etc. — silently skipped the vlc rebuild. `#716`'s detangle would have shipped a stale vlc `:develop` image on the first run; stage would have continued running the bug. The new filter matches the tripbot filter's shape — broad enough to never miss a transitive-dep change, at the cost of some unnecessary rebuilds (the native-runner vlc build is ~3-4 min, cheap insurance). ([#717])
+
 ## [v2.17.0] — 2026-05-28
 
 Minor release. TripBot gets a live Discord bot session (four slash commands mirroring the Twitch leaderboards), gated behind the first flag of a new Postgres-backed feature-flag system with a read-only admin-panel listing. NATS adoption begins with phase 1 — `ShowMiddleText` parallel-publishes to `tripbot.<env>.onscreens.middle.show` while HTTP stays the source of truth. A silent-disconnect watchdog auto-recovers from the prod failure mode where OBS's RTMP write socket goes half-open and frames keep streaming into the void while Twitch shows offline. Twitch token handling closes a cron-desync gap that bit prod on 2026-05-26 (refresh-on-startup + expiry-timestamp gauge, plus a 30→45 minute refresh window that spares the helix 401 self-heal from firing on the routine cycle). Leaderboard rendering swaps space-padded monospace for CSS grid alignment so scores line up under the regular Trebuchet stack.
@@ -1198,3 +1210,5 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#712]: https://github.com/adanalife/tripbot/pull/712
 [#713]: https://github.com/adanalife/tripbot/pull/713
 [#714]: https://github.com/adanalife/tripbot/pull/714
+[#716]: https://github.com/adanalife/tripbot/pull/716
+[#717]: https://github.com/adanalife/tripbot/pull/717

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -21,8 +21,8 @@ import (
 	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
-	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/natsclient"
+	"github.com/adanalife/tripbot/pkg/obs/watchdog"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -159,7 +159,7 @@ func startNATS() {
 // 3 consecutive minute-spaced misalignments. First seen in prod on
 // 2026-05-27, ~30h into an OBS session.
 func startSilentDisconnectWatchdog(ctx context.Context) {
-	go obs.WatchSilentDisconnect(ctx, obs.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
+	go watchdog.WatchSilentDisconnect(ctx, watchdog.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
 }
 
 // startDiscord brings up the bot's Discord slash-command session when

--- a/pkg/obs/watchdog/watchdog.go
+++ b/pkg/obs/watchdog/watchdog.go
@@ -1,4 +1,11 @@
-package obs
+// Package watchdog implements the silent-disconnect detector that
+// cross-checks OBS's outputActive state against Twitch's live status
+// and force-restarts the OBS stream on sustained divergence. Lives
+// here (not in the parent pkg/obs package) so binaries that only need
+// pkg/obs's WebSocket helpers — vlc-server in particular — don't drag
+// in pkg/config/tripbot or pkg/twitch transitively. cmd/tripbot is
+// the sole consumer.
+package watchdog
 
 import (
 	"context"
@@ -7,6 +14,7 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/twitch"
 )
 
@@ -31,7 +39,7 @@ type WatchdogDeps struct {
 // outputReconnecting=false AND Twitch offline) needs intervention.
 func DefaultWatchdogDeps() WatchdogDeps {
 	return WatchdogDeps{
-		OBSActive: GetStreamActiveSteady,
+		OBSActive: obs.GetStreamActiveSteady,
 		TwitchLive: func(ctx context.Context) (bool, error) {
 			live, err := twitch.IsChannelLive(ctx, c.Conf.ChannelName)
 			if err == nil {
@@ -48,7 +56,7 @@ func DefaultWatchdogDeps() WatchdogDeps {
 // the manual recovery sequence we ran by hand the first time the silent
 // half-open hit prod (see the 2026-05-27 incident).
 func defaultRestart(ctx context.Context) error {
-	if err := StopStream(ctx); err != nil {
+	if err := obs.StopStream(ctx); err != nil {
 		return err
 	}
 	select {
@@ -56,7 +64,7 @@ func defaultRestart(ctx context.Context) error {
 		return ctx.Err()
 	case <-time.After(3 * time.Second):
 	}
-	return StartStream(ctx)
+	return obs.StartStream(ctx)
 }
 
 // WatchSilentDisconnect detects the silent half-open RTMP state where OBS

--- a/pkg/obs/watchdog/watchdog_test.go
+++ b/pkg/obs/watchdog/watchdog_test.go
@@ -1,4 +1,4 @@
-package obs
+package watchdog
 
 import (
 	"context"


### PR DESCRIPTION
Patch release. Hotfix for v2.17.0's import-chain regression that took prod vlc-server down for 13 minutes during the rollout.

## What's in it

- [tripbot#716](https://github.com/adanalife/tripbot/pull/716/changes) — **obs: move silent-disconnect watchdog out of `pkg/obs` into `pkg/obs/watchdog`.** The watchdog file imported `pkg/config/tripbot` + `pkg/twitch` at the package level; `pkg/twitch` transitively imports `pkg/database`, whose `init()` `log.Fatalf`s on missing `DATABASE_USER`/`DB`/`HOST`. Because all files in a Go package compile together, anything importing `pkg/obs` inherited the chain. cmd/vlc-server has imported `pkg/obs` for ages for one call (`obs.PollStreamingActive`), so v2.17.0's vlc-server refused to boot without 9 placeholder env vars stamped into its ConfigMap. Moving the watchdog into its own subpackage leaves `pkg/obs` with only `control.go` + `streaming.go` — `go list -deps ./cmd/vlc-server` now shows zero `pkg/config/tripbot`, `pkg/database`, `pkg/twitch`, or `pkg/oauthtokens` references.
- [tripbot#717](https://github.com/adanalife/tripbot/pull/717/changes) — **release-development: broaden the vlc paths-filter to `pkg/**`.** The narrow vlc filter only matched `pkg/{vlc,onscreens}-{server,client}/` paths, so any change to a shared package — including #716's `pkg/obs` detangle — silently skipped the vlc rebuild. Without this fix, the v2.17.1 `:develop` vlc image would have stayed on the pre-detangle code.

## Verified on stage

Rolled stage's vlc-server to the new `:develop` image (containing #716 via the #717 filter fix). Stage's ConfigMap has **none** of the placeholder env vars — pod boots `1/1 Running` with all three supervisord processes (`syslog`, `onscreens-server`, `vlc`) in `RUNNING state`, libvlc stats poller + RTSP watchdog + next-frame refresher up, OBS WebSocket connected, dashcam clips playing. No `required key missing` or `you must set DATABASE_USER` fatals. End-to-end proof that the detangle works without the workaround env vars.

## After this merges

1. `auto-tag.yml` → tag `v2.17.1` (default patch bump — no `#minor`/`#major` in this commit)
2. `release.yml` builds + publishes `adanalife/{tripbot,vlc,obs}:v2.17.1` multi-arch
3. Bump prod vlc-server: `kubectl rollout restart deploy/vlc-server -n prod-1` (prod uses `:latest` + `imagePullPolicy: Always`, so the restart re-pulls — note the RollingUpdate strategy needs [adanalife/infra#618](https://github.com/adanalife/infra/pull/618/changes) merged + applied first, or this restart will stick Pending on the GPU constraint)
4. Mark [adanalife/infra#620](https://github.com/adanalife/infra/pull/620/changes) ready, merge, `task k8s:{prod,stage,dev}:apply` — the 7 placeholder env vars drop everywhere

## Test plan

- [x] `task test:macos` green (all packages, including the moved `pkg/obs/watchdog`)
- [x] `go list -deps ./cmd/vlc-server` + `./cmd/onscreens-server` audit — no tripbot-only packages
- [x] Stage rollout: vlc-server on new `:develop` image boots without any placeholder env vars
- [ ] After merge: `auto-tag.yml` creates `v2.17.1` and `release.yml` ships images
- [ ] Bump prod vlc-server, observe healthy rollout
- [ ] Apply [adanalife/infra#620](https://github.com/adanalife/infra/pull/620/changes), confirm prod stays healthy without placeholders