### PR TITLE
fix(server): disable WriteTimeout so the SSE live console streams

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -20,15 +20,15 @@ func eventsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	rc := http.NewResponseController(w)
 
-	// Ordinary handlers run under the server's 15s WriteTimeout; an SSE stream
-	// is long-lived, so clear the write deadline for this connection. This
-	// reaches the underlying writer through the negroni + otelhttp wrappers
-	// because each implements Unwrap() (do NOT type-assert http.Flusher —
-	// negroni's writer fails that assertion). Best-effort: if a wrapper doesn't
-	// support deadlines the connection still works, it just gets recycled at the
-	// 15s WriteTimeout — and the browser's EventSource auto-reconnects.
+	// Best-effort clear of any per-connection write deadline. The server runs
+	// with WriteTimeout=0 (see server.go) precisely because this doesn't work
+	// through the negroni + otelhttp HTTP/2 wrapper chain ("feature not
+	// supported") — so a failure here is expected and harmless, logged at debug
+	// only. On a stack that does support it, this self-heals if WriteTimeout is
+	// ever reinstated. (Do NOT type-assert http.Flusher — negroni's writer fails
+	// that assertion; use ResponseController.)
 	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		slog.WarnContext(ctx, "sse: could not clear write deadline; stream will recycle at WriteTimeout", "err", err)
+		slog.DebugContext(ctx, "sse: write deadline not clearable on this stack (WriteTimeout=0 covers it)", "err", err)
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -119,12 +119,20 @@ func Start(ctx context.Context) {
 
 	srv := &http.Server{
 		Addr: fmt.Sprintf("0.0.0.0:%s", c.Conf.TripbotServerPort),
-		// Good practice to set timeouts to avoid Slowloris attacks.
-		WriteTimeout:   time.Second * 15,
-		ReadTimeout:    time.Second * 15,
-		IdleTimeout:    time.Second * 60,
-		MaxHeaderBytes: 1 << 20, // 1 MB
-		Handler:        otelhttp.NewHandler(app, c.Conf.ServerType),
+		// WriteTimeout is 0 (disabled) because the admin panel's live console
+		// streams Server-Sent Events on /admin/events — a long-lived response a
+		// fixed write deadline would sever. The Go-idiomatic per-request
+		// http.ResponseController.SetWriteDeadline doesn't reach the underlying
+		// writer through the negroni + otelhttp (httpsnoop) HTTP/2 wrapper chain
+		// ("feature not supported"), so disabling it server-wide is the reliable
+		// fix. Slowloris protection is preserved by ReadHeaderTimeout (the header
+		// read is the attack vector WriteTimeout never really guarded anyway).
+		ReadTimeout:       time.Second * 15,
+		ReadHeaderTimeout: time.Second * 15,
+		WriteTimeout:      0,
+		IdleTimeout:       time.Second * 60,
+		MaxHeaderBytes:    1 << 20, // 1 MB
+		Handler:           otelhttp.NewHandler(app, c.Conf.ServerType),
 	}
 
 	// Run ListenAndServe in a goroutine so we can block on ctx.Done() and


### PR DESCRIPTION
## Problem

The admin panel's chat console went live-silent — messages only appeared on page reload (recent-history render worked; live SSE did not).

## Root cause

The server's `WriteTimeout: 15s` severs the long-lived `/admin/events` SSE response. The handler tries to clear the per-connection deadline with `http.ResponseController.SetWriteDeadline`, but on the negroni + otelhttp (httpsnoop) **HTTP/2** wrapper chain that returns `"feature not supported"` — the `Unwrap` chain never reaches a writer implementing it. So the stream recycled every ~15–20s, the 20s heartbeat (past the deadline) never fired, and any message outside a connection's first 15s was dropped.

## Fix

- `WriteTimeout: 0` (SSE needs a long-lived response) + `ReadHeaderTimeout: 15s` (the actual slowloris guard).
- Demote the deadline-clear failure to debug — `WriteTimeout=0` is now the reliable mechanism; the call stays as best-effort self-heal if the timeout is ever reinstated on a supporting stack.

## Verification

Controlled test on stage with a known NATS publish, capturing the SSE stream both **directly from the pod** (port-forward) and **through the tailnet ingress**: the event arrived **live and instantly on both**, proving the server flushes correctly and there's **no proxy buffering** — the timeout was the sole cause. `gofmt` + `go test ./pkg/server/...` green.