### PR TITLE
feat: bot output + per-user colors in the live chat console

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -10,6 +10,7 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/feature"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
@@ -132,6 +133,11 @@ func Initialize() *twitch.Client {
 func Say(msg string) {
 	// include the message in the log
 	mylog.ChatMsg(c.Conf.BotUsername, msg)
+	// mirror the bot's own output onto the event bus so it shows in the admin
+	// live console — Twitch doesn't echo our sent messages back via
+	// PrivateMessage, so without this the console would miss everything the bot
+	// says. Fire-and-forget; no-op when NATS is unconfigured.
+	eventbus.EmitChatMessage(context.Background(), c.Conf.Environment, c.Conf.BotUsername, msg)
 	// figure out what channel to speak to
 	speakTo := c.Conf.ChannelName
 	if c.Conf.OutputChannel != "" {

--- a/pkg/chatbot/say_test.go
+++ b/pkg/chatbot/say_test.go
@@ -1,0 +1,45 @@
+package chatbot
+
+import (
+	"encoding/json"
+	"testing"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/eventbus"
+)
+
+// TestSay_PublishesBotOutputToEventbus asserts the bot's own chat output is
+// mirrored onto the event bus (so it shows in the admin live console — Twitch
+// doesn't echo our sent messages back via PrivateMessage). recordingNATS
+// (nats_test.go) satisfies eventbus.Publisher too, so we reuse it.
+func TestSay_PublishesBotOutputToEventbus(t *testing.T) {
+	rec := &recordingNATS{}
+	saved := eventbus.Default
+	eventbus.SetPublisher(rec)
+	t.Cleanup(func() { eventbus.Default = saved })
+
+	// client is nil in tests, so client.Say panics — but the eventbus emit
+	// happens first. Catch the panic and assert the publish landed.
+	func() {
+		defer func() { _ = recover() }()
+		Say("hello chat")
+	}()
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	p := rec.Publishes[0]
+	if want := "tripbot." + c.Conf.Environment + ".chat.message"; p.Subject != want {
+		t.Errorf("subject = %q, want %q", p.Subject, want)
+	}
+	var ev eventbus.ChatMessage
+	if err := json.Unmarshal(p.Payload, &ev); err != nil {
+		t.Fatalf("bad payload: %v", err)
+	}
+	if ev.Username != c.Conf.BotUsername {
+		t.Errorf("username = %q, want bot %q", ev.Username, c.Conf.BotUsername)
+	}
+	if ev.Text != "hello chat" {
+		t.Errorf("text = %q, want hello chat", ev.Text)
+	}
+}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -905,13 +905,25 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     const d = new Date(iso);
     if (!isNaN(d.getTime())) t.textContent = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   });
+  // Give each username a stable color derived from a hash of the name, so the
+  // same chatter is always the same hue. L/S tuned to stay legible on both the
+  // dark and light panel themes.
+  const colorFor = (name) => {
+    let h = 0;
+    for (let i = 0; i < name.length; i++) h = (Math.imul(h, 31) + name.charCodeAt(i)) >>> 0;
+    return 'hsl(' + (h % 360) + ' 65% 60%)';
+  };
+  const colorize = (root) => root.querySelectorAll('.chat-line .cu').forEach(el => {
+    if (!el.dataset.colored) { el.style.color = colorFor(el.textContent); el.dataset.colored = '1'; }
+  });
+  const decorate = (root) => { localize(root); colorize(root); };
   log.addEventListener('htmx:afterSwap', () => {
     log.querySelectorAll('.chat-empty').forEach(el => el.remove());
     while (log.childElementCount > 200) log.removeChild(log.firstElementChild);
-    localize(log);
+    decorate(log);
     pin();
   });
-  localize(log); // localize the server-rendered history
+  decorate(log); // localize times + color usernames in the server-rendered history
   pin(); // pin on initial load (history rendered server-side)
 })();
 


### PR DESCRIPTION
Two follow-ups to the live chat console (#719), both requested while testing on stage.

## Bot output in the feed
Twitch doesn't echo the bot's own sent messages back over IRC, so the console was missing everything **tripbot** says. `chatbot.Say()` now emits the bot's line to the event bus (alongside the existing Loki log), so bot output shows live like any other chatter. Fire-and-forget; no-op without NATS. Test added (reuses the `recordingNATS` fake, which satisfies `eventbus.Publisher`).

## Per-user colors
Each username gets a **stable color** derived from a hash of the name — same chatter, same hue every time. Applied client-side to both the server-rendered history and live-swapped lines (a `dataset` guard avoids recompute). Saturation/lightness tuned to stay legible on both the dark and light panel themes. The bot and broadcaster get their own consistent colors too.

`go test ./pkg/chatbot/... ./pkg/server/...` green.