### PR TITLE
fix: bot command responses missing from the live console

### DIFF
--- a/pkg/chatbot/irc.go
+++ b/pkg/chatbot/irc.go
@@ -1,13 +1,5 @@
 package chatbot
 
-import (
-	"fmt"
-	"log/slog"
-
-	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
-	c "github.com/adanalife/tripbot/pkg/config/tripbot"
-)
-
 // IRC is the subset of the IRC client surface chatbot commands depend on
 // to send chat output. Tests inject a fake; production uses the package-backed
 // realIRC adapter wired in defaultApp. Mirrors the Onscreens/VLC pattern.
@@ -16,27 +8,13 @@ type IRC interface {
 	Whisper(username, msg string) // whisper to a specific user
 }
 
-// realIRC delegates to the package-level twitch IRC client.
-// Mirrors the existing Say()/Whisper() free functions in chatbot.go.
+// realIRC delegates to the package-level Say/Whisper so ALL bot chat output
+// flows through one path: the Loki log line, the event-bus mirror (so the admin
+// live console shows the bot's own output — Twitch doesn't echo it back), and
+// the actual client.Say. This adapter previously duplicated Say()'s body and so
+// skipped the event-bus emit, leaving command responses (which go through
+// a.IRC.Say) out of the live console.
 type realIRC struct{}
 
-func (realIRC) Say(msg string) {
-	// include the message in the log
-	mylog.ChatMsg(c.Conf.BotUsername, msg)
-	// figure out what channel to speak to
-	speakTo := c.Conf.ChannelName
-	if c.Conf.OutputChannel != "" {
-		speakTo = c.Conf.OutputChannel
-	}
-	// say the message to chat
-	client.Say(speakTo, msg)
-}
-
-func (realIRC) Whisper(username, msg string) {
-	//TODO: include whispers in log
-	slog.Info("sending whisper", "to", username, "text", msg)
-	// go-twitch-irc v4 removed the Whisper() send method; replicate the
-	// v2 behavior by sending the raw IRC /w command via PRIVMSG on the
-	// bot's own channel.
-	client.Say(c.Conf.BotUsername, fmt.Sprintf("/w %s %s", username, msg))
-}
+func (realIRC) Say(msg string)               { Say(msg) }
+func (realIRC) Whisper(username, msg string) { Whisper(username, msg) }


### PR DESCRIPTION
Follow-up to #722. Chatting with the bot showed no reply in the admin live console.

**Cause:** #722 added the event-bus mirror only to the package-level `Say()` (the `sayFn` path — follows/subs/social aliases). But most command responses go through `a.IRC.Say` → `realIRC.Say`, which **duplicated** `Say()`'s body and called `client.Say` directly, skipping the emit.

**Fix:** collapse `realIRC` to delegate to the package `Say`/`Whisper`, so all bot output flows through one path (Loki log + event-bus mirror + `client.Say`). Removes the duplicated body too. `go test ./pkg/chatbot/...` green.