### PR TITLE
feat(server): live-update the admin panel chatter count

### DIFF
--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -98,3 +98,26 @@ func EmitChatMessage(ctx context.Context, env, username, text string) {
 		EmittedAt: emittedAt(),
 	})
 }
+
+// --- viewers.count --------------------------------------------------------
+
+// ViewerCount is the wire format for tripbot.<env>.viewers.count — the
+// authoritative chatter total Twitch reports, published on each chatter-list
+// refresh so the admin panel's "in chat" number updates live.
+type ViewerCount struct {
+	Count     int    `json:"count"`
+	EmittedAt string `json:"emitted_at"`
+}
+
+// ViewerCountSubject returns the subscribe/publish subject for viewer-count
+// updates in env. The admin hub builds the same string to subscribe.
+func ViewerCountSubject(env string) string { return subject(env, "viewers", "count") }
+
+// EmitViewerCount publishes the current chatter total. The admin hub compares
+// it to the previous value to flash the count green (rising) or red (falling).
+func EmitViewerCount(ctx context.Context, env string, count int) {
+	emit(ctx, ViewerCountSubject(env), ViewerCount{
+		Count:     count,
+		EmittedAt: emittedAt(),
+	})
+}

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -80,6 +80,43 @@ func TestEmitChatMessage(t *testing.T) {
 	}
 }
 
+func TestViewerCountSubject(t *testing.T) {
+	for _, env := range []string{"prod", "stage", "development"} {
+		if got, want := ViewerCountSubject(env), "tripbot."+env+".viewers.count"; got != want {
+			t.Errorf("ViewerCountSubject(%q) = %q, want %q", env, got, want)
+		}
+	}
+}
+
+func TestEmitViewerCount(t *testing.T) {
+	rec := withRecorder(t)
+
+	fixed := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = func() time.Time { return time.Now().UTC() } })
+
+	EmitViewerCount(context.Background(), "development", 42)
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	pub := rec.Publishes[0]
+	if pub.Subject != "tripbot.development.viewers.count" {
+		t.Errorf("subject = %q, want tripbot.development.viewers.count", pub.Subject)
+	}
+
+	var ev ViewerCount
+	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Count != 42 {
+		t.Errorf("count = %d, want 42", ev.Count)
+	}
+	if ev.EmittedAt != fixed.Format(time.RFC3339Nano) {
+		t.Errorf("emitted_at = %q, want %q", ev.EmittedAt, fixed.Format(time.RFC3339Nano))
+	}
+}
+
 // TestEmit_NoNATS_NoPanic asserts the production publisher is a silent no-op
 // when NATS is unconfigured (natsclient.Conn() is nil), so local dev / tests
 // that never call natsclient.Connect don't crash.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -708,16 +708,29 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   .chat-line .cu { color:#58a6ff; font-weight:600; }
   .chat-line .ct { color:var(--fg); }
   .chat-empty { color:var(--dim); font-style:italic; padding:6px 0; }
+  /* live viewer count — a subtle, quick colour flash on the number: green when
+     it rises, red when it falls. The inner .chatters-count span is re-inserted
+     on each SSE update so the animation re-triggers; with only a "from" keyframe
+     it animates back to the number's natural colour. Steady state is unstyled. */
+  @keyframes flash-up   { from { color:#3fb950; } }
+  @keyframes flash-down { from { color:#f85149; } }
+  .chatters-count.flash-up   { animation:flash-up .8s ease-out; }
+  .chatters-count.flash-down { animation:flash-down .8s ease-out; }
 </style>
 </head>
 <body>
-<main>
+<!-- hx-ext="sse" + sse-connect open ONE EventSource on /admin/events for the
+     whole panel; every live region below (chat, viewer count, …) is an
+     sse-swap target nested under it. -->
+<main hx-ext="sse" sse-connect="/admin/events">
   <!-- A Dana Life mark, referenced from the website (the single owner of brand
        assets) rather than copied in — see vault general/logo.md. The anchor
        wraps the mark so clicking it refreshes the page. -->
   <a class="logo-link" href="/" title="refresh"><img class="logo" src="https://www.dana.lol/assets/logo.png" alt="A Dana Life" width="44" height="44"></a>
   <h1>tripbot <code class="env {{envColorClass .Env}}">{{.Env}}</code></h1>
-  <p class="meta">up {{.Uptime}} · {{.Chatters}} in chat</p>
+  <!-- #chatters is the stable sse-swap target; the inner .chatters-count span is
+       replaced (innerHTML) on each "viewers" event so its flash animation re-fires. -->
+  <p class="meta">up {{.Uptime}} · <span id="chatters" sse-swap="viewers" hx-swap="innerHTML"><span class="chatters-count">{{.Chatters}}</span></span> in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
 
   {{if .Reauth}}
@@ -748,13 +761,11 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
 
   <details class="chat" open>
     <summary>chat</summary>
-    <!-- sse-connect opens /admin/events; #chat-log receives the "chat" event
-         and appends each rendered line. Recent history is rendered server-side
-         from the hub's ring buffer below; live lines stream in on top. -->
-    <div hx-ext="sse" sse-connect="/admin/events">
-      <div id="chat-log" class="chat-log" sse-swap="chat" hx-swap="beforeend scroll:bottom">
-        {{range .ChatHistory}}<div class="chat-line"><time class="ct-ts" datetime="{{.At.Format "2006-01-02T15:04:05Z07:00"}}">{{.At.Format "15:04"}}</time> <span class="cu">{{.Username}}</span> <span class="ct">{{.Text}}</span></div>{{else}}<div class="chat-empty">waiting for chat…</div>{{end}}
-      </div>
+    <!-- #chat-log receives the "chat" SSE event (the panel-wide sse-connect lives
+         on <main>) and appends each rendered line. Recent history is rendered
+         server-side from the hub's ring buffer; live lines stream in on top. -->
+    <div id="chat-log" class="chat-log" sse-swap="chat" hx-swap="beforeend scroll:bottom">
+      {{range .ChatHistory}}<div class="chat-line"><time class="ct-ts" datetime="{{.At.Format "2006-01-02T15:04:05Z07:00"}}">{{.At.Format "15:04"}}</time> <span class="cu">{{.Username}}</span> <span class="ct">{{.Text}}</span></div>{{else}}<div class="chat-empty">waiting for chat…</div>{{end}}
     </div>
   </details>
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -343,7 +343,8 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`<a href="https://github.com/adanalife/tripbot/blob/feedfacecafe/CHANGELOG.md">v8.8.8-osc</a>`, // onscreens version → changelog@sha
 		">vlc-server<",       // vlc row label
 		">onscreens-server<", // onscreens row label
-		"12 in chat",         // chatter count
+		`<span class="chatters-count">12</span>`,            // initial chatter count (server-rendered, unflashed)
+		`id="chatters" sse-swap="viewers" hx-swap="innerHTML"`, // live count target wired for SSE updates
 		`<code class="env env-prod">production</code>`,     // env in monospace chip, prod-coloured
 		`<title>tripbot — adanalife_ (production)</title>`, // env rendered in <title> for tab disambiguation
 		"now playing",                        // now-playing section shown when vlc healthy

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -52,6 +52,12 @@ type Hub struct {
 	mu   sync.RWMutex
 	chat []ChatLine
 	subs map[chan sseEvent]struct{}
+
+	// viewers is the last chatter total seen; viewersKnown gates the very first
+	// value so it sets the baseline without flashing (we can't know a direction
+	// with nothing to compare against).
+	viewers      int
+	viewersKnown bool
 }
 
 // NewHub returns an unstarted hub. Safe to construct at package-init time — it
@@ -70,19 +76,34 @@ func (h *Hub) Start(ctx context.Context) {
 		return
 	}
 
-	subj := eventbus.ChatMessageSubject(c.Conf.Environment)
-	sub, err := conn.Subscribe(subj, func(m *nats.Msg) {
-		h.handleChat(ctx, m.Data)
-	})
-	if err != nil {
-		slog.ErrorContext(ctx, "live-console hub subscribe failed", "err", err, "subject", subj)
-		return
+	env := c.Conf.Environment
+	subscriptions := []struct {
+		subject string
+		handler func(context.Context, []byte)
+	}{
+		{eventbus.ChatMessageSubject(env), h.handleChat},
+		{eventbus.ViewerCountSubject(env), h.handleViewerCount},
 	}
-	slog.InfoContext(ctx, "live-console hub subscribed", "subject", subj)
+
+	var subs []*nats.Subscription
+	for _, s := range subscriptions {
+		handler := s.handler // capture per-iteration for the closure
+		sub, err := conn.Subscribe(s.subject, func(m *nats.Msg) {
+			handler(ctx, m.Data)
+		})
+		if err != nil {
+			slog.ErrorContext(ctx, "live-console hub subscribe failed", "err", err, "subject", s.subject)
+			continue
+		}
+		slog.InfoContext(ctx, "live-console hub subscribed", "subject", s.subject)
+		subs = append(subs, sub)
+	}
 
 	go func() {
 		<-ctx.Done()
-		_ = sub.Unsubscribe()
+		for _, sub := range subs {
+			_ = sub.Unsubscribe()
+		}
 		h.closeAll()
 	}()
 }
@@ -96,6 +117,38 @@ func (h *Hub) handleChat(ctx context.Context, data []byte) {
 	line := ChatLine{Username: ev.Username, Text: ev.Text, At: parseEmitted(ev.EmittedAt)}
 	h.appendChat(line)
 	h.broadcast(sseEvent{Name: "chat", Data: renderChatLine(line)})
+}
+
+// handleViewerCount updates the live "in chat" number. It compares the new
+// total to the last one seen so the panel can flash the count green (rising)
+// or red (falling); the first value seen just sets the baseline (no flash).
+func (h *Hub) handleViewerCount(ctx context.Context, data []byte) {
+	var ev eventbus.ViewerCount
+	if err := json.Unmarshal(data, &ev); err != nil {
+		slog.ErrorContext(ctx, "live-console hub: bad viewer-count payload", "err", err)
+		return
+	}
+	dir := h.updateViewers(ev.Count)
+	h.broadcast(sseEvent{Name: "viewers", Data: renderViewerCount(ev.Count, dir)})
+}
+
+// updateViewers records the new count and returns the flash direction relative
+// to the previous value: "up", "down", or "" (unchanged, or the first value).
+func (h *Hub) updateViewers(count int) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	dir := ""
+	if h.viewersKnown {
+		switch {
+		case count > h.viewers:
+			dir = "up"
+		case count < h.viewers:
+			dir = "down"
+		}
+	}
+	h.viewers = count
+	h.viewersKnown = true
+	return dir
 }
 
 // parseEmitted turns an event's emitted_at (RFC3339Nano UTC) into a time,
@@ -187,6 +240,25 @@ func renderChatLine(line ChatLine) string {
 	var sb strings.Builder
 	if err := chatLineTmpl.Execute(&sb, line); err != nil {
 		slog.Error("live-console hub: render chat line", "err", err)
+		return ""
+	}
+	return sb.String()
+}
+
+// viewerCountTmpl renders the inner chatter-count span. It's swapped into the
+// stable #chatters container (innerHTML), so a fresh element is inserted each
+// update — the flash-up/flash-down CSS animation re-triggers naturally on
+// insert, and the steady state (no flash class) has no animation.
+var viewerCountTmpl = template.Must(template.New("viewers").Parse(
+	`<span class="chatters-count{{if .Flash}} flash-{{.Flash}}{{end}}">{{.Count}}</span>`))
+
+func renderViewerCount(count int, dir string) string {
+	var sb strings.Builder
+	if err := viewerCountTmpl.Execute(&sb, struct {
+		Count int
+		Flash string
+	}{Count: count, Flash: dir}); err != nil {
+		slog.Error("live-console hub: render viewer count", "err", err)
 		return ""
 	}
 	return sb.String()

--- a/pkg/server/hub_test.go
+++ b/pkg/server/hub_test.go
@@ -110,6 +110,71 @@ func TestHub_handleChat_badPayloadNoCrash(t *testing.T) {
 	}
 }
 
+// TestHub_updateViewers_flashDirection walks the count through first-value,
+// rise, fall, and no-change to assert the flash direction the panel renders.
+func TestHub_updateViewers_flashDirection(t *testing.T) {
+	h := NewHub()
+	// First value sets the baseline — no flash (nothing to compare against).
+	if dir := h.updateViewers(10); dir != "" {
+		t.Errorf("first value: dir = %q, want \"\" (baseline, no flash)", dir)
+	}
+	if dir := h.updateViewers(12); dir != "up" {
+		t.Errorf("rise: dir = %q, want up", dir)
+	}
+	if dir := h.updateViewers(11); dir != "down" {
+		t.Errorf("fall: dir = %q, want down", dir)
+	}
+	if dir := h.updateViewers(11); dir != "" {
+		t.Errorf("unchanged: dir = %q, want \"\" (no flash)", dir)
+	}
+}
+
+func TestHub_handleViewerCount_broadcastsRenderedCount(t *testing.T) {
+	h := NewHub()
+	client := h.register()
+
+	payload, _ := json.Marshal(eventbus.ViewerCount{Count: 7, EmittedAt: "2026-05-29T13:05:00Z"})
+	h.handleViewerCount(context.Background(), payload)
+
+	ev := <-client
+	if ev.Name != "viewers" {
+		t.Errorf("event name = %q, want viewers", ev.Name)
+	}
+	// First value: no flash class, count present.
+	if !strings.Contains(ev.Data, `class="chatters-count"`) || !strings.Contains(ev.Data, ">7<") {
+		t.Errorf("fragment %q missing unflashed count 7", ev.Data)
+	}
+
+	// A rise should carry the flash-up class.
+	payload, _ = json.Marshal(eventbus.ViewerCount{Count: 9, EmittedAt: "2026-05-29T13:06:00Z"})
+	h.handleViewerCount(context.Background(), payload)
+	ev = <-client
+	if !strings.Contains(ev.Data, "flash-up") || !strings.Contains(ev.Data, ">9<") {
+		t.Errorf("fragment %q missing flash-up / count 9", ev.Data)
+	}
+}
+
+func TestHub_handleViewerCount_badPayloadNoCrash(t *testing.T) {
+	h := NewHub()
+	h.handleViewerCount(context.Background(), []byte("not json"))
+	// A bad payload must not flip viewersKnown or set a count.
+	if h.viewersKnown {
+		t.Errorf("bad payload should not establish a baseline")
+	}
+}
+
+func TestRenderViewerCount(t *testing.T) {
+	if got := renderViewerCount(5, ""); got != `<span class="chatters-count">5</span>` {
+		t.Errorf("unflashed = %q", got)
+	}
+	if got := renderViewerCount(5, "up"); !strings.Contains(got, "chatters-count flash-up") {
+		t.Errorf("up = %q, want flash-up class", got)
+	}
+	if got := renderViewerCount(5, "down"); !strings.Contains(got, "chatters-count flash-down") {
+		t.Errorf("down = %q, want flash-down class", got)
+	}
+}
+
 func TestRenderChatLine_escapesHTML(t *testing.T) {
 	got := renderChatLine(ChatLine{Username: "evil", Text: "<script>alert(1)</script>"})
 	if strings.Contains(got, "<script>") {

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -9,6 +9,7 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/events"
+	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
@@ -30,6 +31,10 @@ func UpdateSession(ctx context.Context) {
 	// fetch the latest chatters from Twitch
 	twitch.UpdateChatters()
 	currentChatters := twitch.Chatters()
+
+	// Publish the authoritative chatter total so the admin panel's live console
+	// updates the "in chat" number (and flashes it on a change) without a reload.
+	eventbus.EmitViewerCount(ctx, c.Conf.Environment, twitch.ChatterCount())
 
 	// log out the people who aren't present
 	for username, user := range LoggedIn {


### PR DESCRIPTION
Second live-update slice for the admin panel, following the chat console (#719). The **"N in chat"** number now updates without a reload and flashes briefly when it changes — **green when it rises, red when it falls**.

## How it works
- **`pkg/eventbus`** — new `tripbot.<env>.viewers.count` observation event + `EmitViewerCount`, same fire-and-forget shape as `chat.message`.
- **`pkg/users/session.go`** — publishes the **authoritative Helix chatter total** on each `UpdateChatters` tick (~61s — the same number the panel already shows). Chosen over counting raw IRC JOIN/PART, which Twitch batches unreliably; this keeps the live value pinned to the source of truth.
- **`pkg/server/hub.go`** — subscribes to multiple subjects now; remembers the prior count and tags each update up/down/unchanged. The first value seen sets the baseline with **no flash**.
- **`pkg/server/admin.go`** — hoisted the SSE connection up to `<main>` so chat, the viewer count, and future live cards all share **one EventSource**. The count lives in a stable `#chatters` swap target; the inner span is replaced (innerHTML) on each update so the flash animation re-fires.

## The flash
Subtle and quick by design — a colour-only change on the number (`from { color:#3fb950 }` green / `#f85149` red, 0.8s ease-out back to its natural colour). No background pulse.

## Tests
- `pkg/eventbus` — subject + envelope for `EmitViewerCount`.
- `pkg/server/hub` — direction logic (baseline/up/down/unchanged), rendered fragment carries the right flash class, bad-payload safety.
- `pkg/server/admin_test.go` — updated to assert the wired `#chatters` target + server-rendered initial count.

Verifies the same publish→NATS→hub→SSE→htmx path as the chat slice, extended to an OOB-style count swap. Flash feel to be confirmed live on stage.