### PR TITLE
feat(server): live-update the now-playing card on video change

### DIFF
--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -121,3 +121,31 @@ func EmitViewerCount(ctx context.Context, env string, count int) {
 		EmittedAt: emittedAt(),
 	})
 }
+
+// --- video.changed --------------------------------------------------------
+
+// VideoChanged is the wire format for tripbot.<env>.video.changed — published
+// when VLC switches to a new clip. State is the full state name (e.g.
+// "Wyoming"); Flagged marks a no-GPS clip. The admin panel's "now playing"
+// card updates from this without a reload.
+type VideoChanged struct {
+	File      string `json:"file"`
+	State     string `json:"state"`
+	Flagged   bool   `json:"flagged"`
+	EmittedAt string `json:"emitted_at"`
+}
+
+// VideoChangedSubject returns the subscribe/publish subject for video-change
+// events in env.
+func VideoChangedSubject(env string) string { return subject(env, "video", "changed") }
+
+// EmitVideoChanged publishes a video switch. The emitted_at doubles as the
+// clip's start time, so the panel can tick an elapsed timer from it.
+func EmitVideoChanged(ctx context.Context, env, file, state string, flagged bool) {
+	emit(ctx, VideoChangedSubject(env), VideoChanged{
+		File:      file,
+		State:     state,
+		Flagged:   flagged,
+		EmittedAt: emittedAt(),
+	})
+}

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -117,6 +117,43 @@ func TestEmitViewerCount(t *testing.T) {
 	}
 }
 
+func TestVideoChangedSubject(t *testing.T) {
+	for _, env := range []string{"prod", "stage", "development"} {
+		if got, want := VideoChangedSubject(env), "tripbot."+env+".video.changed"; got != want {
+			t.Errorf("VideoChangedSubject(%q) = %q, want %q", env, got, want)
+		}
+	}
+}
+
+func TestEmitVideoChanged(t *testing.T) {
+	rec := withRecorder(t)
+
+	fixed := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = func() time.Time { return time.Now().UTC() } })
+
+	EmitVideoChanged(context.Background(), "development", "wy_0042.MP4", "Wyoming", true)
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	pub := rec.Publishes[0]
+	if pub.Subject != "tripbot.development.video.changed" {
+		t.Errorf("subject = %q, want tripbot.development.video.changed", pub.Subject)
+	}
+
+	var ev VideoChanged
+	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.File != "wy_0042.MP4" || ev.State != "Wyoming" || !ev.Flagged {
+		t.Errorf("envelope = %+v, want file=wy_0042.MP4 state=Wyoming flagged=true", ev)
+	}
+	if ev.EmittedAt != fixed.Format(time.RFC3339Nano) {
+		t.Errorf("emitted_at = %q, want %q", ev.EmittedAt, fixed.Format(time.RFC3339Nano))
+	}
+}
+
 // TestEmit_NoNATS_NoPanic asserts the production publisher is a silent no-op
 // when NATS is unconfigured (natsclient.Conn() is nil), so local dev / tests
 // that never call natsclient.Connect don't crash.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -98,10 +98,14 @@ type versionInfo struct {
 }
 
 // nowPlaying is the current-video summary shown when vlc-server is healthy.
+// SinceUnix is the clip's start time as a Unix timestamp; the page's JS ticker
+// counts the elapsed display up from it (and resets it on each live video swap)
+// so progress keeps moving without a reload.
 type nowPlaying struct {
-	File     string
-	State    string
-	Progress string
+	File      string
+	State     string
+	Progress  string
+	SinceUnix int64
 }
 
 // streamControl drives the OBS stream toggle widget. Reachable=false hides
@@ -380,10 +384,12 @@ func currentVideo(vlcOK bool) *nowPlaying {
 	if v.Slug == "" {
 		return nil
 	}
+	progress := currentProgress()
 	return &nowPlaying{
-		File:     v.File(),
-		State:    v.State,
-		Progress: currentProgress().Round(time.Second).String(),
+		File:      v.File(),
+		State:     v.State,
+		Progress:  progress.Round(time.Second).String(),
+		SinceUnix: time.Now().Add(-progress).Unix(),
 	}
 }
 
@@ -798,12 +804,11 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   {{if or .Now .Audio.Title}}
   <details class="now-playing">
     <summary>now playing</summary>
+    <!-- #now-line is the sse-swap target for "video" events; its inner markup
+         mirrors hub.go's videoLineTmpl so a live swap matches a fresh render.
+         The .now-elapsed span is counted up by the page's JS ticker. -->
     {{with .Now}}
-    <p class="now">
-      <span class="file">{{.File}}</span>
-      {{if .State}}<span class="state">· {{.State}}</span>{{end}}
-      {{if .Progress}}<span class="state">· {{.Progress}}</span>{{end}}
-    </p>
+    <p class="now" id="now-line" sse-swap="video" hx-swap="innerHTML"><span class="file">{{.File}}</span>{{if .State}} <span class="state">· {{.State}}</span>{{end}} <span class="state">· <span class="now-elapsed" data-since="{{.SinceUnix}}">{{.Progress}}</span></span></p>
     {{end}}
     {{if .Audio.Title}}
     <p class="audio">
@@ -936,6 +941,27 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   });
   decorate(log); // localize times + color usernames in the server-rendered history
   pin(); // pin on initial load (history rendered server-side)
+})();
+
+// "Now playing" elapsed timer. Each .now-elapsed span carries data-since (the
+// clip's start as a Unix timestamp); tick it up once a second so the progress
+// keeps moving without a reload. A live "video" swap replaces the span with a
+// fresh data-since, so the count resets to the new clip automatically.
+(function() {
+  const fmt = (s) => {
+    s = Math.max(0, Math.floor(s));
+    const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+    return (h ? h + 'h' : '') + (h || m ? m + 'm' : '') + sec + 's';
+  };
+  const tick = () => {
+    const now = Date.now() / 1000;
+    document.querySelectorAll('.now-elapsed[data-since]').forEach(el => {
+      const since = Number(el.dataset.since);
+      if (since) el.textContent = fmt(now - since);
+    });
+  };
+  tick();
+  setInterval(tick, 1000);
 })();
 
 // iOS Home Screen apps return to a stale cached page on reopen — even with

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -348,9 +348,11 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`<code class="env env-prod">production</code>`,     // env in monospace chip, prod-coloured
 		`<title>tripbot — adanalife_ (production)</title>`, // env rendered in <title> for tab disambiguation
 		"now playing",                        // now-playing section shown when vlc healthy
+		`id="now-line" sse-swap="video"`,     // now-playing line wired for live video swaps
 		"wy_0042.MP4",                        // current video file
 		"Wyoming",                            // current video state
-		"3m12s",                              // clip progress
+		`class="now-elapsed" data-since=`,    // elapsed span the JS ticker counts up
+		"3m12s",                              // clip progress (initial server render)
 		`>obs</a>`,                           // one-word OBS link
 		`>grafana</a>`,                       // one-word grafana link
 		`>traefik</a>`,                       // one-word traefik link

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -83,6 +83,7 @@ func (h *Hub) Start(ctx context.Context) {
 	}{
 		{eventbus.ChatMessageSubject(env), h.handleChat},
 		{eventbus.ViewerCountSubject(env), h.handleViewerCount},
+		{eventbus.VideoChangedSubject(env), h.handleVideoChanged},
 	}
 
 	var subs []*nats.Subscription
@@ -149,6 +150,18 @@ func (h *Hub) updateViewers(count int) string {
 	h.viewers = count
 	h.viewersKnown = true
 	return dir
+}
+
+// handleVideoChanged forwards a video switch to the panel's "now playing"
+// card. There's no ring to keep — the page renders the current video on load
+// and this just refreshes it; the hub holds no video state.
+func (h *Hub) handleVideoChanged(ctx context.Context, data []byte) {
+	var ev eventbus.VideoChanged
+	if err := json.Unmarshal(data, &ev); err != nil {
+		slog.ErrorContext(ctx, "live-console hub: bad video payload", "err", err)
+		return
+	}
+	h.broadcast(sseEvent{Name: "video", Data: renderVideoLine(ev)})
 }
 
 // parseEmitted turns an event's emitted_at (RFC3339Nano UTC) into a time,
@@ -259,6 +272,32 @@ func renderViewerCount(count int, dir string) string {
 		Flash string
 	}{Count: count, Flash: dir}); err != nil {
 		slog.Error("live-console hub: render viewer count", "err", err)
+		return ""
+	}
+	return sb.String()
+}
+
+// videoLineTmpl renders the inner of the "now playing" line — file, state, and
+// an elapsed-time span the page's JS ticker counts up from data-since. Swapped
+// (innerHTML) into the stable #now-line target. The markup mirrors the
+// server-rendered version in admin.go's template (same duplication the chat
+// line uses) so a live swap looks identical to a fresh page render. A
+// just-switched clip starts at 0s; the ticker takes over within a second.
+var videoLineTmpl = template.Must(template.New("videoline").Parse(
+	`<span class="file">{{.File}}</span>{{if .State}} <span class="state">· {{.State}}</span>{{end}} <span class="state">· <span class="now-elapsed" data-since="{{.SinceUnix}}">{{.Progress}}</span></span>`))
+
+func renderVideoLine(ev eventbus.VideoChanged) string {
+	var sb strings.Builder
+	if err := videoLineTmpl.Execute(&sb, struct {
+		File, State, Progress string
+		SinceUnix             int64
+	}{
+		File:      ev.File,
+		State:     ev.State,
+		Progress:  "0s",
+		SinceUnix: parseEmitted(ev.EmittedAt).Unix(),
+	}); err != nil {
+		slog.Error("live-console hub: render video line", "err", err)
 		return ""
 	}
 	return sb.String()

--- a/pkg/server/hub_test.go
+++ b/pkg/server/hub_test.go
@@ -175,6 +175,44 @@ func TestRenderViewerCount(t *testing.T) {
 	}
 }
 
+func TestHub_handleVideoChanged_broadcastsNowLine(t *testing.T) {
+	h := NewHub()
+	client := h.register()
+
+	since := time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC)
+	payload, _ := json.Marshal(eventbus.VideoChanged{
+		File: "wy_0042.MP4", State: "Wyoming", Flagged: false,
+		EmittedAt: since.Format(time.RFC3339Nano),
+	})
+	h.handleVideoChanged(context.Background(), payload)
+
+	ev := <-client
+	if ev.Name != "video" {
+		t.Errorf("event name = %q, want video", ev.Name)
+	}
+	if !strings.Contains(ev.Data, "wy_0042.MP4") || !strings.Contains(ev.Data, "Wyoming") {
+		t.Errorf("fragment %q missing file/state", ev.Data)
+	}
+	// elapsed span carries the clip start (emitted_at) as data-since so the JS
+	// ticker counts up from the right moment.
+	if !strings.Contains(ev.Data, `class="now-elapsed"`) ||
+		!strings.Contains(ev.Data, `data-since="`+itoa(int(since.Unix()))+`"`) {
+		t.Errorf("fragment %q missing now-elapsed with data-since=%d", ev.Data, since.Unix())
+	}
+}
+
+func TestHub_handleVideoChanged_badPayloadNoCrash(t *testing.T) {
+	h := NewHub()
+	h.handleVideoChanged(context.Background(), []byte("not json"))
+}
+
+func TestRenderVideoLine_escapesHTML(t *testing.T) {
+	got := renderVideoLine(eventbus.VideoChanged{File: "<script>x</script>", State: "Wyoming"})
+	if strings.Contains(got, "<script>") {
+		t.Errorf("file not escaped: %q", got)
+	}
+}
+
 func TestRenderChatLine_escapesHTML(t *testing.T) {
 	got := renderChatLine(ChatLine{Username: "evil", Text: "<script>alert(1)</script>"})
 	if strings.Contains(got, "<script>") {

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
@@ -78,6 +79,12 @@ func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 			"file", p.CurrentlyPlaying.File(),
 			"state", helpers.StateToStateAbbrev(p.CurrentlyPlaying.State),
 		)
+
+		// Announce the switch so the admin panel's "now playing" card updates
+		// live (no-op when NATS is unconfigured). emitted_at doubles as the
+		// clip start time for the panel's elapsed ticker.
+		eventbus.EmitVideoChanged(ctx, c.Conf.Environment,
+			p.CurrentlyPlaying.File(), p.CurrentlyPlaying.State, p.CurrentlyPlaying.Flagged)
 
 		// show the no-GPS image
 		if p.CurrentlyPlaying.Flagged {


### PR DESCRIPTION
Third live-update slice for the admin panel. When VLC switches clips, the **"now playing"** card refreshes without a reload — file + state update, and a JS ticker counts the elapsed time up from the new clip's start.

> **Stacked on #725** (viewer count). Base is `feat/live-panel-viewers` so the diff here shows only this slice. Merge #725 first; this will retarget to `develop` (I'll rebase if needed).

## How it works
- **`pkg/eventbus`** — new `tripbot.<env>.video.changed` event + `EmitVideoChanged` (file, state, flagged). `emitted_at` doubles as the clip start time.
- **`pkg/video/video.go`** — emits from the change block, right after the "now playing" log, so the panel learns of a switch the moment the 60s playback poll detects it.
- **`pkg/server/hub.go`** — subscribes to `video.changed` and broadcasts a rendered now-line fragment. No ring kept — the page renders the current video on load; this just refreshes it.
- **`pkg/server/admin.go`** — `#now-line` is the sse-swap target; its inner markup mirrors the hub's `videoLineTmpl` so a live swap matches a fresh render. A `.now-elapsed` span carries the clip start as `data-since`, and a 1s JS ticker counts it up — resetting automatically on each video swap.

## Tests
- `pkg/eventbus` — subject + envelope for `EmitVideoChanged`.
- `pkg/server/hub` — broadcasts a now-line with file/state and `data-since` from `emitted_at`; bad-payload safety; HTML escaping.
- `pkg/server/admin_test.go` — asserts the `#now-line` wiring + `.now-elapsed` span alongside the existing now-playing checks.