### PR TITLE
feat(twitch,server): live token-expiry countdown on the admin panel

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -41,6 +41,9 @@ var (
 	// token; the admin panel renders a re-auth prompt for each. Overridable in
 	// tests. Reads in-memory token state — no DB or network call.
 	accountsNeedingReauth = mytwitch.AccountsNeedingReauth
+	// authStatuses reports every identity's live token state (expiry +
+	// reauth reason) for the panel's countdown card. Overridable in tests.
+	authStatuses = mytwitch.TokenStatuses
 	// obsStreamStatus reports whether OBS is currently streaming. Function-seam
 	// so handler tests can stub without opening a real OBS WebSocket. Default
 	// hits OBS via pkg/obs (fresh connection per call — see obs.GetStreamStatus).
@@ -149,8 +152,9 @@ type adminData struct {
 	PanelHost      string // host the panel was reached at; the Twitch embed needs it as parent=
 	Links          []navLink
 	Flags          []featureFlag            // feature flags + their state; empty hides the section
-	Reauth         []mytwitch.AccountReauth // accounts whose token needs re-auth; empty when healthy
-	ChatHistory    []ChatLine               // recent chat from the live-console hub; live lines stream in via SSE
+	Reauth         []mytwitch.AccountReauth      // accounts whose token needs re-auth; empty when healthy
+	AuthStatuses   []mytwitch.AccountTokenStatus // every identity's token state; drives the live expiry-countdown card
+	ChatHistory    []ChatLine                    // recent chat from the live-console hub; live lines stream in via SSE
 }
 
 // adminHandler serves the human-facing root page on the tripbot Ingress: a
@@ -178,6 +182,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Links:          gatherLinks(),
 		Flags:          gatherFlags(r.Context()),
 		Reauth:         accountsNeedingReauth(),
+		AuthStatuses:   authStatuses(),
 		ChatHistory:    eventHub.snapshotChat(),
 	}
 
@@ -560,6 +565,10 @@ func panelHost(r *http.Request) string {
 
 var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
 	"envColorClass": envColorClass,
+	// authCard / reauthCallout render the same fragments the hub pushes live,
+	// so the initial server render and a later SSE swap are byte-identical.
+	"authCard":      func(s []mytwitch.AccountTokenStatus) template.HTML { return template.HTML(renderAuthCard(s)) },
+	"reauthCallout": func(r []mytwitch.AccountReauth) template.HTML { return template.HTML(renderReauthCallout(r)) },
 }).Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -722,6 +731,17 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   @keyframes flash-down { from { color:#f85149; } }
   .chatters-count.flash-up   { animation:flash-up .8s ease-out; }
   .chatters-count.flash-down { animation:flash-down .8s ease-out; }
+  /* live auth/token card — compact muted line under the accounts line. Each
+     identity shows "expires in N" (JS-filled from data-expires); .auth-soon
+     reddens it under the threshold, .auth-expired once past, and .auth-warn
+     marks a missing/expired token whose row carries a re-auth link instead. */
+  .auth { color:var(--dim); margin:0 0 18px; font-size:.82em; }
+  .auth-row { margin-right:12px; white-space:nowrap; }
+  .auth-who { color:var(--muted); }
+  .auth-expires.auth-soon { color:#f0883e; font-weight:600; }
+  .auth-expires.auth-expired { color:#f85149; font-weight:600; }
+  .auth-row.auth-warn .auth-who { color:#f0883e; }
+  a.auth-reauth { color:#ffb454; font-weight:600; }
 </style>
 </head>
 <body>
@@ -738,16 +758,16 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
        replaced (innerHTML) on each "viewers" event so its flash animation re-fires. -->
   <p class="meta">up {{.Uptime}} · <span id="chatters" sse-swap="viewers" hx-swap="innerHTML"><span class="chatters-count">{{.Chatters}}</span></span> in chat</p>
   <p class="accounts">broadcaster <a href="https://twitch.tv/{{.Channel}}">{{.Channel}}</a> · bot <a href="https://twitch.tv/{{.Bot}}">{{.Bot}}</a></p>
+  <!-- live token-expiry card: per-identity "expires in N" countdown (the JS
+       ticker counts it down + reddens it near expiry), or a re-auth link when a
+       token is missing/expired. The hub's 30s poller OOB-swaps #auth-card;
+       authCard renders the same fragment here for the initial paint. -->
+  <p class="auth" id="auth-card" sse-swap="auth" hx-swap="innerHTML">{{authCard .AuthStatuses}}</p>
 
-  {{if .Reauth}}
-  <div class="reauth">
-    <h2>action needed: re-authenticate</h2>
-    <p>tripbot can't talk to Twitch until these accounts are re-authorized. Sign in as the named account on each — the flow re-prompts which account to use, so sign out of Twitch (or use a private window) if it grabs the wrong one.</p>
-    <div class="btns">
-      {{range .Reauth}}<a class="btn" href="{{.InitURL}}">Sign in as {{.LoginAs}} <span class="why">({{.Account}} · {{.Reason}})</span></a>{{end}}
-    </div>
-  </div>
-  {{end}}
+  <!-- #reauth-card fills (banner appears) or empties (banner disappears) live as
+       the hub's auth poller pushes "reauth" events; reauthCallout renders the
+       same markup for the initial paint. -->
+  <div id="reauth-card" sse-swap="reauth" hx-swap="innerHTML">{{reauthCallout .Reauth}}</div>
 
   <h2>status</h2>
   <ul>
@@ -958,6 +978,35 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     document.querySelectorAll('.now-elapsed[data-since]').forEach(el => {
       const since = Number(el.dataset.since);
       if (since) el.textContent = fmt(now - since);
+    });
+  };
+  tick();
+  setInterval(tick, 1000);
+})();
+
+// Auth token countdown. Each .auth-expires carries data-expires (Unix seconds);
+// show "expires in N" counting down, redden it under 15 min (.auth-soon) and
+// once past (.auth-expired). The hub re-pushes the card every 30s, but this
+// keeps the displayed remaining fresh between pushes.
+(function() {
+  const SOON = 15 * 60; // seconds — redden threshold
+  const fmt = (s) => {
+    if (s <= 0) return 'expired';
+    const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60);
+    if (h) return 'expires in ' + h + 'h ' + m + 'm';
+    if (m) return 'expires in ' + m + 'm';
+    return 'expires in <1m';
+  };
+  const tick = () => {
+    const now = Date.now() / 1000;
+    document.querySelectorAll('.auth-expires[data-expires]').forEach(el => {
+      const exp = Number(el.dataset.expires);
+      // A zero/sentinel expiry (year-1 epoch) means "unknown" — don't show it as expired.
+      if (!exp || exp < 1e9) { el.textContent = 'expires —'; el.classList.remove('auth-soon', 'auth-expired'); return; }
+      const rem = exp - now;
+      el.textContent = fmt(rem);
+      el.classList.toggle('auth-soon', rem > 0 && rem < SOON);
+      el.classList.toggle('auth-expired', rem <= 0);
     });
   };
   tick();

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -281,6 +281,9 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	defer SetTwitchConnected(false)
 	SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
+	withAuthStatuses(t, []mytwitch.AccountTokenStatus{
+		{Account: "bot", LoginAs: "tripbot4000", ExpiresAt: time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)},
+	})
 	withNowPlaying(t, nowPlayingTrack{Artist: "Test Artist", Title: "Test Track"})
 
 	// stand in for vlc-server: readiness ping + version endpoint
@@ -349,6 +352,9 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`<title>tripbot — adanalife_ (production)</title>`, // env rendered in <title> for tab disambiguation
 		"now playing",                        // now-playing section shown when vlc healthy
 		`id="now-line" sse-swap="video"`,     // now-playing line wired for live video swaps
+		`id="auth-card" sse-swap="auth"`,     // live token-expiry card wired for SSE
+		`class="auth-expires" data-expires="4070908800"`, // bot expiry (2099-01-01) for the JS countdown
+		`id="reauth-card" sse-swap="reauth"`, // reauth callout container wired for live appear/clear
 		"wy_0042.MP4",                        // current video file
 		"Wyoming",                            // current video state
 		`class="now-elapsed" data-since=`,    // elapsed span the JS ticker counts up
@@ -448,6 +454,16 @@ func withReauth(t *testing.T, accounts []mytwitch.AccountReauth) {
 	t.Cleanup(func() { accountsNeedingReauth = saved })
 }
 
+// withAuthStatuses swaps the authStatuses seam so the admin handler sees a
+// fixed per-identity token state (for the live expiry-countdown card) without
+// depending on global in-memory token state.
+func withAuthStatuses(t *testing.T, statuses []mytwitch.AccountTokenStatus) {
+	t.Helper()
+	saved := authStatuses
+	authStatuses = func() []mytwitch.AccountTokenStatus { return statuses }
+	t.Cleanup(func() { authStatuses = saved })
+}
+
 // withNowPlaying swaps the SomaFM fetcher so the admin handler sees a fixed
 // audio track (or empty for "no audio info") without hitting somafm.com from
 // a test.
@@ -501,6 +517,9 @@ func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
 	withReauth(t, nil) // all tokens healthy
+	withAuthStatuses(t, []mytwitch.AccountTokenStatus{
+		{Account: "bot", LoginAs: "tripbot4000", ExpiresAt: time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)},
+	})
 
 	rec := httptest.NewRecorder()
 	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))

--- a/pkg/server/authcard.go
+++ b/pkg/server/authcard.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+	"html/template"
+	"log/slog"
+	"strings"
+	"time"
+
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// authPollInterval is how often the hub re-reads token state and pushes a fresh
+// auth card + reauth callout. Token expiry moves on the order of minutes/hours,
+// so 30s is plenty; the page's JS ticker counts the displayed "expires in N"
+// down between polls.
+const authPollInterval = 30 * time.Second
+
+// tokenStatusesFn is the seam the hub polls for live token state. This is
+// pull-based — the documented exception to the hub's otherwise NATS-only
+// sourcing (see the admin-live-console ADR), mirroring the admin page's reauth
+// seam. Reads in-memory token state, so it's cheap to poll. Overridable in tests.
+var tokenStatusesFn = mytwitch.TokenStatuses
+
+// pollAuth pushes the auth card + reauth callout on start and every
+// authPollInterval thereafter, until ctx is done. Pull-based, so it runs even
+// when NATS is unconfigured (the SSE clients exist regardless of NATS). A page
+// loaded between polls renders its initial auth state server-side (see
+// adminData.AuthStatuses), so missing the retroactive push is harmless.
+func (h *Hub) pollAuth(ctx context.Context) {
+	push := func() {
+		statuses := tokenStatusesFn()
+		h.broadcast(sseEvent{Name: "auth", Data: renderAuthCard(statuses)})
+		h.broadcast(sseEvent{Name: "reauth", Data: renderReauthCallout(reauthsFromStatuses(statuses))})
+	}
+	push()
+	t := time.NewTicker(authPollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			push()
+		}
+	}
+}
+
+// reauthsFromStatuses narrows the full per-identity status list to just the
+// accounts that need operator re-auth, in the shape the callout renders.
+func reauthsFromStatuses(statuses []mytwitch.AccountTokenStatus) []mytwitch.AccountReauth {
+	var out []mytwitch.AccountReauth
+	for _, s := range statuses {
+		if s.Reason != "" {
+			out = append(out, mytwitch.AccountReauth{
+				Account: s.Account, LoginAs: s.LoginAs, Reason: s.Reason, InitURL: s.InitURL,
+			})
+		}
+	}
+	return out
+}
+
+// authCardTmpl renders one inline row per identity: the account label plus
+// either a re-auth link (when the token is missing/expired) or an .auth-expires
+// span carrying the expiry as data-since-style data-expires (Unix seconds) that
+// the page's JS counts down. Single source of truth — the initial server render
+// (admin.go's authCard FuncMap) and the live hub push both go through here.
+var authCardTmpl = template.Must(template.New("authcard").Parse(
+	`{{range .}}<span class="auth-row{{if .Reason}} auth-warn{{end}}"><span class="auth-who">{{.Account}}</span> ` +
+		`{{if .Reason}}<a class="auth-reauth" href="{{.InitURL}}">re-authenticate</a>` +
+		`{{else}}<span class="auth-expires" data-expires="{{.ExpiresAt.Unix}}">…</span>{{end}}</span> {{end}}`))
+
+func renderAuthCard(statuses []mytwitch.AccountTokenStatus) string {
+	var sb strings.Builder
+	if err := authCardTmpl.Execute(&sb, statuses); err != nil {
+		slog.Error("live-console hub: render auth card", "err", err)
+		return ""
+	}
+	return sb.String()
+}
+
+// reauthCalloutTmpl renders the prominent "action needed" callout, or nothing
+// when no account needs re-auth (so the live #reauth-card empties out and the
+// banner disappears without a reload). Markup mirrors the server-rendered
+// version this replaces.
+var reauthCalloutTmpl = template.Must(template.New("reauthcallout").Parse(
+	`{{if .}}<div class="reauth"><h2>action needed: re-authenticate</h2>` +
+		`<p>tripbot can't talk to Twitch until these accounts are re-authorized. Sign in as the named account on each — the flow re-prompts which account to use, so sign out of Twitch (or use a private window) if it grabs the wrong one.</p>` +
+		`<div class="btns">{{range .}}<a class="btn" href="{{.InitURL}}">Sign in as {{.LoginAs}} <span class="why">({{.Account}} · {{.Reason}})</span></a>{{end}}</div></div>{{end}}`))
+
+func renderReauthCallout(reauths []mytwitch.AccountReauth) string {
+	var sb strings.Builder
+	if err := reauthCalloutTmpl.Execute(&sb, reauths); err != nil {
+		slog.Error("live-console hub: render reauth callout", "err", err)
+		return ""
+	}
+	return sb.String()
+}

--- a/pkg/server/authcard_test.go
+++ b/pkg/server/authcard_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+func TestRenderAuthCard(t *testing.T) {
+	exp := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+	got := renderAuthCard([]mytwitch.AccountTokenStatus{
+		{Account: "bot", LoginAs: "tripbot4000", ExpiresAt: exp},
+		{Account: "broadcaster", LoginAs: "adanalife_", Reason: "missing", InitURL: "https://x/auth/init?account=broadcaster"},
+	})
+
+	// Healthy row: an .auth-expires span carrying the expiry as data-expires
+	// (Unix seconds) for the JS countdown.
+	if !strings.Contains(got, `class="auth-expires" data-expires="`+itoa(int(exp.Unix()))+`"`) {
+		t.Errorf("healthy row missing data-expires: %q", got)
+	}
+	if !strings.Contains(got, ">bot<") {
+		t.Errorf("missing bot label: %q", got)
+	}
+	// Unhealthy row: a re-auth link and the warn class instead of a countdown.
+	if !strings.Contains(got, `class="auth-reauth"`) || !strings.Contains(got, "auth-warn") {
+		t.Errorf("unhealthy row missing reauth link/warn: %q", got)
+	}
+}
+
+func TestRenderReauthCallout(t *testing.T) {
+	// No account needs re-auth → empty string, so the live #reauth-card clears.
+	if got := renderReauthCallout(nil); got != "" {
+		t.Errorf("healthy → empty callout, got %q", got)
+	}
+	got := renderReauthCallout([]mytwitch.AccountReauth{
+		{Account: "bot", LoginAs: "tripbot4000", Reason: "missing", InitURL: "https://x/auth/init"},
+	})
+	if !strings.Contains(got, "action needed") || !strings.Contains(got, "Sign in as tripbot4000") {
+		t.Errorf("callout missing expected content: %q", got)
+	}
+}
+
+func TestReauthsFromStatuses(t *testing.T) {
+	out := reauthsFromStatuses([]mytwitch.AccountTokenStatus{
+		{Account: "bot", Reason: ""}, // healthy → excluded
+		{Account: "broadcaster", LoginAs: "adanalife_", Reason: "expired", InitURL: "u"},
+	})
+	if len(out) != 1 || out[0].Account != "broadcaster" || out[0].Reason != "expired" {
+		t.Fatalf("got %+v, want only the broadcaster (expired)", out)
+	}
+}
+
+func TestHub_pollAuth_pushesAuthAndReauthOnStart(t *testing.T) {
+	saved := tokenStatusesFn
+	tokenStatusesFn = func() []mytwitch.AccountTokenStatus {
+		return []mytwitch.AccountTokenStatus{
+			{Account: "bot", LoginAs: "tripbot4000", Reason: "missing", InitURL: "u"},
+		}
+	}
+	t.Cleanup(func() { tokenStatusesFn = saved })
+
+	h := NewHub()
+	client := h.register()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go h.pollAuth(ctx)
+
+	// pollAuth pushes both an "auth" and a "reauth" event immediately on start.
+	got := map[string]string{}
+	for i := 0; i < 2; i++ {
+		select {
+		case ev := <-client:
+			got[ev.Name] = ev.Data
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for auth events; got %v", got)
+		}
+	}
+	if _, ok := got["auth"]; !ok {
+		t.Errorf("no auth event pushed on start")
+	}
+	if !strings.Contains(got["reauth"], "action needed") {
+		t.Errorf("reauth event missing callout for a missing token: %q", got["reauth"])
+	}
+}

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -70,6 +70,10 @@ func NewHub() *Hub {
 // ctx.Done. No-op (logs + returns) when NATS is unconfigured, so local dev and
 // tests run fine with an empty console.
 func (h *Hub) Start(ctx context.Context) {
+	// Auth state is pull-based (not over NATS), so the countdown card works even
+	// when NATS is unconfigured — start it before the nil-conn bail-out.
+	go h.pollAuth(ctx)
+
 	conn := natsclient.Conn()
 	if conn == nil {
 		slog.InfoContext(ctx, "live-console hub: NATS unconfigured; console will be empty")

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -350,6 +350,48 @@ func AccountsNeedingReauth() []AccountReauth {
 	return out
 }
 
+// AccountTokenStatus is the live token state for one identity, for the admin
+// panel's auth card. ExpiresAt drives a "expires in N" countdown; Reason is ""
+// when healthy, else "missing"/"expired" and the panel elevates InitURL.
+type AccountTokenStatus struct {
+	Account   string    // "bot" | "broadcaster" — the /auth/init account selector
+	LoginAs   string    // the exact Twitch username
+	ExpiresAt time.Time // zero when the expiry is unknown (e.g. a missing token)
+	Reason    string    // "" healthy, else "missing" | "expired"
+	InitURL   string    // /auth/init URL for this account
+}
+
+// TokenStatuses returns the live token state for each configured identity: the
+// bot always, and the broadcaster when a distinct broadcaster identity exists
+// (ChannelName set and != BotUsername). Unlike AccountsNeedingReauth — which
+// reports only the unhealthy accounts — this returns every identity so the
+// panel can show a per-identity expiry countdown even while healthy. Reads
+// in-memory token state; no DB or network call.
+func TokenStatuses() []AccountTokenStatus {
+	tokenMu.RLock()
+	bot := currentUserToken
+	bcast := currentBroadcasterToken
+	tokenMu.RUnlock()
+
+	out := []AccountTokenStatus{{
+		Account:   "bot",
+		LoginAs:   c.Conf.BotUsername,
+		ExpiresAt: bot.ExpiresAt,
+		Reason:    tokenReason(bot),
+		InitURL:   AuthInitURL("bot"),
+	}}
+	if c.Conf.ChannelName != "" && c.Conf.ChannelName != c.Conf.BotUsername {
+		out = append(out, AccountTokenStatus{
+			Account:   "broadcaster",
+			LoginAs:   c.Conf.ChannelName,
+			ExpiresAt: bcast.ExpiresAt,
+			Reason:    tokenReason(bcast),
+			InitURL:   AuthInitURL("broadcaster"),
+		})
+	}
+	return out
+}
+
 // ErrIdentityMismatch is returned by GenerateUserAccessToken when the
 // discovered identity (via helix.GetUsers) doesn't match expectedLogin.
 // Callers should surface it with retry guidance; the wrong-identity row is

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -295,6 +295,43 @@ func TestAccountsNeedingReauth_BroadcasterExpired(t *testing.T) {
 	}
 }
 
+func TestTokenStatuses_HealthyReportsExpiryForEveryIdentity(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	botExp := time.Now().Add(3 * time.Hour)
+	bcastExp := time.Now().Add(2 * time.Hour)
+	setTokens(t,
+		oauthtokens.Token{AccessToken: "good", ExpiresAt: botExp},
+		oauthtokens.Token{AccessToken: "good", ExpiresAt: bcastExp},
+	)
+
+	got := TokenStatuses()
+	if len(got) != 2 {
+		t.Fatalf("got %d statuses, want 2 (bot + broadcaster): %+v", len(got), got)
+	}
+	// Unlike AccountsNeedingReauth, healthy identities are still reported (with
+	// their expiry) so the panel can show a countdown.
+	if got[0].Account != "bot" || got[0].Reason != "" || !got[0].ExpiresAt.Equal(botExp) {
+		t.Errorf("bot status = %+v, want healthy with botExp", got[0])
+	}
+	if got[1].Account != "broadcaster" || got[1].Reason != "" || !got[1].ExpiresAt.Equal(bcastExp) {
+		t.Errorf("broadcaster status = %+v, want healthy with bcastExp", got[1])
+	}
+}
+
+func TestTokenStatuses_CarriesReauthReason(t *testing.T) {
+	withReauthConf(t, "tripbot4000", "adanalife_")
+	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
+	setTokens(t, oauthtokens.Token{}, healthy) // bot blank → missing
+
+	got := TokenStatuses()
+	if len(got) != 2 || got[0].Account != "bot" || got[0].Reason != "missing" {
+		t.Fatalf("got %+v, want bot row with Reason=missing", got)
+	}
+	if !strings.Contains(got[0].InitURL, "account=bot") {
+		t.Errorf("InitURL %q should target the bot account", got[0].InitURL)
+	}
+}
+
 // When the bot and broadcaster are the same account, there's no separate
 // broadcaster row — a blank broadcaster slot must not produce a phantom
 // re-auth prompt.


### PR DESCRIPTION
Fourth live-update slice. Each Twitch identity (bot + broadcaster) shows **"expires in N"** on the admin panel, counting down live and reddening as expiry nears; the re-auth banner now appears and clears **without a reload**.

> **Stacked on #726 → #725.** Base is `feat/live-panel-now-playing` so the diff shows only this slice. Merge order: #725 → #726 → this.

## How it works
- **`pkg/twitch`** — `TokenStatuses()` reports *every* configured identity's live token state (expiry + reauth reason/link), not just the unhealthy ones `AccountsNeedingReauth` returns — so the panel can show a countdown while healthy. Reads in-memory token state; no DB/network.
- **`pkg/server/authcard.go`** — a 30s hub poller (pull-based — the documented NATS-only *exception*, so it runs even without NATS) pushes two fragments: the per-identity **auth card** and the **reauth callout**. `renderAuthCard` / `renderReauthCallout` are the single source of truth, shared by the initial server render (via FuncMap) and the live SSE push, so a swap is byte-identical to a fresh paint.
- **`pkg/server/admin.go`** — `#auth-card` and `#reauth-card` are sse-swap targets; the callout now lives in a stable container so it can appear/empty live. A JS ticker counts each `.auth-expires` down from its `data-expires` (Unix seconds), reddening under 15 min (`.auth-soon`) and once past (`.auth-expired`).

## Tests
- `pkg/twitch` — `TokenStatuses` reports expiry for healthy identities + carries the reauth reason.
- `pkg/server` — `renderAuthCard` (healthy countdown span vs. reauth link), `renderReauthCallout` (empty when healthy), `reauthsFromStatuses`, and `pollAuth` pushing both events on start via the `tokenStatusesFn` seam.
- `admin_test.go` — asserts the `#auth-card` / `#reauth-card` wiring + the bot expiry `data-expires`.

Closes the highpri **"surface time remaining in the Twitch session"** admin-panel item.