### PR TITLE
feat: chat user-profile popover (click a username)

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -43,3 +43,19 @@ func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	instrumentation.Events.Inc("logout")
 	return nil
 }
+
+// SessionCount returns how many sessions the user has started — i.e. their
+// count of "login" events. Cheap via the events_username_date index
+// (migration 011). Returns 0 on error. Bots are not special-cased here; callers
+// that exclude bots should check users.IsBot.
+func SessionCount(ctx context.Context, username string) int64 {
+	var n int64
+	if err := database.GormDB().WithContext(ctx).
+		Model(&Event{}).
+		Where("username = ? AND event = ?", username, "login").
+		Count(&n).Error; err != nil {
+		slog.ErrorContext(ctx, "session count failed", "err", err, "username", username)
+		return 0
+	}
+	return n
+}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -729,6 +729,18 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   .chat-jump { position:absolute; left:50%; bottom:10px; transform:translateX(-50%); z-index:2; font:inherit; font-size:.8em; padding:4px 12px; border-radius:999px; border:1px solid var(--chip-border); background:var(--chip-bg); color:var(--fg); cursor:pointer; box-shadow:0 2px 8px rgba(0,0,0,.35); }
   .chat-jump:hover { border-color:#58a6ff; color:#9cf; }
   .chat-jump[hidden] { display:none; }
+  /* clickable chat usernames + the profile popover they open */
+  .chat-line .cu { cursor:pointer; }
+  .chat-line .cu:hover { text-decoration:underline; }
+  .user-popover { position:fixed; z-index:20; max-width:240px; background:var(--chip-bg); border:1px solid var(--chip-border); border-radius:8px; padding:12px 14px; box-shadow:0 6px 24px rgba(0,0,0,.45); font-size:.9em; }
+  .user-popover[hidden] { display:none; }
+  .profile-card .profile-name { font-weight:600; margin-bottom:8px; word-break:break-all; }
+  .profile-bot { font-size:.72em; color:var(--dim); border:1px solid var(--chip-border); border-radius:4px; padding:0 5px; vertical-align:middle; }
+  .profile-stats { display:grid; grid-template-columns:auto 1fr; gap:2px 14px; margin:0 0 8px; }
+  .profile-stats dt { color:var(--muted); }
+  .profile-stats dd { margin:0; text-align:right; font-variant-numeric:tabular-nums; }
+  .profile-empty { color:var(--dim); font-style:italic; margin:0 0 8px; }
+  .profile-link { font-size:.85em; }
   /* live viewer count — a subtle, quick colour flash on the number: green when
      it rises, red when it falls. The inner .chatters-count span is re-inserted
      on each SSE update so the animation re-triggers; with only a "from" keyframe
@@ -875,6 +887,10 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     <button id="toggle-all" class="theme-toggle" type="button" title="expand or collapse all sections">▾ expand all</button>
     <button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐ theme</button>
   </div>
+
+  <!-- chat user-profile popover: filled by a fetch when a username in the chat
+       console is clicked (see the profile JS); position:fixed so it floats. -->
+  <div id="user-popover" class="user-popover" hidden></div>
 </main>
 <script>
 // Stream-preview iframe wiring. The disclosure defaults to open so the
@@ -1046,6 +1062,40 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   };
   tick();
   setInterval(tick, 1000);
+})();
+
+// Chat user-profile popover. A delegated click on any chat username (.cu)
+// fetches /admin/user/<name> and floats the returned card near the click;
+// clicking outside or pressing Escape closes it. Delegation covers SSE-added
+// lines without per-line wiring.
+(function() {
+  const pop = document.getElementById('user-popover');
+  if (!pop) return;
+  let open = false;
+  const hide = () => { pop.hidden = true; open = false; };
+  document.addEventListener('click', (e) => {
+    const cu = e.target.closest('.cu');
+    if (cu) {
+      const name = cu.textContent.trim();
+      if (!name) return;
+      fetch('/admin/user/' + encodeURIComponent(name))
+        .then(r => r.ok ? r.text() : Promise.reject(r.status))
+        .then(html => {
+          pop.innerHTML = html;
+          pop.hidden = false; // unhide before measuring so offset* are real
+          open = true;
+          const pad = 8;
+          const x = Math.min(e.clientX, window.innerWidth - pop.offsetWidth - pad);
+          const y = Math.min(e.clientY + pad, window.innerHeight - pop.offsetHeight - pad);
+          pop.style.left = Math.max(pad, x) + 'px';
+          pop.style.top = Math.max(pad, y) + 'px';
+        })
+        .catch(() => {});
+      return;
+    }
+    if (open && !pop.contains(e.target)) hide();
+  });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hide(); });
 })();
 
 // iOS Home Screen apps return to a stale cached page on reopen — even with

--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/events"
+	"github.com/adanalife/tripbot/pkg/users"
+	"github.com/gorilla/mux"
+)
+
+// findUser / sessionCount are the data seams the profile handler reads through,
+// overridable in tests so the handler renders without a real DB.
+var (
+	findUser     = users.Find
+	sessionCount = events.SessionCount
+)
+
+// userProfile is the chat-console popover payload — a small at-a-glance view of
+// a chatter, events-derived per the tripbot-events-table-design ADR.
+type userProfile struct {
+	Username  string
+	Found     bool
+	IsBot     bool
+	Miles     float32
+	Sessions  int64
+	FirstSeen time.Time
+	LastSeen  time.Time
+}
+
+// userProfileHandler serves GET /admin/user/{username}: the HTML fragment the
+// live console pops over when an operator clicks a username. Phase 2 will add
+// timeout/ban actions here (needs the broadcaster token's
+// moderator:manage:banned_users scope — see the vault TODO).
+func userProfileHandler(w http.ResponseWriter, r *http.Request) {
+	username := strings.ToLower(strings.TrimSpace(mux.Vars(r)["username"]))
+	prof := userProfile{Username: username}
+	if username != "" {
+		if u := findUser(r.Context(), username); u.ID != 0 {
+			prof.Found = true
+			prof.IsBot = u.IsBot
+			prof.Miles = u.Miles
+			prof.FirstSeen = u.DateCreated
+			prof.LastSeen = u.LastSeen
+			prof.Sessions = sessionCount(r.Context(), username)
+		}
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := userProfileTmpl.Execute(w, prof); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't render user profile", "err", err)
+	}
+}
+
+// userProfileTmpl renders the popover fragment. html/template escapes the
+// username everywhere it appears (incl. the Twitch URL).
+var userProfileTmpl = template.Must(template.New("profile").Parse(`<div class="profile-card">
+  <div class="profile-name">{{.Username}}{{if .IsBot}} <span class="profile-bot">bot</span>{{end}}</div>
+  {{- if .Found}}
+  <dl class="profile-stats">
+    <dt>miles</dt><dd>{{printf "%.1f" .Miles}}</dd>
+    <dt>sessions</dt><dd>{{.Sessions}}</dd>
+    <dt>first seen</dt><dd>{{.FirstSeen.Format "2006-01-02"}}</dd>
+    <dt>last seen</dt><dd>{{.LastSeen.Format "2006-01-02 15:04"}}</dd>
+  </dl>
+  {{- else}}
+  <p class="profile-empty">no record for this user yet</p>
+  {{- end}}
+  <a class="profile-link" href="https://twitch.tv/{{.Username}}" target="_blank" rel="noopener">view on Twitch ↗</a>
+</div>`))

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/users"
+	"github.com/gorilla/mux"
+)
+
+// withProfileSeams stubs the DB-backed data reads so the handler renders without
+// a real database.
+func withProfileSeams(t *testing.T, u users.User, sessions int64) {
+	t.Helper()
+	savedFind, savedCount := findUser, sessionCount
+	t.Cleanup(func() { findUser, sessionCount = savedFind, savedCount })
+	findUser = func(context.Context, string) users.User { return u }
+	sessionCount = func(context.Context, string) int64 { return sessions }
+}
+
+func renderProfile(t *testing.T, username string) string {
+	t.Helper()
+	r := mux.NewRouter()
+	r.Handle("/admin/user/{username}", http.HandlerFunc(userProfileHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/user/"+username, nil))
+	return rec.Body.String()
+}
+
+func TestUserProfileHandler_Found(t *testing.T) {
+	withProfileSeams(t, users.User{
+		ID:          42,
+		Username:    "danalol",
+		Miles:       123.0,
+		IsBot:       false,
+		DateCreated: time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),
+		LastSeen:    time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC),
+	}, 87)
+
+	body := renderProfile(t, "danalol")
+	for _, want := range []string{
+		"danalol",
+		"123.0",      // miles
+		">87<",       // sessions
+		"2019-05-01", // first seen
+		`href="https://twitch.tv/danalol"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "no record") {
+		t.Errorf("found user should not render the empty state")
+	}
+}
+
+func TestUserProfileHandler_NotFound(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 0}, 0)
+
+	body := renderProfile(t, "ghost")
+	if !strings.Contains(body, "no record") {
+		t.Errorf("expected empty state, got %q", body)
+	}
+	if !strings.Contains(body, "ghost") {
+		t.Errorf("empty card should still name the user")
+	}
+}
+
+func TestUserProfileHandler_BotBadge(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 7, Username: "tripbot4000", IsBot: true}, 3)
+	if body := renderProfile(t, "tripbot4000"); !strings.Contains(body, "profile-bot") {
+		t.Errorf("expected bot badge, got %q", body)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,6 +73,7 @@ func Start(ctx context.Context) {
 	// the vendored htmx assets it loads. The /admin POST subrouter below is
 	// POST-only, so the GET stream registers on r directly.
 	r.Handle("/admin/events", tagged("/admin/events", eventsHandler)).Methods("GET")
+	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())
 
 	// admin actions — tailnet-only by virtue of where the Ingress is


### PR DESCRIPTION
Click a username in the live chat console → a small popover with that chatter's stats. Requested follow-up to the chat console.

## What
- **`pkg/events.SessionCount`** — login-event count for a user (cheap via the `events_username_date` index, per the events-table-design ADR).
- **`GET /admin/user/{username}`** (`pkg/server/profile.go`) — renders an HTML fragment: miles, sessions, first/last seen, bot badge, Twitch link. Behind `findUser`/`sessionCount` seams so it's tested without a DB (found / not-found / bot cases).
- **Frontend** — a delegated click on `.cu` fetches the fragment and floats a `position:fixed` popover near the click; outside-click / Escape closes it. Delegation covers SSE-added lines with no per-line markup change (so it stays orthogonal to #730).

## Scope
**Phase 1: read-only.** Phase 2 puts **timeout/ban** buttons on this card — that calls Helix `moderation/bans` as the broadcaster and needs the `moderator:manage:banned_users` scope (a broadcaster re-auth) + a `pkg/twitch` helper. Tracked in `tripbot/tripbot/TODO.md`; I'd verify the destructive path for real before shipping it.

`go test ./pkg/server/...` green. Orthogonal to #730 (distinct regions of admin.go).