### PR TITLE
feat: profile popover — monthly miles + 'unknown' dates

### DIFF
--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -8,27 +9,34 @@ import (
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/events"
+	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/gorilla/mux"
 )
 
-// findUser / sessionCount are the data seams the profile handler reads through,
-// overridable in tests so the handler renders without a real DB.
+// findUser / sessionCount / monthlyMiles are the data seams the profile handler
+// reads through, overridable in tests so the handler renders without a real DB.
+// Each is an operator-triggered read (one click), not a hot path, so the extra
+// monthly-score query is fine.
 var (
 	findUser     = users.Find
 	sessionCount = events.SessionCount
+	monthlyMiles = func(ctx context.Context, u users.User) float32 {
+		return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard())
+	}
 )
 
 // userProfile is the chat-console popover payload — a small at-a-glance view of
 // a chatter, events-derived per the tripbot-events-table-design ADR.
 type userProfile struct {
-	Username  string
-	Found     bool
-	IsBot     bool
-	Miles     float32
-	Sessions  int64
-	FirstSeen time.Time
-	LastSeen  time.Time
+	Username     string
+	Found        bool
+	IsBot        bool
+	Miles        float32 // lifetime
+	MonthlyMiles float32 // current month
+	Sessions     int64
+	FirstSeen    time.Time
+	LastSeen     time.Time
 }
 
 // userProfileHandler serves GET /admin/user/{username}: the HTML fragment the
@@ -43,6 +51,7 @@ func userProfileHandler(w http.ResponseWriter, r *http.Request) {
 			prof.Found = true
 			prof.IsBot = u.IsBot
 			prof.Miles = u.Miles
+			prof.MonthlyMiles = monthlyMiles(r.Context(), u)
 			prof.FirstSeen = u.DateCreated
 			prof.LastSeen = u.LastSeen
 			prof.Sessions = sessionCount(r.Context(), username)
@@ -62,9 +71,10 @@ var userProfileTmpl = template.Must(template.New("profile").Parse(`<div class="p
   {{- if .Found}}
   <dl class="profile-stats">
     <dt>miles</dt><dd>{{printf "%.1f" .Miles}}</dd>
+    <dt>this month</dt><dd>{{printf "%.1f" .MonthlyMiles}}</dd>
     <dt>sessions</dt><dd>{{.Sessions}}</dd>
-    <dt>first seen</dt><dd>{{.FirstSeen.Format "2006-01-02"}}</dd>
-    <dt>last seen</dt><dd>{{.LastSeen.Format "2006-01-02 15:04"}}</dd>
+    <dt>first seen</dt><dd>{{if .FirstSeen.IsZero}}unknown{{else}}{{.FirstSeen.Format "2006-01-02"}}{{end}}</dd>
+    <dt>last seen</dt><dd>{{if .LastSeen.IsZero}}unknown{{else}}{{.LastSeen.Format "2006-01-02 15:04"}}{{end}}</dd>
   </dl>
   {{- else}}
   <p class="profile-empty">no record for this user yet</p>

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -14,12 +14,13 @@ import (
 
 // withProfileSeams stubs the DB-backed data reads so the handler renders without
 // a real database.
-func withProfileSeams(t *testing.T, u users.User, sessions int64) {
+func withProfileSeams(t *testing.T, u users.User, sessions int64, monthly float32) {
 	t.Helper()
-	savedFind, savedCount := findUser, sessionCount
-	t.Cleanup(func() { findUser, sessionCount = savedFind, savedCount })
+	savedFind, savedCount, savedMonthly := findUser, sessionCount, monthlyMiles
+	t.Cleanup(func() { findUser, sessionCount, monthlyMiles = savedFind, savedCount, savedMonthly })
 	findUser = func(context.Context, string) users.User { return u }
 	sessionCount = func(context.Context, string) int64 { return sessions }
+	monthlyMiles = func(context.Context, users.User) float32 { return monthly }
 }
 
 func renderProfile(t *testing.T, username string) string {
@@ -39,12 +40,13 @@ func TestUserProfileHandler_Found(t *testing.T) {
 		IsBot:       false,
 		DateCreated: time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),
 		LastSeen:    time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC),
-	}, 87)
+	}, 87, 42.0)
 
 	body := renderProfile(t, "danalol")
 	for _, want := range []string{
 		"danalol",
-		"123.0",      // miles
+		"123.0",      // lifetime miles
+		"42.0",       // this month
 		">87<",       // sessions
 		"2019-05-01", // first seen
 		`href="https://twitch.tv/danalol"`,
@@ -59,7 +61,7 @@ func TestUserProfileHandler_Found(t *testing.T) {
 }
 
 func TestUserProfileHandler_NotFound(t *testing.T) {
-	withProfileSeams(t, users.User{ID: 0}, 0)
+	withProfileSeams(t, users.User{ID: 0}, 0, 0)
 
 	body := renderProfile(t, "ghost")
 	if !strings.Contains(body, "no record") {
@@ -71,8 +73,22 @@ func TestUserProfileHandler_NotFound(t *testing.T) {
 }
 
 func TestUserProfileHandler_BotBadge(t *testing.T) {
-	withProfileSeams(t, users.User{ID: 7, Username: "tripbot4000", IsBot: true}, 3)
+	withProfileSeams(t, users.User{ID: 7, Username: "tripbot4000", IsBot: true}, 3, 0)
 	if body := renderProfile(t, "tripbot4000"); !strings.Contains(body, "profile-bot") {
 		t.Errorf("expected bot badge, got %q", body)
+	}
+}
+
+// TestUserProfileHandler_UnknownDates covers a found user with no event history
+// (zero-value timestamps — e.g. a freshly-seeded account): show "unknown", not
+// Go's 0001-01-01 zero time.
+func TestUserProfileHandler_UnknownDates(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 9, Username: "freshacct"}, 0, 0)
+	body := renderProfile(t, "freshacct")
+	if strings.Contains(body, "0001") {
+		t.Errorf("zero time should not render as 0001-...: %q", body)
+	}
+	if !strings.Contains(body, "unknown") {
+		t.Errorf("expected 'unknown' for zero-value seen dates: %q", body)
 	}
 }


### PR DESCRIPTION
Two small follow-ups to the profile popover (#731), from stage testing:

- **Monthly miles** — adds a 'this month' row next to lifetime miles, via a `monthlyMiles` seam (`u.GetScore(scoreboards.CurrentMilesScoreboard())`). **No perf concern** — it's one indexed query per popover open, which is an operator click, not a hot path.
- **'unknown' dates** — a found account with no event history was rendering Go's zero time (`0001-01-01`); now shows `unknown` for zero-value first/last-seen.

Tests updated (monthly assertion + a zero-dates case). `go test ./pkg/server/...` green.