### PR TITLE
feat: 'show full route' corpus overlay on the live map

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -758,6 +758,8 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   .map-box { height:280px; margin-top:8px; border-radius:8px; overflow:hidden; background:var(--chip-bg); }
   .van-marker { font-size:22px; line-height:24px; text-align:center; }
   .map-box .leaflet-control-attribution { font-size:.65em; }
+  .map-toggle { margin-top:8px; background:none; border:none; color:var(--dim); font:inherit; font-size:.85em; cursor:pointer; padding:2px 6px; }
+  .map-toggle:hover { color:var(--fg); }
   /* live viewer count — a subtle, quick colour flash on the number: green when
      it rises, red when it falls. The inner .chatters-count span is re-inserted
      on each SSE update so the animation re-triggers; with only a "from" keyframe
@@ -883,6 +885,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
          #map-sink receives live "map" SSE points (read on afterSwap by the JS). -->
     <div id="map" class="map-box" data-trail="{{.MapTrailJSON}}"></div>
     <div id="map-sink" sse-swap="map" hx-swap="innerHTML" hidden></div>
+    <button id="corpus-toggle" class="map-toggle" type="button">show full route</button>
   </details>
 
   <details class="controls">
@@ -1163,6 +1166,30 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     line.setLatLngs(trail);
     recenter(true);
   });
+
+  // "show full route" toggle: lazily fetch the whole-corpus route and draw it as
+  // a faint background line behind the live trail. Remembered in localStorage.
+  const corpusBtn = document.getElementById('corpus-toggle');
+  let corpusLine = null;
+  const renderCorpus = (fit) => {
+    fetch('/admin/map/corpus').then(r => r.ok ? r.json() : Promise.reject(r.status)).then(pts => {
+      corpusLine = L.polyline(pts, { color: '#888', weight: 1.5, opacity: 0.4 }).addTo(map);
+      corpusLine.bringToBack();
+      if (fit && pts.length) map.fitBounds(corpusLine.getBounds(), { padding: [20, 20] });
+    }).catch(() => {});
+  };
+  const setCorpus = (on, fit) => {
+    if (on) {
+      if (corpusLine) { corpusLine.addTo(map); if (fit) map.fitBounds(corpusLine.getBounds(), { padding: [20, 20] }); }
+      else renderCorpus(fit);
+    } else if (corpusLine) {
+      map.removeLayer(corpusLine);
+    }
+    if (corpusBtn) corpusBtn.textContent = on ? 'hide full route' : 'show full route';
+    localStorage.setItem('map-corpus', on ? '1' : '0');
+  };
+  if (corpusBtn) corpusBtn.addEventListener('click', () => setCorpus(!(corpusLine && map.hasLayer(corpusLine)), true));
+  setCorpus(localStorage.getItem('map-corpus') === '1', false);
 
   // The map sits in a <details>; Leaflet needs a size recalc when the container
   // is first laid out or revealed.

--- a/pkg/server/map.go
+++ b/pkg/server/map.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// corpusRoute is the data seam the map-overlay endpoint reads through,
+// overridable in tests so the handler renders without a DB.
+var corpusRoute = video.CorpusRoute
+
+// maxCorpusPoints caps the corpus polyline. It's a faint background route, so a
+// few thousand points is ample detail — and keeps the JSON + the Leaflet path
+// light. Larger corpora are evenly downsampled.
+const maxCorpusPoints = 2500
+
+// mapCorpusHandler serves GET /admin/map/corpus: the full dashcam route as JSON
+// [[lat,lng],…]. Loaded lazily by the map's "show full route" toggle, cached an
+// hour (the corpus rarely changes).
+func mapCorpusHandler(w http.ResponseWriter, r *http.Request) {
+	pts := downsample(corpusRoute(r.Context()), maxCorpusPoints)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	if err := json.NewEncoder(w).Encode(pts); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't encode corpus route", "err", err)
+	}
+}
+
+// downsample returns at most max evenly-spaced points, always keeping the last
+// one so the route reaches its end. max <= 0 or a short input is returned as-is.
+func downsample(pts [][2]float64, max int) [][2]float64 {
+	if max <= 0 || len(pts) <= max {
+		return pts
+	}
+	step := (len(pts) + max - 1) / max
+	out := make([][2]float64, 0, max+1)
+	for i := 0; i < len(pts); i += step {
+		out = append(out, pts[i])
+	}
+	if last := pts[len(pts)-1]; out[len(out)-1] != last {
+		out = append(out, last)
+	}
+	return out
+}

--- a/pkg/server/map_test.go
+++ b/pkg/server/map_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func withCorpusRoute(t *testing.T, pts [][2]float64) {
+	t.Helper()
+	saved := corpusRoute
+	t.Cleanup(func() { corpusRoute = saved })
+	corpusRoute = func(context.Context) [][2]float64 { return pts }
+}
+
+func TestMapCorpusHandler(t *testing.T) {
+	withCorpusRoute(t, [][2]float64{{41.5, -110.2}, {41.6, -110.3}})
+
+	rec := httptest.NewRecorder()
+	mapCorpusHandler(rec, httptest.NewRequest(http.MethodGet, "/admin/map/corpus", nil))
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got [][2]float64
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not valid JSON: %v\n%s", err, rec.Body.String())
+	}
+	if len(got) != 2 || got[0][0] != 41.5 || got[1][1] != -110.3 {
+		t.Errorf("route = %v, want the two seeded points", got)
+	}
+}
+
+func TestDownsample(t *testing.T) {
+	short := [][2]float64{{1, 1}, {2, 2}}
+	if out := downsample(short, 10); len(out) != 2 {
+		t.Errorf("short input: len = %d, want 2 (unchanged)", len(out))
+	}
+	if out := downsample(short, 0); len(out) != 2 {
+		t.Errorf("max<=0: should return input unchanged")
+	}
+
+	big := make([][2]float64, 1000)
+	for i := range big {
+		big[i] = [2]float64{float64(i), 0}
+	}
+	out := downsample(big, 100)
+	if len(out) > 101 {
+		t.Errorf("downsampled len = %d, want <= 101", len(out))
+	}
+	if out[len(out)-1] != big[len(big)-1] {
+		t.Errorf("last point not preserved: got %v want %v", out[len(out)-1], big[len(big)-1])
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -74,6 +74,7 @@ func Start(ctx context.Context) {
 	// POST-only, so the GET stream registers on r directly.
 	r.Handle("/admin/events", tagged("/admin/events", eventsHandler)).Methods("GET")
 	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
+	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())
 
 	// admin actions — tailnet-only by virtue of where the Ingress is

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -39,7 +39,7 @@ func load(ctx context.Context, slug string) (Video, error) {
 	return vid, result.Error
 }
 
-//TODO: combine this with load()?
+// TODO: combine this with load()?
 func loadById(ctx context.Context, id int64) (Video, error) {
 	var vid Video
 	result := database.GormDB().WithContext(ctx).First(&vid, id)
@@ -50,7 +50,7 @@ func loadById(ctx context.Context, id int64) (Video, error) {
 }
 
 // create will create a new Video from a slug
-//TODO: this is kinda weird, we create an empty Video
+// TODO: this is kinda weird, we create an empty Video
 // and then we save it to the DB... maybe we could just
 // save right to the DB? It would take some refactoring.
 func create(ctx context.Context, file string) (Video, error) {
@@ -92,7 +92,7 @@ func create(ctx context.Context, file string) (Video, error) {
 }
 
 // save() will store the video in the DB
-//TODO: I think this can be achieved much easier, c.p. user save
+// TODO: I think this can be achieved much easier, c.p. user save
 func (v Video) save(ctx context.Context) error {
 	var err error
 	flagged := v.Flagged
@@ -131,8 +131,8 @@ func (v Video) save(ctx context.Context) error {
 }
 
 // Next() finds the next unflagged video
-//TODO: should this be NextUnflagged?
-//TODO: handle errors in here?
+// TODO: should this be NextUnflagged?
+// TODO: handle errors in here?
 func (v Video) Next(ctx context.Context) Video {
 	vid := v
 	for { // ever
@@ -190,4 +190,31 @@ func FindRandomByState(ctx context.Context, state string) (Video, error) {
 		return vid, result.Error
 	}
 	return vid, nil
+}
+
+// CorpusRoute returns the GPS coordinates of every non-flagged dashcam clip,
+// ordered by film time — the full route the van drove. The admin map's
+// background-route overlay renders this. Flagged clips and 0/0 are excluded.
+// Returns [][2]float64 of {lat, lng}; nil on error.
+func CorpusRoute(ctx context.Context) [][2]float64 {
+	type coord struct {
+		Lat float64
+		Lng float64
+	}
+	var rows []coord
+	err := database.GormDB().WithContext(ctx).
+		Model(&Video{}).
+		Select("lat, lng").
+		Where("NOT flagged AND (lat != 0 OR lng != 0)").
+		Order("date_filmed").
+		Scan(&rows).Error
+	if err != nil {
+		slog.ErrorContext(ctx, "corpus route query failed", "err", err)
+		return nil
+	}
+	out := make([][2]float64, len(rows))
+	for i, r := range rows {
+		out[i] = [2]float64{r.Lat, r.Lng}
+	}
+	return out
 }


### PR DESCRIPTION
Follow-up to the live map (#733): the breadcrumb trail is sparse until it accumulates, so this adds a **toggle that overlays the full dashcam route** — every non-flagged clip's GPS, ordered by film time — as a faint background line. The whole cross-country journey shows immediately, with the live 🚐 + recent trail on top.

- **`pkg/video.CorpusRoute`** — ordered coords of all non-flagged clips.
- **`GET /admin/map/corpus`** — JSON `[[lat,lng],…]`, **downsampled to 2500 pts**, cached 1h; fetched **lazily** only when the toggle is first switched on (keeps page load light).
- **Frontend** — a `show full route` / `hide full route` button (state persisted in localStorage); on enable it draws the faint polyline and fits the map to the route.

Pure-code → bot-restart deploy. Tests: handler + downsample (cap + last-point preserved). `go test ./pkg/video/... ./pkg/server/...` green.