### PR TITLE
refactor(background): construct *Scheduler instead of a package global

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -75,6 +75,12 @@ var version = "dev"
 
 var client *twitch.Client
 
+// scheduler is the background cron scheduler, constructed in startCron and
+// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
+// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
+// can stop it.
+var scheduler *background.Scheduler
+
 var telemetryShutdown telemetry.ShutdownFunc
 
 // discordSession is set by startDiscord when the Discord bot is enabled
@@ -277,8 +283,15 @@ func findInitialVideo() {
 
 // startCron starts the background workers
 func startCron() {
-	// start cron and attach cronjobs
-	background.StartCron()
+	s, err := background.New()
+	if err != nil {
+		slog.Error("error creating background scheduler", "err", err)
+		os.Exit(1)
+	}
+	scheduler = s
+	scheduler.Start()
+	// let !shutdown stop the same scheduler instance
+	chatbot.SetScheduler(scheduler)
 	scheduleBackgroundJobs()
 }
 
@@ -447,7 +460,9 @@ func gracefulShutdown() {
 	if err != nil {
 		slog.Error("error closing DB connection", "err", err)
 	}
-	background.StopCron()
+	if err := scheduler.Stop(); err != nil {
+		slog.Error("error shutting down gocron scheduler", "err", err)
+	}
 	sentry.Flush(time.Second * 5)
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -486,7 +501,7 @@ func scheduleBackgroundJobs() {
 // addJob registers a gocron job at the given interval, wrapping fn with
 // tracedJob so each tick opens a span and centralising the error logging.
 func addJob(interval time.Duration, name string, fn func(context.Context)) {
-	_, err := background.Scheduler.NewJob(
+	_, err := scheduler.NewJob(
 		gocron.DurationJob(interval),
 		gocron.NewTask(tracedJob(name, fn)),
 	)

--- a/pkg/background/cron.go
+++ b/pkg/background/cron.go
@@ -1,34 +1,50 @@
 package background
 
 import (
-	"log"
 	"log/slog"
 
 	"github.com/go-co-op/gocron/v2"
 )
 
-var Scheduler gocron.Scheduler
-
-func StartCron() {
-	slog.Info("starting cron")
-	s, err := gocron.NewScheduler()
-	if err != nil {
-		log.Fatalf("error creating gocron scheduler: %v", err)
-	}
-	Scheduler = s
-	Scheduler.Start()
+// Scheduler owns the gocron scheduler. Construct one with New(), Start() it,
+// register work with NewJob(), and Stop() it during shutdown. Replaces the
+// former package-level Scheduler global so the scheduler is constructed in
+// main() and injected rather than reached through package state.
+type Scheduler struct {
+	sched gocron.Scheduler
 }
 
-// StopCron shuts down the scheduler. In-flight job contexts are canceled,
-// so any ctx-aware work in those jobs unwinds rather than running to
-// completion. Cron jobs here are short idempotent ticks that retry on the
-// next interval, so losing an in-flight execution is fine.
-func StopCron() {
+// New constructs a Scheduler. The underlying gocron scheduler is created but
+// not started; call Start once jobs are registered.
+func New() (*Scheduler, error) {
+	s, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, err
+	}
+	return &Scheduler{sched: s}, nil
+}
+
+// Start begins executing registered jobs.
+func (s *Scheduler) Start() {
+	slog.Info("starting cron")
+	s.sched.Start()
+}
+
+// NewJob registers a job. It mirrors gocron's NewJob signature so callers keep
+// using gocron.DurationJob / gocron.NewTask directly.
+func (s *Scheduler) NewJob(jd gocron.JobDefinition, task gocron.Task, opts ...gocron.JobOption) (gocron.Job, error) {
+	return s.sched.NewJob(jd, task, opts...)
+}
+
+// Stop shuts down the scheduler. In-flight job contexts are canceled, so any
+// ctx-aware work in those jobs unwinds rather than running to completion. Cron
+// jobs here are short idempotent ticks that retry on the next interval, so
+// losing an in-flight execution is fine. Safe to call on a nil receiver or
+// before Start, so shutdown paths can call it unconditionally.
+func (s *Scheduler) Stop() error {
+	if s == nil || s.sched == nil {
+		return nil
+	}
 	slog.Info("stopping cron")
-	if Scheduler == nil {
-		return
-	}
-	if err := Scheduler.Shutdown(); err != nil {
-		slog.Error("error shutting down gocron scheduler", "err", err)
-	}
+	return s.sched.Shutdown()
 }

--- a/pkg/background/cron_test.go
+++ b/pkg/background/cron_test.go
@@ -1,0 +1,59 @@
+package background
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+)
+
+func TestNewStartStop(t *testing.T) {
+	s, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("New() returned nil scheduler")
+	}
+
+	ran := make(chan struct{}, 1)
+	if _, err := s.NewJob(
+		gocron.DurationJob(10*time.Millisecond),
+		gocron.NewTask(func() {
+			select {
+			case ran <- struct{}{}:
+			default:
+			}
+		}),
+	); err != nil {
+		t.Fatalf("NewJob returned error: %v", err)
+	}
+
+	s.Start()
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not run within 2s of Start")
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop() returned error: %v", err)
+	}
+}
+
+// Stop is safe before Start and on a nil scheduler so shutdown paths can call
+// it unconditionally.
+func TestStopIsNilSafe(t *testing.T) {
+	var s *Scheduler
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop() on nil receiver returned error: %v", err)
+	}
+
+	fresh, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if err := fresh.Stop(); err != nil {
+		t.Fatalf("Stop() before Start returned error: %v", err)
+	}
+}

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -63,6 +63,11 @@ type App struct {
 	// which delegates to the pkg/natsclient singleton (no-op when
 	// NATS_URL is empty).
 	NATS NATS
+	// Cron stops the background scheduler during !shutdown. Tests inject
+	// noopCron{}; production uses realCron which delegates to the
+	// constructed *background.Scheduler cmd/tripbot installs via
+	// SetScheduler once cron has started.
+	Cron Cron
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -85,6 +90,7 @@ var defaultApp = &App{
 	NowPlaying: newRealNowPlaying(),
 	Flags:      realFlags{},
 	NATS:       realNATS{},
+	Cron:       realCron{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 
-	"github.com/adanalife/tripbot/pkg/background"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
@@ -518,7 +517,9 @@ func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 	a.IRC.Say("Shutting down...")
 	slog.InfoContext(ctx, "shutdown: currently playing", "video", a.Video.Current())
-	background.StopCron()
+	if err := a.Cron.Stop(); err != nil {
+		slog.ErrorContext(ctx, "cron shutdown failed during !shutdown", "err", err)
+	}
 	a.Sessions.Shutdown(ctx)
 	err := database.Connection().Close()
 	if err != nil {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -56,6 +56,7 @@ func newTestApp(vid video.Video) *App {
 		NowPlaying: noopNowPlaying{},
 		Flags:      noopFlags{},
 		NATS:       noopNATS{},
+		Cron:       noopCron{},
 	}
 }
 

--- a/pkg/chatbot/cron.go
+++ b/pkg/chatbot/cron.go
@@ -1,0 +1,43 @@
+package chatbot
+
+import "sync"
+
+// Cron is the background-scheduler surface the chatbot needs: stopping the
+// scheduler during !shutdown. *background.Scheduler satisfies it directly.
+type Cron interface {
+	Stop() error
+}
+
+// realCron is the production Cron adapter the App is wired with at package
+// init. Delegates to scheduler, which cmd/tripbot replaces with the
+// constructed *background.Scheduler via SetScheduler once cron has started.
+// Mirrors the realFlags shape.
+type realCron struct{}
+
+func (realCron) Stop() error {
+	cronMu.RLock()
+	s := scheduler
+	cronMu.RUnlock()
+	return s.Stop()
+}
+
+// scheduler is the Cron realCron delegates to. Initialised to a no-op so the
+// brief startup window before cmd/tripbot installs the real scheduler — and
+// every test App — has a safe Stop().
+var (
+	cronMu    sync.RWMutex
+	scheduler Cron = noopCron{}
+)
+
+// noopCron swallows Stop. Used before SetScheduler runs and in tests.
+type noopCron struct{}
+
+func (noopCron) Stop() error { return nil }
+
+// SetScheduler installs the Cron that realCron delegates to. Called from
+// cmd/tripbot once the background scheduler is constructed and started.
+func SetScheduler(s Cron) {
+	cronMu.Lock()
+	scheduler = s
+	cronMu.Unlock()
+}


### PR DESCRIPTION
## What

Continues the Phase B no-globals sweep (after the HTTP clients and `pkg/video`). Converts `pkg/background` from a package-level `Scheduler gocron.Scheduler` global + `StartCron`/`StopCron` free functions to a constructed `*Scheduler` returned by `New()`, with `Start` / `NewJob` / `Stop` methods.

## Why

Part of the broader app-injection / no-globals refactor (`vault/decisions/chatbot-app-injection-pattern.md`, phase B leaves). The scheduler is now built in `main()` and injected rather than reached through mutable package state.

## Shape

- **`pkg/background`** — `New() (*Scheduler, error)`; `Start()`, `NewJob(...)` (mirrors gocron's signature so callers keep using `gocron.DurationJob`/`NewTask`), `Stop() error` (nil-safe on the receiver, preserving the old nil-`Scheduler` guard).
- **`cmd/tripbot`** — holds the constructed `*Scheduler` in a package var shared by `scheduleBackgroundJobs` (job registration) and `gracefulShutdown` (Stop).
- **`pkg/chatbot`** — `!shutdown` no longer reaches the global. `App` gains a `Cron` field; `realCron` delegates to a settable no-op-by-default seam (mirrors the `Flags`/`NATS` runtime-installer pattern), wired at startup via `chatbot.SetScheduler`.

## Tests

Adds `pkg/background`'s first test file (lifecycle: New → NewJob → Start → job runs → Stop; plus Stop nil-safety). `newTestApp()` gets `Cron: noopCron{}`. Full non-vlc suite passes.