### PR TITLE
feat(chatbot): inject Twitch Helix surface as App.Twitch

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -75,6 +75,12 @@ var version = "dev"
 
 var client *twitch.Client
 
+// scheduler is the background cron scheduler, constructed in startCron and
+// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
+// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
+// can stop it.
+var scheduler *background.Scheduler
+
 var telemetryShutdown telemetry.ShutdownFunc
 
 // discordSession is set by startDiscord when the Discord bot is enabled
@@ -277,8 +283,15 @@ func findInitialVideo() {
 
 // startCron starts the background workers
 func startCron() {
-	// start cron and attach cronjobs
-	background.StartCron()
+	s, err := background.New()
+	if err != nil {
+		slog.Error("error creating background scheduler", "err", err)
+		os.Exit(1)
+	}
+	scheduler = s
+	scheduler.Start()
+	// let !shutdown stop the same scheduler instance
+	chatbot.SetScheduler(scheduler)
 	scheduleBackgroundJobs()
 }
 
@@ -447,7 +460,9 @@ func gracefulShutdown() {
 	if err != nil {
 		slog.Error("error closing DB connection", "err", err)
 	}
-	background.StopCron()
+	if err := scheduler.Stop(); err != nil {
+		slog.Error("error shutting down gocron scheduler", "err", err)
+	}
 	sentry.Flush(time.Second * 5)
 	if telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -486,7 +501,7 @@ func scheduleBackgroundJobs() {
 // addJob registers a gocron job at the given interval, wrapping fn with
 // tracedJob so each tick opens a span and centralising the error logging.
 func addJob(interval time.Duration, name string, fn func(context.Context)) {
-	_, err := background.Scheduler.NewJob(
+	_, err := scheduler.NewJob(
 		gocron.DurationJob(interval),
 		gocron.NewTask(tracedJob(name, fn)),
 	)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -207,7 +207,7 @@ func startEventSub(ctx context.Context) {
 			"reauth_url", mytwitch.AuthInitURL("broadcaster"))
 		return
 	}
-	if mytwitch.ChannelID == "" {
+	if mytwitch.ChannelID() == "" {
 		// getChannelID is lazy on first call; calling GetSubscribers /
 		// GetFollowerCount typically populates it. updateSubscribers()
 		// above already ran, so this is belt-and-suspenders.
@@ -218,7 +218,7 @@ func startEventSub(ctx context.Context) {
 		err := eventsub.Run(ctx, eventsub.Config{
 			ClientID:          mytwitch.ClientID,
 			BroadcasterToken:  token,
-			BroadcasterUserID: mytwitch.ChannelID,
+			BroadcasterUserID: mytwitch.ChannelID(),
 		}, eventsub.Handlers{
 			OnFollow:    chatbot.AnnounceNewFollower,
 			OnSubscribe: chatbot.AnnounceSubscriber,

--- a/pkg/background/cron.go
+++ b/pkg/background/cron.go
@@ -1,34 +1,50 @@
 package background
 
 import (
-	"log"
 	"log/slog"
 
 	"github.com/go-co-op/gocron/v2"
 )
 
-var Scheduler gocron.Scheduler
-
-func StartCron() {
-	slog.Info("starting cron")
-	s, err := gocron.NewScheduler()
-	if err != nil {
-		log.Fatalf("error creating gocron scheduler: %v", err)
-	}
-	Scheduler = s
-	Scheduler.Start()
+// Scheduler owns the gocron scheduler. Construct one with New(), Start() it,
+// register work with NewJob(), and Stop() it during shutdown. Replaces the
+// former package-level Scheduler global so the scheduler is constructed in
+// main() and injected rather than reached through package state.
+type Scheduler struct {
+	sched gocron.Scheduler
 }
 
-// StopCron shuts down the scheduler. In-flight job contexts are canceled,
-// so any ctx-aware work in those jobs unwinds rather than running to
-// completion. Cron jobs here are short idempotent ticks that retry on the
-// next interval, so losing an in-flight execution is fine.
-func StopCron() {
+// New constructs a Scheduler. The underlying gocron scheduler is created but
+// not started; call Start once jobs are registered.
+func New() (*Scheduler, error) {
+	s, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, err
+	}
+	return &Scheduler{sched: s}, nil
+}
+
+// Start begins executing registered jobs.
+func (s *Scheduler) Start() {
+	slog.Info("starting cron")
+	s.sched.Start()
+}
+
+// NewJob registers a job. It mirrors gocron's NewJob signature so callers keep
+// using gocron.DurationJob / gocron.NewTask directly.
+func (s *Scheduler) NewJob(jd gocron.JobDefinition, task gocron.Task, opts ...gocron.JobOption) (gocron.Job, error) {
+	return s.sched.NewJob(jd, task, opts...)
+}
+
+// Stop shuts down the scheduler. In-flight job contexts are canceled, so any
+// ctx-aware work in those jobs unwinds rather than running to completion. Cron
+// jobs here are short idempotent ticks that retry on the next interval, so
+// losing an in-flight execution is fine. Safe to call on a nil receiver or
+// before Start, so shutdown paths can call it unconditionally.
+func (s *Scheduler) Stop() error {
+	if s == nil || s.sched == nil {
+		return nil
+	}
 	slog.Info("stopping cron")
-	if Scheduler == nil {
-		return
-	}
-	if err := Scheduler.Shutdown(); err != nil {
-		slog.Error("error shutting down gocron scheduler", "err", err)
-	}
+	return s.sched.Shutdown()
 }

--- a/pkg/background/cron_test.go
+++ b/pkg/background/cron_test.go
@@ -1,0 +1,59 @@
+package background
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+)
+
+func TestNewStartStop(t *testing.T) {
+	s, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("New() returned nil scheduler")
+	}
+
+	ran := make(chan struct{}, 1)
+	if _, err := s.NewJob(
+		gocron.DurationJob(10*time.Millisecond),
+		gocron.NewTask(func() {
+			select {
+			case ran <- struct{}{}:
+			default:
+			}
+		}),
+	); err != nil {
+		t.Fatalf("NewJob returned error: %v", err)
+	}
+
+	s.Start()
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not run within 2s of Start")
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop() returned error: %v", err)
+	}
+}
+
+// Stop is safe before Start and on a nil scheduler so shutdown paths can call
+// it unconditionally.
+func TestStopIsNilSafe(t *testing.T) {
+	var s *Scheduler
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop() on nil receiver returned error: %v", err)
+	}
+
+	fresh, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if err := fresh.Stop(); err != nil {
+		t.Fatalf("Stop() before Start returned error: %v", err)
+	}
+}

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -68,6 +68,11 @@ type App struct {
 	// constructed *background.Scheduler cmd/tripbot installs via
 	// SetScheduler once cron has started.
 	Cron Cron
+	// Twitch is the command-time Twitch Helix surface (follow lookups today).
+	// Tests inject a recordingTwitch; production uses realTwitch which
+	// delegates to the pkg/twitch client. The future swap point for an
+	// out-of-process Helix/auth service.
+	Twitch Twitch
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -91,6 +96,7 @@ var defaultApp = &App{
 	Flags:      realFlags{},
 	NATS:       realNATS{},
 	Cron:       realCron{},
+	Twitch:     realTwitch{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -63,6 +63,11 @@ type App struct {
 	// which delegates to the pkg/natsclient singleton (no-op when
 	// NATS_URL is empty).
 	NATS NATS
+	// Cron stops the background scheduler during !shutdown. Tests inject
+	// noopCron{}; production uses realCron which delegates to the
+	// constructed *background.Scheduler cmd/tripbot installs via
+	// SetScheduler once cron has started.
+	Cron Cron
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -85,6 +90,7 @@ var defaultApp = &App{
 	NowPlaying: newRealNowPlaying(),
 	Flags:      realFlags{},
 	NATS:       realNATS{},
+	Cron:       realCron{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -19,7 +19,6 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
-	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
@@ -80,7 +79,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !flag", "username", user.Username)
-	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10*time.Second)
 }
 
 func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
@@ -129,7 +128,7 @@ func (a *App) followageCmd(ctx context.Context, user *users.User, params []strin
 		username = helpers.StripAtSign(params[0])
 	}
 
-	followedAt, ok := mytwitch.FollowedAt(username)
+	followedAt, ok := a.Twitch.FollowedAt(username)
 	if !ok {
 		if other {
 			a.IRC.Say(fmt.Sprintf("@%s isn't following the channel.", username))
@@ -371,7 +370,7 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 }
 
-//TODO: refactor to use golang '...' syntax
+// TODO: refactor to use golang '...' syntax
 func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !guess", "username", user.Username)
 	var msg string
@@ -409,7 +408,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
 		msg = fmt.Sprintf("@%s got it! We're in %s", user.Username, vid.State)
 		// show the flag for the state
-		a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+		a.Onscreens.ShowFlag(ctx, 10*time.Second)
 		// increase their guess score
 		user.AddToScore(ctx, guessScoreboard, 1.0)
 		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
@@ -430,14 +429,14 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state
-	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10*time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
 	a.IRC.Say(msg)
 }
 
-//TODO: maybe there could be a !cancel command or something
-//TODO: use fancy golang ... syntax?
+// TODO: maybe there could be a !cancel command or something
+// TODO: use fancy golang ... syntax?
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !report", "username", user.Username)
 	message := strings.Join(params, " ")
@@ -529,7 +528,7 @@ func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	os.Exit(0)
 }
 
-//TODO: this will always be lower case, find out why
+// TODO: this will always be lower case, find out why
 // middleCmd sets the text at the bottom-middle of the stream
 func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !middle", "username", user.Username)

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 
-	"github.com/adanalife/tripbot/pkg/background"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
@@ -518,7 +517,9 @@ func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 	a.IRC.Say("Shutting down...")
 	slog.InfoContext(ctx, "shutdown: currently playing", "video", a.Video.Current())
-	background.StopCron()
+	if err := a.Cron.Stop(); err != nil {
+		slog.ErrorContext(ctx, "cron shutdown failed during !shutdown", "err", err)
+	}
 	a.Sessions.Shutdown(ctx)
 	err := database.Connection().Close()
 	if err != nil {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -56,6 +56,7 @@ func newTestApp(vid video.Video) *App {
 		NowPlaying: noopNowPlaying{},
 		Flags:      noopFlags{},
 		NATS:       noopNATS{},
+		Cron:       noopCron{},
 	}
 }
 

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -57,6 +57,7 @@ func newTestApp(vid video.Video) *App {
 		Flags:      noopFlags{},
 		NATS:       noopNATS{},
 		Cron:       noopCron{},
+		Twitch:     noopTwitch{},
 	}
 }
 

--- a/pkg/chatbot/cron.go
+++ b/pkg/chatbot/cron.go
@@ -1,0 +1,43 @@
+package chatbot
+
+import "sync"
+
+// Cron is the background-scheduler surface the chatbot needs: stopping the
+// scheduler during !shutdown. *background.Scheduler satisfies it directly.
+type Cron interface {
+	Stop() error
+}
+
+// realCron is the production Cron adapter the App is wired with at package
+// init. Delegates to scheduler, which cmd/tripbot replaces with the
+// constructed *background.Scheduler via SetScheduler once cron has started.
+// Mirrors the realFlags shape.
+type realCron struct{}
+
+func (realCron) Stop() error {
+	cronMu.RLock()
+	s := scheduler
+	cronMu.RUnlock()
+	return s.Stop()
+}
+
+// scheduler is the Cron realCron delegates to. Initialised to a no-op so the
+// brief startup window before cmd/tripbot installs the real scheduler — and
+// every test App — has a safe Stop().
+var (
+	cronMu    sync.RWMutex
+	scheduler Cron = noopCron{}
+)
+
+// noopCron swallows Stop. Used before SetScheduler runs and in tests.
+type noopCron struct{}
+
+func (noopCron) Stop() error { return nil }
+
+// SetScheduler installs the Cron that realCron delegates to. Called from
+// cmd/tripbot once the background scheduler is constructed and started.
+func SetScheduler(s Cron) {
+	cronMu.Lock()
+	scheduler = s
+	cronMu.Unlock()
+}

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -1,0 +1,29 @@
+package chatbot
+
+import (
+	"time"
+
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// Twitch is the command-time Twitch Helix surface the chatbot needs. Today
+// that's only follow lookups (followageCmd); it grows as admin-panel Helix
+// features land (ban/timeout, send-as-broadcaster — see
+// vault/tripbot/tripbot/TODO.md).
+//
+// It is deliberately the seam where, once the Twitch Helix API moves into its
+// own service (vault/tripbot/TODO.md "Extract Twitch Helix API into a separate
+// service"), the in-process adapter below is swapped for an HTTP client —
+// without touching any command code.
+type Twitch interface {
+	FollowedAt(username string) (time.Time, bool)
+}
+
+// realTwitch is the production adapter the App is wired with at package init.
+// Delegates to the package-level pkg/twitch shim (defaultClient). Mirrors the
+// realIRC / realOnscreens shape.
+type realTwitch struct{}
+
+func (realTwitch) FollowedAt(username string) (time.Time, bool) {
+	return mytwitch.FollowedAt(username)
+}

--- a/pkg/chatbot/twitch_test.go
+++ b/pkg/chatbot/twitch_test.go
@@ -1,0 +1,71 @@
+package chatbot
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// noopTwitch satisfies Twitch for tests that don't care about follow lookups.
+type noopTwitch struct{}
+
+func (noopTwitch) FollowedAt(string) (time.Time, bool) { return time.Time{}, false }
+
+// recordingTwitch captures FollowedAt lookups and returns a staged result so
+// tests can assert both the username queried and the rendered reply.
+type recordingTwitch struct {
+	Result  time.Time
+	OK      bool
+	Lookups []string
+}
+
+func (r *recordingTwitch) FollowedAt(username string) (time.Time, bool) {
+	r.Lookups = append(r.Lookups, username)
+	return r.Result, r.OK
+}
+
+func TestFollowageCmd_Following_RepliesWithDuration(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	app.Twitch = &recordingTwitch{Result: time.Now().Add(-48 * time.Hour), OK: true}
+
+	app.followageCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if got := strings.Join(rec.Says, " "); !strings.Contains(got, "following for") {
+		t.Fatalf("expected a following-duration reply, got %q", rec.Says)
+	}
+}
+
+func TestFollowageCmd_NotFollowing_SelfPrompt(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	app.Twitch = &recordingTwitch{OK: false}
+
+	app.followageCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if got := strings.Join(rec.Says, " "); !strings.Contains(got, "follow button") {
+		t.Fatalf("expected the not-following self prompt, got %q", rec.Says)
+	}
+}
+
+func TestFollowageCmd_OtherUser_LooksUpStrippedName(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	twitch := &recordingTwitch{OK: false}
+	app.Twitch = twitch
+
+	app.followageCmd(context.Background(), newTestUser("viewer1"), []string{"@someoneElse"})
+
+	if len(twitch.Lookups) != 1 || twitch.Lookups[0] != "someoneElse" {
+		t.Fatalf("expected a lookup for the @-stripped target, got %v", twitch.Lookups)
+	}
+	if got := strings.Join(rec.Says, " "); !strings.Contains(got, "isn't following") {
+		t.Fatalf("expected the other-user not-following reply, got %q", rec.Says)
+	}
+}

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -63,6 +62,16 @@ var BroadcasterScopes = []string{
 // bootstrap CLI." Re-exported from oauthtokens for caller convenience.
 var ErrNoToken = oauthtokens.ErrNoToken
 
+// ClientID, ClientSecret are the static app credentials, set from env in
+// init(). They are not per-instance mutable state, so they stay package-level
+// (read directly by cmd/tripbot's EventSub setup) rather than moving onto
+// Client. AppAccessToken — which IS mutable, set during Client() — lives on
+// the Client struct.
+var (
+	ClientID     string
+	ClientSecret string
+)
+
 // AuthInitURL returns the operator-facing re-bootstrap URL for the given
 // account ("bot" or "broadcaster"). Visiting it kicks off the OAuth flow —
 // pkg/server's /auth/init handler mints a fresh CSRF state and 302-redirects to
@@ -99,35 +108,6 @@ func accountLabel(username string) string {
 	return "bot"
 }
 
-// currentTwitchClient is the lazy-initialized bot helix client. IRC auth +
-// any Helix endpoint authorized against the bot's identity goes through this.
-var currentTwitchClient *helix.Client
-
-// broadcasterTwitchClient is the lazy-initialized broadcaster helix client.
-// Endpoints that authorize against the channel-owner identity (GetSubscriptions,
-// GetChannelFollows total, channel.update, mod actions) go through this — the
-// bot client would 401 since the user-access-token's identity matters, not
-// just its scope set.
-var broadcasterTwitchClient *helix.Client
-
-// ClientID, ClientSecret are set from env at init.
-// AppAccessToken is set in Client() (Client Credentials grant) and shared by
-// both helix clients.
-var (
-	ClientID       string
-	ClientSecret   string
-	AppAccessToken string
-)
-
-// tokenMu guards both currentUserToken (bot) and currentBroadcasterToken.
-// RWMutex because reads (IRCAuthToken, CurrentUserAccessToken) outnumber
-// writes (LoadFromDB, refresh).
-var (
-	tokenMu                 sync.RWMutex
-	currentUserToken        oauthtokens.Token
-	currentBroadcasterToken oauthtokens.Token
-)
-
 // init requires the static credentials needed to build a helix client.
 // TWITCH_AUTH_TOKEN is intentionally NOT required — the IRC token now lives
 // in the oauth_tokens table and is loaded via LoadFromDB at boot.
@@ -147,9 +127,9 @@ func init() {
 
 // Client returns the shared helix client, lazy-initializing on first call.
 // First-call side effect: requests an App Access Token (Client Credentials).
-func Client() (*helix.Client, error) {
-	if currentTwitchClient != nil {
-		return currentTwitchClient, nil
+func (cl *API) Client() (*helix.Client, error) {
+	if cl.currentTwitchClient != nil {
+		return cl.currentTwitchClient, nil
 	}
 	client, err := helix.NewClient(&helix.Options{
 		ClientID:     ClientID,
@@ -173,10 +153,10 @@ func Client() (*helix.Client, error) {
 		slog.Error("error getting app access token from twitch", "err", err)
 		return nil, err
 	}
-	AppAccessToken = resp.Data.AccessToken
-	client.SetAppAccessToken(AppAccessToken)
+	cl.appAccessToken = resp.Data.AccessToken
+	client.SetAppAccessToken(cl.appAccessToken)
 
-	currentTwitchClient = client
+	cl.currentTwitchClient = client
 	return client, nil
 }
 
@@ -188,12 +168,12 @@ func Client() (*helix.Client, error) {
 //
 // The App Access Token is reused from Client(); each helix.Client only needs
 // the per-identity user-access-token to differ.
-func BroadcasterClient() (*helix.Client, error) {
-	if broadcasterTwitchClient != nil {
-		return broadcasterTwitchClient, nil
+func (cl *API) BroadcasterClient() (*helix.Client, error) {
+	if cl.broadcasterTwitchClient != nil {
+		return cl.broadcasterTwitchClient, nil
 	}
-	// Ensure Client() ran so AppAccessToken is set.
-	if _, err := Client(); err != nil {
+	// Ensure Client() ran so appAccessToken is set.
+	if _, err := cl.Client(); err != nil {
 		return nil, err
 	}
 	client, err := helix.NewClient(&helix.Options{
@@ -205,15 +185,15 @@ func BroadcasterClient() (*helix.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("twitch: building broadcaster client: %w", err)
 	}
-	if AppAccessToken != "" {
-		client.SetAppAccessToken(AppAccessToken)
+	if cl.appAccessToken != "" {
+		client.SetAppAccessToken(cl.appAccessToken)
 	}
-	tokenMu.RLock()
-	if currentBroadcasterToken.AccessToken != "" {
-		client.SetUserAccessToken(currentBroadcasterToken.AccessToken)
+	cl.tokenMu.RLock()
+	if cl.currentBroadcasterToken.AccessToken != "" {
+		client.SetUserAccessToken(cl.currentBroadcasterToken.AccessToken)
 	}
-	tokenMu.RUnlock()
-	broadcasterTwitchClient = client
+	cl.tokenMu.RUnlock()
+	cl.broadcasterTwitchClient = client
 	return client, nil
 }
 
@@ -223,7 +203,7 @@ func BroadcasterClient() (*helix.Client, error) {
 // seeded via `task tripbot:auth:bootstrap:broadcaster`.
 //
 // Returns ErrNoToken only when the bot row is missing.
-func LoadFromDB() error {
+func (cl *API) LoadFromDB() error {
 	botUser := c.Conf.BotUsername
 	broadcasterUser := c.Conf.ChannelName
 
@@ -231,11 +211,11 @@ func LoadFromDB() error {
 	if err != nil {
 		return err
 	}
-	tokenMu.Lock()
-	currentUserToken = t
-	tokenMu.Unlock()
-	if currentTwitchClient != nil {
-		currentTwitchClient.SetUserAccessToken(t.AccessToken)
+	cl.tokenMu.Lock()
+	cl.currentUserToken = t
+	cl.tokenMu.Unlock()
+	if cl.currentTwitchClient != nil {
+		cl.currentTwitchClient.SetUserAccessToken(t.AccessToken)
 	}
 	instrumentation.TwitchTokenExpiry.SetExpiresAt("bot", t.ExpiresAt)
 
@@ -256,11 +236,11 @@ func LoadFromDB() error {
 		slog.Error("failed to load broadcaster oauth_tokens row", "err", berr, "broadcaster", broadcasterUser)
 		return nil
 	}
-	tokenMu.Lock()
-	currentBroadcasterToken = bt
-	tokenMu.Unlock()
-	if broadcasterTwitchClient != nil {
-		broadcasterTwitchClient.SetUserAccessToken(bt.AccessToken)
+	cl.tokenMu.Lock()
+	cl.currentBroadcasterToken = bt
+	cl.tokenMu.Unlock()
+	if cl.broadcasterTwitchClient != nil {
+		cl.broadcasterTwitchClient.SetUserAccessToken(bt.AccessToken)
 	}
 	instrumentation.TwitchTokenExpiry.SetExpiresAt("broadcaster", bt.ExpiresAt)
 	return nil
@@ -268,31 +248,31 @@ func LoadFromDB() error {
 
 // IRCAuthToken returns the bot's IRC oauth: token, ready for
 // twitch.NewClient. Returns "" if no token has been loaded.
-func IRCAuthToken() string {
-	tokenMu.RLock()
-	defer tokenMu.RUnlock()
-	if currentUserToken.AccessToken == "" {
+func (cl *API) IRCAuthToken() string {
+	cl.tokenMu.RLock()
+	defer cl.tokenMu.RUnlock()
+	if cl.currentUserToken.AccessToken == "" {
 		return ""
 	}
-	return "oauth:" + currentUserToken.AccessToken
+	return "oauth:" + cl.currentUserToken.AccessToken
 }
 
 // CurrentUserAccessToken returns the raw access token (no oauth: prefix).
 // Used by pkg/server/twitch.go's /auth/twitch JSON endpoint until that
 // endpoint is deleted in a separate PR.
-func CurrentUserAccessToken() string {
-	tokenMu.RLock()
-	defer tokenMu.RUnlock()
-	return currentUserToken.AccessToken
+func (cl *API) CurrentUserAccessToken() string {
+	cl.tokenMu.RLock()
+	defer cl.tokenMu.RUnlock()
+	return cl.currentUserToken.AccessToken
 }
 
 // BroadcasterUserAccessToken returns the broadcaster's raw access token
 // (no oauth: prefix), or "" if no broadcaster row has been loaded.
 // Consumed by pkg/eventsub when subscribing to broadcaster-gated events.
-func BroadcasterUserAccessToken() string {
-	tokenMu.RLock()
-	defer tokenMu.RUnlock()
-	return currentBroadcasterToken.AccessToken
+func (cl *API) BroadcasterUserAccessToken() string {
+	cl.tokenMu.RLock()
+	defer cl.tokenMu.RUnlock()
+	return cl.currentBroadcasterToken.AccessToken
 }
 
 // AccountReauth describes an account whose in-memory token is missing or
@@ -324,11 +304,11 @@ func tokenReason(t oauthtokens.Token) string {
 // re-auth. Returns nil when everything's healthy. The broadcaster is only
 // considered when a distinct broadcaster identity exists (ChannelName set and
 // != BotUsername) — otherwise there's no separate row to re-auth.
-func AccountsNeedingReauth() []AccountReauth {
-	tokenMu.RLock()
-	botReason := tokenReason(currentUserToken)
-	bcastReason := tokenReason(currentBroadcasterToken)
-	tokenMu.RUnlock()
+func (cl *API) AccountsNeedingReauth() []AccountReauth {
+	cl.tokenMu.RLock()
+	botReason := tokenReason(cl.currentUserToken)
+	bcastReason := tokenReason(cl.currentBroadcasterToken)
+	cl.tokenMu.RUnlock()
 
 	var out []AccountReauth
 	if botReason != "" {
@@ -367,11 +347,11 @@ type AccountTokenStatus struct {
 // reports only the unhealthy accounts — this returns every identity so the
 // panel can show a per-identity expiry countdown even while healthy. Reads
 // in-memory token state; no DB or network call.
-func TokenStatuses() []AccountTokenStatus {
-	tokenMu.RLock()
-	bot := currentUserToken
-	bcast := currentBroadcasterToken
-	tokenMu.RUnlock()
+func (cl *API) TokenStatuses() []AccountTokenStatus {
+	cl.tokenMu.RLock()
+	bot := cl.currentUserToken
+	bcast := cl.currentBroadcasterToken
+	cl.tokenMu.RUnlock()
 
 	out := []AccountTokenStatus{{
 		Account:   "bot",
@@ -423,10 +403,10 @@ func (e *ErrIdentityMismatch) Error() string {
 //
 // Returns error (no longer swallows); ErrIdentityMismatch on identity check
 // failure. Callers: /auth/callback handler, cmd/auth-bootstrap.
-func GenerateUserAccessToken(code string, expectedLogin string) error {
+func (cl *API) GenerateUserAccessToken(code string, expectedLogin string) error {
 	// Ensure App Access Token is set so the one-shot client can fall back
 	// for endpoints that allow app auth.
-	if _, err := Client(); err != nil {
+	if _, err := cl.Client(); err != nil {
 		return err
 	}
 	bootstrapClient, err := helix.NewClient(&helix.Options{
@@ -438,8 +418,8 @@ func GenerateUserAccessToken(code string, expectedLogin string) error {
 	if err != nil {
 		return fmt.Errorf("twitch: building bootstrap client: %w", err)
 	}
-	if AppAccessToken != "" {
-		bootstrapClient.SetAppAccessToken(AppAccessToken)
+	if cl.appAccessToken != "" {
+		bootstrapClient.SetAppAccessToken(cl.appAccessToken)
 	}
 
 	resp, err := bootstrapClient.RequestUserAccessToken(code)
@@ -463,7 +443,7 @@ func GenerateUserAccessToken(code string, expectedLogin string) error {
 	}
 	// account="" — mid-bootstrap, re-reading the (not-yet-written) token would
 	// be wrong; surface the failure to the caller instead.
-	if checkHelixResp(context.Background(), "GetUsers", "", &usersResp.ResponseCommon) {
+	if cl.checkHelixResp(context.Background(), "GetUsers", "", &usersResp.ResponseCommon) {
 		return fmt.Errorf("twitch: GetUsers returned %d during bootstrap", usersResp.StatusCode)
 	}
 	if len(usersResp.Data.Users) == 0 {
@@ -500,18 +480,18 @@ func GenerateUserAccessToken(code string, expectedLogin string) error {
 	// = row written but in-memory unchanged (logged so the operator notices).
 	switch u.Login {
 	case c.Conf.BotUsername:
-		tokenMu.Lock()
-		currentUserToken = tok
-		tokenMu.Unlock()
-		if currentTwitchClient != nil {
-			currentTwitchClient.SetUserAccessToken(tok.AccessToken)
+		cl.tokenMu.Lock()
+		cl.currentUserToken = tok
+		cl.tokenMu.Unlock()
+		if cl.currentTwitchClient != nil {
+			cl.currentTwitchClient.SetUserAccessToken(tok.AccessToken)
 		}
 	case c.Conf.ChannelName:
-		tokenMu.Lock()
-		currentBroadcasterToken = tok
-		tokenMu.Unlock()
-		if broadcasterTwitchClient != nil {
-			broadcasterTwitchClient.SetUserAccessToken(tok.AccessToken)
+		cl.tokenMu.Lock()
+		cl.currentBroadcasterToken = tok
+		cl.tokenMu.Unlock()
+		if cl.broadcasterTwitchClient != nil {
+			cl.broadcasterTwitchClient.SetUserAccessToken(tok.AccessToken)
 		}
 	default:
 		slog.Warn("OAuth bootstrap completed for unknown identity; oauth_tokens row written but in-memory state unchanged",
@@ -525,14 +505,14 @@ func GenerateUserAccessToken(code string, expectedLogin string) error {
 // minutes of expiry. Each leg uses its own Postgres advisory lock so two
 // running tripbots (local dev + cluster pod) sharing the same account can't
 // race the rotation.
-func RefreshUserAccessToken(ctx context.Context) {
+func (cl *API) RefreshUserAccessToken(ctx context.Context) {
 	botUser := c.Conf.BotUsername
 	broadcasterUser := c.Conf.ChannelName
 
-	refreshOne(ctx, botUser, applyBotToken, false)
+	cl.refreshOne(ctx, botUser, cl.applyBotToken, false)
 
 	if broadcasterUser != "" && broadcasterUser != botUser {
-		refreshOne(ctx, broadcasterUser, applyBroadcasterToken, false)
+		cl.refreshOne(ctx, broadcasterUser, cl.applyBroadcasterToken, false)
 	}
 }
 
@@ -545,18 +525,18 @@ func RefreshUserAccessToken(ctx context.Context) {
 // restart. When neither yields a usable token — e.g. a DB-restored row whose
 // refresh_token is also revoked — the in-memory slot is left blanked and the
 // reauth link is logged; the admin panel's re-auth prompt then covers it.
-func Reauth(ctx context.Context, account string) {
+func (cl *API) Reauth(ctx context.Context, account string) {
 	username := c.Conf.BotUsername
-	apply := applyBotToken
+	apply := cl.applyBotToken
 	if account == "broadcaster" {
 		username = c.Conf.ChannelName
-		apply = applyBroadcasterToken
+		apply = cl.applyBroadcasterToken
 	}
-	refreshOne(ctx, username, apply, true)
+	cl.refreshOne(ctx, username, apply, true)
 	// Re-read regardless of the refresh outcome: a concurrent auth-bootstrap
 	// may have written a fresh token that a refresh with the (also-stale)
 	// refresh_token couldn't produce.
-	if err := LoadFromDB(); err != nil {
+	if err := cl.LoadFromDB(); err != nil {
 		slog.WarnContext(ctx, "reauth: no usable token after refresh + DB re-read",
 			"err", err, "login_as", username, "reauth_url", AuthInitURL(account))
 	}
@@ -566,24 +546,24 @@ func Reauth(ctx context.Context, account string) {
 // bot helix client. Passed to refreshOne so the per-identity slot logic
 // stays out of the refresh dance itself. A zero Token (the refresh-failed
 // signal) flows through naturally: the slot blanks and the gauge records 0.
-func applyBotToken(tok oauthtokens.Token) {
-	tokenMu.Lock()
-	currentUserToken = tok
-	tokenMu.Unlock()
-	if currentTwitchClient != nil {
-		currentTwitchClient.SetUserAccessToken(tok.AccessToken)
+func (cl *API) applyBotToken(tok oauthtokens.Token) {
+	cl.tokenMu.Lock()
+	cl.currentUserToken = tok
+	cl.tokenMu.Unlock()
+	if cl.currentTwitchClient != nil {
+		cl.currentTwitchClient.SetUserAccessToken(tok.AccessToken)
 	}
 	instrumentation.TwitchTokenExpiry.SetExpiresAt("bot", tok.ExpiresAt)
 }
 
 // applyBroadcasterToken writes the rotated token into the broadcaster slot
 // + primes the broadcaster helix client.
-func applyBroadcasterToken(tok oauthtokens.Token) {
-	tokenMu.Lock()
-	currentBroadcasterToken = tok
-	tokenMu.Unlock()
-	if broadcasterTwitchClient != nil {
-		broadcasterTwitchClient.SetUserAccessToken(tok.AccessToken)
+func (cl *API) applyBroadcasterToken(tok oauthtokens.Token) {
+	cl.tokenMu.Lock()
+	cl.currentBroadcasterToken = tok
+	cl.tokenMu.Unlock()
+	if cl.broadcasterTwitchClient != nil {
+		cl.broadcasterTwitchClient.SetUserAccessToken(tok.AccessToken)
 	}
 	instrumentation.TwitchTokenExpiry.SetExpiresAt("broadcaster", tok.ExpiresAt)
 }
@@ -601,7 +581,7 @@ func applyBroadcasterToken(tok oauthtokens.Token) {
 //
 // TODO: helix client surface should move behind an interface so this
 // function can be unit-tested without a real Twitch round-trip.
-func refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token), force bool) {
+func (cl *API) refreshOne(ctx context.Context, username string, applyInMemory func(oauthtokens.Token), force bool) {
 	acquired, release, err := oauthtokens.TryRefreshLock("twitch", username)
 	if err != nil {
 		slog.ErrorContext(ctx, "oauth refresh lock acquisition failed", "err", err, "username", username)
@@ -636,7 +616,7 @@ func refreshOne(ctx context.Context, username string, applyInMemory func(oauthto
 		return
 	}
 
-	client, err := Client()
+	client, err := cl.Client()
 	if err != nil {
 		slog.ErrorContext(ctx, "helix client unavailable for refresh", "err", err, "username", username)
 		return

--- a/pkg/twitch/authentication_test.go
+++ b/pkg/twitch/authentication_test.go
@@ -10,59 +10,47 @@ import (
 	"github.com/adanalife/tripbot/pkg/oauthtokens"
 )
 
-// resetToken restores currentUserToken after a test mutation.
-func resetToken(t *testing.T) {
-	t.Helper()
-	saved := currentUserToken
-	t.Cleanup(func() {
-		tokenMu.Lock()
-		currentUserToken = saved
-		tokenMu.Unlock()
-	})
-}
-
-// resetBroadcasterToken restores currentBroadcasterToken after a mutation.
-func resetBroadcasterToken(t *testing.T) {
-	t.Helper()
-	saved := currentBroadcasterToken
-	t.Cleanup(func() {
-		tokenMu.Lock()
-		currentBroadcasterToken = saved
-		tokenMu.Unlock()
-	})
+// clientWithTokens builds a fresh *API seeded with the given bot +
+// broadcaster tokens. Each test gets its own isolated client — no shared
+// global to save/restore, no mutex dance for single-goroutine setup.
+func clientWithTokens(bot, bcast oauthtokens.Token) *API {
+	cl := New()
+	cl.currentUserToken = bot
+	cl.currentBroadcasterToken = bcast
+	return cl
 }
 
 func TestIRCAuthToken_PrefixesOauth(t *testing.T) {
-	resetToken(t)
-	tokenMu.Lock()
-	currentUserToken = oauthtokens.Token{AccessToken: "abc123"}
-	tokenMu.Unlock()
-
-	got := IRCAuthToken()
-	if got != "oauth:abc123" {
+	cl := clientWithTokens(oauthtokens.Token{AccessToken: "abc123"}, oauthtokens.Token{})
+	if got := cl.IRCAuthToken(); got != "oauth:abc123" {
 		t.Errorf("IRCAuthToken() = %q, want %q", got, "oauth:abc123")
 	}
 }
 
 func TestIRCAuthToken_EmptyWhenUnloaded(t *testing.T) {
-	resetToken(t)
-	tokenMu.Lock()
-	currentUserToken = oauthtokens.Token{}
-	tokenMu.Unlock()
-
-	if got := IRCAuthToken(); got != "" {
+	cl := clientWithTokens(oauthtokens.Token{}, oauthtokens.Token{})
+	if got := cl.IRCAuthToken(); got != "" {
 		t.Errorf("IRCAuthToken() with empty token = %q, want \"\"", got)
 	}
 }
 
 func TestCurrentUserAccessToken_ReturnsRaw(t *testing.T) {
-	resetToken(t)
-	tokenMu.Lock()
-	currentUserToken = oauthtokens.Token{AccessToken: "raw-no-prefix"}
-	tokenMu.Unlock()
-
-	if got := CurrentUserAccessToken(); got != "raw-no-prefix" {
+	cl := clientWithTokens(oauthtokens.Token{AccessToken: "raw-no-prefix"}, oauthtokens.Token{})
+	if got := cl.CurrentUserAccessToken(); got != "raw-no-prefix" {
 		t.Errorf("CurrentUserAccessToken() = %q, want %q", got, "raw-no-prefix")
+	}
+}
+
+// TestNew_IsolatedState confirms the new-shape payoff: two constructed clients
+// don't share token state the way the old package globals did.
+func TestNew_IsolatedState(t *testing.T) {
+	a := clientWithTokens(oauthtokens.Token{AccessToken: "a-tok"}, oauthtokens.Token{})
+	b := New()
+	if a.IRCAuthToken() == "" {
+		t.Fatal("client a should carry its seeded token")
+	}
+	if b.IRCAuthToken() != "" {
+		t.Errorf("client b should be empty; got %q — state leaked between instances", b.IRCAuthToken())
 	}
 }
 
@@ -127,23 +115,15 @@ func TestBroadcasterScopes_DisjointFromBotScopes(t *testing.T) {
 }
 
 func TestBroadcasterTokenLoaded_FalseWhenEmpty(t *testing.T) {
-	resetBroadcasterToken(t)
-	tokenMu.Lock()
-	currentBroadcasterToken = oauthtokens.Token{}
-	tokenMu.Unlock()
-
-	if broadcasterTokenLoaded() {
+	cl := clientWithTokens(oauthtokens.Token{}, oauthtokens.Token{})
+	if cl.broadcasterTokenLoaded() {
 		t.Error("broadcasterTokenLoaded() = true with empty token; want false")
 	}
 }
 
 func TestBroadcasterTokenLoaded_TrueWhenSet(t *testing.T) {
-	resetBroadcasterToken(t)
-	tokenMu.Lock()
-	currentBroadcasterToken = oauthtokens.Token{AccessToken: "broadcaster-tok"}
-	tokenMu.Unlock()
-
-	if !broadcasterTokenLoaded() {
+	cl := clientWithTokens(oauthtokens.Token{}, oauthtokens.Token{AccessToken: "broadcaster-tok"})
+	if !cl.broadcasterTokenLoaded() {
 		t.Error("broadcasterTokenLoaded() = false with token set; want true")
 	}
 }
@@ -211,16 +191,13 @@ func TestErrNoToken_AliasesOAuthTokens(t *testing.T) {
 // TestIRCAuthToken_ConcurrentReads is a smoke check that the RWMutex doesn't
 // deadlock under parallel reads while a writer takes the lock.
 func TestIRCAuthToken_ConcurrentReads(t *testing.T) {
-	resetToken(t)
-	tokenMu.Lock()
-	currentUserToken = oauthtokens.Token{AccessToken: "race-check"}
-	tokenMu.Unlock()
+	cl := clientWithTokens(oauthtokens.Token{AccessToken: "race-check"}, oauthtokens.Token{})
 
 	done := make(chan struct{})
 	for i := 0; i < 8; i++ {
 		go func() {
 			for j := 0; j < 100; j++ {
-				_ = IRCAuthToken()
+				_ = cl.IRCAuthToken()
 			}
 			done <- struct{}{}
 		}()
@@ -244,21 +221,12 @@ func withReauthConf(t *testing.T, bot, channel string) {
 	t.Cleanup(func() { c.Conf.BotUsername, c.Conf.ChannelName = savedBot, savedChan })
 }
 
-func setTokens(t *testing.T, bot, bcast oauthtokens.Token) {
-	t.Helper()
-	resetToken(t)
-	resetBroadcasterToken(t)
-	tokenMu.Lock()
-	currentUserToken, currentBroadcasterToken = bot, bcast
-	tokenMu.Unlock()
-}
-
 func TestAccountsNeedingReauth_AllHealthy(t *testing.T) {
 	withReauthConf(t, "tripbot4000", "adanalife_")
 	future := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
-	setTokens(t, future, future)
+	cl := clientWithTokens(future, future)
 
-	if got := AccountsNeedingReauth(); got != nil {
+	if got := cl.AccountsNeedingReauth(); got != nil {
 		t.Fatalf("AccountsNeedingReauth() = %+v, want nil when both tokens are healthy", got)
 	}
 }
@@ -266,9 +234,9 @@ func TestAccountsNeedingReauth_AllHealthy(t *testing.T) {
 func TestAccountsNeedingReauth_BotMissing(t *testing.T) {
 	withReauthConf(t, "tripbot4000", "adanalife_")
 	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
-	setTokens(t, oauthtokens.Token{}, healthy) // bot blank → missing
+	cl := clientWithTokens(oauthtokens.Token{}, healthy) // bot blank → missing
 
-	got := AccountsNeedingReauth()
+	got := cl.AccountsNeedingReauth()
 	if len(got) != 1 {
 		t.Fatalf("got %d accounts, want 1: %+v", len(got), got)
 	}
@@ -284,9 +252,9 @@ func TestAccountsNeedingReauth_BroadcasterExpired(t *testing.T) {
 	withReauthConf(t, "tripbot4000", "adanalife_")
 	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
 	expired := oauthtokens.Token{AccessToken: "stale", ExpiresAt: time.Now().Add(-time.Hour)}
-	setTokens(t, healthy, expired)
+	cl := clientWithTokens(healthy, expired)
 
-	got := AccountsNeedingReauth()
+	got := cl.AccountsNeedingReauth()
 	if len(got) != 1 {
 		t.Fatalf("got %d accounts, want 1: %+v", len(got), got)
 	}
@@ -299,12 +267,12 @@ func TestTokenStatuses_HealthyReportsExpiryForEveryIdentity(t *testing.T) {
 	withReauthConf(t, "tripbot4000", "adanalife_")
 	botExp := time.Now().Add(3 * time.Hour)
 	bcastExp := time.Now().Add(2 * time.Hour)
-	setTokens(t,
+	cl := clientWithTokens(
 		oauthtokens.Token{AccessToken: "good", ExpiresAt: botExp},
 		oauthtokens.Token{AccessToken: "good", ExpiresAt: bcastExp},
 	)
 
-	got := TokenStatuses()
+	got := cl.TokenStatuses()
 	if len(got) != 2 {
 		t.Fatalf("got %d statuses, want 2 (bot + broadcaster): %+v", len(got), got)
 	}
@@ -321,9 +289,9 @@ func TestTokenStatuses_HealthyReportsExpiryForEveryIdentity(t *testing.T) {
 func TestTokenStatuses_CarriesReauthReason(t *testing.T) {
 	withReauthConf(t, "tripbot4000", "adanalife_")
 	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
-	setTokens(t, oauthtokens.Token{}, healthy) // bot blank → missing
+	cl := clientWithTokens(oauthtokens.Token{}, healthy) // bot blank → missing
 
-	got := TokenStatuses()
+	got := cl.TokenStatuses()
 	if len(got) != 2 || got[0].Account != "bot" || got[0].Reason != "missing" {
 		t.Fatalf("got %+v, want bot row with Reason=missing", got)
 	}
@@ -338,9 +306,9 @@ func TestTokenStatuses_CarriesReauthReason(t *testing.T) {
 func TestAccountsNeedingReauth_NoSeparateBroadcaster(t *testing.T) {
 	withReauthConf(t, "tripbot4000", "tripbot4000")
 	healthy := oauthtokens.Token{AccessToken: "good", ExpiresAt: time.Now().Add(time.Hour)}
-	setTokens(t, healthy, oauthtokens.Token{}) // broadcaster slot blank, but irrelevant
+	cl := clientWithTokens(healthy, oauthtokens.Token{}) // broadcaster slot blank, but irrelevant
 
-	if got := AccountsNeedingReauth(); got != nil {
+	if got := cl.AccountsNeedingReauth(); got != nil {
 		t.Fatalf("AccountsNeedingReauth() = %+v, want nil when no distinct broadcaster identity", got)
 	}
 }

--- a/pkg/twitch/client.go
+++ b/pkg/twitch/client.go
@@ -1,0 +1,79 @@
+package twitch
+
+import (
+	"sync"
+
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
+	"github.com/nicklaw5/helix/v2"
+)
+
+// API owns the mutable Twitch state that used to live in package-level
+// globals: the two helix clients, the App Access Token, the per-identity
+// user-access-tokens, and the cached channel/viewer/audience data. It is the
+// in-process implementation of "talk to Twitch"; construct one with New().
+//
+// (Named API rather than Client because the package already exposes a
+// Client() helix-getter that callers depend on — the type can be renamed once
+// the shims in shims.go are deleted.)
+//
+// Fields are grouped into two clusters on purpose. The **auth core** (helix
+// clients + tokens) is the cohesive unit that is slated to move into its own
+// auth service (see vault/tripbot/TODO.md "Extract Twitch Helix API into a
+// separate service") — keeping it visually distinct here marks that future
+// seam. The **query/viewer** cluster is cached read-state derived from Helix.
+//
+// Methods are still fronted by package-level free-function shims (see
+// shims.go) delegating to defaultClient, so existing callers are unchanged
+// while the globals are eliminated; threading a constructed *API through
+// callers and deleting the shims is a later step.
+type API struct {
+	// --- auth core (future auth-service boundary) ---
+
+	// currentTwitchClient is the lazy-initialized bot helix client. IRC auth +
+	// any Helix endpoint authorized against the bot's identity goes through it.
+	currentTwitchClient *helix.Client
+	// broadcasterTwitchClient is the lazy-initialized broadcaster helix client.
+	// Endpoints that authorize against the channel-owner identity
+	// (GetSubscriptions, GetChannelFollows total, channel.update, mod actions)
+	// go through it — the bot client would 401 since the user-access-token's
+	// identity matters, not just its scope set.
+	broadcasterTwitchClient *helix.Client
+	// appAccessToken is set in Client() (Client Credentials grant) and shared
+	// by both helix clients.
+	appAccessToken string
+
+	// tokenMu guards currentUserToken (bot) and currentBroadcasterToken.
+	// RWMutex because reads (IRCAuthToken, CurrentUserAccessToken) outnumber
+	// writes (LoadFromDB, refresh).
+	tokenMu                 sync.RWMutex
+	currentUserToken        oauthtokens.Token
+	currentBroadcasterToken oauthtokens.Token
+
+	// --- query / viewer state (cached Helix reads) ---
+
+	// channelID is the twitch-internal user ID for the channel.
+	channelID string
+	// botID is the Twitch user ID for the bot account (moderator identity for
+	// API calls that require moderator:read:chatters).
+	botID string
+	// subscribers is the usernames of the current subscribers.
+	subscribers []string
+	// currentChatters holds the most recent chatter list from the Helix API.
+	currentChatters []helix.ChatChatter
+	// chatterCount is the total reported by the API (may exceed
+	// len(currentChatters) when the channel has more than one page of chatters).
+	chatterCount int
+}
+
+// New constructs an API with zero mutable state. The helix clients and App
+// Access Token are built lazily on first use (Client()/BroadcasterClient());
+// the static ClientID/ClientSecret credentials are read from env in init().
+func New() *API {
+	return &API{}
+}
+
+// defaultClient backs the package-level free-function shims in shims.go. It
+// preserves the previous "call twitch.Foo() from anywhere" surface while the
+// globals are gone. Constructed at package-init; New() touches no env, so it
+// is safe before init() populates ClientID/ClientSecret.
+var defaultClient = New()

--- a/pkg/twitch/helix_resp.go
+++ b/pkg/twitch/helix_resp.go
@@ -30,14 +30,14 @@ import (
 // is re-established from the DB and the next call uses a fresh one. Pass ""
 // to opt out — for app-access-token calls (getChannelID's GetUsers) and the
 // mid-bootstrap GetUsers, where re-reading a user token wouldn't help.
-func checkHelixResp(ctx context.Context, endpoint, account string, resp *helix.ResponseCommon) bool {
+func (cl *API) checkHelixResp(ctx context.Context, endpoint, account string, resp *helix.ResponseCommon) bool {
 	if resp == nil || resp.StatusCode < 400 {
 		return false
 	}
 	slog.ErrorContext(ctx, fmt.Sprintf("helix %s returned %d: %s", endpoint, resp.StatusCode, resp.ErrorMessage))
 	instrumentation.TwitchHelixErrors.Inc(endpoint, resp.StatusCode)
 	if resp.StatusCode == http.StatusUnauthorized && account != "" {
-		Reauth(ctx, account)
+		cl.Reauth(ctx, account)
 	}
 	return true
 }

--- a/pkg/twitch/helix_resp_test.go
+++ b/pkg/twitch/helix_resp_test.go
@@ -8,39 +8,44 @@ import (
 )
 
 func TestCheckHelixResp_NilResponse(t *testing.T) {
-	if checkHelixResp(context.Background(), "GetUsers", "", nil) {
+	cl := New()
+	if cl.checkHelixResp(context.Background(), "GetUsers", "", nil) {
 		t.Fatal("nil response should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_Success(t *testing.T) {
+	cl := New()
 	rc := &helix.ResponseCommon{StatusCode: 200}
-	if checkHelixResp(context.Background(), "GetUsers", "", rc) {
+	if cl.checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("200 should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_NoContent(t *testing.T) {
+	cl := New()
 	// 204 is still success — guard against >= 400, not != 200
 	rc := &helix.ResponseCommon{StatusCode: 204}
-	if checkHelixResp(context.Background(), "GetUsers", "", rc) {
+	if cl.checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("204 should not be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_ClientError(t *testing.T) {
+	cl := New()
 	// 403 was the concrete 2026-05-15 incident: bot lost mod scope on the
 	// channel, GetChannelChatChatters returned 403 with empty Data. 403 is a
 	// scope problem, not a stale token — no reauth, but still flagged.
 	rc := &helix.ResponseCommon{StatusCode: 403, ErrorMessage: "insufficient scope"}
-	if !checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", rc) {
+	if !cl.checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", rc) {
 		t.Fatal("403 should be treated as an error")
 	}
 }
 
 func TestCheckHelixResp_ServerError(t *testing.T) {
+	cl := New()
 	rc := &helix.ResponseCommon{StatusCode: 503, ErrorMessage: "unavailable"}
-	if !checkHelixResp(context.Background(), "GetSubscriptions", "broadcaster", rc) {
+	if !cl.checkHelixResp(context.Background(), "GetSubscriptions", "broadcaster", rc) {
 		t.Fatal("5xx should be treated as an error")
 	}
 }
@@ -49,8 +54,9 @@ func TestCheckHelixResp_ServerError(t *testing.T) {
 // Reauth (which would make a live Twitch refresh call) — the app-token and
 // mid-bootstrap callsites rely on this opt-out.
 func TestCheckHelixResp_UnauthorizedNoAccountSkipsReauth(t *testing.T) {
+	cl := New()
 	rc := &helix.ResponseCommon{StatusCode: 401, ErrorMessage: "invalid oauth token"}
-	if !checkHelixResp(context.Background(), "GetUsers", "", rc) {
+	if !cl.checkHelixResp(context.Background(), "GetUsers", "", rc) {
 		t.Fatal("401 should be treated as an error")
 	}
 }

--- a/pkg/twitch/shims.go
+++ b/pkg/twitch/shims.go
@@ -1,0 +1,55 @@
+package twitch
+
+import (
+	"context"
+	"time"
+
+	"github.com/nicklaw5/helix/v2"
+)
+
+// This file preserves the package-level free-function API that callers used
+// before pkg/twitch held a *Client. Each shim delegates to defaultClient so
+// existing call sites (pkg/users, pkg/server, pkg/obs/watchdog, cmd/tripbot,
+// cmd/auth-bootstrap, pkg/eventsub, pkg/chatbot) keep working unchanged while
+// the package-level mutable globals are gone.
+//
+// These shims are transitional. Once a constructed *Client is threaded through
+// those callers, this whole file (and defaultClient) is deleted — see the
+// Phase B/C plan and vault/decisions/chatbot-app-injection-pattern.md.
+
+// --- auth / token ---
+
+func Client() (*helix.Client, error)            { return defaultClient.Client() }
+func BroadcasterClient() (*helix.Client, error) { return defaultClient.BroadcasterClient() }
+func LoadFromDB() error                         { return defaultClient.LoadFromDB() }
+func IRCAuthToken() string                      { return defaultClient.IRCAuthToken() }
+func CurrentUserAccessToken() string            { return defaultClient.CurrentUserAccessToken() }
+func BroadcasterUserAccessToken() string        { return defaultClient.BroadcasterUserAccessToken() }
+func AccountsNeedingReauth() []AccountReauth    { return defaultClient.AccountsNeedingReauth() }
+func TokenStatuses() []AccountTokenStatus       { return defaultClient.TokenStatuses() }
+
+func GenerateUserAccessToken(code string, expectedLogin string) error {
+	return defaultClient.GenerateUserAccessToken(code, expectedLogin)
+}
+func RefreshUserAccessToken(ctx context.Context) { defaultClient.RefreshUserAccessToken(ctx) }
+func Reauth(ctx context.Context, account string) { defaultClient.Reauth(ctx, account) }
+
+// --- audience / viewer queries ---
+
+func GetSubscribers(ctx context.Context)    { defaultClient.GetSubscribers(ctx) }
+func GetFollowerCount(ctx context.Context)  { defaultClient.GetFollowerCount(ctx) }
+func UserIsSubscriber(username string) bool { return defaultClient.UserIsSubscriber(username) }
+func UserIsFollower(username string) bool   { return defaultClient.UserIsFollower(username) }
+func FollowedAt(username string) (time.Time, bool) {
+	return defaultClient.FollowedAt(username)
+}
+func ChatterCount() int             { return defaultClient.ChatterCount() }
+func Chatters() map[string]struct{} { return defaultClient.Chatters() }
+func UpdateChatters()               { defaultClient.UpdateChatters() }
+func ChannelID() string             { return defaultClient.ChannelID() }
+
+// --- streams ---
+
+func IsChannelLive(ctx context.Context, login string) (bool, error) {
+	return defaultClient.IsChannelLive(ctx, login)
+}

--- a/pkg/twitch/streams.go
+++ b/pkg/twitch/streams.go
@@ -15,11 +15,11 @@ import (
 //
 // Authorizes against the app-access-token — GetStreams is public and does
 // not need a user token.
-func IsChannelLive(ctx context.Context, login string) (bool, error) {
+func (cl *API) IsChannelLive(ctx context.Context, login string) (bool, error) {
 	if login == "" {
 		return false, fmt.Errorf("IsChannelLive: empty login")
 	}
-	client, err := Client()
+	client, err := cl.Client()
 	if err != nil {
 		return false, fmt.Errorf("twitch API client unavailable: %w", err)
 	}
@@ -29,7 +29,7 @@ func IsChannelLive(ctx context.Context, login string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("GetStreams: %w", err)
 	}
-	if checkHelixResp(ctx, "GetStreams", "", &resp.ResponseCommon) {
+	if cl.checkHelixResp(ctx, "GetStreams", "", &resp.ResponseCommon) {
 		return false, fmt.Errorf("GetStreams returned %d", resp.StatusCode)
 	}
 	live := len(resp.Data.Streams) > 0

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -12,16 +12,9 @@ import (
 	"github.com/nicklaw5/helix/v2"
 )
 
-// ChannelID contains the twitch-internal user ID
-var ChannelID string
-
-// subscribers is a list of the usernames of the current subscribers
-//TODO: this could include tier and gift info if we wanted
-var subscribers []string
-
 // getChannelID makes a request to twitch to get the user ID for the channel
-func getChannelID(username string) string {
-	client, err := Client()
+func (cl *API) getChannelID(username string) string {
+	client, err := cl.Client()
 	if err != nil {
 		slog.Error("twitch API client unavailable", "err", err)
 		return ""
@@ -39,7 +32,7 @@ func getChannelID(username string) string {
 	}
 	// account="" — GetUsers here authorizes against the app-access-token, not a
 	// user token, so re-reading a user token wouldn't fix a 401.
-	if checkHelixResp(context.Background(), "GetUsers", "", &resp.ResponseCommon) {
+	if cl.checkHelixResp(context.Background(), "GetUsers", "", &resp.ResponseCommon) {
 		return ""
 	}
 
@@ -56,44 +49,44 @@ func getChannelID(username string) string {
 // ctx is forward-compat plumbing for nesting helix HTTP under the parent
 // cron span; the helix client doesn't accept ctx yet, but the log lines
 // get a trace_id link via slog.InfoContext.
-func GetSubscribers(ctx context.Context) {
-	if !broadcasterTokenLoaded() {
+func (cl *API) GetSubscribers(ctx context.Context) {
+	if !cl.broadcasterTokenLoaded() {
 		slog.InfoContext(ctx, "skipping GetSubscribers: no broadcaster oauth_tokens row")
 		return
 	}
-	bclient, err := BroadcasterClient()
+	bclient, err := cl.BroadcasterClient()
 	if err != nil {
 		slog.ErrorContext(ctx, "broadcaster helix client unavailable", "err", err)
 		return
 	}
 	//TODO: should we do this elsewhere as well?
-	if ChannelID == "" {
-		ChannelID = getChannelID(c.Conf.ChannelName)
+	if cl.channelID == "" {
+		cl.channelID = cl.getChannelID(c.Conf.ChannelName)
 	}
 	resp, err := bclient.GetSubscriptions(&helix.SubscriptionsParams{
-		BroadcasterID: ChannelID,
+		BroadcasterID: cl.channelID,
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting subscriptions from twitch", "err", err)
 		return
 	}
-	if checkHelixResp(ctx, "GetSubscriptions", "broadcaster", &resp.ResponseCommon) {
+	if cl.checkHelixResp(ctx, "GetSubscriptions", "broadcaster", &resp.ResponseCommon) {
 		// keep the prior subscriber list rather than zeroing it out
 		return
 	}
 
 	// reset the current subscriber list
-	subscribers = []string{}
+	cl.subscribers = []string{}
 
 	// pull out the usernames
 	for _, sub := range resp.Data.Subscriptions {
-		subscribers = append(subscribers, strings.ToLower(sub.UserName))
+		cl.subscribers = append(cl.subscribers, strings.ToLower(sub.UserName))
 	}
 
-	instrumentation.TwitchAudience.SetSubscribers(int64(len(subscribers)))
+	instrumentation.TwitchAudience.SetSubscribers(int64(len(cl.subscribers)))
 
-	if len(subscribers) > 0 {
-		slog.InfoContext(ctx, "subscribers", "count", len(subscribers), "names", strings.Join(subscribers, ", "))
+	if len(cl.subscribers) > 0 {
+		slog.InfoContext(ctx, "subscribers", "count", len(cl.subscribers), "names", strings.Join(cl.subscribers, ", "))
 	} else {
 		slog.InfoContext(ctx, "no subscribers", "channel", c.Conf.ChannelName)
 	}
@@ -102,27 +95,27 @@ func GetSubscribers(ctx context.Context) {
 // GetFollowerCount fetches the current total follower count for the
 // channel. Authorizes against the broadcaster identity (moderator:read:followers
 // on the channel-owner token). ctx is forward-compat plumbing (see GetSubscribers).
-func GetFollowerCount(ctx context.Context) {
-	if !broadcasterTokenLoaded() {
+func (cl *API) GetFollowerCount(ctx context.Context) {
+	if !cl.broadcasterTokenLoaded() {
 		slog.InfoContext(ctx, "skipping GetFollowerCount: no broadcaster oauth_tokens row")
 		return
 	}
-	bclient, err := BroadcasterClient()
+	bclient, err := cl.BroadcasterClient()
 	if err != nil {
 		slog.ErrorContext(ctx, "broadcaster helix client unavailable", "err", err)
 		return
 	}
-	if ChannelID == "" {
-		ChannelID = getChannelID(c.Conf.ChannelName)
+	if cl.channelID == "" {
+		cl.channelID = cl.getChannelID(c.Conf.ChannelName)
 	}
 	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
-		BroadcasterID: ChannelID,
+		BroadcasterID: cl.channelID,
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting follower count from twitch", "err", err)
 		return
 	}
-	if checkHelixResp(ctx, "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
+	if cl.checkHelixResp(ctx, "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		return
 	}
 	instrumentation.TwitchAudience.SetFollowers(int64(resp.Data.Total))
@@ -130,8 +123,8 @@ func GetFollowerCount(ctx context.Context) {
 }
 
 // UserIsSubscriber returns true if the user subscribes to the channel
-func UserIsSubscriber(username string) bool {
-	for _, sub := range subscribers {
+func (cl *API) UserIsSubscriber(username string) bool {
+	for _, sub := range cl.subscribers {
 		if username == sub {
 			return true
 		}
@@ -142,33 +135,33 @@ func UserIsSubscriber(username string) bool {
 // UserIsFollower returns true if the user follows the channel.
 // Authorizes against the broadcaster identity (moderator:read:followers).
 // When the broadcaster token isn't loaded yet, fail closed.
-func UserIsFollower(username string) bool {
+func (cl *API) UserIsFollower(username string) bool {
 	// I can't follow myself so just do this
 	if c.UserIsAdmin(username) {
 		return true
 	}
 
-	if !broadcasterTokenLoaded() {
+	if !cl.broadcasterTokenLoaded() {
 		return false
 	}
-	bclient, err := BroadcasterClient()
+	bclient, err := cl.BroadcasterClient()
 	if err != nil {
 		slog.Error("broadcaster helix client unavailable", "err", err)
 		return false
 	}
 
 	// get the channel ID for the given user
-	userID := getChannelID(username)
+	userID := cl.getChannelID(username)
 
 	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
-		BroadcasterID: ChannelID,
+		BroadcasterID: cl.channelID,
 		UserID:        userID,
 	})
 	if err != nil {
 		slog.Error("error getting user follows", "err", err)
 		return false
 	}
-	if checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
+	if cl.checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		// fail closed: when we can't verify follow status, treat as non-follower
 		return false
 	}
@@ -185,27 +178,27 @@ func UserIsFollower(username string) bool {
 // broadcaster identity (moderator:read:followers) and fails closed: ok=false
 // when the broadcaster token isn't loaded, the lookup errors, or the user
 // doesn't follow.
-func FollowedAt(username string) (time.Time, bool) {
-	if !broadcasterTokenLoaded() {
+func (cl *API) FollowedAt(username string) (time.Time, bool) {
+	if !cl.broadcasterTokenLoaded() {
 		return time.Time{}, false
 	}
-	bclient, err := BroadcasterClient()
+	bclient, err := cl.BroadcasterClient()
 	if err != nil {
 		slog.Error("broadcaster helix client unavailable", "err", err)
 		return time.Time{}, false
 	}
 
-	userID := getChannelID(username)
+	userID := cl.getChannelID(username)
 
 	resp, err := bclient.GetChannelFollows(&helix.GetChannelFollowsParams{
-		BroadcasterID: ChannelID,
+		BroadcasterID: cl.channelID,
 		UserID:        userID,
 	})
 	if err != nil {
 		slog.Error("error getting user follows", "err", err)
 		return time.Time{}, false
 	}
-	if checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
+	if cl.checkHelixResp(context.Background(), "GetChannelFollows", "broadcaster", &resp.ResponseCommon) {
 		return time.Time{}, false
 	}
 
@@ -218,8 +211,8 @@ func FollowedAt(username string) (time.Time, bool) {
 // broadcasterTokenLoaded reports whether the broadcaster's user-access-token
 // has been populated. Cheaper than building the helix client just to discover
 // the user-token slot is empty.
-func broadcasterTokenLoaded() bool {
-	tokenMu.RLock()
-	defer tokenMu.RUnlock()
-	return currentBroadcasterToken.AccessToken != ""
+func (cl *API) broadcasterTokenLoaded() bool {
+	cl.tokenMu.RLock()
+	defer cl.tokenMu.RUnlock()
+	return cl.currentBroadcasterToken.AccessToken != ""
 }

--- a/pkg/twitch/twitch_test.go
+++ b/pkg/twitch/twitch_test.go
@@ -3,10 +3,8 @@ package twitch
 import "testing"
 
 func TestUserIsSubscriber(t *testing.T) {
-	saved := subscribers
-	defer func() { subscribers = saved }()
-
-	subscribers = []string{"alice", "bob", "carol"}
+	cl := New()
+	cl.subscribers = []string{"alice", "bob", "carol"}
 
 	tests := []struct {
 		username string
@@ -21,7 +19,7 @@ func TestUserIsSubscriber(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.username, func(t *testing.T) {
-			if got := UserIsSubscriber(tt.username); got != tt.want {
+			if got := cl.UserIsSubscriber(tt.username); got != tt.want {
 				t.Fatalf("UserIsSubscriber(%q) = %v, want %v", tt.username, got, tt.want)
 			}
 		})
@@ -29,11 +27,8 @@ func TestUserIsSubscriber(t *testing.T) {
 }
 
 func TestUserIsSubscriberEmptyList(t *testing.T) {
-	saved := subscribers
-	defer func() { subscribers = saved }()
-
-	subscribers = nil
-	if UserIsSubscriber("anyone") {
+	cl := New() // subscribers nil
+	if cl.UserIsSubscriber("anyone") {
 		t.Fatal("expected false when subscribers is nil")
 	}
 }

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -8,26 +8,22 @@ import (
 	"github.com/nicklaw5/helix/v2"
 )
 
-// BotID is the Twitch user ID for the bot account (moderator identity for
-// API calls that require moderator:read:chatters).
-var BotID string
-
-// currentChatters holds the most recent chatter list from the Helix API.
-var currentChatters []helix.ChatChatter
-
-// chatterCount is the total reported by the API (may exceed len(currentChatters)
-// if the channel has more than the default page size of chatters).
-var chatterCount int
+// ChannelID returns the cached twitch-internal user ID for the channel. It is
+// populated lazily by UpdateChatters / GetSubscribers; "" until then. Exposed
+// for cmd/tripbot's EventSub subscription setup.
+func (cl *API) ChannelID() string {
+	return cl.channelID
+}
 
 // ChatterCount returns the number of chatters as reported by Twitch.
-func ChatterCount() int {
-	return chatterCount
+func (cl *API) ChatterCount() int {
+	return cl.chatterCount
 }
 
 // Chatters returns a set of current chatter logins.
-func Chatters() map[string]struct{} {
+func (cl *API) Chatters() map[string]struct{} {
 	chatters := make(map[string]struct{})
-	for _, chatter := range currentChatters {
+	for _, chatter := range cl.currentChatters {
 		chatters[chatter.UserLogin] = struct{}{}
 	}
 	return chatters
@@ -36,34 +32,34 @@ func Chatters() map[string]struct{} {
 // UpdateChatters fetches the current chatter list via the Helix chat/chatters
 // endpoint and updates the in-memory state. Requires the bot account to be a
 // moderator of the channel (moderator:read:chatters scope).
-func UpdateChatters() {
-	client, err := Client()
+func (cl *API) UpdateChatters() {
+	client, err := cl.Client()
 	if err != nil {
 		slog.Error("twitch API client unavailable", "err", err)
 		return
 	}
-	if ChannelID == "" {
-		ChannelID = getChannelID(c.Conf.ChannelName)
+	if cl.channelID == "" {
+		cl.channelID = cl.getChannelID(c.Conf.ChannelName)
 	}
-	if BotID == "" {
-		BotID = getChannelID(c.Conf.BotUsername)
+	if cl.botID == "" {
+		cl.botID = cl.getChannelID(c.Conf.BotUsername)
 	}
 
 	resp, err := client.GetChannelChatChatters(&helix.GetChatChattersParams{
-		BroadcasterID: ChannelID,
-		ModeratorID:   BotID,
+		BroadcasterID: cl.channelID,
+		ModeratorID:   cl.botID,
 	})
 	if err != nil {
 		slog.Error("error getting chatters from twitch", "err", err)
 		return
 	}
-	if checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", &resp.ResponseCommon) {
+	if cl.checkHelixResp(context.Background(), "GetChannelChatChatters", "bot", &resp.ResponseCommon) {
 		// don't overwrite cached chatter state with an empty response —
 		// 4xx here means the bot lost a scope or moderator role and the
 		// next call probably succeeds once that's fixed.
 		return
 	}
 
-	currentChatters = resp.Data.Chatters
-	chatterCount = resp.Data.Total
+	cl.currentChatters = resp.Data.Chatters
+	cl.chatterCount = resp.Data.Total
 }


### PR DESCRIPTION
## What

Adds `App.Twitch` — an interface for the chatbot's command-time Twitch Helix surface — continuing the [chatbot-app-injection pattern](../blob/develop/vault/decisions/chatbot-app-injection-pattern.md). Today it's a single method, `FollowedAt` (used by `followageCmd`).

## Why

This is the **seam** the *"Extract Twitch Helix API into a separate service"* item (`vault/tripbot/TODO.md`) needs: once auth/Helix moves out of process, the in-process `realTwitch` adapter swaps for an HTTP client **without touching any command code**.

It also unlocks unit tests for `followageCmd` (following/not-following, self/other, `@`-stripping) — none of which were testable while the command reached package-level `mytwitch.FollowedAt` directly.

> `App.Twitch` was considered and dropped in phase A (the ADR notes this) because the only callers then were startup wiring. `followageCmd` is now a genuine command-time caller, so the seam earns its place.

## Shape

- `pkg/chatbot/twitch.go` — `Twitch` interface + `realTwitch{}` delegating to the `pkg/twitch` shim (mirrors `realIRC`/`realOnscreens`).
- `App.Twitch` field + `defaultApp` wiring; `newTestApp()` gets `noopTwitch{}`.
- `followageCmd` switches `mytwitch.FollowedAt(...)` → `a.Twitch.FollowedAt(...)`; the now-unused `mytwitch` import drops from `commands.go`.
- `pkg/chatbot/twitch_test.go` — `noopTwitch`/`recordingTwitch` fakes + 3 `followageCmd` tests.

## Stacking

Stacked on #738 (`pkg/twitch` → `*API`). Rebases onto `develop` as the stack merges.