### PR TITLE
ci: cancel superseded :develop image builds via concurrency group

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - develop
 
+# Only build the newest develop merge. A push that lands while a prior run is
+# still building cancels that run, so rapid back-to-back merges don't fan out
+# into N parallel multi-arch builds all pulling base images from Docker Hub
+# (rate-limit avoidance). A superseded run's images would be immediately stale
+# anyway, since the next merge's HEAD is what stage deploys.
+concurrency:
+  group: release-development
+  cancel-in-progress: true
+
 jobs:
   # Per-image path filters. tripbot and vlc rebuild on any Go change to
   # their respective code surfaces; obs only rebuilds when its Dockerfile


### PR DESCRIPTION
## What

Adds a workflow-level `concurrency` block to `release-development.yml`:

```yaml
concurrency:
  group: release-development
  cancel-in-progress: true
```

## Why

Every push to `develop` triggered a fresh **Release Development** run with no concurrency control. Rapid back-to-back merges therefore fanned out into multiple parallel runs — up to 4 images × 2 arches each, every build leg pulling base images from Docker Hub. That's a fast path to Docker Hub rate limiting.

With this change, a push that lands while a prior run is still building cancels that run. Only the newest merge builds — which is correct, since a superseded run's `:develop` images would be immediately stale anyway (stage deploys the latest HEAD).

The group is a static string (not keyed by ref) because this workflow only ever runs on `develop`, so all runs should share one concurrency lane.