### PR TITLE
ci: enforce gofmt + add gitleaks/actionlint/shellcheck/check-json pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+      # The gofmt hook (and the golang-based gitleaks/actionlint hooks) need
+      # the Go toolchain on PATH; mise installs it from .tool-versions.
+      - uses: jdx/mise-action@v2
       - uses: pre-commit/action@v3.0.1
         env:
           SKIP: no-commit-to-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
       - id: trailing-whitespace
       - id: check-yaml
         args: [--allow-multiple-documents]
+      - id: check-json
       - id: check-executables-have-shebangs
 
       # Cross platform
@@ -34,6 +35,39 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
       - id: detect-private-key
+
+  # Secrets: broad scan layered on top of the narrow detect-aws-credentials
+  # / detect-private-key checks above. Sub-second.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  # GitHub Actions workflow linting — fast, and catches the kind of
+  # workflow breakage super-linter's actionlint pass would.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  # Shell script linting (bin/, script/).
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # Go formatting — gofmt only (not full golangci-lint) to avoid the
+  # libvlc/cgo build issues that made super-linter disable Go. Auto-fixes
+  # and fails the run if any file needed reformatting; re-stage and commit.
+  # Needs the Go toolchain on PATH — CI provides it via mise (.tool-versions).
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        description: Format Go code with gofmt.
+        entry: gofmt -l -w
+        language: system
+        types: [go]
 
   # Python: ruff handles both lint and format. Matches super-linter's
   # PYTHON_RUFF + PYTHON_RUFF_FORMAT (PYTHON_BLACK is disabled there to

--- a/bin/current-file.sh
+++ b/bin/current-file.sh
@@ -9,12 +9,12 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 #TODO: check for presence of file here
-if [ ! -f $PIDFILE ]; then
+if [ ! -f "$PIDFILE" ]; then
   echo "Pidfile not found. Is OBS(OS X)/VLC(linux) running??"
   exit 2
 fi
 
-output=$(lsof -p "$(cat $PIDFILE)" 2>/dev/null)
+output=$(lsof -p "$(cat "$PIDFILE")" 2>/dev/null)
 
 # shellcheck disable=SC2181
 if [ $? -eq 0 ]; then

--- a/cmd/auth-bootstrap/auth-bootstrap.go
+++ b/cmd/auth-bootstrap/auth-bootstrap.go
@@ -7,18 +7,18 @@
 // --account=bot|broadcaster.
 //
 // Flow:
-//   1. Verify DB reachable.
-//   2. Generate CSRF state, build authorize URL with BotScopes or
-//      BroadcasterScopes per --account. ForceVerify=true so Twitch re-prompts
-//      which account to sign in as (instead of silently reusing the session
-//      cookie from the previous leg).
-//   3. Spin up a tiny localhost:8080 HTTP listener for the OAuth callback.
-//   4. Open the browser to the authorize URL. Sign in as the matching account.
-//   5. Twitch redirects to localhost:8080/auth/callback. The handler validates
-//      state, exchanges the code via mytwitch.GenerateUserAccessToken (which
-//      Upserts the row keyed by whichever account signed in), and signals
-//      completion.
-//   6. Exit cleanly.
+//  1. Verify DB reachable.
+//  2. Generate CSRF state, build authorize URL with BotScopes or
+//     BroadcasterScopes per --account. ForceVerify=true so Twitch re-prompts
+//     which account to sign in as (instead of silently reusing the session
+//     cookie from the previous leg).
+//  3. Spin up a tiny localhost:8080 HTTP listener for the OAuth callback.
+//  4. Open the browser to the authorize URL. Sign in as the matching account.
+//  5. Twitch redirects to localhost:8080/auth/callback. The handler validates
+//     state, exchanges the code via mytwitch.GenerateUserAccessToken (which
+//     Upserts the row keyed by whichever account signed in), and signals
+//     completion.
+//  6. Exit cleanly.
 //
 // The Twitch app's registered redirect URI is http://localhost:8080/auth/callback;
 // this CLI relies on that registration matching what helix.Client sends.

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -81,7 +81,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) flagCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !flag", "username", user.Username)
-	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10*time.Second)
 }
 
 func (a *App) versionCmd(ctx context.Context, user *users.User, _ []string) {
@@ -372,7 +372,7 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 }
 
-//TODO: refactor to use golang '...' syntax
+// TODO: refactor to use golang '...' syntax
 func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !guess", "username", user.Username)
 	var msg string
@@ -410,7 +410,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	if strings.ToLower(guess) == strings.ToLower(vid.State) {
 		msg = fmt.Sprintf("@%s got it! We're in %s", user.Username, vid.State)
 		// show the flag for the state
-		a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+		a.Onscreens.ShowFlag(ctx, 10*time.Second)
 		// increase their guess score
 		user.AddToScore(ctx, guessScoreboard, 1.0)
 		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
@@ -431,14 +431,14 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// show the flag for the state
-	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10*time.Second)
 	// record that they know the location now
 	user.SetLastLocationTime()
 	a.IRC.Say(msg)
 }
 
-//TODO: maybe there could be a !cancel command or something
-//TODO: use fancy golang ... syntax?
+// TODO: maybe there could be a !cancel command or something
+// TODO: use fancy golang ... syntax?
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !report", "username", user.Username)
 	message := strings.Join(params, " ")
@@ -528,7 +528,7 @@ func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	os.Exit(0)
 }
 
-//TODO: this will always be lower case, find out why
+// TODO: this will always be lower case, find out why
 // middleCmd sets the text at the bottom-middle of the stream
 func (a *App) middleCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !middle", "username", user.Username)

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -186,7 +186,7 @@ type fakeUser struct {
 }
 
 func (f *fakeUser) HasCommandAvailable(_ context.Context) bool { return f.follower }
-func (f *fakeUser) IsSubscriber() bool        { return f.subscriber }
+func (f *fakeUser) IsSubscriber() bool                         { return f.subscriber }
 
 // realUserAsChat wraps *users.User so it satisfies chatUser in tests
 // where we want to pass a struct with known field values.

--- a/pkg/chatbot/nats_test.go
+++ b/pkg/chatbot/nats_test.go
@@ -17,7 +17,7 @@ func (noopNATS) Publish(_ context.Context, _ string, _ []byte) {}
 // subject + payload pair. Goroutine-safe so concurrent commands don't
 // race the slice.
 type recordingNATS struct {
-	mu       sync.Mutex
+	mu        sync.Mutex
 	Publishes []recordedPublish
 }
 

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -48,8 +48,8 @@ func (r realOnscreens) HideMiddleText(ctx context.Context) error {
 // tripbot.<env>.onscreens.middle.show. Snake_case so a future protobuf
 // schema maps 1-1.
 type middleTextEvent struct {
-	Msg        string `json:"msg"`
-	EmittedAt  string `json:"emitted_at"`
+	Msg       string `json:"msg"`
+	EmittedAt string `json:"emitted_at"`
 }
 
 func (r realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {

--- a/pkg/chatbot/onscreens_test.go
+++ b/pkg/chatbot/onscreens_test.go
@@ -10,11 +10,11 @@ import (
 // overlay surface — it just swallows every call.
 type noopOnscreens struct{}
 
-func (noopOnscreens) ShowFlag(_ context.Context, _ time.Duration) error                      { return nil }
-func (noopOnscreens) ShowLeaderboard(_ context.Context, _ string, _ [][]string) error        { return nil }
-func (noopOnscreens) HideMiddleText(_ context.Context) error                                 { return nil }
-func (noopOnscreens) ShowMiddleText(_ context.Context, _ string) error                       { return nil }
-func (noopOnscreens) ShowTimewarp(_ context.Context) error                                   { return nil }
+func (noopOnscreens) ShowFlag(_ context.Context, _ time.Duration) error               { return nil }
+func (noopOnscreens) ShowLeaderboard(_ context.Context, _ string, _ [][]string) error { return nil }
+func (noopOnscreens) HideMiddleText(_ context.Context) error                          { return nil }
+func (noopOnscreens) ShowMiddleText(_ context.Context, _ string) error                { return nil }
+func (noopOnscreens) ShowTimewarp(_ context.Context) error                            { return nil }
 
 // recordingOnscreens captures every call made to it so tests can assert
 // the chatbot invoked the expected overlay method with the expected args.

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -133,7 +133,7 @@ func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {
 	// update the currently-playing video
 	a.Video.GetCurrentlyPlaying(ctx)
 	// show the flag for the state
-	a.Onscreens.ShowFlag(ctx, 10 * time.Second)
+	a.Onscreens.ShowFlag(ctx, 10*time.Second)
 	// update our record of last time it ran
 	lastTimewarpTime = time.Now()
 }

--- a/pkg/chatbot/sessions_test.go
+++ b/pkg/chatbot/sessions_test.go
@@ -12,10 +12,10 @@ import (
 // reads as empty, and Shutdown is a no-op.
 type noopSessions struct{}
 
-func (noopSessions) Find(_ context.Context, _ string) users.User           { return users.User{} }
-func (noopSessions) LifetimeLeaderboard() [][]string                       { return nil }
-func (noopSessions) Shutdown(_ context.Context)                            {}
-func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error      { return nil }
+func (noopSessions) Find(_ context.Context, _ string) users.User      { return users.User{} }
+func (noopSessions) LifetimeLeaderboard() [][]string                  { return nil }
+func (noopSessions) Shutdown(_ context.Context)                       {}
+func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error { return nil }
 
 // recordingSessions captures every call made to it so tests can assert
 // the chatbot queried the expected user / leaderboard surfaces.

--- a/pkg/chatbot/song.go
+++ b/pkg/chatbot/song.go
@@ -20,8 +20,8 @@ type NowPlaying interface {
 }
 
 const (
-	somaFMNowPlayingURL = "https://somafm.com/songs/gsclassic.json"
-	nowPlayingCacheTTL  = 30 * time.Second
+	somaFMNowPlayingURL   = "https://somafm.com/songs/gsclassic.json"
+	nowPlayingCacheTTL    = 30 * time.Second
 	nowPlayingHTTPTimeout = 5 * time.Second
 )
 

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -11,7 +11,7 @@ import (
 // playing video — it just returns the zero value for every call.
 type noopVideo struct{}
 
-func (noopVideo) Current() video.Video                           { return video.Video{} }
+func (noopVideo) Current() video.Video                              { return video.Video{} }
 func (noopVideo) GetCurrentlyPlaying(_ context.Context) video.Video { return video.Video{} }
 func (noopVideo) FindRandomByState(_ context.Context, _ string) (video.Video, error) {
 	return video.Video{}, nil

--- a/pkg/chatbot/vlc_test.go
+++ b/pkg/chatbot/vlc_test.go
@@ -9,10 +9,10 @@ import (
 // — it just swallows every call.
 type noopVLC struct{}
 
-func (noopVLC) PlayRandom(_ context.Context) error                       { return nil }
-func (noopVLC) PlayFileInPlaylist(_ context.Context, _ string) error     { return nil }
-func (noopVLC) Skip(_ context.Context, _ int) error                      { return nil }
-func (noopVLC) Back(_ context.Context, _ int) error                      { return nil }
+func (noopVLC) PlayRandom(_ context.Context) error                   { return nil }
+func (noopVLC) PlayFileInPlaylist(_ context.Context, _ string) error { return nil }
+func (noopVLC) Skip(_ context.Context, _ int) error                  { return nil }
+func (noopVLC) Back(_ context.Context, _ int) error                  { return nil }
 
 // recordingVLC captures every call made to it so tests can assert that
 // the chatbot drove playback as expected. All call records are appended

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,4 +1,4 @@
-//TODO: this would be better as just 'db'
+// TODO: this would be better as just 'db'
 package database
 
 import (
@@ -14,9 +14,9 @@ import (
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // this is how we will share the DB connection

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -77,7 +77,7 @@ func DurationToMiles(dur time.Duration) float32 {
 }
 
 // GoogleMapsURL returns a google maps link to the coords provided
-//TODO find query param for zoom level
+// TODO find query param for zoom level
 func GoogleMapsURL(lat, long float64) string {
 	return fmt.Sprintf("https://maps.google.com/?q=%.5f%%2C%.5f&ll=%.5f%%2C%.5f&z=5", lat, long, lat, long)
 }
@@ -193,7 +193,7 @@ func sunriseSunset(utcDate time.Time, lat, long float64) (time.Time, time.Time) 
 	return ActualDate(rise, lat, long), ActualDate(set, lat, long)
 }
 
-//TODO: text the admin if it errors opening browser?
+// TODO: text the admin if it errors opening browser?
 func OpenInBrowser(url string) {
 	slog.Info("opening url in browser", "url", url)
 	err := open.Run(url)
@@ -202,7 +202,7 @@ func OpenInBrowser(url string) {
 	}
 }
 
-//TODO: remove this and all darwin-only support
+// TODO: remove this and all darwin-only support
 // RunningOnDarwin returns true if we're on darwin (OS X)
 func RunningOnDarwin() bool {
 	return runtime.GOOS == "darwin"
@@ -221,7 +221,7 @@ func RunningOnLinux() bool {
 // this nastiness taken from:
 // https://gist.github.com/davidnewhall/3627895a9fc8fa0affbd747183abca39
 // Write a pid file, but first make sure it doesn't exist with a running pid.
-//TODO: consider refactoring to use PidExists()
+// TODO: consider refactoring to use PidExists()
 func WritePidFile(pidFile string) error {
 	// Read in the pid file as a slice of bytes.
 	if piddata, err := ioutil.ReadFile(pidFile); err == nil {

--- a/pkg/helpers/states.go
+++ b/pkg/helpers/states.go
@@ -23,7 +23,7 @@ func StateToStateAbbrev(state string) string {
 	return ""
 }
 
-//TODO: this doesn't handle the case where the state is invalid
+// TODO: this doesn't handle the case where the state is invalid
 func TitlecaseState(state string) string {
 	if len(state) == 2 {
 		state = StateAbbrevToState(state)

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	goobs "github.com/andreykaipov/goobs"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	goobs "github.com/andreykaipov/goobs"
 )
 
 // PollStreamingActive connects to the OBS WebSocket and updates the

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -65,7 +65,7 @@ func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard 
 	return nil
 }
 
-//TODO: this is taken right from the !guessleaderboard command, DRY it?
+// TODO: this is taken right from the !guessleaderboard command, DRY it?
 func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
 	// select users to show in leaderboard
 	size := 10
@@ -136,7 +136,7 @@ func (c *Client) HideGPSImage(ctx context.Context) error {
 	return nil
 }
 
-//TODO: move this to a common location
+// TODO: move this to a common location
 //
 // Transport-layer errors log at Debug, not Error: each wrapper above this
 // (HideMiddleText, ShowGPSImage, …) logs the operation-specific failure at

--- a/pkg/onscreens-server/onscreens.go
+++ b/pkg/onscreens-server/onscreens.go
@@ -39,7 +39,7 @@ func newOnscreen() *Onscreen {
 }
 
 // backgroundLoop will loop forever, hiding the Onscreen if needed
-//TODO: add signal to end the loop
+// TODO: add signal to end the loop
 func (osc *Onscreen) backgroundLoop() {
 	for { // forever
 		if osc.IsShowing && osc.isExpired() {

--- a/pkg/scoreboards/scores.go
+++ b/pkg/scoreboards/scores.go
@@ -22,7 +22,7 @@ type Score struct {
 }
 
 // GetScoreByName returns the score value for a given username and scoreboard name
-//TODO: this could be achieved with a single query
+// TODO: this could be achieved with a single query
 func GetScoreByName(ctx context.Context, username, scoreboardName string) (float32, error) {
 	userID, err := getUserIDByName(ctx, username)
 	if err != nil {
@@ -43,7 +43,7 @@ func GetScoreByName(ctx context.Context, username, scoreboardName string) (float
 }
 
 // AddToScoreByName increases the score value for a given username and scoreboard name
-//TODO: this could be achieved with less queries
+// TODO: this could be achieved with less queries
 func AddToScoreByName(ctx context.Context, username, scoreboardName string, scoreToAdd float32) error {
 	userID, err := getUserIDByName(ctx, username)
 	if err != nil {
@@ -78,7 +78,7 @@ func findOrCreateScore(ctx context.Context, userID, scoreboardID uint16) (Score,
 }
 
 // findScore will look up the score in the DB
-//TODO: this shouldn't be necessary, join the tables instead
+// TODO: this shouldn't be necessary, join the tables instead
 func findScore(ctx context.Context, userID, scoreboardID uint16) (Score, error) {
 	var score Score
 	result := database.GormDB().WithContext(ctx).
@@ -111,7 +111,7 @@ func (s Score) save(ctx context.Context) error {
 }
 
 // getUserIDByName fetches the user ID for a given username
-//TODO: this shouldn't be necessary, join the tables instead
+// TODO: this shouldn't be necessary, join the tables instead
 func getUserIDByName(ctx context.Context, username string) (uint16, error) {
 	var result struct{ ID uint16 }
 	err := database.GormDB().WithContext(ctx).Raw("SELECT id FROM users WHERE username = ?", username).Scan(&result).Error

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -344,28 +344,28 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		`/CHANGELOG.md">v1.2.3</a>`, // tripbot version tag → changelog (ref is sha or master)
 		`<a href="https://github.com/adanalife/tripbot/blob/deadbeefcafe/CHANGELOG.md">v9.9.9-vlc</a>`, // vlc version → changelog@sha
 		`<a href="https://github.com/adanalife/tripbot/blob/feedfacecafe/CHANGELOG.md">v8.8.8-osc</a>`, // onscreens version → changelog@sha
-		">vlc-server<",       // vlc row label
-		">onscreens-server<", // onscreens row label
-		`<span class="chatters-count">12</span>`,            // initial chatter count (server-rendered, unflashed)
+		">vlc-server<",                                         // vlc row label
+		">onscreens-server<",                                   // onscreens row label
+		`<span class="chatters-count">12</span>`,               // initial chatter count (server-rendered, unflashed)
 		`id="chatters" sse-swap="viewers" hx-swap="innerHTML"`, // live count target wired for SSE updates
-		`<code class="env env-prod">production</code>`,     // env in monospace chip, prod-coloured
-		`<title>tripbot — adanalife_ (production)</title>`, // env rendered in <title> for tab disambiguation
-		"now playing",                        // now-playing section shown when vlc healthy
-		`id="now-line" sse-swap="video"`,     // now-playing line wired for live video swaps
-		`id="auth-card" sse-swap="auth"`,     // live token-expiry card wired for SSE
+		`<code class="env env-prod">production</code>`,         // env in monospace chip, prod-coloured
+		`<title>tripbot — adanalife_ (production)</title>`,     // env rendered in <title> for tab disambiguation
+		"now playing",                                    // now-playing section shown when vlc healthy
+		`id="now-line" sse-swap="video"`,                 // now-playing line wired for live video swaps
+		`id="auth-card" sse-swap="auth"`,                 // live token-expiry card wired for SSE
 		`class="auth-expires" data-expires="4070908800"`, // bot expiry (2099-01-01) for the JS countdown
-		`id="reauth-card" sse-swap="reauth"`, // reauth callout container wired for live appear/clear
-		"wy_0042.MP4",                        // current video file
-		"Wyoming",                            // current video state
-		`class="now-elapsed" data-since=`,    // elapsed span the JS ticker counts up
-		"3m12s",                              // clip progress (initial server render)
-		`>obs</a>`,                           // one-word OBS link
-		`>grafana</a>`,                       // one-word grafana link
-		`>traefik</a>`,                       // one-word traefik link
-		`>hubble</a>`,                        // one-word hubble link
-		"https://obs-prod.tail020deb.ts.net", // tailnet OBS href
-		grafanaURL,                           // grafana href
-		traefikURL,                           // traefik href
+		`id="reauth-card" sse-swap="reauth"`,             // reauth callout container wired for live appear/clear
+		"wy_0042.MP4",                                    // current video file
+		"Wyoming",                                        // current video state
+		`class="now-elapsed" data-since=`,                // elapsed span the JS ticker counts up
+		"3m12s",                                          // clip progress (initial server render)
+		`>obs</a>`,                                       // one-word OBS link
+		`>grafana</a>`,                                   // one-word grafana link
+		`>traefik</a>`,                                   // one-word traefik link
+		`>hubble</a>`,                                    // one-word hubble link
+		"https://obs-prod.tail020deb.ts.net",             // tailnet OBS href
+		grafanaURL,                                       // grafana href
+		traefikURL,                                       // traefik href
 		// Environment is "production" above → hubble link carries ?namespace=prod-1
 		"https://hubble-prod.tail020deb.ts.net/?namespace=prod-1",
 	} {

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -16,7 +16,7 @@ import (
 var ChannelID string
 
 // subscribers is a list of the usernames of the current subscribers
-//TODO: this could include tier and gift info if we wanted
+// TODO: this could include tier and gift info if we wanted
 var subscribers []string
 
 // getChannelID makes a request to twitch to get the user ID for the channel

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
-	"github.com/adanalife/tripbot/pkg/events"
 	"github.com/adanalife/tripbot/pkg/eventbus"
+	"github.com/adanalife/tripbot/pkg/events"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
@@ -78,7 +78,7 @@ func LogoutIfNecessary(ctx context.Context, username string) {
 }
 
 // login will record the users presence in the DB
-//TODO: do we want to make a DB update here? we could do it on logout()
+// TODO: do we want to make a DB update here? we could do it on logout()
 func login(ctx context.Context, username string) *User {
 	now := time.Now()
 

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -18,7 +18,7 @@ import (
 )
 
 type User struct {
-	ID          uint16    `gorm:"primaryKey"`
+	ID          uint16 `gorm:"primaryKey"`
 	Username    string
 	Miles       float32
 	NumVisits   uint16
@@ -211,7 +211,7 @@ func (u *User) SetLastLocationTime() {
 	u.lastLocation = time.Now()
 }
 
-//TODO: maybe return an err here?
+// TODO: maybe return an err here?
 // create() will actually create the DB record
 func create(ctx context.Context, username string) User {
 	slog.InfoContext(ctx, "creating user", "username", username)

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -39,7 +39,7 @@ func load(ctx context.Context, slug string) (Video, error) {
 	return vid, result.Error
 }
 
-//TODO: combine this with load()?
+// TODO: combine this with load()?
 func loadById(ctx context.Context, id int64) (Video, error) {
 	var vid Video
 	result := database.GormDB().WithContext(ctx).First(&vid, id)
@@ -50,7 +50,7 @@ func loadById(ctx context.Context, id int64) (Video, error) {
 }
 
 // create will create a new Video from a slug
-//TODO: this is kinda weird, we create an empty Video
+// TODO: this is kinda weird, we create an empty Video
 // and then we save it to the DB... maybe we could just
 // save right to the DB? It would take some refactoring.
 func create(ctx context.Context, file string) (Video, error) {
@@ -92,7 +92,7 @@ func create(ctx context.Context, file string) (Video, error) {
 }
 
 // save() will store the video in the DB
-//TODO: I think this can be achieved much easier, c.p. user save
+// TODO: I think this can be achieved much easier, c.p. user save
 func (v Video) save(ctx context.Context) error {
 	var err error
 	flagged := v.Flagged
@@ -131,8 +131,8 @@ func (v Video) save(ctx context.Context) error {
 }
 
 // Next() finds the next unflagged video
-//TODO: should this be NextUnflagged?
-//TODO: handle errors in here?
+// TODO: should this be NextUnflagged?
+// TODO: handle errors in here?
 func (v Video) Next(ctx context.Context) Video {
 	vid := v
 	for { // ever

--- a/pkg/video/type.go
+++ b/pkg/video/type.go
@@ -14,7 +14,7 @@ import (
 
 // Videos represent a video file containing dashcam footage
 type Video struct {
-	ID          int           `gorm:"primaryKey"`
+	ID          int `gorm:"primaryKey"`
 	Slug        string
 	Lat         float64
 	Lng         float64
@@ -27,7 +27,7 @@ type Video struct {
 }
 
 // Location returns a lat/lng pair
-//TODO: refactor out the error return value
+// TODO: refactor out the error return value
 func (v Video) Location() (float64, float64, error) {
 	var err error
 	if v.Flagged {
@@ -36,8 +36,8 @@ func (v Video) Location() (float64, float64, error) {
 	return v.Lat, v.Lng, err
 }
 
-//TODO: add color, include location/state/lat/lng?
-//TODO: where else does this get used tho?
+// TODO: add color, include location/state/lat/lng?
+// TODO: where else does this get used tho?
 // ex: 2018_0514_224801_013_a_opt
 func (v Video) String() string {
 	return v.Slug

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -23,7 +23,7 @@ type Client struct {
 // will still send the request, just without a parent span linking it to the
 // caller's trace.
 //
-//TODO: eventually support HTTPS
+// TODO: eventually support HTTPS
 func New(host string) *Client {
 	return &Client{
 		serverURL:  "http://" + host,
@@ -88,7 +88,7 @@ func (c *Client) Back(ctx context.Context, n int) error {
 	return nil
 }
 
-//TODO: move this to a common location
+// TODO: move this to a common location
 //
 // Transport-layer errors log at Debug, not Error: each wrapper above this
 // (CurrentlyPlaying, PlayRandom, …) logs the operation-specific failure at

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -206,7 +206,7 @@ func (s *Server) faviconHandler(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, "assets/favicon.ico")
 }
 
-//TODO: use more StatusExpectationFailed instead of http.StatusUnprocessableEntity
+// TODO: use more StatusExpectationFailed instead of http.StatusUnprocessableEntity
 func (s *Server) catchAllHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 )
 
-//TODO: should we handle the case where index is outside range?
+// TODO: should we handle the case where index is outside range?
 // or just explicitly pass in what we get here?
 func (s *Server) playAtIndex(index int) error {
 	// start playing the media

--- a/pkg/vlc-server/playback_test.go
+++ b/pkg/vlc-server/playback_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestNextIndex(t *testing.T) {
 	tests := []struct {
-		name             string
-		current, offset  int
-		length           int
-		want             int
+		name            string
+		current, offset int
+		length          int
+		want            int
 	}{
 		{"forward in range", 2, 1, 10, 3},
 		{"forward wraps to start", 9, 1, 10, 0},

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -42,9 +42,9 @@ var vlcCmdFlags []string
 // `sout-keep` preserves the chain across playlist transitions so OBS
 // doesn't see EOF on every clip change.
 //
-//   rtsp   — RTSP listener only (container default).
-//   window — no sout; libvlc plays to its native window via --vout.
-//   both   — duplicate to a local display target and the RTSP listener.
+//	rtsp   — RTSP listener only (container default).
+//	window — no sout; libvlc plays to its native window via --vout.
+//	both   — duplicate to a local display target and the RTSP listener.
 func mediaOptions() []string {
 	const rtspChain = "rtp{sdp=rtsp://:8554/dashcam}"
 	switch c.Conf.VlcOutput {
@@ -154,7 +154,7 @@ func (s *Server) Health() error {
 // that case there's nothing to drain and we skip straight to libvlc
 // cleanup.
 //
-//TODO: are there more things to close gracefully?
+// TODO: are there more things to close gracefully?
 func (s *Server) Shutdown(ctx context.Context) {
 	if s.http != nil {
 		slog.InfoContext(ctx, "shutting down VLC web server")


### PR DESCRIPTION
Enforces `gofmt` and extends the pre-commit baseline with the same fast hooks being rolled out across the adanalife repos.

## What

- **gofmt** (local hook) — fails the commit on any unformatted Go. Kept gofmt-only (not full golangci-lint) to dodge the libvlc/cgo build issues that made super-linter disable Go in the first place.
- **gitleaks** — broad secret scan, alongside the existing narrow `detect-aws-credentials` / `detect-private-key`.
- **actionlint** — lints GitHub Actions workflow YAML.
- **shellcheck** — lints shell scripts under `bin/` and `script/`.
- **check-json** — JSON syntax validation.

## Commits (atomic)

1. `style: gofmt the tree` — one-time `gofmt -w` sweep clearing pre-existing drift across 29 files (formatting only, no logic changes). Required so the new hook doesn't fail on unrelated files.
2. `ci: add gofmt, gitleaks, actionlint, shellcheck, and check-json pre-commit hooks` — the config + a `jdx/mise-action` step in the pre-commit CI workflow so the Go toolchain is present for the gofmt hook.
3. `fix(bin): quote PIDFILE expansions in current-file.sh` — resolves the two SC2086 findings shellcheck surfaces.

## Why gofmt wasn't enforced before

super-linter has `VALIDATE_GO: false` ("not working with C libs") and the golangci workflow runs only revive + errcheck, so gofmt drift was landing on `develop` unnoticed.

## Validation

`pre-commit run --all-files` passes every hook.

## Context

Part of a shared pre-commit baseline rollout across the adanalife repos. Sibling PRs: infra #622, website #228, resume #16.