### PR TITLE
fix: resolve .env.<env> from repo root so bare `go test` finds it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 ### CI
 
 - **`go test` finds the repo-root `.env.testing` from any directory.** `config.SetEnvironment` resolved the dotenv file with a cwd-relative `godotenv.Load`, so a package's test binary — which runs from its own dir — never found the checked-in `.env.testing` and either `log.Fatalf`'d in a config `init()` or required a manual `set -a; . ./.env.testing; set +a`. The lookup now anchors at the module root (nearest ancestor with `go.mod`), so `ENV=testing go test ./pkg/...` works with no sourcing, matching the `task test` / `task test:macos` paths. Deployed binaries with no `go.mod` ancestor fall back to the bare relative path, preserving cluster behavior. ([#743])
+
 ## [v2.18.0] — 2026-05-29
 
 Minor release. The admin panel's live console fills in around the chat pane shipped in v2.17.2: a live viewer count, a now-playing card that updates the instant the video changes, a token-expiry countdown, usable chat scrollback that only auto-scrolls when pinned to the bottom, a click-a-username profile popover (monthly miles + handling for 'unknown' dates), and a live location map with a breadcrumb trail and a 'show full route' corpus overlay. onscreens-server moves to its own standalone slim image with a multi-arch release pipeline. Internals: background jobs construct a `*Scheduler` instead of reaching for a package global, and the OpenTelemetry dependencies get bumped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### CI
+
+- **`go test` finds the repo-root `.env.testing` from any directory.** `config.SetEnvironment` resolved the dotenv file with a cwd-relative `godotenv.Load`, so a package's test binary — which runs from its own dir — never found the checked-in `.env.testing` and either `log.Fatalf`'d in a config `init()` or required a manual `set -a; . ./.env.testing; set +a`. The lookup now anchors at the module root (nearest ancestor with `go.mod`), so `ENV=testing go test ./pkg/...` works with no sourcing, matching the `task test` / `task test:macos` paths. Deployed binaries with no `go.mod` ancestor fall back to the bare relative path, preserving cluster behavior. ([#743])
+
 ## [v2.17.0] — 2026-05-28
 
 Minor release. TripBot gets a live Discord bot session (four slash commands mirroring the Twitch leaderboards), gated behind the first flag of a new Postgres-backed feature-flag system with a read-only admin-panel listing. NATS adoption begins with phase 1 — `ShowMiddleText` parallel-publishes to `tripbot.<env>.onscreens.middle.show` while HTTP stays the source of truth. A silent-disconnect watchdog auto-recovers from the prod failure mode where OBS's RTMP write socket goes half-open and frames keep streaming into the void while Twitch shows offline. Twitch token handling closes a cron-desync gap that bit prod on 2026-05-26 (refresh-on-startup + expiry-timestamp gauge, plus a 30→45 minute refresh window that spares the helix 401 self-heal from firing on the routine cycle). Leaderboard rendering swaps space-padded monospace for CSS grid alignment so scores line up under the regular Trebuchet stack.
@@ -1198,3 +1202,4 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#712]: https://github.com/adanalife/tripbot/pull/712
 [#713]: https://github.com/adanalife/tripbot/pull/713
 [#714]: https://github.com/adanalife/tripbot/pull/714
+[#743]: https://github.com/adanalife/tripbot/pull/743

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/joho/godotenv"
 )
@@ -45,7 +46,12 @@ func SetEnvironment() {
 	}
 
 	// load ENV vars from .env file
-	err = godotenv.Load(".env." + env)
+	//
+	// resolveFromRepoRoot lets bare `go test ./pkg/foo` find the repo-root
+	// .env.testing: a package's test binary runs from its own dir, so a plain
+	// cwd-relative Load can't see the file. Walking up to go.mod makes the
+	// blessed `task test` paths and host-side `go test` behave identically.
+	err = godotenv.Load(resolveFromRepoRoot(".env." + env))
 
 	// In cluster contexts (staging/production) the .env file is not shipped —
 	// env values come from envconfig instead — so the missing-file error is
@@ -60,5 +66,31 @@ func SetEnvironment() {
 	// doesn't overwrite existing values, so shell-env and .env.<env> stay
 	// authoritative. Silent no-op in containers without this file present
 	// (e.g. the cluster pod).
-	_ = godotenv.Load("infra/docker/env.docker")
+	_ = godotenv.Load(resolveFromRepoRoot("infra/docker/env.docker"))
+}
+
+// resolveFromRepoRoot turns a repo-relative path into an absolute one anchored
+// at the module root (the nearest ancestor dir containing go.mod), so dotenv
+// files resolve regardless of the process's working directory. This is what
+// makes host-side `go test ./pkg/...` — whose test binaries run from each
+// package's own dir — load the same .env.testing that `task test` does.
+//
+// If no go.mod is found above cwd (e.g. a deployed binary in a container where
+// the dotenv files don't exist anyway), the bare relative path is returned and
+// godotenv.Load no-ops on the missing file, preserving the prior behavior.
+func resolveFromRepoRoot(rel string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return rel
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, rel)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return rel // reached filesystem root without finding go.mod
+		}
+		dir = parent
+	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// resolveFromRepoRoot should anchor a repo-relative path at the nearest
+// ancestor dir containing go.mod, regardless of how deep cwd is — this is what
+// lets a package's test binary (running from its own dir) find the repo-root
+// .env.testing.
+func TestResolveFromRepoRootFindsGoMod(t *testing.T) {
+	// EvalSymlinks because macOS resolves /tmp -> /private/tmp once we chdir,
+	// and resolveFromRepoRoot derives its result from os.Getwd().
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(root, "pkg", "config", "tripbot")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	chdir(t, nested)
+
+	got := resolveFromRepoRoot(".env.testing")
+	want := filepath.Join(root, ".env.testing")
+	if got != want {
+		t.Errorf("resolveFromRepoRoot(%q) = %q, want %q", ".env.testing", got, want)
+	}
+}
+
+// When no go.mod exists above cwd (e.g. a deployed binary), the bare relative
+// path is returned so godotenv.Load no-ops on the missing file as before.
+func TestResolveFromRepoRootFallsBackWithoutGoMod(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	if got := resolveFromRepoRoot(".env.production"); got != ".env.production" {
+		t.Errorf("resolveFromRepoRoot fallback = %q, want bare %q", got, ".env.production")
+	}
+}
+
+// chdir switches into dir for the duration of the test, restoring the original
+// working directory afterward. t.TempDir()s used here have no go.mod ancestor
+// outside themselves, so the resolver's walk terminates at the filesystem root.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}


### PR DESCRIPTION
## What

`config.SetEnvironment()` loaded the dotenv file with a **cwd-relative** `godotenv.Load(".env." + env)`. A package's `go test` binary runs from that package's own directory, so the repo-root `.env.testing` was never found. The result: every host-side `go test ./pkg/foo` either `log.Fatalf`'d in a config `init()` on missing required keys (`CHANNEL_NAME`, etc.), or forced the manual `set -a; . ./.env.testing; set +a` dance first.

This anchors the lookup at the **module root** (nearest ancestor dir containing `go.mod`) via a new `resolveFromRepoRoot` helper, applied to both the `.env.<env>` load and the `infra/docker/env.docker` base layer.

## Why this is the right layer

`.env.testing` is already checked in, populated with fake values, and wired into both blessed paths (`task test` via compose `env_file`, `task test:macos` via `dotenv:`). The only gap was **bare `go test`**, which neither path covers. Fixing the loader fixes every package at once, rather than sprinkling `TestMain`s.

## Behavior

- `ENV=testing go test ./pkg/...` now works from any directory with **no sourcing** — verified against `pkg/chatbot`, `pkg/scoreboards`, `pkg/users` (all previously needed env injection).
- In a deployed binary with no `go.mod` ancestor (the cluster pod), `resolveFromRepoRoot` returns the bare relative path and `godotenv.Load` no-ops on the absent file — **prior cluster behavior preserved**.
- New `pkg/config` unit tests cover both the found-`go.mod` and fallback paths.

## Test

```
ENV=testing go test ./pkg/chatbot/ ./pkg/scoreboards/ ./pkg/users/   # all ok, no sourcing
go test ./pkg/config/                                                # resolver unit tests
```