### PR TITLE
fix(onscreens): use URL-safe base64 for overlay query params

### DIFF
--- a/pkg/helpers/base64_url_test.go
+++ b/pkg/helpers/base64_url_test.go
@@ -1,0 +1,36 @@
+package helpers
+
+import (
+	"net/url"
+	"testing"
+)
+
+// TestBase64SurvivesQueryParsing guards the onscreens bug (VLC-SERVER-B /
+// TRIPBOT-86): the encoded value must survive being placed in an unescaped
+// query parameter and parsed back out by net/url, the way onscreens-client
+// builds URLs and onscreens-server reads them. Standard base64 fails this
+// because its '+' is decoded to a space by query parsing; the URL-safe
+// alphabet does not.
+func TestBase64SurvivesQueryParsing(t *testing.T) {
+	// Leaderboard overlay HTML — under standard base64 this contains a '+' at
+	// byte 27, the exact payload shape behind the production errors.
+	content := `<div class="lb-grid"><div class="lb-title">Correct Guesses This Month</div>`
+
+	encoded := Base64Encode(content)
+
+	// Mirror onscreens-client: interpolate the encoded value straight into the
+	// query string with no escaping.
+	u, err := url.Parse("http://vlc-server:8081/onscreens/leaderboard/show?content=" + encoded)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+
+	// Mirror onscreens-server: read it back via Query().
+	got, err := Base64Decode(u.Query().Get("content"))
+	if err != nil {
+		t.Fatalf("Base64Decode after query parse: %v", err)
+	}
+	if got != content {
+		t.Errorf("content corrupted through query parsing: got %q, want %q", got, content)
+	}
+}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -77,7 +77,7 @@ func DurationToMiles(dur time.Duration) float32 {
 }
 
 // GoogleMapsURL returns a google maps link to the coords provided
-//TODO find query param for zoom level
+// TODO find query param for zoom level
 func GoogleMapsURL(lat, long float64) string {
 	return fmt.Sprintf("https://maps.google.com/?q=%.5f%%2C%.5f&ll=%.5f%%2C%.5f&z=5", lat, long, lat, long)
 }
@@ -193,7 +193,7 @@ func sunriseSunset(utcDate time.Time, lat, long float64) (time.Time, time.Time) 
 	return ActualDate(rise, lat, long), ActualDate(set, lat, long)
 }
 
-//TODO: text the admin if it errors opening browser?
+// TODO: text the admin if it errors opening browser?
 func OpenInBrowser(url string) {
 	slog.Info("opening url in browser", "url", url)
 	err := open.Run(url)
@@ -202,7 +202,7 @@ func OpenInBrowser(url string) {
 	}
 }
 
-//TODO: remove this and all darwin-only support
+// TODO: remove this and all darwin-only support
 // RunningOnDarwin returns true if we're on darwin (OS X)
 func RunningOnDarwin() bool {
 	return runtime.GOOS == "darwin"
@@ -221,7 +221,7 @@ func RunningOnLinux() bool {
 // this nastiness taken from:
 // https://gist.github.com/davidnewhall/3627895a9fc8fa0affbd747183abca39
 // Write a pid file, but first make sure it doesn't exist with a running pid.
-//TODO: consider refactoring to use PidExists()
+// TODO: consider refactoring to use PidExists()
 func WritePidFile(pidFile string) error {
 	// Read in the pid file as a slice of bytes.
 	if piddata, err := ioutil.ReadFile(pidFile); err == nil {
@@ -286,11 +286,11 @@ func PidExists(pid int) (bool, error) {
 
 // https://stackoverflow.com/a/28672789
 func Base64Encode(str string) string {
-	return base64.StdEncoding.EncodeToString([]byte(str))
+	return base64.URLEncoding.EncodeToString([]byte(str))
 }
 
 func Base64Decode(str string) (string, error) {
-	data, err := base64.StdEncoding.DecodeString(str)
+	data, err := base64.URLEncoding.DecodeString(str)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem

`onscreens-client` interpolates `Base64Encode(content)` straight into the `?content=` / `?msg=` query string with no escaping. The shared helper used standard base64, whose alphabet includes `+`. `net/url` query parsing on `onscreens-server` decodes `+` to a space, so `base64.StdEncoding.DecodeString` failed at the first `+` — byte 27 for the leaderboard overlay HTML — and the handler returned 422.

Two Sentry issues are the two ends of this one bug:
- [VLC-SERVER-B](https://a-dana-life.sentry.io/issues/VLC-SERVER-B) — `base64.CorruptInputError: illegal base64 data at input byte 27` (server side, ~113 events, escalating)
- [TRIPBOT-86](https://a-dana-life.sentry.io/issues/TRIPBOT-86) — `non-200 response from server` / status 422 (client side, ~112 events, escalating)

## Fix

Switch the shared `Base64Encode`/`Base64Decode` helpers to `base64.URLEncoding`. The URL-safe alphabet (`-`, `_`) survives an unescaped query value intact. Client and server both route through these helpers so they change in lockstep, and the encoded form is never persisted (all 23 call sites are ephemeral overlay URL params), so there's no migration concern.

Added `encoding_test.go` with a round-trip test and a test that pushes the encoded value through `net/url` query parsing — the latter reproduces the original corruption and fails on the old standard-base64 helper.

## Note on rollout

`tripbot` and `vlc-server` deploy as separate images. During a rolling deploy there's a brief window where a new (URL-safe) client could hit an old (std-decode) server; those requests fail the same way they already do today, so no regression — it clears once both are on this build.

Fixes VLC-SERVER-B
Fixes TRIPBOT-86