### PR TITLE
refactor(geo): extract reverse-geocoding into injectable pkg/geo

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -12,11 +12,11 @@ import (
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/adanalife/tripbot/pkg/geo"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	"github.com/gempir/go-twitch-irc/v4"
-	"github.com/kelvins/geocoder"
 	"gorm.io/gorm"
 )
 
@@ -68,6 +68,10 @@ type App struct {
 	// constructed *background.Scheduler cmd/tripbot installs via
 	// SetScheduler once cron has started.
 	Cron Cron
+	// Geocoder turns GPS coords into a place name for !location. Tests inject
+	// a recordingGeocoder / noopGeocoder; production uses realGeocoder which
+	// delegates to the pkg/geo default configured in Initialize.
+	Geocoder Geocoder
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -91,6 +95,7 @@ var defaultApp = &App{
 	Flags:      realFlags{},
 	NATS:       realNATS{},
 	Cron:       realCron{},
+	Geocoder:   realGeocoder{},
 }
 
 // used to determine which help message to display
@@ -110,8 +115,9 @@ func Initialize() *twitch.Client {
 	var err error
 	Uptime = time.Now()
 
-	// set up geocoder (for translating coords to places)
-	geocoder.ApiKey = c.Conf.GoogleMapsAPIKey
+	// set up the process-wide geocoder (coords -> places). realGeocoder and
+	// pkg/video both route through this default.
+	geo.SetDefault(geo.New(c.Conf.GoogleMapsAPIKey))
 
 	// initialize the twitch API client. Non-fatal: if Twitch is unreachable
 	// at boot, log and continue so the process stays up (readiness reports

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -226,7 +226,7 @@ func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 	// extract the coordinates
 	lat, lng, err := vid.Location()
 	// geocode the location
-	address, _ := helpers.CityFromCoords(lat, lng)
+	address, _ := a.Geocoder.City(lat, lng)
 	if err != nil {
 		slog.ErrorContext(ctx, "geocoding error", "err", err)
 	}

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -57,6 +57,7 @@ func newTestApp(vid video.Video) *App {
 		Flags:      noopFlags{},
 		NATS:       noopNATS{},
 		Cron:       noopCron{},
+		Geocoder:   noopGeocoder{},
 	}
 }
 

--- a/pkg/chatbot/geocode.go
+++ b/pkg/chatbot/geocode.go
@@ -1,0 +1,17 @@
+package chatbot
+
+import "github.com/adanalife/tripbot/pkg/geo"
+
+// Geocoder is the subset of reverse-geocoding that chatbot commands depend on
+// (just City, for !location). Tests inject a fake; production uses
+// realGeocoder, which delegates to the process-wide pkg/geo default configured
+// in Initialize.
+type Geocoder interface {
+	City(lat, lon float64) (string, error)
+}
+
+// realGeocoder routes to pkg/geo's package-level default Geocoder, installed
+// via geo.SetDefault in Initialize once config is loaded.
+type realGeocoder struct{}
+
+func (realGeocoder) City(lat, lon float64) (string, error) { return geo.City(lat, lon) }

--- a/pkg/chatbot/geocode_test.go
+++ b/pkg/chatbot/geocode_test.go
@@ -1,0 +1,23 @@
+package chatbot
+
+import "fmt"
+
+// noopGeocoder is the default Geocoder in newTestApp: every lookup returns an
+// empty string, no error. Commands that geocode but whose result the test
+// doesn't assert on use this.
+type noopGeocoder struct{}
+
+func (noopGeocoder) City(_, _ float64) (string, error) { return "", nil }
+
+// recordingGeocoder captures City calls and returns a staged result, so tests
+// can assert the command geocoded the expected coordinates.
+type recordingGeocoder struct {
+	City_ string // staged return value
+	Err   error  // staged error
+	Calls []string
+}
+
+func (r *recordingGeocoder) City(lat, lon float64) (string, error) {
+	r.Calls = append(r.Calls, fmt.Sprintf("City(%v,%v)", lat, lon))
+	return r.City_, r.Err
+}

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -1,0 +1,95 @@
+// Package geo turns dashcam GPS coordinates into place names (city, state)
+// via reverse geocoding. It wraps the kelvins/geocoder SDK behind a small
+// Geocoder interface so command-time callers can inject a fake in tests
+// instead of reaching for a package-level global and a live Google Maps call.
+//
+// The SDK exposes its API key only as a package-level global
+// (geocoder.ApiKey), so New sets that global as a side effect. That global is
+// an SDK constraint we can't remove here; what this package does remove is our
+// own code reading it to make decisions — the disabled check now reads the
+// Client's own apiKey field, and callers depend on the Geocoder interface
+// rather than the SDK directly.
+package geo
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kelvins/geocoder"
+)
+
+// ErrDisabled is returned by City/State when no Google Maps API key is
+// configured. Callers treat it as a soft-disable signal (skip the lookup,
+// fall back to an empty result) rather than a real error — geocoding is
+// optional and absent in local dev. Replaces helpers.ErrMapsDisabled.
+var ErrDisabled = errors.New("geo: maps API disabled (no GOOGLE_MAPS_API_KEY set)")
+
+// Geocoder is the reverse-geocoding surface command-time callers depend on.
+// Production uses *Client; tests inject a fake.
+type Geocoder interface {
+	City(lat, lon float64) (string, error)
+	State(lat, lon float64) (string, error)
+}
+
+// Client is the production Geocoder. Construct with New.
+type Client struct {
+	apiKey string
+}
+
+// New returns a Client configured with the given Google Maps API key, and
+// sets the kelvins/geocoder package global so the SDK's reverse-geocode call
+// authenticates. An empty key yields a Client whose City/State short-circuit
+// with ErrDisabled (no HTTP, no Sentry noise).
+func New(apiKey string) *Client {
+	geocoder.ApiKey = apiKey
+	return &Client{apiKey: apiKey}
+}
+
+// City returns "City, State" for the coordinates, or "Somewhere in <State>"
+// when the SDK has no city for the point. Returns ErrDisabled when no key is
+// configured.
+func (c *Client) City(lat, lon float64) (string, error) {
+	if c.apiKey == "" {
+		return "", ErrDisabled
+	}
+	addresses, err := geocoder.GeocodingReverse(geocoder.Location{Latitude: lat, Longitude: lon})
+	if err != nil {
+		return "", err
+	}
+	address := addresses[0]
+	if address.City == "" {
+		return fmt.Sprintf("Somewhere in %s", address.State), nil
+	}
+	return fmt.Sprintf("%s, %s", address.City, address.State), nil
+}
+
+// State returns the US state name for the coordinates. Returns ErrDisabled
+// when no key is configured.
+func (c *Client) State(lat, lon float64) (string, error) {
+	if c.apiKey == "" {
+		return "", ErrDisabled
+	}
+	addresses, err := geocoder.GeocodingReverse(geocoder.Location{Latitude: lat, Longitude: lon})
+	if err != nil {
+		return "", err
+	}
+	return addresses[0].State, nil
+}
+
+// defaultClient backs the package-level City/State free functions for callers
+// that aren't constructed with a Geocoder dependency (pkg/video's import path,
+// the collect-gps script). Disabled until SetDefault is called at startup.
+var defaultClient Geocoder = &Client{}
+
+// SetDefault installs the process-wide Geocoder used by the package-level
+// City/State functions. Called once at startup (chatbot.Initialize, or a
+// script's init) after config is loaded.
+func SetDefault(g Geocoder) {
+	defaultClient = g
+}
+
+// City reverse-geocodes via the process-wide default Geocoder.
+func City(lat, lon float64) (string, error) { return defaultClient.City(lat, lon) }
+
+// State reverse-geocodes via the process-wide default Geocoder.
+func State(lat, lon float64) (string, error) { return defaultClient.State(lat, lon) }

--- a/pkg/geo/geo_test.go
+++ b/pkg/geo/geo_test.go
@@ -1,0 +1,54 @@
+package geo
+
+import (
+	"errors"
+	"testing"
+)
+
+// A zero-key Client must short-circuit with ErrDisabled and never touch the
+// network — this is the steady state in local dev and any env without a Maps
+// key, and the whole point of the sentinel.
+func TestDisabledClientShortCircuits(t *testing.T) {
+	c := New("")
+
+	if _, err := c.City(40.7, -111.8); !errors.Is(err, ErrDisabled) {
+		t.Errorf("City with empty key: got %v, want ErrDisabled", err)
+	}
+	if _, err := c.State(40.7, -111.8); !errors.Is(err, ErrDisabled) {
+		t.Errorf("State with empty key: got %v, want ErrDisabled", err)
+	}
+}
+
+// The package-level default starts disabled, so City/State are safe to call
+// before SetDefault runs (e.g. a code path reached before startup wiring).
+func TestPackageDefaultDisabledByDefault(t *testing.T) {
+	orig := defaultClient
+	t.Cleanup(func() { defaultClient = orig })
+	defaultClient = &Client{}
+
+	if _, err := State(40.7, -111.8); !errors.Is(err, ErrDisabled) {
+		t.Errorf("package State before SetDefault: got %v, want ErrDisabled", err)
+	}
+}
+
+func TestSetDefaultInstallsGeocoder(t *testing.T) {
+	orig := defaultClient
+	t.Cleanup(func() { defaultClient = orig })
+
+	SetDefault(stubGeocoder{city: "Provo, Utah", state: "Utah"})
+
+	got, err := City(40.2, -111.6)
+	if err != nil {
+		t.Fatalf("City: unexpected error %v", err)
+	}
+	if got != "Provo, Utah" {
+		t.Errorf("City: got %q, want %q", got, "Provo, Utah")
+	}
+}
+
+type stubGeocoder struct {
+	city, state string
+}
+
+func (s stubGeocoder) City(_, _ float64) (string, error)  { return s.city, nil }
+func (s stubGeocoder) State(_, _ float64) (string, error) { return s.state, nil }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -16,50 +16,14 @@ import (
 	"time"
 
 	"github.com/bradfitz/latlong"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hako/durafmt"
-	"github.com/kelvins/geocoder"
 	"github.com/nathan-osman/go-sunrise"
 	"github.com/skratchdot/open-golang/open"
 )
 
-// ErrMapsDisabled is returned by City/StateFromCoords when no Google Maps
-// API key is configured. Callers can treat it as a soft-disable signal
-// (skip the lookup, fall back to an empty result) rather than a real error.
-var ErrMapsDisabled = errors.New("maps API disabled: no GOOGLE_MAPS_API_KEY set")
-
-func CityFromCoords(lat, lon float64) (string, error) {
-	if geocoder.ApiKey == "" {
-		return "", ErrMapsDisabled
-	}
-	location := geocoder.Location{Latitude: lat, Longitude: lon}
-
-	addresses, err := geocoder.GeocodingReverse(location)
-	if err != nil {
-		return "", err
-	}
-
-	address := addresses[0]
-	addStr := fmt.Sprintf("%s, %s", address.City, address.State)
-	if address.City == "" {
-		addStr = fmt.Sprintf("Somewhere in %s", address.State)
-	}
-	return addStr, err
-}
-
-func StateFromCoords(lat, lon float64) (string, error) {
-	if geocoder.ApiKey == "" {
-		return "", ErrMapsDisabled
-	}
-	location := geocoder.Location{Latitude: lat, Longitude: lon}
-
-	addresses, err := geocoder.GeocodingReverse(location)
-	if err != nil {
-		spew.Dump(err)
-		return "", err
-	}
-	return addresses[0].State, err
-}
+// Reverse geocoding (coords -> city/state) moved to pkg/geo, which wraps the
+// kelvins/geocoder SDK behind an injectable Geocoder interface. helpers stays
+// a pure, dependency-free utility package.
 
 // ProjectRoot returns the root directory of the project
 func ProjectRoot() string {

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/database"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/geo"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"gorm.io/gorm"
 )
@@ -108,10 +109,10 @@ func (v Video) save(ctx context.Context) error {
 
 	if !flagged {
 		// figure out which state we're in
-		state, err = helpers.StateFromCoords(lat, lng)
-		// ErrMapsDisabled is the expected steady-state when no Maps key
+		state, err = geo.State(lat, lng)
+		// ErrDisabled is the expected steady-state when no Maps key
 		// is configured; don't spam Sentry on every video import.
-		if err != nil && !errors.Is(err, helpers.ErrMapsDisabled) {
+		if err != nil && !errors.Is(err, geo.ErrDisabled) {
 			slog.ErrorContext(ctx, "error geocoding coords", "err", err)
 		}
 	}

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/geo"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/video"
-	"github.com/kelvins/geocoder"
 )
 
 // this will hold the filename passed in via the CLI
@@ -26,7 +26,7 @@ func init() {
 	// 	log.Fatal("Error loading .env file")
 	// }
 
-	geocoder.ApiKey = c.Conf.GoogleMapsAPIKey
+	geo.SetDefault(geo.New(c.Conf.GoogleMapsAPIKey))
 
 	flag.StringVar(&videoFile, "file", "", "File to load")
 	flag.BoolVar(&current, "current", false, "Use currently-playing video")


### PR DESCRIPTION
## Why

`helpers.CityFromCoords` / `StateFromCoords` reached into the kelvins/geocoder **package-level global** (`geocoder.ApiKey`) and made a live Google Maps call from inside an otherwise-pure utility package. Two problems:

1. The disabled-check read *another package's* global to make a decision.
2. chatbot's `!location` command couldn't be tested without hitting the network — exactly the shape the chatbot-app-injection ADR exists to fix, just living in `helpers` instead of `chatbot`.

This came out of a "is `helpers` a bad design?" review: the answer was *no* for ~21 of its 23 functions (pure, stateless, already tested) — but these two were the genuine wart. This PR extracts just those.

## What

New **`pkg/geo`**:
- `Geocoder` interface (`City`/`State`)
- `*Client` that holds the API key **as a field** — the disabled-check now reads `c.apiKey`, not the SDK global
- package-level `City`/`State` funcs backed by a default installed via `geo.SetDefault`, for callers not constructed with a dependency
- `ErrDisabled` sentinel (replaces `helpers.ErrMapsDisabled`)

Wiring:
- **pkg/chatbot** gets an `App.Geocoder` injection point (`realGeocoder` in prod, `noopGeocoder`/`recordingGeocoder` fakes for tests), matching the existing App-injection pattern. `Initialize` installs the default via `geo.SetDefault(geo.New(key))`.
- **pkg/video** + the **collect-gps** script call `geo.State` / configure the default.
- **helpers** drops the `geocoder` and `spew` imports and goes back to a pure, dependency-free utility package.

## Honest caveat

The kelvins SDK exposes its key **only** as a package global, so `geo.New` sets it as a side effect. That global is the SDK's constraint — what this removes is *our code* reading it to make decisions, giving the SDK a single owner.

## Tests

`pkg/geo` has unit tests for the disabled path, the package default, and `SetDefault` (no network). A command-level `locationCmd` test is a deliberate **follow-up**: it needs a sqlmock expectation for `user.Save()`, incidental to this change — the `App.Geocoder` seam + `recordingGeocoder` fake are already in place to unblock it.

Build + `go vet` + `go test` green across `pkg/geo`, `pkg/helpers`, `pkg/chatbot`, `pkg/video`, `script/collect-gps`.