### PR TITLE
admin map: break trail on GPS jumps, bridge with dashed line

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1143,7 +1143,46 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   }).addTo(map);
 
   const van = L.divIcon({ className: 'van-marker', html: '🚐', iconSize: [24, 24], iconAnchor: [12, 12] });
-  const line = L.polyline(trail, { color: '#58a6ff', weight: 3, opacity: 0.75 }).addTo(map);
+
+  // Consecutive breadcrumbs farther apart than this are treated as a
+  // discontinuity (a timewarp clip or a bad GPS fix), not a driven path: the
+  // solid trail breaks and the gap is bridged with a faint dashed segment so the
+  // jump reads as "not real driving" rather than a straight slash across the map.
+  const JUMP_KM = 50;
+  const distKm = (a, b) => {
+    const R = 6371, rad = d => d * Math.PI / 180;
+    const dLat = rad(b[0] - a[0]), dLng = rad(b[1] - a[1]);
+    const s = Math.sin(dLat / 2) ** 2 + Math.cos(rad(a[0])) * Math.cos(rad(b[0])) * Math.sin(dLng / 2) ** 2;
+    return 2 * R * Math.asin(Math.sqrt(s));
+  };
+  // Split the trail into solid runs (consecutive points within JUMP_KM) and the
+  // dashed bridge segments spanning each jump. Both are fed to Leaflet as
+  // multi-polylines (arrays of latlng arrays).
+  const splitTrail = (pts) => {
+    const runs = [], bridges = [];
+    if (!pts.length) return { runs, bridges };
+    let run = [pts[0]];
+    for (let i = 1; i < pts.length; i++) {
+      if (distKm(pts[i - 1], pts[i]) > JUMP_KM) {
+        runs.push(run);
+        bridges.push([pts[i - 1], pts[i]]);
+        run = [pts[i]];
+      } else {
+        run.push(pts[i]);
+      }
+    }
+    runs.push(run);
+    return { runs, bridges };
+  };
+
+  const solid = L.polyline([], { color: '#58a6ff', weight: 3, opacity: 0.75 }).addTo(map);
+  const dashed = L.polyline([], { color: '#58a6ff', weight: 2, opacity: 0.4, dashArray: '4 6' }).addTo(map);
+  const drawTrail = () => {
+    const { runs, bridges } = splitTrail(trail);
+    solid.setLatLngs(runs);
+    dashed.setLatLngs(bridges);
+  };
+  drawTrail();
   let marker = null;
   let hasPoint = false;
 
@@ -1164,7 +1203,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     if (isNaN(lat) || isNaN(lng)) return;
     trail.push([lat, lng]);
     if (trail.length > 100) trail.shift();
-    line.setLatLngs(trail);
+    drawTrail();
     recenter(true);
   });
 


### PR DESCRIPTION
The admin-panel live map pushed every `video.changed` breadcrumb onto a single Leaflet polyline, so a timewarp clip or a bad GPS fix drew one long straight segment slashing across the map.

This splits the trail into **solid runs** of consecutive points within `JUMP_KM` (50 km) and renders each cross-jump gap as a **faint dashed bridge** — the 🚐 still moves to the new spot, but the discontinuity reads as "not a driven path" rather than a real road.

## Changes
- `pkg/server/admin.go` (inline map JS only): added a haversine `distKm` + `splitTrail` helper; replaced the single `line` polyline with a `solid` multi-polyline (the runs) and a `dashed` multi-polyline (the bridges). Both the initial `data-trail` seed and the SSE `htmx:afterSwap` append path now redraw through `drawTrail()`.
- No Go logic / data changes — the breadcrumb trail (`hub.go`) is untouched; this is purely how it renders.

## Notes
- `JUMP_KM = 50` is a single tunable constant. 50 km wont trip on normal clip-to-clip driving but catches teleports and null-ish bad fixes. Easy to dial in once it is seen on real data.
- Verified `splitTrail` logic in isolation (normal run stays solid; a 4,125 km SF→NYC teleport breaks into a separate run + one dashed bridge; empty / single-point cases safe). `go test ./pkg/server/` green.