### PR TITLE
dashcam-cv DB prereqs: pgvector frame_embeddings + cv:stats task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -171,3 +171,11 @@ tasks:
       CGO_LDFLAGS: -L/Applications/VLC.app/Contents/MacOS/lib -Wl,-rpath,/Applications/VLC.app/Contents/MacOS/lib -Wno-error=incompatible-function-pointer-types
     cmds:
       - mise exec -- go build -o bin/vlc-server ./cmd/vlc-server
+
+  cv:stats:
+    desc: 'Quick dashcam-cv coverage/size/rate via psql, no model load (NS=stage-1 default)'
+    vars:
+      NS: '{{.NS | default "stage-1"}}'
+    cmds:
+      - >-
+        kubectl -n {{.NS}} exec postgres-0 -- bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT (SELECT count(*) FROM videos WHERE NOT flagged) AS total_videos, (SELECT count(DISTINCT video_id) FROM frame_embeddings) AS embedded, (SELECT count(*) FROM frame_embeddings) AS frames, (SELECT count(DISTINCT video_id) FROM frame_embeddings WHERE date_created > now() - make_interval(hours => 1)) AS videos_last_hr, pg_size_pretty(pg_total_relation_size('"'"'frame_embeddings'"'"')) AS size;"'

--- a/db/migrate/015_create_frame_embeddings.down.sql
+++ b/db/migrate/015_create_frame_embeddings.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS frame_embeddings;
+-- Leave the `vector` extension installed: dropping it would break any other
+-- consumer, and it's harmless to keep.

--- a/db/migrate/015_create_frame_embeddings.up.sql
+++ b/db/migrate/015_create_frame_embeddings.up.sql
@@ -1,0 +1,22 @@
+-- Visual-search frame embeddings for the dashcam corpus (see tripbot/cv/ and
+-- vault/tripbot/dashcam-cv-plan.md). Requires the pgvector extension, which the
+-- postgres image provides (pgvector/pgvector:pg16).
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE frame_embeddings (
+  id           BIGSERIAL PRIMARY KEY,
+  video_id     INTEGER NOT NULL REFERENCES videos(id),
+  ts_sec       FLOAT   NOT NULL,            -- timestamp within the video (seconds)
+  embedding    vector(1152) NOT NULL,       -- SigLIP2 so400m NaFlex image embedding (1152-dim)
+  model        VARCHAR(64) NOT NULL,        -- e.g. 'transformers:google/siglip2-so400m-patch16-naflex'
+  date_created TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Idempotent re-runs: (video_id, ts_sec, model) is unique so ON CONFLICT DO
+-- NOTHING makes embed_video() safe to re-run / overlap with future pipeline ingest.
+CREATE UNIQUE INDEX frame_embeddings_dedupe ON frame_embeddings (video_id, ts_sec, model);
+
+-- Approximate-nearest-neighbour index for cosine search. Built here for
+-- correctness; for the corpus-wide batch, prefer creating it AFTER the bulk
+-- insert (much faster) — drop+recreate around the load if needed.
+CREATE INDEX frame_embeddings_ann ON frame_embeddings USING hnsw (embedding vector_cosine_ops);

--- a/db/migrate/016_drop_moments_viewings.down.sql
+++ b/db/migrate/016_drop_moments_viewings.down.sql
@@ -1,0 +1,27 @@
+-- Recreate moments (006) + viewings (007) verbatim from their original bodies
+-- for reversibility.
+CREATE TABLE moments (
+  id             SERIAL PRIMARY KEY,
+  video_id       INTEGER NOT NULL,
+  next_moment    INTEGER,
+  prev_moment    INTEGER,
+  lat            FLOAT DEFAULT 0,
+  lng            FLOAT DEFAULT 0,
+  address        VARCHAR,
+  locality       VARCHAR,
+  region         VARCHAR,
+  postcode       VARCHAR,
+  country        VARCHAR,
+  flagged        BOOLEAN DEFAULT FALSE,
+  time_offset    VARCHAR(10),
+  date_created   TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE viewings (
+  id             SERIAL PRIMARY KEY,
+  user_id        INTEGER NOT NULL,
+  moment_id      INTEGER NOT NULL,
+  view_count     INTEGER NOT NULL DEFAULT 0,
+  rating         FLOAT DEFAULT 'NaN',
+  date_created   TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/db/migrate/016_drop_moments_viewings.up.sql
+++ b/db/migrate/016_drop_moments_viewings.up.sql
@@ -1,0 +1,7 @@
+-- Drop the orphan `moments` (006) + `viewings` (007) tables: Dana's original
+-- 2020 GPS/geocoding design, never wired up. Verified zero references in Go,
+-- templates, scripts, or SQL (pkg/moments was removed in tripbot#542). An old
+-- idea we'd redesign from scratch if revived, so the dead schema shouldn't
+-- linger. See vault/tripbot/dashcam-cv-plan.md.
+DROP TABLE IF EXISTS viewings;
+DROP TABLE IF EXISTS moments;

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -69,7 +69,9 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:16-alpine
+    # pgvector/pgvector:pg16 is a drop-in for postgres:16-alpine that adds the
+    # `vector` extension (used by frame_embeddings / dashcam-cv visual search).
+    image: pgvector/pgvector:pg16
     restart: always
     ports:
       - "5432"


### PR DESCRIPTION
Breaks the repo-agnostic parts of the dashcam-cv work off the big `feat/dashcam-cv` branch, so the schema/tooling can merge on its own timeline independent of the Python in `cv/`. These are the pieces that would stay in tripbot even if the CV Python moved to its own repo. The pgvector schema is **already applied by hand on stage**; this lands it in the repo properly.

### Commits (atomic)
1. **`db`: frame_embeddings table (pgvector) + pgvector image** — migration 015: `vector(1152)` column (SigLIP2 so400m NaFlex), `(video_id, ts_sec, model)` unique index, HNSW cosine index, `CREATE EXTENSION IF NOT EXISTS vector`. Local dev Postgres bumped `postgres:16-alpine → pgvector/pgvector:pg16` (drop-in that ships the extension).
2. **`db`: drop orphan moments + viewings tables** — migration 016: dead 2020 GPS/geocoding schema, never wired up (`pkg/moments` removed in #542). Reversible down-migration.
3. **`task`: cv:stats** — coverage/size/rate via psql in the postgres pod, no model load, no Python.

### Not included (stays with the Python in `feat/dashcam-cv`)
`cv/**`, the `cv.yml` / `cv-release.yml` workflows, `.github/linters/.python-lint`, and the super-linter isort tweak — all coupled to the Python's existence.

### Notes
- Migrations slot in contiguously after 014.
- Migration 016 is independent of the CV work (just rode along on the branch); happy to pull it onto the cv PR instead if you'd rather keep this PR strictly pgvector-scoped.