### PR TITLE
feat(chatbot): inject Twitch Helix surface as App.Twitch

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -72,6 +72,11 @@ type App struct {
 	// a recordingGeocoder / noopGeocoder; production uses realGeocoder which
 	// delegates to the pkg/geo default configured in Initialize.
 	Geocoder Geocoder
+	// Twitch is the command-time Twitch Helix surface (follow lookups today).
+	// Tests inject a recordingTwitch; production uses realTwitch which
+	// delegates to the pkg/twitch client. The future swap point for an
+	// out-of-process Helix/auth service.
+	Twitch Twitch
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -96,6 +101,7 @@ var defaultApp = &App{
 	NATS:       realNATS{},
 	Cron:       realCron{},
 	Geocoder:   realGeocoder{},
+	Twitch:     realTwitch{},
 }
 
 // used to determine which help message to display

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -19,7 +19,6 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
-	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
@@ -129,7 +128,7 @@ func (a *App) followageCmd(ctx context.Context, user *users.User, params []strin
 		username = helpers.StripAtSign(params[0])
 	}
 
-	followedAt, ok := mytwitch.FollowedAt(username)
+	followedAt, ok := a.Twitch.FollowedAt(username)
 	if !ok {
 		if other {
 			a.IRC.Say(fmt.Sprintf("@%s isn't following the channel.", username))

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -58,6 +58,7 @@ func newTestApp(vid video.Video) *App {
 		NATS:       noopNATS{},
 		Cron:       noopCron{},
 		Geocoder:   noopGeocoder{},
+		Twitch:     noopTwitch{},
 	}
 }
 

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -1,0 +1,29 @@
+package chatbot
+
+import (
+	"time"
+
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// Twitch is the command-time Twitch Helix surface the chatbot needs. Today
+// that's only follow lookups (followageCmd); it grows as admin-panel Helix
+// features land (ban/timeout, send-as-broadcaster — see
+// vault/tripbot/tripbot/TODO.md).
+//
+// It is deliberately the seam where, once the Twitch Helix API moves into its
+// own service (vault/tripbot/TODO.md "Extract Twitch Helix API into a separate
+// service"), the in-process adapter below is swapped for an HTTP client —
+// without touching any command code.
+type Twitch interface {
+	FollowedAt(username string) (time.Time, bool)
+}
+
+// realTwitch is the production adapter the App is wired with at package init.
+// Delegates to the package-level pkg/twitch shim (defaultClient). Mirrors the
+// realIRC / realOnscreens shape.
+type realTwitch struct{}
+
+func (realTwitch) FollowedAt(username string) (time.Time, bool) {
+	return mytwitch.FollowedAt(username)
+}

--- a/pkg/chatbot/twitch_test.go
+++ b/pkg/chatbot/twitch_test.go
@@ -1,0 +1,71 @@
+package chatbot
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+// noopTwitch satisfies Twitch for tests that don't care about follow lookups.
+type noopTwitch struct{}
+
+func (noopTwitch) FollowedAt(string) (time.Time, bool) { return time.Time{}, false }
+
+// recordingTwitch captures FollowedAt lookups and returns a staged result so
+// tests can assert both the username queried and the rendered reply.
+type recordingTwitch struct {
+	Result  time.Time
+	OK      bool
+	Lookups []string
+}
+
+func (r *recordingTwitch) FollowedAt(username string) (time.Time, bool) {
+	r.Lookups = append(r.Lookups, username)
+	return r.Result, r.OK
+}
+
+func TestFollowageCmd_Following_RepliesWithDuration(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	app.Twitch = &recordingTwitch{Result: time.Now().Add(-48 * time.Hour), OK: true}
+
+	app.followageCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if got := strings.Join(rec.Says, " "); !strings.Contains(got, "following for") {
+		t.Fatalf("expected a following-duration reply, got %q", rec.Says)
+	}
+}
+
+func TestFollowageCmd_NotFollowing_SelfPrompt(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	app.Twitch = &recordingTwitch{OK: false}
+
+	app.followageCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if got := strings.Join(rec.Says, " "); !strings.Contains(got, "follow button") {
+		t.Fatalf("expected the not-following self prompt, got %q", rec.Says)
+	}
+}
+
+func TestFollowageCmd_OtherUser_LooksUpStrippedName(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingIRC{}
+	app.IRC = rec
+	twitch := &recordingTwitch{OK: false}
+	app.Twitch = twitch
+
+	app.followageCmd(context.Background(), newTestUser("viewer1"), []string{"@someoneElse"})
+
+	if len(twitch.Lookups) != 1 || twitch.Lookups[0] != "someoneElse" {
+		t.Fatalf("expected a lookup for the @-stripped target, got %v", twitch.Lookups)
+	}
+	if got := strings.Join(rec.Says, " "); !strings.Contains(got, "isn't following") {
+		t.Fatalf("expected the other-user not-following reply, got %q", rec.Says)
+	}
+}


### PR DESCRIPTION
## What

Adds `App.Twitch` — an interface for the chatbot's command-time Twitch Helix surface — continuing the [chatbot-app-injection pattern](../blob/develop/vault/decisions/chatbot-app-injection-pattern.md). Today it's a single method, `FollowedAt` (used by `followageCmd`).

## Why

This is the **seam** the *"Extract Twitch Helix API into a separate service"* item (`vault/tripbot/TODO.md`) needs: once auth/Helix moves out of process, the in-process `realTwitch` adapter swaps for an HTTP client **without touching any command code**.

It also unlocks unit tests for `followageCmd` (following/not-following, self/other, `@`-stripping) — none of which were testable while the command reached package-level `mytwitch.FollowedAt` directly.

> `App.Twitch` was considered and dropped in phase A (the ADR notes this) because the only callers then were startup wiring. `followageCmd` is now a genuine command-time caller, so the seam earns its place.

## Shape

- `pkg/chatbot/twitch.go` — `Twitch` interface + `realTwitch{}` delegating to the `pkg/twitch` shim (mirrors `realIRC`/`realOnscreens`).
- `App.Twitch` field + `defaultApp` wiring; `newTestApp()` gets `noopTwitch{}`.
- `followageCmd` switches `mytwitch.FollowedAt(...)` → `a.Twitch.FollowedAt(...)`; the now-unused `mytwitch` import drops from `commands.go`.
- `pkg/chatbot/twitch_test.go` — `noopTwitch`/`recordingTwitch` fakes + 3 `followageCmd` tests.

## Stacking

Stacked on #738 (`pkg/twitch` → `*API`). Rebases onto `develop` as the stack merges.

---
Supersedes #739 (auto-closed when its base branch was deleted by the #738 squash-merge). Rebased onto develop as a single commit.