### PR TITLE
admin panel: htmx upgrades (hx-post actions, live refresh, in-flight feedback)

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -930,7 +930,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
          server-side from the hub's ring buffer; live lines stream in on top. -->
     <div class="chat-wrap">
       <div id="chat-log" class="chat-log" sse-swap="chat" hx-swap="beforeend">
-        {{range .ChatHistory}}<div class="chat-line"><time class="ct-ts" datetime="{{.At.Format "2006-01-02T15:04:05Z07:00"}}">{{.At.Format "15:04"}}</time> <span class="cu">{{.Username}}</span> <span class="ct">{{.Text}}</span></div>{{else}}<div class="chat-empty">waiting for chat…</div>{{end}}
+        {{range .ChatHistory}}<div class="chat-line"><time class="ct-ts" datetime="{{.At.Format "2006-01-02T15:04:05Z07:00"}}">{{.At.Format "15:04"}}</time> <span class="cu" hx-get="/admin/user/{{.Username}}" hx-target="#user-popover" hx-swap="innerHTML" hx-trigger="click">{{.Username}}</span> <span class="ct">{{.Text}}</span></div>{{else}}<div class="chat-empty">waiting for chat…</div>{{end}}
       </div>
       <!-- shown only while scrolled up (see JS): tapping jumps to the newest line -->
       <button id="chat-jump" class="chat-jump" type="button" hidden>↓ new</button>
@@ -1191,38 +1191,30 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   setInterval(tick, 1000);
 })();
 
-// Chat user-profile popover. A delegated click on any chat username (.cu)
-// fetches /admin/user/<name> and floats the returned card near the click;
-// clicking outside or pressing Escape closes it. Delegation covers SSE-added
-// lines without per-line wiring.
+// Chat user-profile popover. Each chat username (.cu) carries hx-get, so htmx
+// fetches /admin/user/<name> into #user-popover on click — including usernames
+// on SSE-added lines, since htmx processes swapped-in content (no delegation
+// needed). We only record where the click landed and, on htmx:afterSwap, reveal
+// + float the card near it; clicking outside or Escape closes it.
 (function() {
   const pop = document.getElementById('user-popover');
   if (!pop) return;
-  let open = false;
-  const hide = () => { pop.hidden = true; open = false; };
+  let lastXY = null, open = false;
   document.addEventListener('click', (e) => {
     const cu = e.target.closest('.cu');
-    if (cu) {
-      const name = cu.textContent.trim();
-      if (!name) return;
-      fetch('/admin/user/' + encodeURIComponent(name))
-        .then(r => r.ok ? r.text() : Promise.reject(r.status))
-        .then(html => {
-          pop.innerHTML = html;
-          pop.hidden = false; // unhide before measuring so offset* are real
-          open = true;
-          const pad = 8;
-          const x = Math.min(e.clientX, window.innerWidth - pop.offsetWidth - pad);
-          const y = Math.min(e.clientY + pad, window.innerHeight - pop.offsetHeight - pad);
-          pop.style.left = Math.max(pad, x) + 'px';
-          pop.style.top = Math.max(pad, y) + 'px';
-        })
-        .catch(() => {});
-      return;
-    }
-    if (open && !pop.contains(e.target)) hide();
+    if (cu) { lastXY = { x: e.clientX, y: e.clientY }; return; } // htmx issues the GET
+    if (open && !pop.contains(e.target)) { pop.hidden = true; open = false; }
   });
-  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hide(); });
+  pop.addEventListener('htmx:afterSwap', () => {
+    pop.hidden = false; // unhide before measuring so offset* are real
+    open = true;
+    const pad = 8, xy = lastXY || { x: pad, y: pad };
+    const x = Math.min(xy.x, window.innerWidth - pop.offsetWidth - pad);
+    const y = Math.min(xy.y + pad, window.innerHeight - pop.offsetHeight - pad);
+    pop.style.left = Math.max(pad, x) + 'px';
+    pop.style.top = Math.max(pad, y) + 'px';
+  });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { pop.hidden = true; open = false; } });
 })();
 
 // Live location map (Leaflet). Seeds a breadcrumb polyline + 🚐 pin from the

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -248,12 +248,14 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	// iOS Safari aggressively caches pages saved as Home Screen apps —
-	// without this, reopening the icon shows stale state until the user
-	// hard-refreshes. no-store forces a fresh fetch every time; the
-	// page is tiny so the cost is trivial.
-	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
-	w.Header().Set("Pragma", "no-cache")
+	// Cache the shell so revisiting (Home Screen reopen, tab return) repaints the
+	// last view instantly instead of a white blank while the page loads. The panel
+	// is live — SSE plus the 15s /admin/refresh poll reconcile any staleness within
+	// seconds — so an aggressive shell cache is safe here. Dropping the old
+	// no-store also lets the browser's back/forward cache restore the page (and
+	// resume its SSE connection) instantly on tab return; stale-while-revalidate
+	// keeps serving the cached paint while a fresh copy loads in the background.
+	w.Header().Set("Cache-Control", "max-age=30, stale-while-revalidate=86400")
 	if err := adminTmpl.Execute(w, data); err != nil {
 		slog.ErrorContext(r.Context(), "couldn't render admin panel", "err", err)
 	}
@@ -1329,20 +1331,11 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   setTimeout(fix, 100);
 })();
 
-// iOS Home Screen apps return to a stale cached page on reopen — even with
-// no-store headers, Safari sometimes serves the old paint. Reload when the
-// tab becomes visible after being hidden ≥10s, so quick app-switches don't
-// reload-spam but a return-from-Home-Screen does.
-(function() {
-  let hiddenAt = 0;
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') {
-      hiddenAt = Date.now();
-    } else if (hiddenAt && Date.now() - hiddenAt >= 10000) {
-      location.reload();
-    }
-  });
-})();
+// No focus/visibility reload here anymore. The shell is cached for an instant
+// repaint and the panel is live (SSE + the 15s /admin/refresh poll), so
+// returning to the tab restores the last view (via the back/forward cache) and
+// self-updates within seconds — a hard reload would just reintroduce the white
+// flash on every return that we're trying to avoid.
 
 // Molly switch, integrated with htmx. Action buttons (restart / stream toggle)
 // carry data-arm-label: the first click arms the button (relabel + redden, 5s

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -119,6 +120,64 @@ type nowPlaying struct {
 type streamControl struct {
 	Reachable bool
 	Active    bool
+}
+
+// streamControlTmpl renders the OBS stream toggle widget. It is the swap target
+// for the stream action POSTs (hx-target="#stream-control", hx-swap="outerHTML")
+// and is rendered identically on initial page load (via the streamControl
+// template func) and by obsStreamActionHandler's response, so a live toggle
+// matches a fresh page render. When OBS is unreachable the toggle is hidden — a
+// click would just fail.
+var streamControlTmpl = template.Must(template.New("streamcontrol").Parse(
+	`<div id="stream-control" class="stream-control"{{if .OOB}} hx-swap-oob="true"{{end}}>` +
+		`{{- if .Reachable}}` +
+		`{{- if .Active}}` +
+		`<button type="button" class="stream stop" hx-post="/admin/obs/stream/stop" hx-target="#stream-control" hx-swap="outerHTML" hx-disabled-elt="this" data-arm-label="click again to confirm stop" data-original-label="stop stream">stop stream</button>` +
+		`{{- else}}` +
+		`<button type="button" class="stream start" hx-post="/admin/obs/stream/start" hx-target="#stream-control" hx-swap="outerHTML" hx-disabled-elt="this" data-arm-label="click again to confirm start" data-original-label="start stream">start stream</button>` +
+		`{{- end}}` +
+		`{{- else}}<p class="stream-unreachable">OBS unreachable</p>{{- end}}` +
+		`</div>`))
+
+// renderStreamControl executes streamControlTmpl to a string. oob=true tags the
+// widget for an out-of-band swap (used by the periodic /admin/refresh poll);
+// false is the inline form used by the initial render (via the streamControl
+// template func) and the action response (which targets #stream-control
+// directly via hx-target).
+func renderStreamControl(sc streamControl, oob bool) string {
+	var sb strings.Builder
+	data := struct {
+		streamControl
+		OOB bool
+	}{sc, oob}
+	if err := streamControlTmpl.Execute(&sb, data); err != nil {
+		slog.Error("couldn't render stream control", "err", err)
+		return ""
+	}
+	return sb.String()
+}
+
+// statusRowsTmpl renders the <li> service-status rows. Extracted so the initial
+// page render (via the statusRows template func) and the /admin/refresh poll
+// produce identical markup, mirroring the streamControl/authCard pattern.
+var statusRowsTmpl = template.Must(template.New("statusrows").Parse(
+	`{{range .}}<li class="row">` +
+		`<span class="dot {{if .OK}}up{{else}}down{{end}}"></span>` +
+		`<span class="name">{{.Name}}</span>` +
+		`{{if .Uptime}}<span class="uptime">up {{.Uptime}}</span>{{end}}` +
+		`{{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}` +
+		`<span class="status">{{.Detail}}</span>` +
+		`<button type="button" class="restart" hx-post="/admin/restart/{{.Name}}" hx-swap="none" hx-disabled-elt="this" data-arm-label="confirm restart" data-original-label="restart">restart</button>` +
+		`</li>{{end}}`))
+
+// renderStatusRows executes statusRowsTmpl to a string.
+func renderStatusRows(s []serviceStatus) string {
+	var sb strings.Builder
+	if err := statusRowsTmpl.Execute(&sb, s); err != nil {
+		slog.Error("couldn't render status rows", "err", err)
+		return ""
+	}
+	return sb.String()
 }
 
 // navLink is one entry in the admin panel's links list.
@@ -353,7 +412,10 @@ func restartActionHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "admin restart failed", "service", service, "err", err)
 	}
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	// The button is hx-swap="none" — no body to return. Immediate feedback is the
+	// in-flight button state; the service drops then reappears in the status rows
+	// on the next panel refresh.
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // obsStreamActionHandler handles POST /admin/obs/stream/{action} (action =
@@ -376,7 +438,46 @@ func obsStreamActionHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.ErrorContext(r.Context(), "obs stream toggle failed", "action", action, "err", err)
 	}
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	// Render from the resulting state: a successful start/stop took effect; a
+	// failed one left the previous state, so the swapped-in widget simply doesn't
+	// flip. The panel's periodic refresh reconciles any drift from OBS state
+	// changed outside the panel. (Source-of-truth philosophy, minus the full-page
+	// reload the old 303 redirect forced.)
+	active := (action == "start") == (err == nil)
+	// HX-Trigger lets the page react beyond the swapped widget — here, open or
+	// close the stream-preview disclosure to match the new state.
+	w.Header().Set("HX-Trigger", fmt.Sprintf(`{"tripbot:stream-changed":{"active":%t}}`, active))
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if _, werr := w.Write([]byte(renderStreamControl(streamControl{Reachable: true, Active: active}, false))); werr != nil {
+		slog.ErrorContext(r.Context(), "couldn't write stream control", "err", werr)
+	}
+}
+
+// refreshHandler serves GET /admin/refresh: the always-present live panel
+// sections — the service status rows and the OBS stream toggle — as out-of-band
+// fragments. A hidden poller on the page (hx-trigger="every 15s") fetches this,
+// so the up/down dots, uptimes, versions, and stream state stay current without
+// a full reload. Conditionally-rendered sections (now-playing audio, feature
+// flags) are intentionally excluded: OOB-swapping into a target that may not be
+// in the DOM is fragile, and those values are low-volatility — they refresh on
+// the next full page load. Same sibling-ping cost as the root render; fine at
+// 15s for a single-operator panel.
+func refreshHandler(w http.ResponseWriter, r *http.Request) {
+	vlc := siblingStatus(r.Context(), "vlc", c.Conf.VlcServerHost)
+	onscreens := siblingStatus(r.Context(), "onscreens", c.Conf.OnscreensServerHost)
+	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+
+	var sb strings.Builder
+	sb.WriteString(`<ul id="status-list" hx-swap-oob="true">`)
+	sb.WriteString(renderStatusRows(gatherStatus(buildSHA(), vlc, onscreens, obs)))
+	sb.WriteString(`</ul>`)
+	sb.WriteString(renderStreamControl(gatherStream(r.Context()), true))
+	if _, err := w.Write([]byte(sb.String())); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't write panel refresh", "err", err)
+	}
 }
 
 // currentVideo summarizes the currently-playing video for the page, but only
@@ -571,6 +672,11 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
 	// so the initial server render and a later SSE swap are byte-identical.
 	"authCard":      func(s []mytwitch.AccountTokenStatus) template.HTML { return template.HTML(renderAuthCard(s)) },
 	"reauthCallout": func(r []mytwitch.AccountReauth) template.HTML { return template.HTML(renderReauthCallout(r)) },
+	// streamControl renders the OBS toggle so the initial paint is byte-identical
+	// to what obsStreamActionHandler swaps in after a live toggle.
+	"streamControl": func(sc streamControl) template.HTML { return template.HTML(renderStreamControl(sc, false)) },
+	// statusRows renders the service-status <li> rows, shared with /admin/refresh.
+	"statusRows": func(s []serviceStatus) template.HTML { return template.HTML(renderStatusRows(s)) },
 }).Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -691,7 +797,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   .reauth a.btn:hover { background:#ffc578; color:#1a1100; }
   .reauth .why { font-family:var(--mono); font-size:.85em; opacity:.85; }
   /* stream toggle — start (green) or stop (red), with a molly-switch two-click confirm */
-  .stream-form { margin:8px 0 12px; }
+  .stream-control { margin:8px 0 12px; }
   button.stream { font:inherit; font-size:.9em; padding:6px 14px; border-radius:5px; border:none; cursor:pointer; transition:background .15s, color .15s; }
   button.stream.start { background:#1f6f3e; color:#e8f7ec; font-weight:600; }
   button.stream.start:hover { background:#2a8a4d; }
@@ -712,10 +818,14 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   details.controls > summary:hover { color:#ccc; }
   details.controls h3 { font-size:.8em; text-transform:uppercase; letter-spacing:.08em; color:#888; margin:14px 0 6px; }
   /* per-service restart — small, unobtrusive, lives at the end of each row */
-  .row .restart-form { margin:0; }
   button.restart { font:inherit; font-size:.8em; padding:3px 9px; border-radius:4px; border:1px solid #2a2a2a; background:#1a1a1a; color:#888; cursor:pointer; transition:background .15s, color .15s, border-color .15s; }
   button.restart:hover { background:#252525; color:#ccc; border-color:#3a3a3a; }
   button.restart.armed { background:#f85149; color:#fff; border-color:#f85149; box-shadow:0 0 0 2px #f8514980; }
+  /* in-flight feedback: htmx adds .htmx-request to an action button while its
+     hx-post is in flight, and hx-disabled-elt also sets :disabled. Dim it + show
+     a progress cursor so a tap reads as "working" and a double-tap is visibly
+     inert until the request settles. */
+  button.htmx-request, button.stream:disabled, button.restart:disabled { opacity:.55; cursor:progress; }
   /* live chat console — recent history rendered server-side, live lines stream
      in via SSE (sse-swap="chat", beforeend). Same disclosure look as the others. */
   details.chat { margin:24px 0 0; }
@@ -807,20 +917,11 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   <div id="reauth-card" sse-swap="reauth" hx-swap="innerHTML">{{reauthCallout .Reauth}}</div>
 
   <h2>status</h2>
-  <ul>
-    {{range .Services}}
-    <li class="row">
-      <span class="dot {{if .OK}}up{{else}}down{{end}}"></span>
-      <span class="name">{{.Name}}</span>
-      {{if .Uptime}}<span class="uptime">up {{.Uptime}}</span>{{end}}
-      {{if .Version}}<span class="ver">{{if .VersionURL}}<a href="{{.VersionURL}}">{{.Version}}</a>{{else}}{{.Version}}{{end}}</span>{{end}}
-      <span class="status">{{.Detail}}</span>
-      <form class="restart-form" method="post" action="/admin/restart/{{.Name}}">
-        <button type="submit" class="restart" data-arm-label="confirm restart" data-original-label="restart" onclick="return armConfirm(this)">restart</button>
-      </form>
-    </li>
-    {{end}}
-  </ul>
+  <!-- #status-list is OOB-swapped by the /admin/refresh poll (see the poller near
+       the footer) so the up/down dots, uptimes, and versions stay current without
+       a full reload. Each row's restart button is hx-post (hx-swap="none" — the
+       service just reappears in these rows on the next refresh). -->
+  <ul id="status-list">{{statusRows .Services}}</ul>
 
   <details class="chat" open>
     <summary>chat</summary>
@@ -891,19 +992,10 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   <details class="controls">
     <summary>controls</summary>
     <h3>stream</h3>
-    {{if .Stream.Reachable}}
-      {{if .Stream.Active}}
-      <form class="stream-form" method="post" action="/admin/obs/stream/stop">
-        <button type="submit" class="stream stop" data-arm-label="click again to confirm stop" data-original-label="stop stream" onclick="return armConfirm(this)">stop stream</button>
-      </form>
-      {{else}}
-      <form class="stream-form" method="post" action="/admin/obs/stream/start">
-        <button type="submit" class="stream start" data-arm-label="click again to confirm start" data-original-label="start stream" onclick="return armConfirm(this)">start stream</button>
-      </form>
-      {{end}}
-    {{else}}
-    <p class="stream-unreachable">OBS unreachable</p>
-    {{end}}
+    <!-- stream toggle: hx-post flips OBS streaming and swaps this widget in place
+         (no full-page reload). The response re-renders from the resulting state,
+         so a failed toggle simply leaves the button unchanged. -->
+    {{streamControl .Stream}}
   </details>
 
   <h2>dashboards</h2>
@@ -915,6 +1007,12 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     <button id="toggle-all" class="theme-toggle" type="button" title="expand or collapse all sections">▾ expand all</button>
     <button id="theme-toggle" class="theme-toggle" type="button" title="toggle theme">◐ theme</button>
   </div>
+
+  <!-- live refresh: every 15s, fetch the always-present panel sections (service
+       status rows + the OBS stream toggle) and OOB-swap them in, so the dots and
+       stream state stay current without a full reload. Conditionally-rendered
+       sections (now-playing audio, feature flags) refresh on full page load. -->
+  <div hx-get="/admin/refresh" hx-trigger="every 15s" hx-swap="none"></div>
 
   <!-- chat user-profile popover: filled by a fetch when a username in the chat
        console is clicked (see the profile JS); position:fixed so it floats. -->
@@ -1254,28 +1352,51 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   });
 })();
 
-// Molly switch: first click arms the button (relabel + redden, 5s window);
-// second click within the window lets the form submit. Click-away or timeout
-// disarms. No deps — vanilla DOM only.
-function armConfirm(btn) {
-  if (btn.dataset.armed === '1') {
-    return true; // confirm — let the form submit
-  }
-  btn.dataset.armed = '1';
-  btn.classList.add('armed');
-  btn.textContent = btn.dataset.armLabel;
+// Molly switch, integrated with htmx. Action buttons (restart / stream toggle)
+// carry data-arm-label: the first click arms the button (relabel + redden, 5s
+// window) and cancels the htmx request; a second click within the window lets it
+// through. Click-away or timeout disarms. htmx:confirm fires before every
+// request, so we gate the molly buttons there and let everything else pass.
+(function() {
+  let armed = null, timer = null;
   const disarm = () => {
-    btn.dataset.armed = '';
-    btn.classList.remove('armed');
-    btn.textContent = btn.dataset.originalLabel;
-    document.removeEventListener('click', outsideClick, true);
+    if (!armed) return;
+    armed.dataset.armed = '';
+    armed.classList.remove('armed');
+    armed.textContent = armed.dataset.originalLabel;
+    armed = null;
+    clearTimeout(timer);
+    document.removeEventListener('click', outside, true);
   };
-  const outsideClick = (e) => { if (e.target !== btn) disarm(); };
-  setTimeout(disarm, 5000);
-  // capture-phase listener so clicks anywhere else disarm before they bubble
-  setTimeout(() => document.addEventListener('click', outsideClick, true), 0);
-  return false; // suppress this submit
-}
+  const outside = (e) => { if (armed && e.target !== armed) disarm(); };
+  document.body.addEventListener('htmx:confirm', (e) => {
+    const btn = e.detail.elt;
+    if (!btn || !btn.dataset || !btn.dataset.armLabel) return; // not a molly button
+    if (btn.dataset.armed === '1') { disarm(); return; }       // armed → let it fire
+    e.preventDefault();                                        // first click: arm + cancel
+    btn.dataset.armed = '1';
+    btn.classList.add('armed');
+    btn.textContent = btn.dataset.armLabel;
+    armed = btn;
+    timer = setTimeout(disarm, 5000);
+    // capture-phase listener so clicks anywhere else disarm before they bubble
+    setTimeout(() => document.addEventListener('click', outside, true), 0);
+  });
+})();
+
+// Stream preview follows a live toggle. obsStreamActionHandler returns an
+// HX-Trigger: tripbot:stream-changed event carrying the new state; open or close
+// the preview disclosure to match, so a toggle made from this panel updates the
+// preview without a reload. Setting .open fires the disclosure's own toggle
+// listener, which lazy-loads / unloads the iframe.
+(function() {
+  const details = document.getElementById('stream-preview');
+  if (!details) return;
+  document.body.addEventListener('tripbot:stream-changed', (e) => {
+    const active = !!(e.detail && e.detail.active);
+    if (details.open !== active) details.open = active;
+  });
+})();
 </script>
 </body>
 </html>`))

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -109,7 +109,7 @@ func withObsStream(t *testing.T, startErr, stopErr error) (started, stopped *int
 	return started, stopped
 }
 
-func TestObsStreamActionHandler_StartRedirectsAndCalls(t *testing.T) {
+func TestObsStreamActionHandler_StartSwapsInStopControl(t *testing.T) {
 	started, _ := withObsStream(t, nil, nil)
 
 	r := mux.NewRouter()
@@ -119,18 +119,27 @@ func TestObsStreamActionHandler_StartRedirectsAndCalls(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
 	}
-	if got := rec.Header().Get("Location"); got != "/" {
-		t.Fatalf("got Location %q, want /", got)
+	body := rec.Body.String()
+	// A successful start flips the widget to offer "stop".
+	if !strings.Contains(body, `id="stream-control"`) {
+		t.Errorf("response should be the stream-control fragment; got %q", body)
+	}
+	if !strings.Contains(body, `hx-post="/admin/obs/stream/stop"`) {
+		t.Errorf("swapped-in widget should now offer stop; got %q", body)
+	}
+	// HX-Trigger tells the page the stream is now active (opens the preview).
+	if got := rec.Header().Get("HX-Trigger"); !strings.Contains(got, `"active":true`) {
+		t.Errorf("HX-Trigger = %q, want stream-changed active:true", got)
 	}
 	if *started != 1 {
 		t.Fatalf("obsStartStream called %d times, want 1", *started)
 	}
 }
 
-func TestObsStreamActionHandler_StopRedirectsAndCalls(t *testing.T) {
+func TestObsStreamActionHandler_StopSwapsInStartControl(t *testing.T) {
 	_, stopped := withObsStream(t, nil, nil)
 
 	r := mux.NewRouter()
@@ -140,8 +149,15 @@ func TestObsStreamActionHandler_StopRedirectsAndCalls(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `hx-post="/admin/obs/stream/start"`) {
+		t.Errorf("swapped-in widget should now offer start; got %q", body)
+	}
+	if got := rec.Header().Get("HX-Trigger"); !strings.Contains(got, `"active":false`) {
+		t.Errorf("HX-Trigger = %q, want stream-changed active:false", got)
 	}
 	if *stopped != 1 {
 		t.Fatalf("obsStopStream called %d times, want 1", *stopped)
@@ -163,10 +179,11 @@ func TestObsStreamActionHandler_UnknownActionIs400(t *testing.T) {
 	}
 }
 
-func TestObsStreamActionHandler_RedirectsEvenOnError(t *testing.T) {
-	// State is the source of truth — refreshed panel will show the actual
-	// state. Surfacing the error in flash UI isn't worth the complexity for
-	// a tailnet-only solo-operator panel.
+func TestObsStreamActionHandler_ErrorLeavesStateUnchanged(t *testing.T) {
+	// State is the source of truth — a failed toggle re-renders the previous
+	// state, so the swapped-in widget simply doesn't flip. Surfacing the error in
+	// flash UI isn't worth the complexity for a tailnet-only solo-operator panel;
+	// the periodic refresh reconciles actual OBS state.
 	started, _ := withObsStream(t, errFakeOBS, nil)
 
 	r := mux.NewRouter()
@@ -176,8 +193,16 @@ func TestObsStreamActionHandler_RedirectsEvenOnError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	// Start failed → widget still offers start (didn't flip to stop).
+	body := rec.Body.String()
+	if !strings.Contains(body, `hx-post="/admin/obs/stream/start"`) {
+		t.Errorf("failed start should leave the widget offering start; got %q", body)
+	}
+	if got := rec.Header().Get("HX-Trigger"); !strings.Contains(got, `"active":false`) {
+		t.Errorf("HX-Trigger = %q, want stream-changed active:false", got)
 	}
 	if *started != 1 {
 		t.Fatalf("obsStartStream called %d times, want 1", *started)
@@ -212,8 +237,8 @@ func TestRestartActionHandler_TripbotCallsSelf(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNoContent)
 	}
 	if *selfCalls != 1 {
 		t.Fatalf("restartSelf called %d times, want 1", *selfCalls)
@@ -235,8 +260,8 @@ func TestRestartActionHandler_VlcProxiesToVlcServerHost(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusSeeOther)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNoContent)
 	}
 	if *selfCalls != 0 {
 		t.Fatalf("restartSelf called %d times, want 0", *selfCalls)
@@ -274,6 +299,64 @@ func TestRestartActionHandler_UnknownServiceIs400(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
+	defer SetTwitchConnected(false)
+	SetTwitchConnected(true)
+
+	// stream active → the OOB widget should offer "stop"
+	savedStatus := obsStreamStatus
+	obsStreamStatus = func(context.Context) (bool, error) { return true, nil }
+	t.Cleanup(func() { obsStreamStatus = savedStatus })
+
+	// ObsServerHost isn't covered by withConf — save/restore it here.
+	savedObs := c.Conf.ObsServerHost
+	t.Cleanup(func() { c.Conf.ObsServerHost = savedObs })
+
+	vlc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health/ready":
+			w.WriteHeader(http.StatusOK)
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag":"v9.9.9-vlc","sha":"deadbeefcafe"}`))
+		default:
+			t.Errorf("unexpected vlc request %q", r.URL.Path)
+		}
+	}))
+	defer vlc.Close()
+
+	withConf(t, func() {
+		c.Conf.VlcServerHost = strings.TrimPrefix(vlc.URL, "http://")
+		c.Conf.OnscreensServerHost = "" // skip the onscreens ping
+	})
+	c.Conf.ObsServerHost = "" // skip the obs sibling ping
+
+	rec := httptest.NewRecorder()
+	refreshHandler(rec, httptest.NewRequest(http.MethodGet, "/admin/refresh", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<ul id="status-list" hx-swap-oob="true">`, // status rows OOB target
+		"in chat",                          // tripbot connected
+		">vlc<",                            // vlc service row
+		`hx-post="/admin/restart/vlc"`,     // restart button rendered in the rows
+		`v9.9.9-vlc`,                       // vlc version pulled through
+		`id="stream-control"`,              // stream widget present
+		`hx-post="/admin/obs/stream/stop"`, // stream active → offers stop
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refresh body missing %q", want)
+		}
+	}
+	// The stream widget must be OOB-tagged so it swaps without a target attr.
+	if !strings.Contains(body, `id="stream-control" class="stream-control" hx-swap-oob="true"`) {
+		t.Errorf("stream-control should be OOB-tagged; got %q", body)
 	}
 }
 

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -323,7 +323,7 @@ func (h *Hub) closeAll() {
 // chatLineTmpl renders one chat row as a single line (no newlines — SSE data
 // must not contain bare newlines). html/template escapes username + text.
 var chatLineTmpl = template.Must(template.New("chatline").Parse(
-	`<div class="chat-line"><time class="ct-ts" datetime="{{.At.Format "2006-01-02T15:04:05Z07:00"}}">{{.At.Format "15:04"}}</time> <span class="cu">{{.Username}}</span> <span class="ct">{{.Text}}</span></div>`))
+	`<div class="chat-line"><time class="ct-ts" datetime="{{.At.Format "2006-01-02T15:04:05Z07:00"}}">{{.At.Format "15:04"}}</time> <span class="cu" hx-get="/admin/user/{{.Username}}" hx-target="#user-popover" hx-swap="innerHTML" hx-trigger="click">{{.Username}}</span> <span class="ct">{{.Text}}</span></div>`))
 
 func renderChatLine(line ChatLine) string {
 	var sb strings.Builder

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,6 +73,9 @@ func Start(ctx context.Context) {
 	// the vendored htmx assets it loads. The /admin POST subrouter below is
 	// POST-only, so the GET stream registers on r directly.
 	r.Handle("/admin/events", tagged("/admin/events", eventsHandler)).Methods("GET")
+	// live panel refresh: hidden poller OOB-swaps the always-present status rows
+	// + stream toggle so they stay current without a full reload.
+	r.Handle("/admin/refresh", tagged("/admin/refresh", refreshHandler)).Methods("GET")
 	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())


### PR DESCRIPTION
Three htmx improvements to the tailnet admin panel, replacing full-page reloads.

**Action buttons → hx-post + OOB.** Restart and stream-toggle buttons no longer full-page POST + 303 redirect (which reloaded the Twitch preview, re-initialized Leaflet, and lost chat scroll). The stream toggle swaps the re-rendered `#stream-control` widget in place — rendered from the resulting state, so a failed toggle simply doesn't flip. Restart posts `hx-swap="none"` and returns 204. `obsStreamActionHandler` sets an `HX-Trigger` (`tripbot:stream-changed`) so the stream preview opens/closes to follow a live toggle. The molly-switch two-click confirm moved from an `onclick` handler to an `htmx:confirm` listener so it gates the requests.

**In-flight feedback.** `hx-disabled-elt` + a `.htmx-request` style (dim + progress cursor) so a tap visibly registers and a double-tap is inert until the request settles.

**Live refresh.** A hidden 15s poller hits `/admin/refresh`, which OOB-swaps the always-present sections (service status rows + OBS stream toggle) so the up/down dots and stream state stay current without a reload. `streamControl`/`statusRows` are extracted to shared render funcs so the initial paint, the action response, and the poll produce identical markup. Conditionally-rendered sections (now-playing audio, feature flags) are intentionally left out — OOB into a maybe-absent target is fragile and they're low-volatility.

`go test ./pkg/server/` passes (obs-stream/restart handler tests updated for the new 200+fragment behavior, plus a new `/admin/refresh` test).