### PR TITLE
refactor(users): encapsulate session globals into *Sessions with an injected ChatterSource

### DIFF
--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -27,5 +27,5 @@ func AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = tier
 	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
 	users.GiveEveryoneMiles(1.0)
-	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", len(users.LoggedIn)))
+	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", users.LoggedInCount()))
 }

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -42,7 +42,7 @@ func (realSessions) Find(ctx context.Context, username string) users.User {
 }
 
 func (realSessions) LifetimeLeaderboard() [][]string {
-	return users.LifetimeMilesLeaderboard
+	return users.LifetimeMilesLeaderboard()
 }
 
 func (realSessions) Shutdown(ctx context.Context) {

--- a/pkg/discord/commands.go
+++ b/pkg/discord/commands.go
@@ -119,7 +119,7 @@ func (s *Session) runLifetimeLeaderboard(ctx context.Context, i *discordgo.Inter
 		slog.ErrorContext(ctx, "discord defer reply failed", "err", err, "command", "totalleaderboard")
 		return
 	}
-	entries := users.LifetimeMilesLeaderboard
+	entries := users.LifetimeMilesLeaderboard()
 	if len(entries) > leaderboardSize {
 		entries = entries[:leaderboardSize]
 	}

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -13,12 +13,11 @@ import (
 	"github.com/logrusorgru/aurora/v3"
 )
 
-var LifetimeMilesLeaderboard [][]string
 var initLeaderboardSize = 25
 var maxLeaderboardSize = 50
 
 // InitLeaderboard creates the initial leaderboard
-func InitLeaderboard(ctx context.Context) {
+func (s *Sessions) InitLeaderboard(ctx context.Context) {
 	var users []User
 
 	result := database.GormDB().WithContext(ctx).
@@ -33,24 +32,24 @@ func InitLeaderboard(ctx context.Context) {
 	for _, user := range users {
 		miles := fmt.Sprintf("%.1f", user.Miles)
 		pair := []string{user.Username, miles}
-		LifetimeMilesLeaderboard = append(LifetimeMilesLeaderboard, pair)
+		s.lifetimeLeaderboard = append(s.lifetimeLeaderboard, pair)
 	}
 }
 
 // UpdateLeaderboard rebuilds the lifetime-miles leaderboard from the
-// LoggedIn map. The work is in-memory (no DB hits), so ctx only carries
-// the cron-tick span for log correlation.
-func UpdateLeaderboard(ctx context.Context) {
-	for _, user := range LoggedIn {
+// session's logged-in users. The work is in-memory (no DB hits), so ctx
+// only carries the cron-tick span for log correlation.
+func (s *Sessions) UpdateLeaderboard(ctx context.Context) {
+	for _, user := range s.loggedIn {
 		// skip adding this user if they're a bot or the channel owner
 		if user.IsBot || c.UserIsAdmin(user.Username) {
 			continue
 		}
-		insertIntoLeaderboard(ctx, *user)
+		s.insertIntoLeaderboard(ctx, *user)
 	}
-	// truncate LifetimeMilesLeaderboard if it gets too big
-	if len(LifetimeMilesLeaderboard) > maxLeaderboardSize {
-		LifetimeMilesLeaderboard = LifetimeMilesLeaderboard[:maxLeaderboardSize]
+	// truncate the leaderboard if it gets too big
+	if len(s.lifetimeLeaderboard) > maxLeaderboardSize {
+		s.lifetimeLeaderboard = s.lifetimeLeaderboard[:maxLeaderboardSize]
 	}
 }
 
@@ -64,44 +63,43 @@ func strToFloat32(ctx context.Context, str string) float32 {
 	return float32(value)
 }
 
-func insertIntoLeaderboard(ctx context.Context, user User) {
+func (s *Sessions) insertIntoLeaderboard(ctx context.Context, user User) {
 	// first we remove this user from the board
-	removeFromLeaderboard(user.Username)
+	s.removeFromLeaderboard(user.Username)
 
 	// get the current miles as a float
 	miles := user.CurrentMiles(ctx)
 
-	for i, pair := range LifetimeMilesLeaderboard {
+	for i, pair := range s.lifetimeLeaderboard {
 		val := strToFloat32(ctx, pair[1])
 		// see if our miles are higher
 		if miles >= val {
 			milesStr := fmt.Sprintf("%.1f", miles)
 			newPair := []string{user.Username, milesStr}
 
-			// insert into LifetimeMilesLeaderboard
+			// insert into the leaderboard
 			// https://github.com/golang/go/wiki/SliceTricks#insert
-			LifetimeMilesLeaderboard = append(LifetimeMilesLeaderboard[:i], append([][]string{newPair}, LifetimeMilesLeaderboard[i:]...)...)
+			s.lifetimeLeaderboard = append(s.lifetimeLeaderboard[:i], append([][]string{newPair}, s.lifetimeLeaderboard[i:]...)...)
 			return
 		}
 	}
 }
 
-// removeFromLeaderboard searches the LifetimeMilesLeaderboard for
-// a username and removes it
-func removeFromLeaderboard(username string) {
-	for i, pair := range LifetimeMilesLeaderboard {
+// removeFromLeaderboard searches the leaderboard for a username and removes it
+func (s *Sessions) removeFromLeaderboard(username string) {
+	for i, pair := range s.lifetimeLeaderboard {
 		if pair[0] == username {
-			// delete from LifetimeMilesLeaderboard
+			// delete from the leaderboard
 			// https://github.com/golang/go/wiki/SliceTricks#delete
-			LifetimeMilesLeaderboard = append(LifetimeMilesLeaderboard[:i], LifetimeMilesLeaderboard[i+1:]...)
+			s.lifetimeLeaderboard = append(s.lifetimeLeaderboard[:i], s.lifetimeLeaderboard[i+1:]...)
 			return
 		}
 	}
 }
 
 // this was used for development
-func printLeaderboard() {
-	for i, pair := range LifetimeMilesLeaderboard {
+func (s *Sessions) printLeaderboard() {
+	for i, pair := range s.lifetimeLeaderboard {
 		fmt.Printf("%d: %s - %s\n", i+1, pair[1], aurora.Magenta(pair[0]))
 	}
 }
@@ -132,3 +130,12 @@ func LeaderboardContent(title string, leaderboard [][]string) string {
 	b.WriteString(`</div>`)
 	return b.String()
 }
+
+// LifetimeMilesLeaderboard returns the cached lifetime-miles leaderboard from
+// the default session. Was a package-level slice; now an accessor over the
+// session-owned state.
+func LifetimeMilesLeaderboard() [][]string { return defaultSessions.lifetimeLeaderboard }
+
+func InitLeaderboard(ctx context.Context) { defaultSessions.InitLeaderboard(ctx) }
+
+func UpdateLeaderboard(ctx context.Context) { defaultSessions.UpdateLeaderboard(ctx) }

--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -124,26 +124,18 @@ func TestLeaderboardContentEscapesHTML(t *testing.T) {
 	}
 }
 
-// snapshotLeaderboard saves the global LifetimeMilesLeaderboard and returns a
-// restore func. Use with defer to keep tests from contaminating each other.
-func snapshotLeaderboard() func() {
-	saved := make([][]string, len(LifetimeMilesLeaderboard))
-	copy(saved, LifetimeMilesLeaderboard)
-	return func() { LifetimeMilesLeaderboard = saved }
-}
-
 func TestRemoveFromLeaderboard(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"alice", "100"}, {"bob", "75"}, {"carol", "50"},
 	}
 
-	removeFromLeaderboard("bob")
+	s.removeFromLeaderboard("bob")
 
-	if len(LifetimeMilesLeaderboard) != 2 {
-		t.Fatalf("expected 2 entries after remove, got %d", len(LifetimeMilesLeaderboard))
+	if len(s.lifetimeLeaderboard) != 2 {
+		t.Fatalf("expected 2 entries after remove, got %d", len(s.lifetimeLeaderboard))
 	}
-	for _, pair := range LifetimeMilesLeaderboard {
+	for _, pair := range s.lifetimeLeaderboard {
 		if pair[0] == "bob" {
 			t.Fatal("bob still present after remove")
 		}
@@ -151,77 +143,67 @@ func TestRemoveFromLeaderboard(t *testing.T) {
 }
 
 func TestRemoveFromLeaderboardMissing(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"alice", "100"}, {"bob", "75"},
 	}
 
-	removeFromLeaderboard("nobody")
+	s.removeFromLeaderboard("nobody")
 
-	if len(LifetimeMilesLeaderboard) != 2 {
-		t.Fatalf("expected unchanged length after missing remove, got %d", len(LifetimeMilesLeaderboard))
+	if len(s.lifetimeLeaderboard) != 2 {
+		t.Fatalf("expected unchanged length after missing remove, got %d", len(s.lifetimeLeaderboard))
 	}
 }
 
 func TestRemoveFromLeaderboardEmpty(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = nil
+	s := New(noopChatterSource{})
 
-	removeFromLeaderboard("alice")
+	s.removeFromLeaderboard("alice")
 
-	if len(LifetimeMilesLeaderboard) != 0 {
-		t.Fatalf("expected empty leaderboard, got %v", LifetimeMilesLeaderboard)
+	if len(s.lifetimeLeaderboard) != 0 {
+		t.Fatalf("expected empty leaderboard, got %v", s.lifetimeLeaderboard)
 	}
 }
 
-// insertIntoLeaderboard pulls miles from User.CurrentMiles, which uses the
-// global LoggedIn map. We seed the map with a session snapshot so the math is
-// deterministic.
+// insertIntoLeaderboard pulls miles from User.CurrentMiles. The user isn't in
+// the default session, so CurrentMiles returns User.Miles directly (no session
+// bonus) — making the math deterministic.
 func TestInsertIntoLeaderboardOrdersByMilesDesc(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"existing-1", "100"},
 		{"existing-2", "50"},
 		{"existing-3", "10"},
 	}
 
-	savedLoggedIn := LoggedIn
-	defer func() { LoggedIn = savedLoggedIn }()
-	LoggedIn = map[string]*User{}
-
-	// Miles=75 from User.Miles directly (no session bonus, since not in LoggedIn).
 	u := User{Username: "newcomer", Miles: 75}
-	insertIntoLeaderboard(context.Background(), u)
+	s.insertIntoLeaderboard(context.Background(), u)
 
-	if len(LifetimeMilesLeaderboard) != 4 {
+	if len(s.lifetimeLeaderboard) != 4 {
 		t.Fatalf("expected 4 entries after insert, got %d: %v",
-			len(LifetimeMilesLeaderboard), LifetimeMilesLeaderboard)
+			len(s.lifetimeLeaderboard), s.lifetimeLeaderboard)
 	}
-	if LifetimeMilesLeaderboard[1][0] != "newcomer" {
-		t.Fatalf("expected newcomer at index 1 (between 100 and 50), got order %v", LifetimeMilesLeaderboard)
+	if s.lifetimeLeaderboard[1][0] != "newcomer" {
+		t.Fatalf("expected newcomer at index 1 (between 100 and 50), got order %v", s.lifetimeLeaderboard)
 	}
 }
 
 func TestInsertIntoLeaderboardReplacesExistingUser(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"alice", "100"},
 		{"bob", "50"},
 	}
 
-	savedLoggedIn := LoggedIn
-	defer func() { LoggedIn = savedLoggedIn }()
-	LoggedIn = map[string]*User{}
-
 	// Bob's miles increased to 200 — should jump above alice and replace his old row.
 	u := User{Username: "bob", Miles: 200}
-	insertIntoLeaderboard(context.Background(), u)
+	s.insertIntoLeaderboard(context.Background(), u)
 
-	if len(LifetimeMilesLeaderboard) != 2 {
+	if len(s.lifetimeLeaderboard) != 2 {
 		t.Fatalf("expected length unchanged after replace, got %d: %v",
-			len(LifetimeMilesLeaderboard), LifetimeMilesLeaderboard)
+			len(s.lifetimeLeaderboard), s.lifetimeLeaderboard)
 	}
-	if LifetimeMilesLeaderboard[0][0] != "bob" {
-		t.Fatalf("expected bob to be #1 with 200 miles, got %v", LifetimeMilesLeaderboard)
+	if s.lifetimeLeaderboard[0][0] != "bob" {
+		t.Fatalf("expected bob to be #1 with 200 miles, got %v", s.lifetimeLeaderboard)
 	}
 }

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -14,72 +14,86 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
 	"github.com/hako/durafmt"
-
-	"github.com/adanalife/tripbot/pkg/twitch"
-	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 )
 
 //TODO: consider moving this whole thing elsewhere (to background perhaps?)
 
-// LoggedIn is a map that contains all the currently logged-in users,
-// mapping their username to a User
-var LoggedIn = make(map[string]*User)
+// Sessions tracks the users currently logged in to one platform's chat plus
+// the derived lifetime-miles leaderboard. It owns what used to be the
+// package-level LoggedIn map and LifetimeMilesLeaderboard slice, so a single
+// process holds exactly one Sessions and a per-platform bot instance gets its
+// own (the prerequisite for running, e.g., a YouTube bot beside the Twitch
+// one). Its view of who is in chat comes from an injected ChatterSource.
+type Sessions struct {
+	source ChatterSource
+	// loggedIn maps username -> User for everyone currently in chat.
+	loggedIn map[string]*User
+	// lifetimeLeaderboard is the cached [username, miles] leaderboard,
+	// hydrated by InitLeaderboard and rebuilt by UpdateLeaderboard.
+	lifetimeLeaderboard [][]string
+}
 
-// UpdateSession will use the data from the Twitch API to maintain a list
-// of currently-logged-in users
-func UpdateSession(ctx context.Context) {
-	// fetch the latest chatters from Twitch
-	twitch.UpdateChatters()
-	currentChatters := twitch.Chatters()
+// New constructs a Sessions backed by the given ChatterSource.
+func New(source ChatterSource) *Sessions {
+	return &Sessions{
+		source:   source,
+		loggedIn: make(map[string]*User),
+	}
+}
+
+// defaultSessions is the process-wide Sessions used by the package-level
+// shims below and by User value-method reads of session state. Production
+// wires it to the Twitch-backed source; tests build their own *Sessions.
+var defaultSessions = New(twitchSource{})
+
+// UpdateSession uses the chatter source to maintain the list of
+// currently-logged-in users.
+func (s *Sessions) UpdateSession(ctx context.Context) {
+	// fetch the latest chatters from the platform
+	s.source.UpdateChatters()
+	currentChatters := s.source.Chatters()
 
 	// Publish the authoritative chatter total so the admin panel's live console
 	// updates the "in chat" number (and flashes it on a change) without a reload.
-	eventbus.EmitViewerCount(ctx, c.Conf.Environment, twitch.ChatterCount())
+	eventbus.EmitViewerCount(ctx, c.Conf.Environment, s.source.ChatterCount())
 
 	// log out the people who aren't present
-	for username, user := range LoggedIn {
+	for username, user := range s.loggedIn {
 		if _, ok := currentChatters[username]; ok {
 			// they're logged in and a current chatter, do nothing
 			continue
-		} else {
-			// they're logged in and NOT a current chatter, so log them out
-			user.logout(ctx)
-			continue
 		}
+		// they're logged in and NOT a current chatter, so log them out
+		s.logout(ctx, user)
 	}
 
 	// log in everybody else
 	//TODO: this could get slow, maybe make a list of users that need to be logged in?
-	for chatter, _ := range currentChatters {
-		LoginIfNecessary(ctx, chatter)
+	for chatter := range currentChatters {
+		s.LoginIfNecessary(ctx, chatter)
 	}
-
-	// PrintCurrentSession()
-	// twitch.PrintCurrentChatters()
 }
 
 // LoginIfNecessary checks the list of currently-logged in users and will
 // run login() if this user isn't currently logged in
-func LoginIfNecessary(ctx context.Context, username string) *User {
-	// check if the user is currently logged in
-	if isLoggedIn(username) {
-		return LoggedIn[username]
+func (s *Sessions) LoginIfNecessary(ctx context.Context, username string) *User {
+	if s.isLoggedIn(username) {
+		return s.loggedIn[username]
 	}
 	// they weren't logged in, so note in the DB
-	return login(ctx, username)
+	return s.login(ctx, username)
 }
 
 // LogoutIfNecessary will log out the user if it finds them in the session
-func LogoutIfNecessary(ctx context.Context, username string) {
-	if isLoggedIn(username) {
-		user := *LoggedIn[username]
-		user.logout(ctx)
+func (s *Sessions) LogoutIfNecessary(ctx context.Context, username string) {
+	if s.isLoggedIn(username) {
+		s.logout(ctx, s.loggedIn[username])
 	}
 }
 
 // login will record the users presence in the DB
 // TODO: do we want to make a DB update here? we could do it on logout()
-func login(ctx context.Context, username string) *User {
+func (s *Sessions) login(ctx context.Context, username string) *User {
 	now := time.Now()
 
 	user := FindOrCreate(ctx, username)
@@ -98,12 +112,12 @@ func login(ctx context.Context, username string) *User {
 	user.save(ctx)
 
 	// just a silly message to confirm subscriber feature is working
-	if mytwitch.UserIsSubscriber(username) {
+	if s.source.IsSubscriber(username) {
 		slog.InfoContext(ctx, "subscriber logged in", "username", username)
 	}
 
 	// add them to the session
-	LoggedIn[username] = &user
+	s.loggedIn[username] = &user
 
 	if err := events.Login(ctx, username, user.sessionID); err != nil {
 		slog.ErrorContext(ctx, "error creating login event", "err", err)
@@ -112,9 +126,9 @@ func login(ctx context.Context, username string) *User {
 	return &user
 }
 
-// User.logout() removes the user from the list of currently-logged in users,
+// logout removes the user from the list of currently-logged in users,
 // and updates the DB with their most up-to-date values
-func (u User) logout(ctx context.Context) {
+func (s *Sessions) logout(ctx context.Context, u *User) {
 	sessionMiles := u.sessionMiles(ctx)
 
 	// print logout message if they're human
@@ -144,40 +158,38 @@ func (u User) logout(ctx context.Context) {
 	}
 
 	// remove them from the session
-	delete(LoggedIn, u.Username)
+	delete(s.loggedIn, u.Username)
 }
 
 // isLoggedIn checks if the user is currently logged in
-func isLoggedIn(username string) bool {
-	if _, ok := LoggedIn[username]; ok {
-		return true
-	}
-	return false
+func (s *Sessions) isLoggedIn(username string) bool {
+	_, ok := s.loggedIn[username]
+	return ok
 }
 
-// ShutDown loops through all of the logged-in users and logs them out
-func Shutdown(ctx context.Context) {
+// Shutdown loops through all of the logged-in users and logs them out
+func (s *Sessions) Shutdown(ctx context.Context) {
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "logged-in users at shutdown")
-		spew.Dump(LoggedIn)
+		spew.Dump(s.loggedIn)
 	}
-	for _, user := range LoggedIn {
-		user.logout(ctx)
+	for _, user := range s.loggedIn {
+		s.logout(ctx, user)
 	}
 }
 
 // GiveEveryoneMiles gives all logged-in users miles
-func GiveEveryoneMiles(gift float32) {
+func (s *Sessions) GiveEveryoneMiles(gift float32) {
 	slog.Info("giving all logged-in users gift miles", "gift", gift)
-	for _, user := range LoggedIn {
+	for _, user := range s.loggedIn {
 		user.Miles += gift
 	}
 }
 
 // sortedUsernameList creates a list of only usernames, and sort it
-func sortedUsernameList() []string {
-	usernames := make([]string, 0, len(LoggedIn))
-	for username, _ := range LoggedIn {
+func (s *Sessions) sortedUsernameList() []string {
+	usernames := make([]string, 0, len(s.loggedIn))
+	for username := range s.loggedIn {
 		usernames = append(usernames, username)
 	}
 	sort.Sort(sort.StringSlice(usernames))
@@ -185,10 +197,10 @@ func sortedUsernameList() []string {
 }
 
 // colorizeUsernames loops over the sorted names and colorizes them
-func colorizeUsernames(usernames []string) []string {
+func (s *Sessions) colorizeUsernames(usernames []string) []string {
 	coloredUsernames := make([]string, 0, len(usernames))
 	for _, username := range usernames {
-		user := *LoggedIn[username]
+		user := *s.loggedIn[username]
 		if user.IsBot {
 			// don't add them to the output
 			continue
@@ -200,9 +212,9 @@ func colorizeUsernames(usernames []string) []string {
 }
 
 // humans returns the users in the session who are not bots
-func humans() []*User {
+func (s *Sessions) humans() []*User {
 	var humans []*User
-	for _, user := range LoggedIn {
+	for _, user := range s.loggedIn {
 		if !user.IsBot {
 			humans = append(humans, user)
 		}
@@ -211,14 +223,14 @@ func humans() []*User {
 }
 
 // countHumans returns the number of humans in the session
-func countHumans() int {
-	return len(humans())
+func (s *Sessions) countHumans() int {
+	return len(s.humans())
 }
 
 // bots returns the users in the session who are known bots
-func bots() []*User {
+func (s *Sessions) bots() []*User {
 	var bots []*User
-	for _, user := range LoggedIn {
+	for _, user := range s.loggedIn {
 		if user.IsBot {
 			bots = append(bots, user)
 		}
@@ -227,21 +239,44 @@ func bots() []*User {
 }
 
 // countBots returns the number of bots in the session
-func countBots() int {
-	return len(bots())
+func (s *Sessions) countBots() int {
+	return len(s.bots())
 }
 
 // PrintCurrentSession simply prints info about the current session.
-// ctx links the snapshot log line to the parent cron-tick span;
-// twitch.ChatterCount doesn't take ctx yet.
-func PrintCurrentSession(ctx context.Context) {
-	usernames := sortedUsernameList()
-	coloredUsernames := colorizeUsernames(usernames)
+// ctx links the snapshot log line to the parent cron-tick span.
+func (s *Sessions) PrintCurrentSession(ctx context.Context) {
+	usernames := s.sortedUsernameList()
+	coloredUsernames := s.colorizeUsernames(usernames)
 
 	slog.InfoContext(ctx, "session snapshot",
-		"chatters", twitch.ChatterCount(),
-		"humans", countHumans(),
-		"bots", countBots(),
+		"chatters", s.source.ChatterCount(),
+		"humans", s.countHumans(),
+		"bots", s.countBots(),
 		"logged_in", strings.Join(coloredUsernames, ", "),
 	)
 }
+
+// Package-level shims delegate to defaultSessions so existing callers
+// (cmd/tripbot, pkg/chatbot, ...) stay unchanged while the package's session
+// state moves onto Sessions. Threading a constructed *Sessions through those
+// callers (and dropping these shims) is a later stage of the no-globals work.
+
+func UpdateSession(ctx context.Context) { defaultSessions.UpdateSession(ctx) }
+
+func LoginIfNecessary(ctx context.Context, username string) *User {
+	return defaultSessions.LoginIfNecessary(ctx, username)
+}
+
+func LogoutIfNecessary(ctx context.Context, username string) {
+	defaultSessions.LogoutIfNecessary(ctx, username)
+}
+
+func Shutdown(ctx context.Context) { defaultSessions.Shutdown(ctx) }
+
+func GiveEveryoneMiles(gift float32) { defaultSessions.GiveEveryoneMiles(gift) }
+
+func PrintCurrentSession(ctx context.Context) { defaultSessions.PrintCurrentSession(ctx) }
+
+// LoggedInCount returns the number of users currently in the default session.
+func LoggedInCount() int { return len(defaultSessions.loggedIn) }

--- a/pkg/users/source.go
+++ b/pkg/users/source.go
@@ -1,0 +1,42 @@
+package users
+
+import "github.com/adanalife/tripbot/pkg/twitch"
+
+// ChatterSource supplies the platform-specific view of who is currently in
+// chat and each viewer's relationship to the channel. It is the seam between
+// session tracking (platform-agnostic) and the chat transport (per-platform).
+//
+// Today the only implementation is twitchSource, backed by Twitch Helix via
+// pkg/twitch. When the multi-platform chat-transport work lands, a YouTube or
+// TikTok adapter drops in here so a per-platform bot instance
+// (PLATFORM=youtube, etc.) tracks its own audience without Sessions changing.
+// See vault/sessions/2026-05-31-multi-platform-streaming-arch.md.
+type ChatterSource interface {
+	// UpdateChatters refreshes the source's notion of who is in chat.
+	UpdateChatters()
+	// Chatters returns the set of usernames currently in chat.
+	Chatters() map[string]struct{}
+	// ChatterCount is the authoritative in-chat total. It can exceed the
+	// number of logged-in users (e.g. lurkers the source counts but that
+	// never appear in chat).
+	ChatterCount() int
+	// IsSubscriber reports whether the user is a paid subscriber/member.
+	IsSubscriber(username string) bool
+	// IsFollower reports whether the user follows the channel.
+	IsFollower(username string) bool
+}
+
+// twitchSource is the Twitch-backed ChatterSource. Its methods delegate to
+// pkg/twitch's package surface; this adapter is the single point of
+// users->twitch coupling, isolating it for the future per-platform split.
+type twitchSource struct{}
+
+func (twitchSource) UpdateChatters()               { twitch.UpdateChatters() }
+func (twitchSource) Chatters() map[string]struct{} { return twitch.Chatters() }
+func (twitchSource) ChatterCount() int             { return twitch.ChatterCount() }
+func (twitchSource) IsSubscriber(username string) bool {
+	return twitch.UserIsSubscriber(username)
+}
+func (twitchSource) IsFollower(username string) bool {
+	return twitch.UserIsFollower(username)
+}

--- a/pkg/users/source_test.go
+++ b/pkg/users/source_test.go
@@ -1,0 +1,70 @@
+package users
+
+import "testing"
+
+// noopChatterSource is a ChatterSource that reports nobody in chat and nobody
+// followed/subscribed. Used by tests that build a *Sessions but don't exercise
+// the source.
+type noopChatterSource struct{}
+
+func (noopChatterSource) UpdateChatters()               {}
+func (noopChatterSource) Chatters() map[string]struct{} { return map[string]struct{}{} }
+func (noopChatterSource) ChatterCount() int             { return 0 }
+func (noopChatterSource) IsSubscriber(_ string) bool    { return false }
+func (noopChatterSource) IsFollower(_ string) bool      { return false }
+
+// recordingChatterSource answers from canned maps and counts calls, so tests
+// can assert the seam actually routes through the injected source.
+type recordingChatterSource struct {
+	subscribers map[string]bool
+	followers   map[string]bool
+	subCalls    int
+	followCalls int
+}
+
+func (recordingChatterSource) UpdateChatters()               {}
+func (recordingChatterSource) Chatters() map[string]struct{} { return map[string]struct{}{} }
+func (recordingChatterSource) ChatterCount() int             { return 0 }
+func (r *recordingChatterSource) IsSubscriber(username string) bool {
+	r.subCalls++
+	return r.subscribers[username]
+}
+func (r *recordingChatterSource) IsFollower(username string) bool {
+	r.followCalls++
+	return r.followers[username]
+}
+
+// User.IsSubscriber routes through the injected ChatterSource — the seam a
+// future YouTube/TikTok adapter swaps into.
+func TestUserIsSubscriberUsesChatterSource(t *testing.T) {
+	prev := defaultSessions.source
+	defer func() { defaultSessions.source = prev }()
+	rec := &recordingChatterSource{subscribers: map[string]bool{"alice": true}}
+	defaultSessions.source = rec
+
+	if !(User{Username: "alice"}).IsSubscriber() {
+		t.Fatal("expected alice to be a subscriber via the injected source")
+	}
+	if (User{Username: "bob"}).IsSubscriber() {
+		t.Fatal("expected bob not to be a subscriber")
+	}
+	if rec.subCalls != 2 {
+		t.Fatalf("expected 2 IsSubscriber calls on the source, got %d", rec.subCalls)
+	}
+}
+
+// Two *Sessions hold independent state — the prerequisite for running a
+// per-platform bot instance (e.g. YouTube) beside the Twitch one without them
+// sharing a global session map.
+func TestSessionsHoldIndependentState(t *testing.T) {
+	a := New(noopChatterSource{})
+	b := New(noopChatterSource{})
+
+	a.lifetimeLeaderboard = [][]string{{"x", "1"}}
+	a.loggedIn["x"] = &User{Username: "x"}
+
+	if len(b.lifetimeLeaderboard) != 0 || len(b.loggedIn) != 0 {
+		t.Fatalf("expected independent *Sessions, but b saw a's state: lb=%v loggedIn=%v",
+			b.lifetimeLeaderboard, b.loggedIn)
+	}
+}

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
-	"github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/google/uuid"
 	"github.com/logrusorgru/aurora/v3"
 	"gorm.io/gorm"
@@ -39,16 +38,16 @@ var guessCooldown = 3 * time.Minute
 
 func (u User) loggedInDur() time.Duration {
 	// exit early if they're not logged in
-	if !isLoggedIn(u.Username) {
+	if !defaultSessions.isLoggedIn(u.Username) {
 		return 0 * time.Second
 	}
 	// lookup the user in the session so the LoggedIn value is current
-	return time.Now().Sub(LoggedIn[u.Username].LoggedIn)
+	return time.Now().Sub(defaultSessions.loggedIn[u.Username].LoggedIn)
 }
 
 func (u User) sessionMiles(ctx context.Context) float32 {
 	// exit early if they're not logged in
-	if !isLoggedIn(u.Username) {
+	if !defaultSessions.isLoggedIn(u.Username) {
 		return 0.0
 	}
 	loggedInDur := u.loggedInDur()
@@ -69,7 +68,7 @@ func (u User) CurrentMiles(ctx context.Context) float32 {
 }
 
 func (u User) BonusMiles() float32 {
-	if isLoggedIn(u.Username) {
+	if defaultSessions.isLoggedIn(u.Username) {
 		loggedInDur := u.loggedInDur()
 		sessionMiles := helpers.DurationToMiles(loggedInDur)
 		return sessionMiles * 0.05
@@ -106,7 +105,7 @@ func SetBot(ctx context.Context, username string, isBot bool) error {
 	}
 	user.IsBot = isBot
 	user.save(ctx)
-	if loggedIn, ok := LoggedIn[username]; ok {
+	if loggedIn, ok := defaultSessions.loggedIn[username]; ok {
 		loggedIn.IsBot = isBot
 	}
 	return nil
@@ -114,12 +113,12 @@ func SetBot(ctx context.Context, username string, isBot bool) error {
 
 // IsFollower returns true if the user is a follower
 func (u User) IsFollower() bool {
-	return twitch.UserIsFollower(u.Username)
+	return defaultSessions.source.IsFollower(u.Username)
 }
 
 // IsSubscriber returns true if the user is a subscriber
 func (u User) IsSubscriber() bool {
-	return twitch.UserIsSubscriber(u.Username)
+	return defaultSessions.source.IsSubscriber(u.Username)
 }
 
 // User.String prints a colored version of the user


### PR DESCRIPTION
## What

Continues the chatbot App-injection / no-globals refactor (Phase B). Converts `pkg/users`' two mutable package globals — the `LoggedIn` session map and the `LifetimeMilesLeaderboard` slice — onto a constructed `*Sessions`, and introduces a `ChatterSource` seam for the platform-specific chatter/subscriber/follower surface.

This is the entangled package the [pkg/twitch conversion](https://github.com/adanalife/tripbot/pull/738/changes) deliberately deferred (`User` value methods read the session globals). It goes after twitch on purpose: `pkg/users` imports `pkg/twitch`, so twitch had to become injectable first.

## Shape

- **`ChatterSource` interface + `twitchSource` adapter** (`source.go`) — the platform-specific view of who's in chat and each viewer's sub/follower status. `twitchSource` delegates to `pkg/twitch`, isolating the `users → twitch` coupling to one adapter.
- **`*Sessions`** (`session.go`, `leaderboard.go`) owns `loggedIn` + `lifetimeLeaderboard`; the session/leaderboard functions become methods. A process-wide `defaultSessions` singleton backs package-level shims, so existing callers (`cmd/tripbot`, chatbot, discord) are unchanged — same wrap-don't-refactor approach as #738.
- Two external var reads become accessors: `LifetimeMilesLeaderboard()` and a new `LoggedInCount()`.

## Why a ChatterSource interface (multi-platform)

Two payoffs beyond removing the globals, both groundwork for the per-platform streaming direction:

1. **Per-instance session state.** Each bot process now holds its own `*Sessions` rather than a shared global map — the prerequisite for running a reduced-functionality YouTube/TikTok instance beside the Twitch one without them clobbering each other's session map.
2. **Injectable chatter source.** The `twitch.*` chatter/sub/follower calls are now behind an interface, so a future YouTube/TikTok chat transport drops in as a different `ChatterSource` without touching `Sessions`. This is the swap point the chat-transport work needs.

## Tests

- Leaderboard tests drop the global save/restore boilerplate for fresh `*Sessions` instances.
- New: `User.IsSubscriber` routes through the injected `ChatterSource`; two `*Sessions` hold independent state (the per-platform prerequisite).
- Full non-vlc suite green. `pkg/users` is still not pulled into the `vlc-server` / `onscreens-server` binaries (package boundary intact).

## Follow-ups (not this PR)

- Thread a constructed `*Sessions` / `*twitch.API` through callers and drop the package-level shims (pairs with deleting the twitch shims).
- The remaining Phase B packages: `pkg/server`.