### PR TITLE
refactor(server): encapsulate runtime globals into *Server

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -243,7 +243,7 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Flags:          gatherFlags(r.Context()),
 		Reauth:         accountsNeedingReauth(),
 		AuthStatuses:   authStatuses(),
-		ChatHistory:    eventHub.snapshotChat(),
+		ChatHistory:    defaultServer.hub.snapshotChat(),
 		MapTrailJSON:   mapTrailJSON(),
 	}
 
@@ -267,8 +267,8 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 func gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
-		OK:         twitchConnected.Load(),
-		Version:    versionTag,
+		OK:         defaultServer.twitchConnected.Load(),
+		Version:    defaultServer.versionTag,
 		VersionURL: changelogURL(sha),
 		Uptime:     uptimeSince(startedAt),
 	}
@@ -320,7 +320,7 @@ func uptimeSince(t time.Time) string {
 // no flags are loaded yet (startup window before SetFlagClient) so the
 // template's {{if .Flags}} hides the section cleanly.
 func gatherFlags(ctx context.Context) []featureFlag {
-	flags := flagSnapshot(ctx)
+	flags := defaultServer.flagSnapshot(ctx)
 	if len(flags) == 0 {
 		return nil
 	}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -408,8 +408,8 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
 	withChatterCount(t, 12)
 
-	saved := versionTag
-	defer func() { versionTag = saved }()
+	saved := defaultServer.versionTag
+	defer func() { defaultServer.versionTag = saved }()
 	SetVersion("v1.2.3")
 
 	rec := httptest.NewRecorder()
@@ -614,12 +614,12 @@ func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 
 func withFlags(t *testing.T, flags map[string]feature.Flag) {
 	t.Helper()
-	saved := flagClient
+	saved := defaultServer.flagClient
 	SetFlagClient(feature.NewInMemoryClient(flags))
 	t.Cleanup(func() {
-		flagMu.Lock()
-		flagClient = saved
-		flagMu.Unlock()
+		defaultServer.flagMu.Lock()
+		defaultServer.flagClient = saved
+		defaultServer.flagMu.Unlock()
 	})
 }
 
@@ -686,17 +686,17 @@ func TestAdminHandler_HidesFeatureFlagsSectionWhenEmpty(t *testing.T) {
 	}
 }
 
-// withChatHistory swaps the package eventHub for a fresh one seeded with lines,
+// withChatHistory swaps the process hub for a fresh one seeded with lines,
 // restoring the original after the test.
 func withChatHistory(t *testing.T, lines []ChatLine) {
 	t.Helper()
-	saved := eventHub
+	saved := defaultServer.hub
 	h := NewHub()
 	for _, l := range lines {
 		h.appendChat(l)
 	}
-	eventHub = h
-	t.Cleanup(func() { eventHub = saved })
+	defaultServer.hub = h
+	t.Cleanup(func() { defaultServer.hub = saved })
 }
 
 func TestAdminHandler_RendersChatHistoryAndSSEWiring(t *testing.T) {

--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -41,8 +41,8 @@ func eventsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ch := eventHub.register()
-	defer eventHub.unregister(ch)
+	ch := defaultServer.hub.register()
+	defer defaultServer.hub.unregister(ch)
 
 	heartbeat := time.NewTicker(sseHeartbeat)
 	defer heartbeat.Stop()

--- a/pkg/server/events_test.go
+++ b/pkg/server/events_test.go
@@ -79,9 +79,9 @@ func TestEventsHandler_streamsChatEvent(t *testing.T) {
 
 	// Wait until the handler has registered with the hub, so our broadcast
 	// isn't dropped before the client channel exists.
-	waitFor(t, func() bool { return eventHub.numSubscribers() >= 1 })
+	waitFor(t, func() bool { return defaultServer.hub.numSubscribers() >= 1 })
 
-	eventHub.broadcast(sseEvent{Name: "chat", Data: `<div class="chat-line">hi</div>`})
+	defaultServer.hub.broadcast(sseEvent{Name: "chat", Data: `<div class="chat-line">hi</div>`})
 
 	select {
 	case <-rec.writes:
@@ -105,8 +105,8 @@ func TestEventsHandler_streamsChatEvent(t *testing.T) {
 	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
 		t.Errorf("Cache-Control = %q, want no-store", cc)
 	}
-	if eventHub.numSubscribers() != 0 {
-		t.Errorf("subscriber not cleaned up after disconnect: %d", eventHub.numSubscribers())
+	if defaultServer.hub.numSubscribers() != 0 {
+		t.Errorf("subscriber not cleaned up after disconnect: %d", defaultServer.hub.numSubscribers())
 	}
 }
 
@@ -123,9 +123,9 @@ func TestEventsHandler_flattensNewlines(t *testing.T) {
 		eventsHandler(rec, req)
 		close(done)
 	}()
-	waitFor(t, func() bool { return eventHub.numSubscribers() >= 1 })
+	waitFor(t, func() bool { return defaultServer.hub.numSubscribers() >= 1 })
 
-	eventHub.broadcast(sseEvent{Name: "chat", Data: "line1\nline2"})
+	defaultServer.hub.broadcast(sseEvent{Name: "chat", Data: "line1\nline2"})
 	select {
 	case <-rec.writes:
 	case <-time.After(2 * time.Second):

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -8,8 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -29,19 +27,20 @@ var generateUserAccessToken = mytwitch.GenerateUserAccessToken
 // would request a real App Access Token from Twitch).
 var helixClient = mytwitch.Client
 
-// versionTag is set by main via SetVersion; overridden at build time
-// through `-ldflags "-X main.version=..."`.
-var versionTag = "dev"
+// versionTag (Server.versionTag) is set by main via SetVersion; overridden at
+// build time through `-ldflags "-X main.version=..."`.
 
 // SetVersion lets cmd/tripbot inject its build-time version string
 // before the HTTP server starts.
-func SetVersion(v string) {
+func SetVersion(v string) { defaultServer.SetVersion(v) }
+
+func (s *Server) SetVersion(v string) {
 	if v != "" {
-		versionTag = v
+		s.versionTag = v
 	}
 }
 
-// twitchConnected reports whether the bot currently has its Twitch IRC
+// Server.twitchConnected reports whether the bot currently has its Twitch IRC
 // connection. It deliberately does NOT gate the readiness probe: /health/ready
 // is always 200 once the HTTP server is up (see httpmw.ReadinessHandler), so
 // the admin panel, /auth/init and /auth/callback stay reachable through the
@@ -50,44 +49,45 @@ func SetVersion(v string) {
 // admin-panel status row and the tripbot_twitch_connected gauge, so "up but
 // not in chat" is surfaced without pulling the pod out of the Service.
 // cmd/tripbot flips it via SetTwitchConnected on IRC connect / disconnect.
-var twitchConnected atomic.Bool
 
 // SetTwitchConnected updates the chat-connection signal: the in-memory flag
 // the admin panel reads and the tripbot_twitch_connected gauge.
-func SetTwitchConnected(connected bool) {
-	twitchConnected.Store(connected)
+func SetTwitchConnected(connected bool) { defaultServer.SetTwitchConnected(connected) }
+
+func (s *Server) SetTwitchConnected(connected bool) {
+	s.twitchConnected.Store(connected)
 	instrumentation.TwitchConnection.Set(connected)
 }
 
 // TwitchConnected reports the last-known chat-connection state, for the
 // admin panel's status row.
-func TwitchConnected() bool {
-	return twitchConnected.Load()
+func TwitchConnected() bool { return defaultServer.TwitchConnected() }
+
+func (s *Server) TwitchConnected() bool {
+	return s.twitchConnected.Load()
 }
 
-// flagClient is the FlagClient the admin panel enumerates for its "feature
-// flags" section. Defaults to an empty in-memory client so the panel
+// Server.flagClient is the FlagClient the admin panel enumerates for its
+// "feature flags" section. Defaults to an empty in-memory client so the panel
 // renders a blank section during the brief startup window between server
 // start and startFeatureFlags swapping in the Postgres-backed client.
-var (
-	flagMu     sync.RWMutex
-	flagClient feature.FlagClient = feature.NewInMemoryClient(nil)
-)
 
 // SetFlagClient lets cmd/tripbot install the Postgres-backed FlagClient
 // once startFeatureFlags has loaded the initial snapshot.
-func SetFlagClient(fc feature.FlagClient) {
-	flagMu.Lock()
-	flagClient = fc
-	flagMu.Unlock()
+func SetFlagClient(fc feature.FlagClient) { defaultServer.SetFlagClient(fc) }
+
+func (s *Server) SetFlagClient(fc feature.FlagClient) {
+	s.flagMu.Lock()
+	s.flagClient = fc
+	s.flagMu.Unlock()
 }
 
 // flagSnapshot returns the current set of known flags for the admin panel.
-func flagSnapshot(ctx context.Context) []feature.Flag {
-	flagMu.RLock()
-	c := flagClient
-	flagMu.RUnlock()
-	return c.Snapshot(ctx)
+func (s *Server) flagSnapshot(ctx context.Context) []feature.Flag {
+	s.flagMu.RLock()
+	client := s.flagClient
+	s.flagMu.RUnlock()
+	return client.Snapshot(ctx)
 }
 
 // versionHandler returns build metadata as JSON. The tag comes from the
@@ -100,7 +100,7 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 		Sha       string `json:"sha"`
 		BuiltAt   string `json:"built_at"`
 		StartedAt string `json:"started_at"`
-	}{Tag: versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
+	}{Tag: defaultServer.versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -30,8 +30,8 @@ func TestTwitchConnectedSignal(t *testing.T) {
 }
 
 func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
-	saved := versionTag
-	defer func() { versionTag = saved }()
+	saved := defaultServer.versionTag
+	defer func() { defaultServer.versionTag = saved }()
 	SetVersion("v9.9.9-test")
 
 	req := httptest.NewRequest(http.MethodGet, "/version", nil)

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -228,7 +228,7 @@ func renderMapPoint(p mapPoint) string {
 // [[lat,lng],…] string for the page's map data attribute (empty "[]" when
 // there's no trail yet).
 func mapTrailJSON() string {
-	trail := eventHub.snapshotMapTrail()
+	trail := defaultServer.hub.snapshotMapTrail()
 	pts := make([][2]float64, len(trail))
 	for i, p := range trail {
 		pts[i] = [2]float64{p.Lat, p.Lng}
@@ -379,10 +379,11 @@ func renderVideoLine(ev eventbus.VideoChanged) string {
 	return sb.String()
 }
 
-// eventHub is the process-wide live-console hub. Constructed at package init
+// Server.hub is the process-wide live-console hub. Constructed in New()
 // (cheap, no I/O); its NATS subscription starts later via StartEventHub.
-var eventHub = NewHub()
 
 // StartEventHub begins the hub's NATS subscription. Call from main() AFTER
 // natsclient.Connect — at server.Start time NATS isn't connected yet.
-func StartEventHub(ctx context.Context) { eventHub.Start(ctx) }
+func StartEventHub(ctx context.Context) { defaultServer.StartEventHub(ctx) }
+
+func (s *Server) StartEventHub(ctx context.Context) { s.hub.Start(ctx) }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -26,7 +29,36 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var server *http.Server
+// Server holds the web server's mutable runtime state — the live-console hub,
+// the Twitch chat-connection flag, the build version tag, and the feature-flag
+// client the admin panel reads. cmd/tripbot installs values via the setter
+// methods (SetVersion / SetTwitchConnected / SetFlagClient) before and while
+// Start runs. The package-level functions below delegate to a process-wide
+// defaultServer so existing callers stay unchanged during the no-globals
+// transition.
+type Server struct {
+	hub             *Hub
+	twitchConnected atomic.Bool
+	versionTag      string
+
+	flagMu     sync.RWMutex
+	flagClient feature.FlagClient
+}
+
+// New constructs a Server with default runtime state: a fresh hub, the "dev"
+// version tag (overridden by SetVersion), and an empty in-memory flag client
+// (swapped for the Postgres-backed one via SetFlagClient).
+func New() *Server {
+	return &Server{
+		hub:        NewHub(),
+		versionTag: "dev",
+		flagClient: feature.NewInMemoryClient(nil),
+	}
+}
+
+// defaultServer is the process-wide Server backing the package-level shims and
+// the free-function HTTP handlers (which read defaultServer's fields).
+var defaultServer = New()
 
 // shutdownTimeout is how long Shutdown waits for in-flight requests to
 // finish before forcing connections closed. 15s is the typical sweet spot:
@@ -34,11 +66,14 @@ var server *http.Server
 // handler doesn't block process exit indefinitely.
 const shutdownTimeout = 15 * time.Second
 
+// Start is the package-level shim delegating to defaultServer.
+func Start(ctx context.Context) { defaultServer.Start(ctx) }
+
 // Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
 // via signal.NotifyContext) the server stops accepting new connections and
 // waits up to shutdownTimeout for in-flight requests to complete before
 // returning.
-func Start(ctx context.Context) {
+func (s *Server) Start(ctx context.Context) {
 	slog.InfoContext(ctx, "starting web server", "port", c.Conf.TripbotServerPort)
 
 	r := mux.NewRouter()

--- a/pkg/server/struct_test.go
+++ b/pkg/server/struct_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/adanalife/tripbot/pkg/feature"
+)
+
+// New gives a Server with sensible default runtime state.
+func TestNewServerDefaults(t *testing.T) {
+	s := New()
+	if s.hub == nil {
+		t.Fatal("New() left hub nil")
+	}
+	if s.versionTag != "dev" {
+		t.Errorf("versionTag = %q, want %q", s.versionTag, "dev")
+	}
+	if s.flagClient == nil {
+		t.Fatal("New() left flagClient nil")
+	}
+	if s.TwitchConnected() {
+		t.Error("twitchConnected should default to false")
+	}
+}
+
+// The setters mutate the instance they're called on, and two Servers hold
+// independent runtime state.
+func TestServerSettersAreInstanceScoped(t *testing.T) {
+	a := New()
+	b := New()
+
+	a.SetVersion("v1.2.3")
+	a.SetTwitchConnected(true)
+	a.SetFlagClient(feature.NewInMemoryClient(map[string]feature.Flag{
+		"demo": {Key: "demo"},
+	}))
+
+	if b.versionTag != "dev" || b.TwitchConnected() {
+		t.Errorf("b picked up a's state: version=%q connected=%v", b.versionTag, b.TwitchConnected())
+	}
+	if got := a.flagSnapshot(t.Context()); len(got) != 1 {
+		t.Errorf("a.flagSnapshot = %d flags, want 1", len(got))
+	}
+	if got := b.flagSnapshot(t.Context()); len(got) != 0 {
+		t.Errorf("b.flagSnapshot = %d flags, want 0 (independent of a)", len(got))
+	}
+}


### PR DESCRIPTION
## What

The last Phase B package-globals conversion in the no-globals / App-injection refactor. Lifts `pkg/server`'s mutable package globals onto a constructed `*Server`:

- `eventHub` (the live-console websocket hub) → `Server.hub`
- `twitchConnected` (chat-connection flag) → `Server.twitchConnected`
- `versionTag` (build tag) → `Server.versionTag`
- `flagClient` + `flagMu` (admin-panel feature flags) → `Server.flagClient` / `Server.flagMu`

## Shape

Same wrap-don't-refactor approach as [pkg/twitch #738](https://github.com/adanalife/tripbot/pull/738/changes) and [pkg/users #753](https://github.com/adanalife/tripbot/pull/753/changes):

- `New()` constructs a `*Server`; a process-wide `defaultServer` singleton backs package-level shims, so cmd/tripbot's five callsites (`SetVersion`, `StartEventHub`, `SetFlagClient`, `Start`, `SetTwitchConnected`) are **unchanged**.
- The setter/`Start`/`StartEventHub` functions become methods on `*Server`; free-function HTTP handlers read `defaultServer`'s fields (same as users.go reads `defaultSessions`).
- Deletes the **dead** `var server *http.Server` — never assigned anywhere (`Start` uses a local `srv`).
- `startedAt` / `healthClient` stay package-level: immutable, no setters (same call as leaving `guessCooldown` in the users conversion).

## Tests

- Existing tests that save/restore the package globals now target `defaultServer`'s fields.
- New `struct_test.go`: `New()` defaults, and that the setters are instance-scoped (two `*Server` hold independent version/connection/flag state).
- Full non-vlc suite green; `pkg/server` still isn't pulled into the `vlc-server` / `onscreens-server` binaries (package boundary intact).

## Where this leaves Phase B

With this, every `pkg/*` package with mutable globals is converted (clients, video, background, twitch, users, server). What remains is the cleanup/finale, not new conversions:

- **PR C** — thread the constructed instances (`*twitch.API`, `*Sessions`, `*Server`, ...) through cmd/tripbot + callers and delete the package-level shims.
- **Phase C** — rewire `cmd/tripbot/tripbot.go` into an `App` struct + the registry refactor.