### PR TITLE
refactor(cmd/tripbot): lift globals into a Tripbot struct (Phase C.1)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -73,30 +73,54 @@ func tracedJob(name string, fn func(context.Context)) func(context.Context) {
 // version is overridable at build time via -ldflags "-X main.version=...".
 var version = "dev"
 
-var client *twitch.Client
+// Tripbot holds the bot process's runtime dependencies and wiring. The boot
+// sequence (Run) and graceful shutdown are methods on it, so startup ordering
+// is explicit and the deps that used to be package-level globals are fields.
+type Tripbot struct {
+	version string
 
-// scheduler is the background cron scheduler, constructed in startCron and
-// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
-// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
-// can stop it.
-var scheduler *background.Scheduler
+	// irc is the go-twitch-irc client, constructed by setUpTwitchClient
+	// (chatbot.Initialize) and shared by connectToTwitch, pollForTwitchToken
+	// and the token-refresh cron job (SetIRCToken).
+	irc *twitch.Client
 
-var telemetryShutdown telemetry.ShutdownFunc
+	// scheduler is the background cron scheduler, constructed in startCron and
+	// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
+	// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
+	// can stop it.
+	scheduler *background.Scheduler
 
-// discordSession is set by startDiscord when the Discord bot is enabled
-// for this env; gracefulShutdown calls Stop on it to deregister the
-// per-guild slash commands. Nil when Discord stays gated off.
-var discordSession *discord.Session
+	telemetryShutdown telemetry.ShutdownFunc
 
-// flagClient is the process-wide feature flag evaluator. Initialised to an
-// empty in-memory client so unknown keys evaluate to false during the brief
-// startup window before startFeatureFlags swaps in the Postgres-backed
-// client — same fail-closed contract as pkg/feature.
-var flagClient feature.FlagClient = feature.NewInMemoryClient(nil)
+	// discordSession is set by startDiscord when the Discord bot is enabled
+	// for this env; gracefulShutdown calls Stop on it to deregister the
+	// per-guild slash commands. Nil when Discord stays gated off.
+	discordSession *discord.Session
 
-// main performs the various steps to get the bot running
+	// flagClient is the process-wide feature flag evaluator. Initialised to an
+	// empty in-memory client so unknown keys evaluate to false during the brief
+	// startup window before startFeatureFlags swaps in the Postgres-backed
+	// client — same fail-closed contract as pkg/feature.
+	flagClient feature.FlagClient
+}
+
+// NewTripbot constructs a Tripbot with default runtime state. Dependencies
+// that need I/O or ordering (the IRC client, scheduler, Discord session,
+// Postgres-backed flag client) are filled in by the boot-sequence methods.
+func NewTripbot(version string) *Tripbot {
+	return &Tripbot{
+		version:    version,
+		flagClient: feature.NewInMemoryClient(nil),
+	}
+}
+
 func main() {
-	slog.Info("tripbot starting", "version", version)
+	NewTripbot(version).Run()
+}
+
+// Run performs the various steps to get the bot running.
+func (t *Tripbot) Run() {
+	slog.Info("tripbot starting", "version", t.version)
 	createRandomSeed()
 	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
 	// to trigger a graceful shutdown so in-flight requests aren't cut.
@@ -104,26 +128,26 @@ func main() {
 	// the app cleanup off the same signals.
 	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignals()
-	listenForShutdown()
-	initializeTelemetry()
-	initializeErrorLogger()
-	server.SetVersion(version)
-	startHttpServer(shutdownCtx)
-	findInitialVideo()
+	t.listenForShutdown()
+	t.initializeTelemetry()
+	t.initializeErrorLogger()
+	server.SetVersion(t.version)
+	t.startHttpServer(shutdownCtx)
+	t.findInitialVideo()
 	users.InitLeaderboard(context.Background())
-	startCron()
-	startFeatureFlags(shutdownCtx)
-	loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
-	refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
-	setUpTwitchClient()                    // required for the below
-	updateSubscribers()
-	getCurrentUsers()
-	startEventSub(shutdownCtx)
-	startNATS()
+	t.startCron()
+	t.startFeatureFlags(shutdownCtx)
+	t.loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
+	t.refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
+	t.setUpTwitchClient()                    // required for the below
+	t.updateSubscribers()
+	t.getCurrentUsers()
+	t.startEventSub(shutdownCtx)
+	t.startNATS()
 	server.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
-	startDiscord(shutdownCtx)
-	startSilentDisconnectWatchdog(shutdownCtx)
-	connectToTwitch()
+	t.startDiscord(shutdownCtx)
+	t.startSilentDisconnectWatchdog(shutdownCtx)
+	t.connectToTwitch()
 }
 
 // featureFlagRefreshInterval is how often the Postgres-backed flag client
@@ -137,7 +161,7 @@ const featureFlagRefreshInterval = 30 * time.Second
 // empty in-memory client in place — every flag evaluates to its default
 // (false) until the next restart loads cleanly. Mirrors the loadTwitchToken
 // "stay up with limited functionality" pattern.
-func startFeatureFlags(ctx context.Context) {
+func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 	fc, err := feature.NewPostgresClient(ctx, database.GormDB(), featureFlagRefreshInterval)
 	if err != nil {
 		slog.WarnContext(ctx, "feature flag client init failed; flags will default to off",
@@ -145,7 +169,7 @@ func startFeatureFlags(ctx context.Context) {
 			"err", err)
 		return
 	}
-	flagClient = fc
+	t.flagClient = fc
 	chatbot.SetFlagClient(fc)
 	server.SetFlagClient(fc)
 	go fc.Start(ctx)
@@ -156,7 +180,7 @@ func startFeatureFlags(ctx context.Context) {
 // is skipped and publishes no-op silently; chatbot.realOnscreens.
 // ShowMiddleText still mirrors to NATS but the publish becomes a nil
 // check, leaving HTTP as the sole transport.
-func startNATS() {
+func (t *Tripbot) startNATS() {
 	natsclient.Connect(c.Conf.NatsURL, "tripbot")
 }
 
@@ -165,7 +189,7 @@ func startNATS() {
 // API shows the channel offline, and force-restarts the stream after
 // 3 consecutive minute-spaced misalignments. First seen in prod on
 // 2026-05-27, ~30h into an OBS session.
-func startSilentDisconnectWatchdog(ctx context.Context) {
+func (t *Tripbot) startSilentDisconnectWatchdog(ctx context.Context) {
 	go watchdog.WatchSilentDisconnect(ctx, watchdog.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
 }
 
@@ -174,12 +198,12 @@ func startSilentDisconnectWatchdog(ctx context.Context) {
 // flag is on. Every failure path here logs and returns so it can't block
 // (or crash) tripbot startup — Discord is additive to the core IRC /
 // EventSub paths.
-func startDiscord(ctx context.Context) {
+func (t *Tripbot) startDiscord(ctx context.Context) {
 	if ok, reason := discord.ShouldStart(c.Conf); !ok {
 		slog.InfoContext(ctx, "discord disabled", "reason", reason)
 		return
 	}
-	if !flagClient.Bool(ctx, discord.FlagKey, feature.EvalContext{Env: c.Conf.Environment}) {
+	if !t.flagClient.Bool(ctx, discord.FlagKey, feature.EvalContext{Env: c.Conf.Environment}) {
 		slog.InfoContext(ctx, "discord disabled by feature flag", "flag", discord.FlagKey)
 		return
 	}
@@ -192,14 +216,14 @@ func startDiscord(ctx context.Context) {
 		slog.ErrorContext(ctx, "discord start failed", "err", err)
 		return
 	}
-	discordSession = session
+	t.discordSession = session
 }
 
 // startEventSub kicks off the EventSub WebSocket listener in a goroutine
 // so real-time follow/subscribe events fire chat shouts without a 5min
 // polling delay. Skipped (logged, not fatal) when the broadcaster row
 // isn't loaded — the bot still runs without real-time alerts.
-func startEventSub(ctx context.Context) {
+func (t *Tripbot) startEventSub(ctx context.Context) {
 	token := mytwitch.BroadcasterUserAccessToken()
 	if token == "" {
 		slog.WarnContext(ctx, "skipping eventsub: no broadcaster oauth_tokens row; bootstrap with `task tripbot:auth:bootstrap:broadcaster`",
@@ -236,28 +260,28 @@ func createRandomSeed() {
 }
 
 // listenForShutdown creates a background job that listens for a graceful shutdown request
-func listenForShutdown() {
+func (t *Tripbot) listenForShutdown() {
 	helpers.WritePidFile(c.Conf.TripbotPidFile)
 	// start the graceful shutdown listener
-	go gracefulShutdown()
+	go t.gracefulShutdown()
 }
 
 // initializeTelemetry brings up OpenTelemetry providers (traces, metrics,
 // logs). No-ops cleanly if OTEL_SDK_DISABLED is set or no OTLP endpoint
 // is configured — see pkg/telemetry.
-func initializeTelemetry() {
+func (t *Tripbot) initializeTelemetry() {
 	ctx := context.Background()
-	shutdown, err := telemetry.Init(ctx, "tripbot", version)
+	shutdown, err := telemetry.Init(ctx, "tripbot", t.version)
 	if err != nil {
 		// telemetry init failure shouldn't crash the bot — log and continue.
 		slog.WarnContext(ctx, "telemetry init failed", "err", err)
 	}
-	telemetryShutdown = shutdown
+	t.telemetryShutdown = shutdown
 }
 
 // initializeErrorLogger makes sure the logger is configured
-func initializeErrorLogger() {
-	terrors.Initialize(c.Conf, version)
+func (t *Tripbot) initializeErrorLogger() {
+	terrors.Initialize(c.Conf, t.version)
 }
 
 // startHttpServer starts a webserver, which is
@@ -265,14 +289,14 @@ func initializeErrorLogger() {
 // honored by the server for graceful shutdown — when it's canceled,
 // the server stops accepting new connections and drains in-flight
 // requests up to its shutdown timeout.
-func startHttpServer(ctx context.Context) {
+func (t *Tripbot) startHttpServer(ctx context.Context) {
 	// start the HTTP server
 	go server.Start(ctx)
 }
 
 // findInitialVideo will determine the vido that is currently-playing
 // we want to run this early, otherwise it will be unset until the first cron job runs
-func findInitialVideo() {
+func (t *Tripbot) findInitialVideo() {
 	video.GetCurrentlyPlaying(context.Background())
 	v := video.CurrentlyPlaying()
 	_, err := video.LoadOrCreate(context.Background(), v.String())
@@ -282,17 +306,17 @@ func findInitialVideo() {
 }
 
 // startCron starts the background workers
-func startCron() {
+func (t *Tripbot) startCron() {
 	s, err := background.New()
 	if err != nil {
 		slog.Error("error creating background scheduler", "err", err)
 		os.Exit(1)
 	}
-	scheduler = s
-	scheduler.Start()
+	t.scheduler = s
+	t.scheduler.Start()
 	// let !shutdown stop the same scheduler instance
-	chatbot.SetScheduler(scheduler)
-	scheduleBackgroundJobs()
+	chatbot.SetScheduler(t.scheduler)
+	t.scheduleBackgroundJobs()
 }
 
 // loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
@@ -305,14 +329,14 @@ func startCron() {
 // no longer gates on Twitch) so the admin panel + /auth/init are reachable
 // to re-auth; "not in chat" is surfaced via the admin panel + the
 // tripbot_twitch_connected gauge instead.
-func loadTwitchToken(ctx context.Context) {
+func (t *Tripbot) loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
 		slog.WarnContext(ctx, "no usable Twitch token at boot; starting without a chat connection and polling",
 			"login_as", c.Conf.BotUsername,
 			"fix", "task tripbot:auth:bootstrap",
 			"reauth_url", mytwitch.AuthInitURL("bot"),
 			"err", err)
-		go pollForTwitchToken(ctx)
+		go t.pollForTwitchToken(ctx)
 	}
 }
 
@@ -320,7 +344,7 @@ func loadTwitchToken(ctx context.Context) {
 // available, then syncs the freshly-loaded IRC token into the client so
 // connectToTwitch's reconnect loop authenticates on its next attempt. Started
 // only when the token was missing at boot; stops on shutdown.
-func pollForTwitchToken(ctx context.Context) {
+func (t *Tripbot) pollForTwitchToken(ctx context.Context) {
 	// Check often so the token is picked up promptly once it lands, but log
 	// the "still waiting" warning at a much slower cadence — boot already
 	// logged the reauth link once, so re-surfacing it every 15s is just noise.
@@ -351,8 +375,8 @@ func pollForTwitchToken(ctx context.Context) {
 			// Push the freshly-loaded token into the (already-constructed)
 			// IRC client so the connect loop's next try uses it instead of
 			// the empty token captured at chatbot.Initialize.
-			if tok := mytwitch.IRCAuthToken(); tok != "" && client != nil {
-				client.SetIRCToken(tok)
+			if tok := mytwitch.IRCAuthToken(); tok != "" && t.irc != nil {
+				t.irc.SetIRCToken(tok)
 			}
 			return
 		}
@@ -366,40 +390,40 @@ func pollForTwitchToken(ctx context.Context) {
 // in-memory token stale until the cron catches up — up to an hour. refreshOne
 // early-returns when the stored token is healthy, so this is a no-op in the
 // common case.
-func refreshTokensIfNearExpiry(ctx context.Context) {
+func (t *Tripbot) refreshTokensIfNearExpiry(ctx context.Context) {
 	mytwitch.RefreshUserAccessToken(ctx)
 }
 
 // setUpTwitchClient sets up the Twitch client,
 // used by many bot features
-func setUpTwitchClient() {
+func (t *Tripbot) setUpTwitchClient() {
 	// set up the Twitch client
-	client = chatbot.Initialize()
+	t.irc = chatbot.Initialize()
 }
 
 // updateSubscribers gets the list of current subscribers
-func updateSubscribers() {
+func (t *Tripbot) updateSubscribers() {
 	// update subscribers list
 	mytwitch.GetSubscribers(context.Background())
 }
 
 // getCurrentUsers gets the users watching the stream
-func getCurrentUsers() {
+func (t *Tripbot) getCurrentUsers() {
 	// fetch initial session
 	users.UpdateSession(context.Background())
 	users.PrintCurrentSession(context.Background())
 }
 
 // connectToTwitch joins Twitch chat and starts listening
-func connectToTwitch() {
-	client.Join(c.Conf.ChannelName)
+func (t *Tripbot) connectToTwitch() {
+	t.irc.Join(c.Conf.ChannelName)
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
 	// Mark the bot connected to chat once the IRC connection is established.
 	// This drives the admin-panel status row + the tripbot_twitch_connected
 	// gauge — it does NOT gate /health/ready, which stays 200 so the pod keeps
 	// serving the admin panel + /auth/* even while the bot is offline.
-	client.OnConnect(func() {
+	t.irc.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
 		server.SetTwitchConnected(true)
 	})
@@ -411,7 +435,7 @@ func connectToTwitch() {
 		// Connect blocks while connected and returns when the connection
 		// drops; mark not-in-chat so the admin panel + gauge reflect the gap
 		// until the next OnConnect fires.
-		err := client.Connect()
+		err := t.irc.Connect()
 		server.SetTwitchConnected(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
@@ -424,7 +448,7 @@ func connectToTwitch() {
 				// for the next Connect attempt.
 				mytwitch.Reauth(context.Background(), "bot")
 				if tok := mytwitch.IRCAuthToken(); tok != "" {
-					client.SetIRCToken(tok)
+					t.irc.SetIRCToken(tok)
 				} else {
 					// Reauth couldn't produce a token (refresh_token revoked and
 					// no fresh row in the DB yet). Surface the re-bootstrap link
@@ -438,7 +462,7 @@ func connectToTwitch() {
 }
 
 // gracefulShutdown catches CTRL-C and cleans up
-func gracefulShutdown() {
+func (t *Tripbot) gracefulShutdown() {
 	ctrlC := make(chan os.Signal, 1)
 	signal.Notify(ctrlC, os.Interrupt, syscall.SIGTERM)
 
@@ -450,8 +474,8 @@ func gracefulShutdown() {
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
 	slog.Info("last played video", "file", video.CurrentlyPlaying().File())
-	if discordSession != nil {
-		if err := discordSession.Stop(); err != nil {
+	if t.discordSession != nil {
+		if err := t.discordSession.Stop(); err != nil {
 			slog.Error("discord stop failed", "err", err)
 		}
 	}
@@ -460,13 +484,13 @@ func gracefulShutdown() {
 	if err != nil {
 		slog.Error("error closing DB connection", "err", err)
 	}
-	if err := scheduler.Stop(); err != nil {
+	if err := t.scheduler.Stop(); err != nil {
 		slog.Error("error shutting down gocron scheduler", "err", err)
 	}
 	sentry.Flush(time.Second * 5)
-	if telemetryShutdown != nil {
+	if t.telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-		if err := telemetryShutdown(flushCtx); err != nil {
+		if err := t.telemetryShutdown(flushCtx); err != nil {
 			slog.ErrorContext(flushCtx, "telemetry shutdown failed", "err", err)
 		}
 		cancel()
@@ -477,31 +501,31 @@ func gracefulShutdown() {
 // scheduleBackgroundJobs schedules the various background jobs.
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
-func scheduleBackgroundJobs() {
+func (t *Tripbot) scheduleBackgroundJobs() {
 	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost)
-	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
-	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
-	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
-	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
-	addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
-	addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
-	addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
-	addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {
+	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
+	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
+	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
+	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
+	t.addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
+	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
+	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
+	t.addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {
 		mytwitch.RefreshUserAccessToken(ctx)
 		// Keep the IRC client's stored token in sync with the rotated credentials.
 		// go-twitch-irc captures the token at construction; without this, any
 		// reconnect after the first rotation replays the original boot-time token.
 		if tok := mytwitch.IRCAuthToken(); tok != "" {
-			client.SetIRCToken(tok)
+			t.irc.SetIRCToken(tok)
 		}
 	})
-	addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", chatbot.Chatter)
+	t.addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", chatbot.Chatter)
 }
 
 // addJob registers a gocron job at the given interval, wrapping fn with
 // tracedJob so each tick opens a span and centralising the error logging.
-func addJob(interval time.Duration, name string, fn func(context.Context)) {
-	_, err := scheduler.NewJob(
+func (t *Tripbot) addJob(interval time.Duration, name string, fn func(context.Context)) {
+	_, err := t.scheduler.NewJob(
 		gocron.DurationJob(interval),
 		gocron.NewTask(tracedJob(name, fn)),
 	)


### PR DESCRIPTION
## What

Phase C.1 of the no-globals / App-injection refactor: the **pure structural lift** of `cmd/tripbot`. Moves the six package globals onto a `Tripbot` struct and converts the boot sequence into methods.

- Globals → fields: `version`, `irc *twitch.Client` (the go-twitch-irc client, was `client`), `scheduler`, `telemetryShutdown`, `discordSession`, `flagClient`.
- `main()` → `NewTripbot(version).Run()`. The `startX()`/`initializeX()` funcs, `gracefulShutdown`, `pollForTwitchToken`, `scheduleBackgroundJobs`, and `addJob` become methods on `*Tripbot`.
- `cronTracer` / `tracedJob` / `createRandomSeed` stay package-level (immutable / pure).

## Behavior-identical

This is a structure-only change:

- **The `Run()` call order is line-for-line identical to the old `main()`** — the ordering is load-bearing (`loadTwitchToken` before `chatbot.Initialize`, `StartEventHub` after `startNATS`, etc.), so it's preserved verbatim.
- Same goroutines (`gracefulShutdown`, `pollForTwitchToken`, EventSub, HTTP server), same `chatbot.SetScheduler` / `server.SetVersion` / `SetFlagClient` installer calls.
- No package-shim deletion yet — that's the per-package threading in Phase C.2+.

Salvages the intent of closed PR #104 (which was incomplete WIP — done fresh here).

## Why

`cmd/tripbot` was the one place still wiring everything via package globals + side-effecting `init`-style functions. Giving the constructed deps a home on a struct is the prerequisite for retiring the wrap-don't-refactor shims left by [twitch #738](https://github.com/adanalife/tripbot/pull/738/changes), [users #753](https://github.com/adanalife/tripbot/pull/753/changes), and [server #754](https://github.com/adanalife/tripbot/pull/754/changes): once `Tripbot` holds the instances, cmd's `mytwitch.*` / `video.*` / `users.*` / `server.*` shim calls can be swapped for `t.<field>.Method()` per package, and the shims deleted.

## Tests / verification

- `cmd/tripbot` is `package main` with no tests and is imported by nothing — blast radius is this one file.
- Full non-vlc suite green; `go build` + `go vet` clean for tripbot, onscreens-server, auth-bootstrap.
- Boot sequence is startup-critical, so worth a pod-SHA check + boot smoke on deploy (per the v2.17 startup-wiring lesson) even though it's behavior-identical.

## Next

Phase C.2+ (follow-up PRs, one per package): `Tripbot` constructs/holds `*twitch.API` / `*server.Server` / `*video.Player` / `*users.Sessions`, thread them through cmd's callsites, delete each package's shims.