### PR TITLE
refactor(server): retire defaultServer, thread the *Server through cmd (Phase C.2)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -90,6 +90,12 @@ type Tripbot struct {
 	// can stop it.
 	scheduler *background.Scheduler
 
+	// srv is the admin-panel / auth / metrics HTTP server, constructed in
+	// NewTripbot. cmd installs runtime state through it (SetVersion,
+	// SetFlagClient, SetTwitchConnected) and starts it (Start, StartEventHub);
+	// the panel's handlers are methods on this instance.
+	srv *server.Server
+
 	telemetryShutdown telemetry.ShutdownFunc
 
 	// discordSession is set by startDiscord when the Discord bot is enabled
@@ -110,6 +116,7 @@ type Tripbot struct {
 func NewTripbot(version string) *Tripbot {
 	return &Tripbot{
 		version:    version,
+		srv:        server.New(),
 		flagClient: feature.NewInMemoryClient(nil),
 	}
 }
@@ -131,7 +138,7 @@ func (t *Tripbot) Run() {
 	t.listenForShutdown()
 	t.initializeTelemetry()
 	t.initializeErrorLogger()
-	server.SetVersion(t.version)
+	t.srv.SetVersion(t.version)
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
 	users.InitLeaderboard(context.Background())
@@ -144,7 +151,7 @@ func (t *Tripbot) Run() {
 	t.getCurrentUsers()
 	t.startEventSub(shutdownCtx)
 	t.startNATS()
-	server.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
+	t.srv.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
 	t.startDiscord(shutdownCtx)
 	t.startSilentDisconnectWatchdog(shutdownCtx)
 	t.connectToTwitch()
@@ -171,7 +178,7 @@ func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 	}
 	t.flagClient = fc
 	chatbot.SetFlagClient(fc)
-	server.SetFlagClient(fc)
+	t.srv.SetFlagClient(fc)
 	go fc.Start(ctx)
 }
 
@@ -291,7 +298,7 @@ func (t *Tripbot) initializeErrorLogger() {
 // requests up to its shutdown timeout.
 func (t *Tripbot) startHttpServer(ctx context.Context) {
 	// start the HTTP server
-	go server.Start(ctx)
+	go t.srv.Start(ctx)
 }
 
 // findInitialVideo will determine the vido that is currently-playing
@@ -425,7 +432,7 @@ func (t *Tripbot) connectToTwitch() {
 	// serving the admin panel + /auth/* even while the bot is offline.
 	t.irc.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
-		server.SetTwitchConnected(true)
+		t.srv.SetTwitchConnected(true)
 	})
 
 	// actually connect to Twitch
@@ -436,7 +443,7 @@ func (t *Tripbot) connectToTwitch() {
 		// drops; mark not-in-chat so the admin panel + gauge reflect the gap
 		// until the next OnConnect fires.
 		err := t.irc.Connect()
-		server.SetTwitchConnected(false)
+		t.srv.SetTwitchConnected(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -222,7 +222,7 @@ type adminData struct {
 // pings, each version linking to its changelog), the currently-playing video
 // when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
 // / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
-func adminHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) adminHandler(w http.ResponseWriter, r *http.Request) {
 	vlc := siblingStatus(r.Context(), "vlc", c.Conf.VlcServerHost)
 	onscreens := siblingStatus(r.Context(), "onscreens", c.Conf.OnscreensServerHost)
 	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
@@ -234,17 +234,17 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Env:            c.Conf.Environment,
 		Uptime:         time.Since(startedAt).Round(time.Second).String(),
 		Chatters:       chatterCount(),
-		Services:       gatherStatus(buildSHA(), vlc, onscreens, obs),
+		Services:       s.gatherStatus(buildSHA(), vlc, onscreens, obs),
 		Now:            currentVideo(vlc.OK),
 		Audio:          nowPlayingFetcher(r.Context()),
 		Stream:         gatherStream(r.Context()),
 		PanelHost:      panelHost(r),
 		Links:          gatherLinks(),
-		Flags:          gatherFlags(r.Context()),
+		Flags:          s.gatherFlags(r.Context()),
 		Reauth:         accountsNeedingReauth(),
 		AuthStatuses:   authStatuses(),
-		ChatHistory:    defaultServer.hub.snapshotChat(),
-		MapTrailJSON:   mapTrailJSON(),
+		ChatHistory:    s.hub.snapshotChat(),
+		MapTrailJSON:   s.mapTrailJSON(),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -264,11 +264,11 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 // gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
 // the already-probed sibling-service rows. Each row carries its build tag in a
 // version column linking to that build's changelog at the deployed sha.
-func gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
+func (s *Server) gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
-		OK:         defaultServer.twitchConnected.Load(),
-		Version:    defaultServer.versionTag,
+		OK:         s.twitchConnected.Load(),
+		Version:    s.versionTag,
 		VersionURL: changelogURL(sha),
 		Uptime:     uptimeSince(startedAt),
 	}
@@ -319,8 +319,8 @@ func uptimeSince(t time.Time) string {
 // flag into the small display row the template renders. Returns nil when
 // no flags are loaded yet (startup window before SetFlagClient) so the
 // template's {{if .Flags}} hides the section cleanly.
-func gatherFlags(ctx context.Context) []featureFlag {
-	flags := defaultServer.flagSnapshot(ctx)
+func (s *Server) gatherFlags(ctx context.Context) []featureFlag {
+	flags := s.flagSnapshot(ctx)
 	if len(flags) == 0 {
 		return nil
 	}
@@ -464,7 +464,7 @@ func obsStreamActionHandler(w http.ResponseWriter, r *http.Request) {
 // in the DOM is fragile, and those values are low-volatility — they refresh on
 // the next full page load. Same sibling-ping cost as the root render; fine at
 // 15s for a single-operator panel.
-func refreshHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) refreshHandler(w http.ResponseWriter, r *http.Request) {
 	vlc := siblingStatus(r.Context(), "vlc", c.Conf.VlcServerHost)
 	onscreens := siblingStatus(r.Context(), "onscreens", c.Conf.OnscreensServerHost)
 	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
@@ -474,7 +474,7 @@ func refreshHandler(w http.ResponseWriter, r *http.Request) {
 
 	var sb strings.Builder
 	sb.WriteString(`<ul id="status-list" hx-swap-oob="true">`)
-	sb.WriteString(renderStatusRows(gatherStatus(buildSHA(), vlc, onscreens, obs)))
+	sb.WriteString(renderStatusRows(s.gatherStatus(buildSHA(), vlc, onscreens, obs)))
 	sb.WriteString(`</ul>`)
 	sb.WriteString(renderStreamControl(gatherStream(r.Context()), true))
 	if _, err := w.Write([]byte(sb.String())); err != nil {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -303,8 +303,8 @@ func TestRestartActionHandler_UnknownServiceIs400(t *testing.T) {
 }
 
 func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 
 	// stream active → the OOB widget should offer "stop"
 	savedStatus := obsStreamStatus
@@ -335,7 +335,7 @@ func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
 	c.Conf.ObsServerHost = "" // skip the obs sibling ping
 
 	rec := httptest.NewRecorder()
-	refreshHandler(rec, httptest.NewRequest(http.MethodGet, "/admin/refresh", nil))
+	srv.refreshHandler(rec, httptest.NewRequest(http.MethodGet, "/admin/refresh", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -361,8 +361,8 @@ func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
 }
 
 func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
 	withAuthStatuses(t, []mytwitch.AccountTokenStatus{
 		{Account: "bot", LoginAs: "tripbot4000", ExpiresAt: time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)},
@@ -408,12 +408,10 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
 	withChatterCount(t, 12)
 
-	saved := defaultServer.versionTag
-	defer func() { defaultServer.versionTag = saved }()
-	SetVersion("v1.2.3")
+	srv.SetVersion("v1.2.3")
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -460,8 +458,8 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 
 func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	withNowPlaying(t, nowPlayingTrack{}) // no audio info — keeps assertion on "now playing" absence valid
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(false)
+	srv := New()
+	srv.SetTwitchConnected(false)
 	withReauth(t, nil)
 
 	withConf(t, func() {
@@ -475,7 +473,7 @@ func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -558,8 +556,8 @@ func withNowPlaying(t *testing.T, track nowPlayingTrack) {
 }
 
 func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(false)
+	srv := New()
+	srv.SetTwitchConnected(false)
 	withNowPlaying(t, nowPlayingTrack{})
 
 	withConf(t, func() {
@@ -574,7 +572,7 @@ func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -595,8 +593,8 @@ func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 
 func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	withNowPlaying(t, nowPlayingTrack{})
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
 	withReauth(t, nil) // all tokens healthy
@@ -605,31 +603,25 @@ func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if strings.Contains(rec.Body.String(), "re-authenticate") {
 		t.Errorf("re-auth prompt should be hidden when no account needs re-auth")
 	}
 }
 
-func withFlags(t *testing.T, flags map[string]feature.Flag) {
+func withFlags(t *testing.T, srv *Server, flags map[string]feature.Flag) {
 	t.Helper()
-	saved := defaultServer.flagClient
-	SetFlagClient(feature.NewInMemoryClient(flags))
-	t.Cleanup(func() {
-		defaultServer.flagMu.Lock()
-		defaultServer.flagClient = saved
-		defaultServer.flagMu.Unlock()
-	})
+	srv.SetFlagClient(feature.NewInMemoryClient(flags))
 }
 
 func TestAdminHandler_RendersFeatureFlagsWhenLoaded(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withFlags(t, map[string]feature.Flag{
+	withFlags(t, srv, map[string]feature.Flag{
 		"discord.bot_enabled": {
 			Key:               "discord.bot_enabled",
 			Description:       "Gates pkg/discord startup.",
@@ -645,7 +637,7 @@ func TestAdminHandler_RendersFeatureFlagsWhenLoaded(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -671,47 +663,44 @@ func TestAdminHandler_RendersFeatureFlagsWhenLoaded(t *testing.T) {
 }
 
 func TestAdminHandler_HidesFeatureFlagsSectionWhenEmpty(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withFlags(t, nil) // no flags loaded
+	withFlags(t, srv, nil) // no flags loaded
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if strings.Contains(rec.Body.String(), "feature flags") {
 		t.Errorf("feature flags section should be hidden when no flags are loaded")
 	}
 }
 
-// withChatHistory swaps the process hub for a fresh one seeded with lines,
-// restoring the original after the test.
-func withChatHistory(t *testing.T, lines []ChatLine) {
+// withChatHistory seeds srv's hub with a fresh ring containing the given lines.
+func withChatHistory(t *testing.T, srv *Server, lines []ChatLine) {
 	t.Helper()
-	saved := defaultServer.hub
 	h := NewHub()
 	for _, l := range lines {
 		h.appendChat(l)
 	}
-	defaultServer.hub = h
-	t.Cleanup(func() { defaultServer.hub = saved })
+	srv.hub = h
 }
 
 func TestAdminHandler_RendersChatHistoryAndSSEWiring(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withChatHistory(t, []ChatLine{
+	withChatHistory(t, srv, []ChatLine{
 		{Username: "alice", Text: "hello", At: time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC)},
 		{Username: "bob", Text: "<b>hi</b>", At: time.Date(2026, 5, 29, 13, 6, 0, 0, time.UTC)},
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -730,15 +719,15 @@ func TestAdminHandler_RendersChatHistoryAndSSEWiring(t *testing.T) {
 }
 
 func TestAdminHandler_ChatEmptyPlaceholder(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withChatHistory(t, nil) // empty ring
+	withChatHistory(t, srv, nil) // empty ring
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if !strings.Contains(rec.Body.String(), "waiting for chat") {
 		t.Errorf("expected empty-chat placeholder when no history")

--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -16,7 +16,7 @@ const sseHeartbeat = 20 * time.Second
 // eventsHandler streams live-console events to the browser over Server-Sent
 // Events. HTMX's sse extension connects here (sse-connect="/admin/events") and
 // routes each named event to its sse-swap target.
-func eventsHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	rc := http.NewResponseController(w)
 
@@ -41,8 +41,8 @@ func eventsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ch := defaultServer.hub.register()
-	defer defaultServer.hub.unregister(ch)
+	ch := s.hub.register()
+	defer s.hub.unregister(ch)
 
 	heartbeat := time.NewTicker(sseHeartbeat)
 	defer heartbeat.Stop()

--- a/pkg/server/events_test.go
+++ b/pkg/server/events_test.go
@@ -66,6 +66,7 @@ func waitFor(t *testing.T, cond func() bool) {
 }
 
 func TestEventsHandler_streamsChatEvent(t *testing.T) {
+	srv := New()
 	rec := newFlushRecorder()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -73,15 +74,15 @@ func TestEventsHandler_streamsChatEvent(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		eventsHandler(rec, req)
+		srv.eventsHandler(rec, req)
 		close(done)
 	}()
 
 	// Wait until the handler has registered with the hub, so our broadcast
 	// isn't dropped before the client channel exists.
-	waitFor(t, func() bool { return defaultServer.hub.numSubscribers() >= 1 })
+	waitFor(t, func() bool { return srv.hub.numSubscribers() >= 1 })
 
-	defaultServer.hub.broadcast(sseEvent{Name: "chat", Data: `<div class="chat-line">hi</div>`})
+	srv.hub.broadcast(sseEvent{Name: "chat", Data: `<div class="chat-line">hi</div>`})
 
 	select {
 	case <-rec.writes:
@@ -105,14 +106,15 @@ func TestEventsHandler_streamsChatEvent(t *testing.T) {
 	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
 		t.Errorf("Cache-Control = %q, want no-store", cc)
 	}
-	if defaultServer.hub.numSubscribers() != 0 {
-		t.Errorf("subscriber not cleaned up after disconnect: %d", defaultServer.hub.numSubscribers())
+	if srv.hub.numSubscribers() != 0 {
+		t.Errorf("subscriber not cleaned up after disconnect: %d", srv.hub.numSubscribers())
 	}
 }
 
 // TestEventsHandler_flattensNewlines guards SSE framing: a data fragment with a
 // stray newline must not break the "event:/data:" framing.
 func TestEventsHandler_flattensNewlines(t *testing.T) {
+	srv := New()
 	rec := newFlushRecorder()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -120,12 +122,12 @@ func TestEventsHandler_flattensNewlines(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		eventsHandler(rec, req)
+		srv.eventsHandler(rec, req)
 		close(done)
 	}()
-	waitFor(t, func() bool { return defaultServer.hub.numSubscribers() >= 1 })
+	waitFor(t, func() bool { return srv.hub.numSubscribers() >= 1 })
 
-	defaultServer.hub.broadcast(sseEvent{Name: "chat", Data: "line1\nline2"})
+	srv.hub.broadcast(sseEvent{Name: "chat", Data: "line1\nline2"})
 	select {
 	case <-rec.writes:
 	case <-time.After(2 * time.Second):

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -32,8 +32,6 @@ var helixClient = mytwitch.Client
 
 // SetVersion lets cmd/tripbot inject its build-time version string
 // before the HTTP server starts.
-func SetVersion(v string) { defaultServer.SetVersion(v) }
-
 func (s *Server) SetVersion(v string) {
 	if v != "" {
 		s.versionTag = v
@@ -52,8 +50,6 @@ func (s *Server) SetVersion(v string) {
 
 // SetTwitchConnected updates the chat-connection signal: the in-memory flag
 // the admin panel reads and the tripbot_twitch_connected gauge.
-func SetTwitchConnected(connected bool) { defaultServer.SetTwitchConnected(connected) }
-
 func (s *Server) SetTwitchConnected(connected bool) {
 	s.twitchConnected.Store(connected)
 	instrumentation.TwitchConnection.Set(connected)
@@ -61,8 +57,6 @@ func (s *Server) SetTwitchConnected(connected bool) {
 
 // TwitchConnected reports the last-known chat-connection state, for the
 // admin panel's status row.
-func TwitchConnected() bool { return defaultServer.TwitchConnected() }
-
 func (s *Server) TwitchConnected() bool {
 	return s.twitchConnected.Load()
 }
@@ -74,8 +68,6 @@ func (s *Server) TwitchConnected() bool {
 
 // SetFlagClient lets cmd/tripbot install the Postgres-backed FlagClient
 // once startFeatureFlags has loaded the initial snapshot.
-func SetFlagClient(fc feature.FlagClient) { defaultServer.SetFlagClient(fc) }
-
 func (s *Server) SetFlagClient(fc feature.FlagClient) {
 	s.flagMu.Lock()
 	s.flagClient = fc
@@ -94,13 +86,13 @@ func (s *Server) flagSnapshot(ctx context.Context) []feature.Flag {
 // build-time ldflag; sha + built_at are read from the binary's embedded
 // VCS info (Go's automatic -buildvcs). started_at is when the process
 // began (admin.startedAt) so callers can derive uptime themselves.
-func versionHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
 		Tag       string `json:"tag"`
 		Sha       string `json:"sha"`
 		BuiltAt   string `json:"built_at"`
 		StartedAt string `json:"started_at"`
-	}{Tag: defaultServer.versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
+	}{Tag: s.versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -16,28 +16,27 @@ import (
 // probe. The probe itself (httpmw.ReadinessHandler with no checks → always
 // 200) is covered in pkg/httpmw; here we just guard the signal accessors.
 func TestTwitchConnectedSignal(t *testing.T) {
-	defer SetTwitchConnected(false) // reset package state for other tests
+	srv := New()
 
-	SetTwitchConnected(false)
-	if TwitchConnected() {
+	srv.SetTwitchConnected(false)
+	if srv.TwitchConnected() {
 		t.Fatalf("after SetTwitchConnected(false), TwitchConnected() = true, want false")
 	}
 
-	SetTwitchConnected(true)
-	if !TwitchConnected() {
+	srv.SetTwitchConnected(true)
+	if !srv.TwitchConnected() {
 		t.Fatalf("after SetTwitchConnected(true), TwitchConnected() = false, want true")
 	}
 }
 
 func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
-	saved := defaultServer.versionTag
-	defer func() { defaultServer.versionTag = saved }()
-	SetVersion("v9.9.9-test")
+	srv := New()
+	srv.SetVersion("v9.9.9-test")
 
 	req := httptest.NewRequest(http.MethodGet, "/version", nil)
 	rec := httptest.NewRecorder()
 
-	versionHandler(rec, req)
+	srv.versionHandler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -224,11 +224,11 @@ func renderMapPoint(p mapPoint) string {
 	return fmt.Sprintf(`<span data-lat="%.6f" data-lng="%.6f"></span>`, p.Lat, p.Lng)
 }
 
-// mapTrailJSON returns the process hub's breadcrumb trail as a JSON
+// mapTrailJSON returns the server hub's breadcrumb trail as a JSON
 // [[lat,lng],…] string for the page's map data attribute (empty "[]" when
 // there's no trail yet).
-func mapTrailJSON() string {
-	trail := defaultServer.hub.snapshotMapTrail()
+func (s *Server) mapTrailJSON() string {
+	trail := s.hub.snapshotMapTrail()
 	pts := make([][2]float64, len(trail))
 	for i, p := range trail {
 		pts[i] = [2]float64{p.Lat, p.Lng}
@@ -384,6 +384,4 @@ func renderVideoLine(ev eventbus.VideoChanged) string {
 
 // StartEventHub begins the hub's NATS subscription. Call from main() AFTER
 // natsclient.Connect — at server.Start time NATS isn't connected yet.
-func StartEventHub(ctx context.Context) { defaultServer.StartEventHub(ctx) }
-
 func (s *Server) StartEventHub(ctx context.Context) { s.hub.Start(ctx) }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,11 +31,10 @@ import (
 
 // Server holds the web server's mutable runtime state — the live-console hub,
 // the Twitch chat-connection flag, the build version tag, and the feature-flag
-// client the admin panel reads. cmd/tripbot installs values via the setter
-// methods (SetVersion / SetTwitchConnected / SetFlagClient) before and while
-// Start runs. The package-level functions below delegate to a process-wide
-// defaultServer so existing callers stay unchanged during the no-globals
-// transition.
+// client the admin panel reads. cmd/tripbot constructs one via New, installs
+// values through the setter methods (SetVersion / SetTwitchConnected /
+// SetFlagClient) before and while Start runs, and the HTTP handlers are
+// methods on it so the panel reads this instance's state — no package global.
 type Server struct {
 	hub             *Hub
 	twitchConnected atomic.Bool
@@ -56,18 +55,11 @@ func New() *Server {
 	}
 }
 
-// defaultServer is the process-wide Server backing the package-level shims and
-// the free-function HTTP handlers (which read defaultServer's fields).
-var defaultServer = New()
-
 // shutdownTimeout is how long Shutdown waits for in-flight requests to
 // finish before forcing connections closed. 15s is the typical sweet spot:
 // long enough that healthy requests complete, short enough that a stuck
 // handler doesn't block process exit indefinitely.
 const shutdownTimeout = 15 * time.Second
-
-// Start is the package-level shim delegating to defaultServer.
-func Start(ctx context.Context) { defaultServer.Start(ctx) }
 
 // Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
 // via signal.NotifyContext) the server stops accepting new connections and
@@ -88,7 +80,7 @@ func (s *Server) Start(ctx context.Context) {
 	hp.Handle("/ready", tagged("/health/ready", httpmw.ReadinessHandler()))
 
 	// version endpoint — returns build metadata as JSON
-	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")
+	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")
 
 	// auth endpoints
 	auth := r.PathPrefix("/auth").Methods("GET").Subrouter()
@@ -102,15 +94,15 @@ func (s *Server) Start(ctx context.Context) {
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
 	// admin panel (status overview + links) on the root path
-	r.Handle("/", tagged("/", adminHandler)).Methods("GET", "HEAD")
+	r.Handle("/", tagged("/", s.adminHandler)).Methods("GET", "HEAD")
 
 	// live console: SSE stream the panel subscribes to (GET, long-lived) +
 	// the vendored htmx assets it loads. The /admin POST subrouter below is
 	// POST-only, so the GET stream registers on r directly.
-	r.Handle("/admin/events", tagged("/admin/events", eventsHandler)).Methods("GET")
+	r.Handle("/admin/events", tagged("/admin/events", s.eventsHandler)).Methods("GET")
 	// live panel refresh: hidden poller OOB-swaps the always-present status rows
 	// + stream toggle so they stay current without a full reload.
-	r.Handle("/admin/refresh", tagged("/admin/refresh", refreshHandler)).Methods("GET")
+	r.Handle("/admin/refresh", tagged("/admin/refresh", s.refreshHandler)).Methods("GET")
 	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())


### PR DESCRIPTION
## What

**Phase C.2** of the no-globals / App-injection refactor, applied to `pkg/server`. [Phase C.1 (#755)](https://github.com/adanalife/tripbot/pull/755) lifted `cmd/tripbot`'s globals onto a `Tripbot` struct; this retires the **`server` package's** `defaultServer` singleton so the constructed `*server.Server` is the single source of truth.

- The HTTP handlers that read server state — `versionHandler`, `adminHandler`, `eventsHandler`, `refreshHandler` — plus their helpers `gatherStatus` / `gatherFlags` / `mapTrailJSON` become `*Server` methods, so the panel reads the **serving instance's** state instead of a package global. Stateless handlers (auth, favicon, catch-all, obs/restart/profile/map) stay free functions.
- Deletes the free-function shims: `Start`, `StartEventHub`, `SetVersion`, `SetTwitchConnected`, `TwitchConnected`, `SetFlagClient`, and the `var defaultServer`.
- `cmd/tripbot` constructs the server in `NewTripbot` (`srv: server.New()`), holds it as `Tripbot.srv`, and its six `server.*` shim callsites become `t.srv.<Method>(...)`.
- Tests construct a per-test `*Server` via `New()` instead of save/restoring `defaultServer` — the save/restore boilerplate drops out (net −21 lines), mirroring the [twitch #738](https://github.com/adanalife/tripbot/pull/738) conversion.

## Behavior-identical

Structure-only: served routes, handler logic, the SSE/hub wiring, and the boot-sequence ordering are unchanged. Only **where the server state lives** moves from a package global onto the cmd-owned instance.

## Tests / verification

- Full non-vlc suite green; `go build` + `go vet` + `gofmt -l` clean for the touched files.
- `pkg/server` tests now each build a fresh `*Server`, so they no longer leak state between tests.
- The admin panel is startup-critical — worth a pod-SHA + boot-smoke check on deploy (per the v2.17 startup-wiring lesson) even though it's behavior-identical.

## Next

Phase C.2 continues per package: **video** next (touches `chatbot`'s `realVideo` adapter + `script/collect-gps`), then **twitch**, then **users** (widest). Note: the **video/users** slices should land *after* [#736 (NATS phase 2)](https://github.com/adanalife/tripbot/pull/736), which edits `video.go` / `users/leaderboard.go`; this server slice is orthogonal to it.