### PR TITLE
refactor(video): retire defaultPlayer; admin now-playing via NATS (Phase C.2)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -29,6 +29,7 @@ import (
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	_ "github.com/dimiro1/banner/autoload"
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/getsentry/sentry-go"
@@ -96,6 +97,13 @@ type Tripbot struct {
 	// the panel's handlers are methods on this instance.
 	srv *server.Server
 
+	// player owns "what's currently playing" — the single process-wide
+	// instance, constructed in NewTripbot. The 60s cron tick refreshes it
+	// (GetCurrentlyPlaying); findInitialVideo + gracefulShutdown read it; it's
+	// installed into chatbot (SetVideoPlayer) so commands read the same state,
+	// and it publishes video.changed to NATS for the admin panel.
+	player *video.Player
+
 	telemetryShutdown telemetry.ShutdownFunc
 
 	// discordSession is set by startDiscord when the Discord bot is enabled
@@ -115,8 +123,12 @@ type Tripbot struct {
 // Postgres-backed flag client) are filled in by the boot-sequence methods.
 func NewTripbot(version string) *Tripbot {
 	return &Tripbot{
-		version:    version,
-		srv:        server.New(),
+		version: version,
+		srv:     server.New(),
+		player: video.NewPlayer(
+			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
+			vlcClient.New(c.Conf.VlcServerHost),
+		),
 		flagClient: feature.NewInMemoryClient(nil),
 	}
 }
@@ -141,6 +153,7 @@ func (t *Tripbot) Run() {
 	t.srv.SetVersion(t.version)
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
+	chatbot.SetVideoPlayer(t.player) // commands read the same Player the cron refreshes
 	users.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)
@@ -151,7 +164,8 @@ func (t *Tripbot) Run() {
 	t.getCurrentUsers()
 	t.startEventSub(shutdownCtx)
 	t.startNATS()
-	t.srv.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
+	t.srv.StartEventHub(shutdownCtx)       // after startNATS: the hub subscribes to the live NATS conn
+	t.player.EmitCurrentVideo(shutdownCtx) // after the hub subscribes: seed its now-playing cache (no NATS replay)
 	t.startDiscord(shutdownCtx)
 	t.startSilentDisconnectWatchdog(shutdownCtx)
 	t.connectToTwitch()
@@ -304,8 +318,8 @@ func (t *Tripbot) startHttpServer(ctx context.Context) {
 // findInitialVideo will determine the vido that is currently-playing
 // we want to run this early, otherwise it will be unset until the first cron job runs
 func (t *Tripbot) findInitialVideo() {
-	video.GetCurrentlyPlaying(context.Background())
-	v := video.CurrentlyPlaying()
+	t.player.GetCurrentlyPlaying(context.Background())
+	v := t.player.Current()
 	_, err := video.LoadOrCreate(context.Background(), v.String())
 	if err != nil {
 		slog.Error("error loading initial video, is there a video playing?", "err", err)
@@ -480,7 +494,7 @@ func (t *Tripbot) gracefulShutdown() {
 	// anything below this probably won't be executed
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
-	slog.Info("last played video", "file", video.CurrentlyPlaying().File())
+	slog.Info("last played video", "file", t.player.Current().File())
 	if t.discordSession != nil {
 		if err := t.discordSession.Stop(); err != nil {
 			slog.Error("discord stop failed", "err", err)
@@ -510,7 +524,7 @@ func (t *Tripbot) gracefulShutdown() {
 // the job-target packages.
 func (t *Tripbot) scheduleBackgroundJobs() {
 	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)
-	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
+	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", t.player.GetCurrentlyPlaying)
 	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
 	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -20,7 +20,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
-	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
 	"github.com/hako/durafmt"
 	"gorm.io/gorm"
@@ -497,7 +496,7 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 		return
 	}
 	vid := a.Video.Current()
-	msg := fmt.Sprintf("currently playing: %s, playtime: %s", vid, video.CurrentProgress())
+	msg := fmt.Sprintf("currently playing: %s, playtime: %s", vid, a.Video.CurrentProgress())
 	lat, lng, err := vid.Location()
 	if err != nil {
 		msg = fmt.Sprintf("%s, err: %s", msg, err)

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -2,34 +2,83 @@ package chatbot
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
 // Video is the subset of the pkg/video surface that chatbot commands depend
-// on. Tests inject a fake; production uses the package-backed realVideo
-// adapter wired in defaultApp. Mirrors the Onscreens/VLC injection pattern.
+// on. Tests inject a fake; production uses the realVideo adapter wired in
+// defaultApp. Mirrors the Onscreens/VLC injection pattern.
 type Video interface {
 	// Current returns the video the system believes is currently playing,
-	// without making any I/O calls. Reads pkg/video's package-level state.
+	// without making any I/O calls.
 	Current() video.Video
-	// GetCurrentlyPlaying refreshes pkg/video's notion of what's currently
-	// playing (an HTTP call to vlc-server in production), updates the
-	// package-level state, and returns the resulting Video.
+	// GetCurrentlyPlaying refreshes the Player's notion of what's currently
+	// playing (an HTTP call to vlc-server in production) and returns it.
 	GetCurrentlyPlaying(ctx context.Context) video.Video
+	// CurrentProgress reports how long the current clip has been playing.
+	CurrentProgress() time.Duration
 	// FindRandomByState returns a random video filmed in the given US state.
 	// Returns *terrors.NoFootageForStateError when no rows match.
 	FindRandomByState(ctx context.Context, state string) (video.Video, error)
 }
 
-// realVideo delegates to pkg/video.
+// videoPlayer is the *video.Player realVideo delegates to. cmd/tripbot installs
+// the single process-wide instance via SetVideoPlayer once it's constructed, so
+// commands read the same playback state the cron tick refreshes. nil until then
+// (brief startup window) and in tests, which inject their own Video fake rather
+// than realVideo — so the nil guards below only ever fire pre-install.
+var (
+	videoMu     sync.RWMutex
+	videoPlayer *video.Player
+)
+
+// SetVideoPlayer installs the Player that realVideo delegates to. Called from
+// cmd/tripbot once the Player is constructed. Mirrors SetScheduler.
+func SetVideoPlayer(p *video.Player) {
+	videoMu.Lock()
+	videoPlayer = p
+	videoMu.Unlock()
+}
+
+func currentPlayer() *video.Player {
+	videoMu.RLock()
+	defer videoMu.RUnlock()
+	return videoPlayer
+}
+
+// realVideo delegates to the installed *video.Player (Current /
+// GetCurrentlyPlaying) and to pkg/video's standalone DB helper
+// (FindRandomByState, which is not Player state).
 type realVideo struct{}
 
-func (realVideo) Current() video.Video { return video.CurrentlyPlaying() }
-func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
-	video.GetCurrentlyPlaying(ctx)
-	return video.CurrentlyPlaying()
+func (realVideo) Current() video.Video {
+	p := currentPlayer()
+	if p == nil {
+		return video.Video{}
+	}
+	return p.Current()
 }
+
+func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
+	p := currentPlayer()
+	if p == nil {
+		return video.Video{}
+	}
+	p.GetCurrentlyPlaying(ctx)
+	return p.Current()
+}
+
+func (realVideo) CurrentProgress() time.Duration {
+	p := currentPlayer()
+	if p == nil {
+		return 0
+	}
+	return p.CurrentProgress()
+}
+
 func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
 	return video.FindRandomByState(ctx, state)
 }

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -3,6 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/adanalife/tripbot/pkg/video"
 )
@@ -13,6 +14,7 @@ type noopVideo struct{}
 
 func (noopVideo) Current() video.Video                              { return video.Video{} }
 func (noopVideo) GetCurrentlyPlaying(_ context.Context) video.Video { return video.Video{} }
+func (noopVideo) CurrentProgress() time.Duration                    { return 0 }
 func (noopVideo) FindRandomByState(_ context.Context, _ string) (video.Video, error) {
 	return video.Video{}, nil
 }
@@ -36,6 +38,10 @@ func (r *recordingVideo) Current() video.Video {
 func (r *recordingVideo) GetCurrentlyPlaying(_ context.Context) video.Video {
 	r.Calls = append(r.Calls, "GetCurrentlyPlaying()")
 	return r.Vid
+}
+func (r *recordingVideo) CurrentProgress() time.Duration {
+	r.Calls = append(r.Calls, "CurrentProgress()")
+	return 0
 }
 func (r *recordingVideo) FindRandomByState(_ context.Context, state string) (video.Video, error) {
 	r.Calls = append(r.Calls, fmt.Sprintf("FindRandomByState(%q)", state))

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -17,7 +17,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/obs"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/gorilla/mux"
 )
 
@@ -29,12 +28,7 @@ var startedAt = time.Now()
 // ping. 2s keeps a slow or hung vlc-server from stalling the panel render.
 var healthClient = &http.Client{Timeout: 2 * time.Second}
 
-// currentlyPlaying / currentProgress are overridable in tests; by default they
-// read pkg/video's in-process state (refreshed by a 60s cron tick), so the
-// admin panel costs nothing to show "now playing".
 var (
-	currentlyPlaying = video.CurrentlyPlaying
-	currentProgress  = video.CurrentProgress
 	// chatterCount is the in-memory count of users in chat, refreshed ~60s by
 	// the UpdateSession cron. Overridable in tests.
 	chatterCount = mytwitch.ChatterCount
@@ -235,7 +229,7 @@ func (s *Server) adminHandler(w http.ResponseWriter, r *http.Request) {
 		Uptime:         time.Since(startedAt).Round(time.Second).String(),
 		Chatters:       chatterCount(),
 		Services:       s.gatherStatus(buildSHA(), vlc, onscreens, obs),
-		Now:            currentVideo(vlc.OK),
+		Now:            s.currentVideo(vlc.OK),
 		Audio:          nowPlayingFetcher(r.Context()),
 		Stream:         gatherStream(r.Context()),
 		PanelHost:      panelHost(r),
@@ -484,22 +478,24 @@ func (s *Server) refreshHandler(w http.ResponseWriter, r *http.Request) {
 
 // currentVideo summarizes the currently-playing video for the page, but only
 // when vlc is healthy (a stale value while vlc is down would be misleading).
-// Reads pkg/video's in-process value — no extra call. Returns nil when nothing
-// is playing yet (empty slug).
-func currentVideo(vlcOK bool) *nowPlaying {
+// Reads the last video.changed cached by the hub from NATS — no in-process
+// pkg/video dependency — so the panel can later be lifted into its own service.
+// Returns nil when no video.changed has arrived yet. Progress is derived from
+// the event's emitted_at (the clip start), matching the live SSE ticker.
+func (s *Server) currentVideo(vlcOK bool) *nowPlaying {
 	if !vlcOK {
 		return nil
 	}
-	v := currentlyPlaying()
-	if v.Slug == "" {
+	ev, ok := s.hub.snapshotNowPlaying()
+	if !ok || ev.File == "" {
 		return nil
 	}
-	progress := currentProgress()
+	started := parseEmitted(ev.EmittedAt)
 	return &nowPlaying{
-		File:      v.File(),
-		State:     v.State,
-		Progress:  progress.Round(time.Second).String(),
-		SinceUnix: time.Now().Add(-progress).Unix(),
+		File:      ev.File,
+		State:     ev.State,
+		Progress:  time.Since(started).Round(time.Second).String(),
+		SinceUnix: started.Unix(),
 	}
 }
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/feature"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
@@ -405,7 +406,7 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
 		c.Conf.Environment = "production"
 	})
-	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
+	withCurrentlyPlaying(t, srv, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
 	withChatterCount(t, 12)
 
 	srv.SetVersion("v1.2.3")
@@ -470,7 +471,7 @@ func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	})
 	// even with a video loaded, an unhealthy vlc hides "now playing" rather
 	// than showing a possibly-stale value.
-	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
+	withCurrentlyPlaying(t, srv, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
 	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -508,14 +509,17 @@ func withConf(t *testing.T, set func()) {
 	set()
 }
 
-// withCurrentlyPlaying swaps the currentlyPlaying / currentProgress seams so
-// the admin handler sees a fixed video + progress without driving the player.
-func withCurrentlyPlaying(t *testing.T, v video.Video, progress time.Duration) {
+// withCurrentlyPlaying seeds srv's hub with a video.changed so the admin
+// handler renders a fixed "now playing" — mirroring how it reads now-playing
+// from the NATS hub cache in production. progress maps to the event's
+// emitted_at (clip start = now - progress).
+func withCurrentlyPlaying(t *testing.T, srv *Server, v video.Video, progress time.Duration) {
 	t.Helper()
-	savedV, savedP := currentlyPlaying, currentProgress
-	currentlyPlaying = func() video.Video { return v }
-	currentProgress = func() time.Duration { return progress }
-	t.Cleanup(func() { currentlyPlaying, currentProgress = savedV, savedP })
+	srv.hub.setNowPlaying(eventbus.VideoChanged{
+		File:      v.File(),
+		State:     v.State,
+		EmittedAt: time.Now().Add(-progress).Format(time.RFC3339Nano),
+	})
 }
 
 // withChatterCount swaps the chatterCount seam to a fixed value.

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -75,6 +75,13 @@ type Hub struct {
 	// mapTrail is the recent GPS breadcrumb trail (bounded by mapTrailSize),
 	// appended on each video.changed that carries a real fix.
 	mapTrail []mapPoint
+
+	// nowPlaying is the last video.changed seen, cached so the initial page
+	// render can show "now playing" from NATS instead of reaching into
+	// pkg/video in-process. nowPlayingKnown gates it (nothing seen yet → the
+	// panel hides the card). Populated by handleVideoChanged.
+	nowPlaying      eventbus.VideoChanged
+	nowPlayingKnown bool
 }
 
 // NewHub returns an unstarted hub. Safe to construct at package-init time — it
@@ -173,15 +180,16 @@ func (h *Hub) updateViewers(count int) string {
 	return dir
 }
 
-// handleVideoChanged forwards a video switch to the panel's "now playing"
-// card. There's no ring to keep — the page renders the current video on load
-// and this just refreshes it; the hub holds no video state.
+// handleVideoChanged caches the switch as the current "now playing" (so the
+// initial page render reads it from here instead of pkg/video in-process) and
+// forwards it to connected panels' "now playing" card.
 func (h *Hub) handleVideoChanged(ctx context.Context, data []byte) {
 	var ev eventbus.VideoChanged
 	if err := json.Unmarshal(data, &ev); err != nil {
 		slog.ErrorContext(ctx, "live-console hub: bad video payload", "err", err)
 		return
 	}
+	h.setNowPlaying(ev)
 	h.broadcast(sseEvent{Name: "video", Data: renderVideoLine(ev)})
 
 	// Drop a breadcrumb for the live map when the clip has a real GPS fix.
@@ -190,6 +198,22 @@ func (h *Hub) handleVideoChanged(ctx context.Context, data []byte) {
 		h.appendMapPoint(p)
 		h.broadcast(sseEvent{Name: "map", Data: renderMapPoint(p)})
 	}
+}
+
+// setNowPlaying caches the latest video.changed as the current clip.
+func (h *Hub) setNowPlaying(ev eventbus.VideoChanged) {
+	h.mu.Lock()
+	h.nowPlaying = ev
+	h.nowPlayingKnown = true
+	h.mu.Unlock()
+}
+
+// snapshotNowPlaying returns the last video.changed seen and whether one has
+// arrived yet, for the initial page render.
+func (h *Hub) snapshotNowPlaying() (eventbus.VideoChanged, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.nowPlaying, h.nowPlayingKnown
 }
 
 // hasFix reports whether a video.changed carries usable coordinates — flagged

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -11,8 +11,6 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/helpers"
-	"github.com/adanalife/tripbot/pkg/natsclient"
-	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
@@ -27,10 +25,9 @@ type onscreens interface {
 
 // Player owns the state of "what's currently playing" and the clients that
 // drive the VLC playback + onscreens overlays. Construct via NewPlayer; the
-// package-level defaultPlayer is wired up at init for callers that still hit
-// the free-function shims below.
+// single process-wide instance lives on cmd/tripbot's Tripbot struct.
 type Player struct {
-	CurrentlyPlaying Video // exported because external callers used to read video.CurrentlyPlaying
+	CurrentlyPlaying Video // exported because external callers read the current video off it
 	curVid, preVid   string
 	timeStarted      time.Time
 	onscreens        onscreens
@@ -41,15 +38,6 @@ type Player struct {
 func NewPlayer(onscreens onscreens, vlc *vlcClient.Client) *Player {
 	return &Player{onscreens: onscreens, vlc: vlc}
 }
-
-// defaultPlayer is the package-level Player used by the free-function shims
-// below. Exists so callers that aren't constructor-injected (cmd/tripbot
-// bootstrap, script/collect-gps) keep working. New consumers should construct
-// their own *Player via NewPlayer().
-var defaultPlayer = NewPlayer(
-	onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
-	vlcClient.New(c.Conf.VlcServerHost),
-)
 
 // GetCurrentlyPlaying will use lsof to figure out
 // which dashcam video is currently playing (seriously).
@@ -116,6 +104,21 @@ func (p *Player) CurrentProgress() time.Duration {
 // Current returns the currently-playing video.
 func (p *Player) Current() Video { return p.CurrentlyPlaying }
 
+// EmitCurrentVideo re-publishes the current clip as a video.changed without a
+// transition. cmd calls this once right after the live-console hub subscribes
+// to NATS, so a freshly-started hub shows "now playing" immediately instead of
+// waiting for the next clip change (NATS core has no replay). No-op when
+// nothing is playing yet. A periodic re-emit for a separately-started console
+// is the tripbot-console split's concern, not this.
+func (p *Player) EmitCurrentVideo(ctx context.Context) {
+	if p.CurrentlyPlaying.Slug == "" {
+		return
+	}
+	eventbus.EmitVideoChanged(ctx, c.Conf.Environment,
+		p.CurrentlyPlaying.File(), p.CurrentlyPlaying.State, p.CurrentlyPlaying.Flagged,
+		p.CurrentlyPlaying.Lat, p.CurrentlyPlaying.Lng)
+}
+
 func (p *Player) figureOutCurrentVideo(ctx context.Context) string {
 	if helpers.RunningOnWindows() {
 		slog.ErrorContext(ctx, "can't run script on windows")
@@ -131,12 +134,3 @@ func (p *Player) figureOutCurrentVideo(ctx context.Context) string {
 	}
 	return outString
 }
-
-// ---- package-level shims (transitional) ----
-// Each free function calls the corresponding method on defaultPlayer. These
-// preserve the existing public surface for unmigrated callers. New consumers
-// should construct their own *Player via NewPlayer().
-
-func GetCurrentlyPlaying(ctx context.Context) { defaultPlayer.GetCurrentlyPlaying(ctx) }
-func CurrentProgress() time.Duration          { return defaultPlayer.CurrentProgress() }
-func CurrentlyPlaying() Video                 { return defaultPlayer.Current() }

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -12,7 +12,10 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/geo"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/video"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
 // this will hold the filename passed in via the CLI
@@ -41,9 +44,14 @@ func main() {
 		if videoFile != "" {
 			log.Fatal("you cannot use -current and -file at the same time")
 		}
-		// preload the currently-playing vid
-		video.GetCurrentlyPlaying(context.Background())
-		videoFile = video.CurrentlyPlaying().String()
+		// preload the currently-playing vid via a constructed Player (no
+		// package-level defaultPlayer anymore).
+		player := video.NewPlayer(
+			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
+			vlcClient.New(c.Conf.VlcServerHost),
+		)
+		player.GetCurrentlyPlaying(context.Background())
+		videoFile = player.Current().String()
 	}
 
 	// a file was passed in via the CLI


### PR DESCRIPTION
## What

**Phase C.2 for `pkg/video`** — retires the package-level `defaultPlayer` singleton and its `GetCurrentlyPlaying` / `CurrentProgress` / `CurrentlyPlaying` free-func shims. The `Player` is shared *mutable* state (the 60s cron tick writes it; chatbot, the admin panel, and shutdown read it), so there's exactly one instance, constructed in `NewTripbot` and held on `Tripbot`.

**Stacked on [#757](https://github.com/adanalife/tripbot/pull/757)** (server C.2) — base will retarget to `develop` when #757 merges. Built on top of #736's `video.go` reshape (interface `onscreens`, NATS-aware client).

## Two commits

**1. `refactor(server): read now-playing from the hub's video.changed cache`**
The admin panel's initial paint read `pkg/video`'s in-process Player via the `currentlyPlaying`/`currentProgress` fn-seams. The hub already subscribes to `video.changed` and forwards it live — it just didn't *retain* it. Now it caches the last one and `currentVideo` (a `*Server` method) reads it; progress derives from the event's `emitted_at`, matching the live SSE ticker. **This removes server's last in-process read of the Player** — decoupling that the [tripbot-console split](../vault) needs (panel → NATS-only). (`map.go`'s `video.CorpusRoute` is a standalone DB read, out of scope.)

**2. `refactor(video): retire defaultPlayer; thread a constructed Player`**
- **cmd**: `t.player` drives `findInitialVideo`, the cron job, and `gracefulShutdown`; installed into chatbot via `chatbot.SetVideoPlayer` (mirrors `SetScheduler`).
- **chatbot**: `realVideo` delegates to the installed `*Player`; the `Video` interface gains `CurrentProgress` (used by `!secretinfo`). `FindRandomByState` stays on the standalone DB helper.
- **script/collect-gps**: constructs its own `Player`.
- **`Player.EmitCurrentVideo`**: re-publishes the current clip once, right after the hub subscribes in `Run()`, so the in-process panel's now-playing cache is seeded immediately (NATS core has no replay). A *periodic* re-emit for a detached console is the console-split's concern.

## Cold-start note

Moving the panel's now-playing to the hub cache would otherwise blank it for ~minutes after a restart (the boot-time `video.changed` fires before the hub subscribes). The one-shot `EmitCurrentVideo` after `StartEventHub` closes that gap for the in-process panel.

## Tests / verification

- Full non-vlc suite green; `go build`/`vet`/`gofmt` clean. `script/collect-gps` + `make-map` build.
- Server tests now seed the hub's `nowPlaying` cache (via `withCurrentlyPlaying`) instead of the deleted seams.
- `defaultPlayer` is gone repo-wide.
- Startup-critical (boot ordering + now-playing) — worth a pod-SHA + boot smoke on deploy.

## Next

**users** is the last C.2 slice (the widest — `User` value methods read `defaultSessions`).