### PR TITLE
refactor(users): retire defaultSessions; per-provider *Sessions (Phase C.2)

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -104,6 +104,15 @@ type Tripbot struct {
 	// and it publishes video.changed to NATS for the admin panel.
 	player *video.Player
 
+	// sessions tracks who's currently in chat (the login map) + the
+	// lifetime-miles leaderboard — the single process-wide instance,
+	// constructed in NewTripbot. Cron jobs refresh it (UpdateSession /
+	// UpdateLeaderboard); boot hydrates it (InitLeaderboard); gracefulShutdown
+	// flushes it (Shutdown); installed into chatbot (SetSessions) + discord so
+	// they read the same state. One *Sessions per chat provider is the
+	// multi-provider seam.
+	sessions *users.Sessions
+
 	telemetryShutdown telemetry.ShutdownFunc
 
 	// discordSession is set by startDiscord when the Discord bot is enabled
@@ -129,6 +138,7 @@ func NewTripbot(version string) *Tripbot {
 			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
 			vlcClient.New(c.Conf.VlcServerHost),
 		),
+		sessions:   users.NewDefault(),
 		flagClient: feature.NewInMemoryClient(nil),
 	}
 }
@@ -154,7 +164,8 @@ func (t *Tripbot) Run() {
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
 	chatbot.SetVideoPlayer(t.player) // commands read the same Player the cron refreshes
-	users.InitLeaderboard(context.Background())
+	chatbot.SetSessions(t.sessions)  // commands + IRC handlers read the same session state
+	t.sessions.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)
 	t.loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
@@ -228,7 +239,7 @@ func (t *Tripbot) startDiscord(ctx context.Context) {
 		slog.InfoContext(ctx, "discord disabled by feature flag", "flag", discord.FlagKey)
 		return
 	}
-	session, err := discord.New(c.Conf.DiscordBotToken, c.Conf.DiscordGuildID)
+	session, err := discord.New(c.Conf.DiscordBotToken, c.Conf.DiscordGuildID, t.sessions)
 	if err != nil {
 		slog.ErrorContext(ctx, "discord init failed", "err", err)
 		return
@@ -431,8 +442,8 @@ func (t *Tripbot) updateSubscribers() {
 // getCurrentUsers gets the users watching the stream
 func (t *Tripbot) getCurrentUsers() {
 	// fetch initial session
-	users.UpdateSession(context.Background())
-	users.PrintCurrentSession(context.Background())
+	t.sessions.UpdateSession(context.Background())
+	t.sessions.PrintCurrentSession(context.Background())
 }
 
 // connectToTwitch joins Twitch chat and starts listening
@@ -500,7 +511,7 @@ func (t *Tripbot) gracefulShutdown() {
 			slog.Error("discord stop failed", "err", err)
 		}
 	}
-	users.Shutdown(context.Background())
+	t.sessions.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {
 		slog.Error("error closing DB connection", "err", err)
@@ -525,10 +536,10 @@ func (t *Tripbot) gracefulShutdown() {
 func (t *Tripbot) scheduleBackgroundJobs() {
 	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)
 	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", t.player.GetCurrentlyPlaying)
-	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
-	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
+	t.addJob(61*time.Second, "users.UpdateSession", t.sessions.UpdateSession)
+	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
 	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
-	t.addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
+	t.addJob(5*time.Minute, "users.PrintCurrentSession", t.sessions.PrintCurrentSession)
 	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
 	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
 	t.addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -2,8 +2,6 @@ package chatbot
 
 import (
 	"fmt"
-
-	"github.com/adanalife/tripbot/pkg/users"
 )
 
 // AnnounceNewFollower says a thank-you to a new follower in chat. Wired
@@ -26,6 +24,6 @@ func AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = isGift
 	_ = tier
 	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
-	users.GiveEveryoneMiles(1.0)
-	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", users.LoggedInCount()))
+	currentSessions().GiveEveryoneMiles(1.0)
+	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -67,7 +67,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 	msg += punctuation[rand.Intn(len(punctuation))]
 
 	// give a little help message if the user is new
-	if user.CurrentMiles(ctx) < 2.0 {
+	if a.Sessions.CurrentMiles(ctx, *user) < 2.0 {
 		msg += " I'm Tripbot, your adventure companion. Try using !commands to interact with me."
 	}
 
@@ -153,8 +153,8 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 	// check to see if an arg was provided
 	if len(params) == 0 {
 		username = user.Username
-		lifetimeMiles = user.CurrentMiles(ctx)
-		monthlyMiles = user.CurrentMonthlyMiles(ctx)
+		lifetimeMiles = a.Sessions.CurrentMiles(ctx, *user)
+		monthlyMiles = a.Sessions.CurrentMonthlyMiles(ctx, *user)
 	} else {
 		username = helpers.StripAtSign(params[0])
 		u := a.Sessions.Find(ctx, username)
@@ -165,8 +165,8 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 			return
 		}
 
-		lifetimeMiles = u.CurrentMiles(ctx)
-		monthlyMiles = u.CurrentMonthlyMiles(ctx)
+		lifetimeMiles = a.Sessions.CurrentMiles(ctx, u)
+		monthlyMiles = a.Sessions.CurrentMonthlyMiles(ctx, u)
 	}
 
 	msg := "@%s has %.2fmi this month"
@@ -195,7 +195,7 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !kilometres", "username", user.Username)
-	km := user.CurrentMiles(ctx) * 1.609344
+	km := a.Sessions.CurrentMiles(ctx, *user) * 1.609344
 	msg := "@%s has %.2f kilometres."
 	msg = fmt.Sprintf(msg, user.Username, km)
 	a.IRC.Say(msg)
@@ -485,7 +485,7 @@ func postReportToDiscord(webhookURL, username, message string) {
 
 func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !bonusmiles", "username", user.Username)
-	bonus := user.BonusMiles()
+	bonus := a.Sessions.BonusMiles(*user)
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
 	a.IRC.Say(msg)
 }

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1168,17 +1169,10 @@ func TestMilesCmd_OtherUser_NotInDB(t *testing.T) {
 }
 
 func TestMilesCmd_Self_WithMiles(t *testing.T) {
-	mock := installMockDB(t)
 	app := newTestApp(video.Video{})
-
-	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
-		WithArgs("viewer1").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
-	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "miles_2026_05"))
-	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
-			AddRow(99, 42, 7, 8.0))
+	// Stage the miles via the Sessions seam; the GetScore math behind
+	// CurrentMonthlyMiles is covered in pkg/users / pkg/scoreboards.
+	app.Sessions = &recordingSessions{Miles: 50.0, MonthlyMiles: 8.0}
 
 	out, restore := captureSay(t)
 	defer restore()
@@ -1193,24 +1187,12 @@ func TestMilesCmd_Self_WithMiles(t *testing.T) {
 	if !strings.Contains(msg, "(50mi total)") {
 		t.Errorf("expected lifetime total in self-lookup, got %q", msg)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
 }
 
 func TestMilesCmd_Self_NewcomerHint(t *testing.T) {
-	mock := installMockDB(t)
 	app := newTestApp(video.Video{})
-
 	// Brand-new user: monthly = 0, lifetime = 0 → triggers both newcomer hints.
-	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
-		WithArgs("newbie").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(99))
-	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "miles_2026_05"))
-	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
-			AddRow(100, 99, 7, 0.0))
+	app.Sessions = &recordingSessions{Miles: 0.0, MonthlyMiles: 0.0}
 
 	out, restore := captureSay(t)
 	defer restore()
@@ -1225,35 +1207,19 @@ func TestMilesCmd_Self_NewcomerHint(t *testing.T) {
 	if !strings.Contains(msg, "takes a bit for me to notice you") {
 		t.Errorf("expected zero-miles-specific hint, got %q", msg)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
 }
 
 func TestMilesCmd_OtherUser_Found(t *testing.T) {
-	mock := installMockDB(t)
 	app := newTestApp(video.Video{})
 
-	// Stage Sessions.Find to return a known user (replaces the old
-	// sqlmock SELECT * FROM users expectation).
+	// Stage Sessions.Find to return a known user, plus the miles the seam
+	// reports for them (the GetScore math is covered in pkg/users).
 	rec := &recordingSessions{
-		FindResult: users.User{ID: 42, Username: "viewer1", Miles: 120.0},
+		FindResult:   users.User{ID: 42, Username: "viewer1", Miles: 120.0},
+		Miles:        120.0,
+		MonthlyMiles: 15.5,
 	}
 	app.Sessions = rec
-
-	// 1. scoreboards.getUserIDByName — raw SELECT id by username
-	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
-		WithArgs("viewer1").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
-
-	// 2. scoreboards.findOrCreateScoreboard — FirstOrCreate SELECT
-	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "miles_2026_05"))
-
-	// 3. scoreboards.findOrCreateScore — FirstOrCreate SELECT for the score row
-	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
-			AddRow(99, 42, 7, 15.5))
 
 	out, restore := captureSay(t)
 	defer restore()
@@ -1268,11 +1234,11 @@ func TestMilesCmd_OtherUser_Found(t *testing.T) {
 	if !strings.Contains(msg, "(120mi total)") {
 		t.Errorf("expected lifetime miles in parens, got %q", msg)
 	}
-	if len(rec.Calls) != 1 || rec.Calls[0] != `Find("viewer1")` {
-		t.Errorf("expected Sessions.Find(\"viewer1\") call, got %v", rec.Calls)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	// the other-user path looks the user up via Sessions.Find, then reads
+	// their miles through the same seam.
+	want := []string{`Find("viewer1")`, `CurrentMiles("viewer1")`, `CurrentMonthlyMiles("viewer1")`}
+	if !slices.Equal(rec.Calls, want) {
+		t.Errorf("expected %v, got %v", want, rec.Calls)
 	}
 }
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -55,9 +55,22 @@ func (cmd *Command) checkAccess(ctx context.Context, user chatUser, sayFn func(s
 	return true
 }
 
+// sessionUser adapts a *users.User plus the installed *Sessions to the
+// chatUser access-check seam — the follower/subscriber + command-availability
+// checks now live on Sessions (per-provider state), not on User.
+type sessionUser struct {
+	s *users.Sessions
+	u *users.User
+}
+
+func (su sessionUser) HasCommandAvailable(ctx context.Context) bool {
+	return su.s.HasCommandAvailable(ctx, su.u)
+}
+func (su sessionUser) IsSubscriber() bool { return su.s.IsSubscriber(*su.u) }
+
 func dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)
-	if !cmd.checkAccess(ctx, user, sayFn) {
+	if !cmd.checkAccess(ctx, sessionUser{currentSessions(), user}, sayFn) {
 		return
 	}
 	// Start a child span under the chatbot.handle_message span from
@@ -169,19 +182,19 @@ func PrivateMessage(msg twitch.PrivateMessage) {
 	// check to see if the message is a command
 	//TODO: also include ones prefixed with whitespace?
 	// log in the user
-	user := users.LoginIfNecessary(ctx, username)
+	user := currentSessions().LoginIfNecessary(ctx, username)
 
 	runCommand(ctx, user, message)
 }
 
 // this event fires when a user joins the channel
 func UserJoin(joinMessage twitch.UserJoinMessage) {
-	users.LoginIfNecessary(context.Background(), joinMessage.User)
+	currentSessions().LoginIfNecessary(context.Background(), joinMessage.User)
 }
 
 // this event fires when a user leaves the channel
 func UserPart(partMessage twitch.UserPartMessage) {
-	users.LogoutIfNecessary(context.Background(), partMessage.User)
+	currentSessions().LogoutIfNecessary(context.Background(), partMessage.User)
 }
 
 // send message to chat if someone subs

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -3,8 +3,6 @@ package chatbot
 import (
 	"context"
 	"testing"
-
-	"github.com/adanalife/tripbot/pkg/users"
 )
 
 func TestNormalizeCommandPrefix(t *testing.T) {
@@ -188,9 +186,9 @@ type fakeUser struct {
 func (f *fakeUser) HasCommandAvailable(_ context.Context) bool { return f.follower }
 func (f *fakeUser) IsSubscriber() bool                         { return f.subscriber }
 
-// realUserAsChat wraps *users.User so it satisfies chatUser in tests
-// where we want to pass a struct with known field values.
-var _ chatUser = (*users.User)(nil)
+// sessionUser (a *users.User + the installed *Sessions) is the production
+// chatUser; this asserts it satisfies the seam.
+var _ chatUser = sessionUser{}
 
 func TestCheckAccess_NoRestrictions(t *testing.T) {
 	cmd := &Command{Trigger: "!test"}

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -2,30 +2,38 @@ package chatbot
 
 import (
 	"context"
+	"sync"
 
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
 // Sessions is the subset of the pkg/users surface that chatbot commands
 // depend on at command-time (user lookups, lifetime-leaderboard reads,
-// graceful shutdown of in-memory session state). Tests inject a fake;
-// production uses the package-backed realSessions adapter wired in
-// defaultApp. Mirrors the Onscreens/VLC/Video/IRC injection pattern.
+// miles computations, graceful shutdown of in-memory session state). Tests
+// inject a fake; production uses the realSessions adapter wired in defaultApp.
+// Mirrors the Onscreens/VLC/Video/IRC injection pattern.
 //
-// The IRC-side session lifecycle (LoginIfNecessary / LogoutIfNecessary)
-// is intentionally NOT on this interface — those are called from the
-// free-function handlers in handlers.go (PrivateMessage / UserJoin /
-// UserPart), which aren't App methods yet. They'll move onto App (and
-// onto this interface) in a follow-up.
+// The IRC-side session lifecycle (LoginIfNecessary / LogoutIfNecessary) and the
+// follower/subscriber + login-count reads are intentionally NOT on this
+// interface — they're called from the free-function handlers in handlers.go /
+// announce.go, which aren't App methods yet, so they reach the installed
+// *Sessions through currentSessions() directly. They'll move onto App (and onto
+// this interface) when those handlers do.
 type Sessions interface {
 	// Find looks up a user by username. Returns User{ID: 0} for an
 	// unknown user (mirrors pkg/users.Find's existing contract).
 	Find(ctx context.Context, username string) users.User
 	// LifetimeLeaderboard returns the current snapshot of the
 	// lifetime-miles leaderboard, a slice of [username, miles] pairs
-	// hydrated at startup by users.InitLeaderboard. Read-only from the
+	// hydrated at startup by InitLeaderboard. Read-only from the
 	// chatbot's perspective.
 	LifetimeLeaderboard() [][]string
+	// CurrentMiles / CurrentMonthlyMiles / BonusMiles compute a user's miles
+	// including the live session bonus, which depends on the session's login
+	// map — hence they live on Sessions and take the User.
+	CurrentMiles(ctx context.Context, u users.User) float32
+	CurrentMonthlyMiles(ctx context.Context, u users.User) float32
+	BonusMiles(u users.User) float32
 	// Shutdown logs out every in-memory session, flushing each user's
 	// state to the DB. Called by !shutdown before the process exits.
 	Shutdown(ctx context.Context)
@@ -34,7 +42,32 @@ type Sessions interface {
 	SetBot(ctx context.Context, username string, isBot bool) error
 }
 
-// realSessions delegates to pkg/users.
+// sessions is the *users.Sessions realSessions (and the free-function IRC
+// handlers) delegate to. cmd/tripbot installs the single process-wide instance
+// via SetSessions once it's constructed. nil until then (brief startup window)
+// and in tests, which inject their own Sessions fake rather than realSessions —
+// so the nil guards below only ever fire pre-install. Mirrors SetVideoPlayer.
+var (
+	sessionsMu sync.RWMutex
+	sessions   *users.Sessions
+)
+
+// SetSessions installs the Sessions that realSessions and the IRC handlers
+// delegate to. Called from cmd/tripbot once Sessions is constructed.
+func SetSessions(s *users.Sessions) {
+	sessionsMu.Lock()
+	sessions = s
+	sessionsMu.Unlock()
+}
+
+func currentSessions() *users.Sessions {
+	sessionsMu.RLock()
+	defer sessionsMu.RUnlock()
+	return sessions
+}
+
+// realSessions delegates to the installed *users.Sessions, plus pkg/users'
+// standalone DB helper (Find, which is not session state).
 type realSessions struct{}
 
 func (realSessions) Find(ctx context.Context, username string) users.User {
@@ -42,13 +75,47 @@ func (realSessions) Find(ctx context.Context, username string) users.User {
 }
 
 func (realSessions) LifetimeLeaderboard() [][]string {
-	return users.LifetimeMilesLeaderboard()
+	s := currentSessions()
+	if s == nil {
+		return nil
+	}
+	return s.LifetimeLeaderboard()
+}
+
+func (realSessions) CurrentMiles(ctx context.Context, u users.User) float32 {
+	s := currentSessions()
+	if s == nil {
+		return u.Miles
+	}
+	return s.CurrentMiles(ctx, u)
+}
+
+func (realSessions) CurrentMonthlyMiles(ctx context.Context, u users.User) float32 {
+	s := currentSessions()
+	if s == nil {
+		return 0
+	}
+	return s.CurrentMonthlyMiles(ctx, u)
+}
+
+func (realSessions) BonusMiles(u users.User) float32 {
+	s := currentSessions()
+	if s == nil {
+		return 0
+	}
+	return s.BonusMiles(u)
 }
 
 func (realSessions) Shutdown(ctx context.Context) {
-	users.Shutdown(ctx)
+	if s := currentSessions(); s != nil {
+		s.Shutdown(ctx)
+	}
 }
 
 func (realSessions) SetBot(ctx context.Context, username string, isBot bool) error {
-	return users.SetBot(ctx, username, isBot)
+	s := currentSessions()
+	if s == nil {
+		return nil
+	}
+	return s.SetBot(ctx, username, isBot)
 }

--- a/pkg/chatbot/sessions_test.go
+++ b/pkg/chatbot/sessions_test.go
@@ -12,10 +12,13 @@ import (
 // reads as empty, and Shutdown is a no-op.
 type noopSessions struct{}
 
-func (noopSessions) Find(_ context.Context, _ string) users.User      { return users.User{} }
-func (noopSessions) LifetimeLeaderboard() [][]string                  { return nil }
-func (noopSessions) Shutdown(_ context.Context)                       {}
-func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error { return nil }
+func (noopSessions) Find(_ context.Context, _ string) users.User                 { return users.User{} }
+func (noopSessions) LifetimeLeaderboard() [][]string                             { return nil }
+func (noopSessions) Shutdown(_ context.Context)                                  {}
+func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error            { return nil }
+func (noopSessions) CurrentMiles(_ context.Context, u users.User) float32        { return u.Miles }
+func (noopSessions) CurrentMonthlyMiles(_ context.Context, _ users.User) float32 { return 0 }
+func (noopSessions) BonusMiles(_ users.User) float32                             { return 0 }
 
 // recordingSessions captures every call made to it so tests can assert
 // the chatbot queried the expected user / leaderboard surfaces.
@@ -28,6 +31,8 @@ type recordingSessions struct {
 	Leaderboard [][]string
 	// SetBotErr is the error SetBot will return for every call.
 	SetBotErr error
+	// Miles / MonthlyMiles / Bonus stage what the miles methods return.
+	Miles, MonthlyMiles, Bonus float32
 }
 
 func (r *recordingSessions) Find(_ context.Context, username string) users.User {
@@ -47,4 +52,19 @@ func (r *recordingSessions) Shutdown(_ context.Context) {
 func (r *recordingSessions) SetBot(_ context.Context, username string, isBot bool) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("SetBot(%q, %t)", username, isBot))
 	return r.SetBotErr
+}
+
+func (r *recordingSessions) CurrentMiles(_ context.Context, u users.User) float32 {
+	r.Calls = append(r.Calls, fmt.Sprintf("CurrentMiles(%q)", u.Username))
+	return r.Miles
+}
+
+func (r *recordingSessions) CurrentMonthlyMiles(_ context.Context, u users.User) float32 {
+	r.Calls = append(r.Calls, fmt.Sprintf("CurrentMonthlyMiles(%q)", u.Username))
+	return r.MonthlyMiles
+}
+
+func (r *recordingSessions) BonusMiles(u users.User) float32 {
+	r.Calls = append(r.Calls, fmt.Sprintf("BonusMiles(%q)", u.Username))
+	return r.Bonus
 }

--- a/pkg/discord/commands.go
+++ b/pkg/discord/commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	"github.com/adanalife/tripbot/pkg/scoreboards"
-	"github.com/adanalife/tripbot/pkg/users"
 )
 
 const leaderboardSize = 10
@@ -119,7 +118,7 @@ func (s *Session) runLifetimeLeaderboard(ctx context.Context, i *discordgo.Inter
 		slog.ErrorContext(ctx, "discord defer reply failed", "err", err, "command", "totalleaderboard")
 		return
 	}
-	entries := users.LifetimeMilesLeaderboard()
+	entries := s.sessions.LifetimeLeaderboard()
 	if len(entries) > leaderboardSize {
 		entries = entries[:leaderboardSize]
 	}

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/users"
 )
 
 // FlagKey is the feature flag that gates Discord bot startup. cmd/tripbot
@@ -50,11 +51,14 @@ type Session struct {
 	s              *discordgo.Session
 	guildID        string
 	registeredCmds []*discordgo.ApplicationCommand
+	// sessions backs the /totalleaderboard command's in-memory read. Supplied
+	// by cmd/tripbot so discord shares the bot's one *users.Sessions instance.
+	sessions *users.Sessions
 }
 
 // New constructs the underlying discordgo session. Does not open the
 // gateway — call Start for that.
-func New(token, guildID string) (*Session, error) {
+func New(token, guildID string, sessions *users.Sessions) (*Session, error) {
 	s, err := discordgo.New("Bot " + token)
 	if err != nil {
 		return nil, fmt.Errorf("discordgo.New: %w", err)
@@ -66,7 +70,7 @@ func New(token, guildID string) (*Session, error) {
 	// INTERACTION_CREATE is reaching us. Bump to LogDebug if even
 	// informational chatter doesn't surface the interaction dispatch.
 	s.LogLevel = discordgo.LogInformational
-	return &Session{s: s, guildID: guildID}, nil
+	return &Session{s: s, guildID: guildID, sessions: sessions}, nil
 }
 
 // Start opens the gateway, registers the slash commands against the

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -67,7 +67,7 @@ func (s *Sessions) insertIntoLeaderboard(ctx context.Context, user User) {
 	s.removeFromLeaderboard(user.Username)
 
 	// get the current miles as a float
-	miles := user.CurrentMiles(ctx)
+	miles := s.CurrentMiles(ctx, user)
 
 	for i, pair := range s.lifetimeLeaderboard {
 		val := strToFloat32(ctx, pair[1])
@@ -103,11 +103,7 @@ func (s *Sessions) printLeaderboard() {
 	}
 }
 
-// LifetimeMilesLeaderboard returns the cached lifetime-miles leaderboard from
-// the default session. Was a package-level slice; now an accessor over the
-// session-owned state.
-func LifetimeMilesLeaderboard() [][]string { return defaultSessions.lifetimeLeaderboard }
-
-func InitLeaderboard(ctx context.Context) { defaultSessions.InitLeaderboard(ctx) }
-
-func UpdateLeaderboard(ctx context.Context) { defaultSessions.UpdateLeaderboard(ctx) }
+// LifetimeLeaderboard returns the cached lifetime-miles leaderboard (a slice of
+// [username, miles] pairs), hydrated by InitLeaderboard and rebuilt by
+// UpdateLeaderboard.
+func (s *Sessions) LifetimeLeaderboard() [][]string { return s.lifetimeLeaderboard }

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -41,10 +41,10 @@ func New(source ChatterSource) *Sessions {
 	}
 }
 
-// defaultSessions is the process-wide Sessions used by the package-level
-// shims below and by User value-method reads of session state. Production
-// wires it to the Twitch-backed source; tests build their own *Sessions.
-var defaultSessions = New(twitchSource{})
+// NewDefault constructs the production Sessions, wired to the Twitch-backed
+// chatter source. cmd/tripbot constructs one and threads it through the boot
+// sequence + into chatbot/discord; tests build their own *Sessions via New.
+func NewDefault() *Sessions { return New(twitchSource{}) }
 
 // UpdateSession uses the chatter source to maintain the list of
 // currently-logged-in users.
@@ -129,7 +129,7 @@ func (s *Sessions) login(ctx context.Context, username string) *User {
 // logout removes the user from the list of currently-logged in users,
 // and updates the DB with their most up-to-date values
 func (s *Sessions) logout(ctx context.Context, u *User) {
-	sessionMiles := u.sessionMiles(ctx)
+	sessionMiles := s.sessionMiles(ctx, *u)
 
 	// print logout message if they're human
 	if !u.IsBot {
@@ -138,13 +138,13 @@ func (s *Sessions) logout(ctx context.Context, u *User) {
 			"user", u.String(),
 			"duration", durafmt.ParseShort(loggedInDur).String(),
 			"session_miles", sessionMiles,
-			"monthly_miles", u.CurrentMonthlyMiles(ctx),
+			"monthly_miles", s.CurrentMonthlyMiles(ctx, *u),
 			"guess_score", u.GetScore(ctx, scoreboards.CurrentGuessScoreboard()),
 		)
 	}
 
 	// update miles
-	u.Miles = u.CurrentMiles(ctx)
+	u.Miles = s.CurrentMiles(ctx, *u)
 	// update the last seen date
 	u.LastSeen = time.Now()
 	// store the user in the db
@@ -257,26 +257,5 @@ func (s *Sessions) PrintCurrentSession(ctx context.Context) {
 	)
 }
 
-// Package-level shims delegate to defaultSessions so existing callers
-// (cmd/tripbot, pkg/chatbot, ...) stay unchanged while the package's session
-// state moves onto Sessions. Threading a constructed *Sessions through those
-// callers (and dropping these shims) is a later stage of the no-globals work.
-
-func UpdateSession(ctx context.Context) { defaultSessions.UpdateSession(ctx) }
-
-func LoginIfNecessary(ctx context.Context, username string) *User {
-	return defaultSessions.LoginIfNecessary(ctx, username)
-}
-
-func LogoutIfNecessary(ctx context.Context, username string) {
-	defaultSessions.LogoutIfNecessary(ctx, username)
-}
-
-func Shutdown(ctx context.Context) { defaultSessions.Shutdown(ctx) }
-
-func GiveEveryoneMiles(gift float32) { defaultSessions.GiveEveryoneMiles(gift) }
-
-func PrintCurrentSession(ctx context.Context) { defaultSessions.PrintCurrentSession(ctx) }
-
-// LoggedInCount returns the number of users currently in the default session.
-func LoggedInCount() int { return len(defaultSessions.loggedIn) }
+// LoggedInCount returns the number of users currently in chat.
+func (s *Sessions) LoggedInCount() int { return len(s.loggedIn) }

--- a/pkg/users/source_test.go
+++ b/pkg/users/source_test.go
@@ -34,18 +34,17 @@ func (r *recordingChatterSource) IsFollower(username string) bool {
 	return r.followers[username]
 }
 
-// User.IsSubscriber routes through the injected ChatterSource — the seam a
-// future YouTube/TikTok adapter swaps into.
-func TestUserIsSubscriberUsesChatterSource(t *testing.T) {
-	prev := defaultSessions.source
-	defer func() { defaultSessions.source = prev }()
+// Sessions.IsSubscriber routes through the injected ChatterSource — the seam a
+// future YouTube/TikTok adapter swaps into (each provider gets its own
+// *Sessions + source).
+func TestSessionsIsSubscriberUsesChatterSource(t *testing.T) {
 	rec := &recordingChatterSource{subscribers: map[string]bool{"alice": true}}
-	defaultSessions.source = rec
+	s := New(rec)
 
-	if !(User{Username: "alice"}).IsSubscriber() {
+	if !s.IsSubscriber(User{Username: "alice"}) {
 		t.Fatal("expected alice to be a subscriber via the injected source")
 	}
-	if (User{Username: "bob"}).IsSubscriber() {
+	if s.IsSubscriber(User{Username: "bob"}) {
 		t.Fatal("expected bob not to be a subscriber")
 	}
 	if rec.subCalls != 2 {

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -36,25 +36,30 @@ type User struct {
 // this is how long they have before they can guess again
 var guessCooldown = 3 * time.Minute
 
-func (u User) loggedInDur() time.Duration {
+// The miles + follower/subscriber computations below are *Sessions methods
+// (not User methods) because they read the session's live login map + chatter
+// source. They take the User as a parameter so the session state and the
+// per-user data stay explicitly separate.
+
+func (s *Sessions) loggedInDur(u User) time.Duration {
 	// exit early if they're not logged in
-	if !defaultSessions.isLoggedIn(u.Username) {
+	if !s.isLoggedIn(u.Username) {
 		return 0 * time.Second
 	}
 	// lookup the user in the session so the LoggedIn value is current
-	return time.Now().Sub(defaultSessions.loggedIn[u.Username].LoggedIn)
+	return time.Now().Sub(s.loggedIn[u.Username].LoggedIn)
 }
 
-func (u User) sessionMiles(ctx context.Context) float32 {
+func (s *Sessions) sessionMiles(ctx context.Context, u User) float32 {
 	// exit early if they're not logged in
-	if !defaultSessions.isLoggedIn(u.Username) {
+	if !s.isLoggedIn(u.Username) {
 		return 0.0
 	}
-	loggedInDur := u.loggedInDur()
+	loggedInDur := s.loggedInDur(u)
 	sessionMiles := helpers.DurationToMiles(loggedInDur)
 	// give subscribers a miles bonus
-	if u.IsSubscriber() {
-		bonusMiles := u.BonusMiles()
+	if s.IsSubscriber(u) {
+		bonusMiles := s.BonusMiles(u)
 		if c.Conf.Verbose {
 			slog.InfoContext(ctx, "subscriber will get bonus miles", "username", u.Username, "bonus_miles", bonusMiles)
 		}
@@ -63,21 +68,21 @@ func (u User) sessionMiles(ctx context.Context) float32 {
 	return sessionMiles
 }
 
-func (u User) CurrentMiles(ctx context.Context) float32 {
-	return u.Miles + u.sessionMiles(ctx)
+func (s *Sessions) CurrentMiles(ctx context.Context, u User) float32 {
+	return u.Miles + s.sessionMiles(ctx, u)
 }
 
-func (u User) BonusMiles() float32 {
-	if defaultSessions.isLoggedIn(u.Username) {
-		loggedInDur := u.loggedInDur()
+func (s *Sessions) BonusMiles(u User) float32 {
+	if s.isLoggedIn(u.Username) {
+		loggedInDur := s.loggedInDur(u)
 		sessionMiles := helpers.DurationToMiles(loggedInDur)
 		return sessionMiles * 0.05
 	}
 	return 0.0
 }
 
-func (u User) CurrentMonthlyMiles(ctx context.Context) float32 {
-	return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard()) + u.sessionMiles(ctx)
+func (s *Sessions) CurrentMonthlyMiles(ctx context.Context, u User) float32 {
+	return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard()) + s.sessionMiles(ctx, u)
 }
 
 // User.save() will take the given user and store it in the DB
@@ -98,27 +103,27 @@ func (u User) save(ctx context.Context) {
 
 // SetBot flips users.is_bot for a username. Returns gorm.ErrRecordNotFound
 // if the user doesn't exist in the DB.
-func SetBot(ctx context.Context, username string, isBot bool) error {
+func (s *Sessions) SetBot(ctx context.Context, username string, isBot bool) error {
 	user := Find(ctx, username)
 	if user.ID == 0 {
 		return gorm.ErrRecordNotFound
 	}
 	user.IsBot = isBot
 	user.save(ctx)
-	if loggedIn, ok := defaultSessions.loggedIn[username]; ok {
+	if loggedIn, ok := s.loggedIn[username]; ok {
 		loggedIn.IsBot = isBot
 	}
 	return nil
 }
 
 // IsFollower returns true if the user is a follower
-func (u User) IsFollower() bool {
-	return defaultSessions.source.IsFollower(u.Username)
+func (s *Sessions) IsFollower(u User) bool {
+	return s.source.IsFollower(u.Username)
 }
 
 // IsSubscriber returns true if the user is a subscriber
-func (u User) IsSubscriber() bool {
-	return defaultSessions.source.IsSubscriber(u.Username)
+func (s *Sessions) IsSubscriber(u User) bool {
+	return s.source.IsSubscriber(u.Username)
 }
 
 // User.String prints a colored version of the user
@@ -163,9 +168,9 @@ func Find(ctx context.Context, username string) User {
 // HasCommandAvailable lets users run a command once a day,
 // unless they are a follower in which case they can run
 // as many as they like
-func (u *User) HasCommandAvailable(ctx context.Context) bool {
+func (s *Sessions) HasCommandAvailable(ctx context.Context, u *User) bool {
 	// followers get unlimited commands
-	if u.IsFollower() {
+	if s.IsFollower(*u) {
 		return true
 	}
 	// check if they ran a command in the last 24 hrs


### PR DESCRIPTION
## What

**Phase C.2 for `pkg/users` — the widest slice.** Retires the process-wide `defaultSessions` singleton and every package-level shim. The session state (login map, lifetime-miles leaderboard) and the chatter source are **per-platform**, so one `*Sessions` per chat provider is the multi-provider seam ([#753](https://github.com/adanalife/tripbot/pull/753)'s stated intent) — the global singleton was the thing blocking a YouTube/TikTok bot beside Twitch.

**Stacked on [#758](https://github.com/adanalife/tripbot/pull/758)** (→ [#757](https://github.com/adanalife/tripbot/pull/757) → develop); base retargets as each merges.

## Changes

- **`pkg/users`** — the session-dependent `User` value-methods (`CurrentMiles`, `CurrentMonthlyMiles`, `BonusMiles`, `IsFollower`, `IsSubscriber`, `HasCommandAvailable`, `SetBot`) move onto `*Sessions`, taking the `User` as a parameter. They read the session's live login map / chatter source, which is per-provider — so `s.CurrentMiles(ctx, u)` makes the "which session" explicit where `u.CurrentMiles()` (reading a global) couldn't. Adds `NewDefault()`; deletes `defaultSessions` + all shims.
- **`cmd/tripbot`** — constructs the one `*Sessions` in `NewTripbot`, threads it through cron jobs / boot / shutdown, installs into chatbot (`SetSessions`, mirrors `SetVideoPlayer`), passes it to discord.
- **`pkg/chatbot`** — `realSessions` + the IRC-lifecycle free functions (handlers, announce) delegate to the installed instance via `currentSessions()`; the `App.Sessions` seam grows the miles methods; a `sessionUser` adapter keeps the `chatUser` access-check seam working now that follower/subscriber live on `Sessions`.
- **`pkg/discord`** — takes the `*Sessions` as a constructor param for `/totalleaderboard`.

## Multi-provider note

Per the design discussion: `pkg/users` is the multi-provider-clean part (one `*Sessions` + `ChatterSource` per platform; `IsFollower`/`IsSubscriber` read the per-platform source). The package-level `chatbot.SetSessions` installer is **transitional** — it matches the existing `SetScheduler`/`SetVideoPlayer` installers and retires together with them when chatbot itself gets the instance refactor. One product question for when a 2nd provider lands: a `User` row is shared (one lifetime `miles` total) but the session is per-provider, so simultaneous presence would accrue session-miles independently.

## Tests / verification

- Full non-vlc suite green; `go build`/`vet`/`gofmt` clean; `defaultSessions` gone repo-wide.
- `pkg/users` tests build a fresh `*Sessions` via `New(source)` instead of swapping a global; the `milesCmd` tests stage miles via the `recordingSessions` seam (the `GetScore` math stays covered in `pkg/users`/`scoreboards`).
- Startup-critical (session boot ordering) — worth a boot smoke on deploy.

## Sequence

This is the **last C.2 slice**. Order: #757 (server) → #736 (NATS, merged) → #758 (video) → #758-stacked **#this** (users).