### PR TITLE
fix(config): default ENV to testing under go test

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/joho/godotenv"
 )
@@ -23,8 +24,18 @@ func SetEnvironment() {
 
 	envVar, ok := os.LookupEnv("ENV")
 	if !ok {
-		envVar = "development"
-		slog.Warn("ENV not set, defaulting to development")
+		// Host-side `go test ./pkg/...` runs with ENV unset; default those to
+		// testing so the repo-root .env.testing (located via resolveFromRepoRoot
+		// below) loads instead of the absent .env.development — the same env
+		// `task test` sets explicitly. testing.Testing() is true only in test
+		// binaries, so `go run` / production are unaffected. Everything else
+		// defaults to development.
+		if testing.Testing() {
+			envVar = "testing"
+		} else {
+			envVar = "development"
+			slog.Warn("ENV not set, defaulting to development")
+		}
 		// envconfig.Process reads from the process env; the defaulted
 		// value has to be visible to the required:"true" field on
 		// TripbotConfig.Environment / VlcServerConfig.Environment.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,6 +44,28 @@ func TestResolveFromRepoRootFallsBackWithoutGoMod(t *testing.T) {
 	}
 }
 
+// With ENV unset under `go test`, SetEnvironment should default to testing (so
+// the repo-root .env.testing loads), not development — otherwise host-side
+// `go test ./pkg/...` fails on the absent .env.development + missing required
+// config keys.
+func TestSetEnvironmentDefaultsToTestingUnderGoTest(t *testing.T) {
+	orig, had := os.LookupEnv("ENV")
+	os.Unsetenv("ENV")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("ENV", orig)
+		} else {
+			os.Unsetenv("ENV")
+		}
+	})
+
+	SetEnvironment()
+
+	if got := os.Getenv("ENV"); got != "testing" {
+		t.Errorf("SetEnvironment() with ENV unset under go test: ENV=%q, want %q", got, "testing")
+	}
+}
+
 // chdir switches into dir for the duration of the test, restoring the original
 // working directory afterward. t.TempDir()s used here have no go.mod ancestor
 // outside themselves, so the resolver's walk terminates at the filesystem root.


### PR DESCRIPTION
## Why

Host-side `go test ./pkg/foo` runs with `ENV` unset. `SetEnvironment` defaulted that to `development` and tried to load the absent `.env.development`, so config loading failed on required keys (`CHANNEL_NAME`, …) — meaning a bare `go test` of any package that loads config errored unless you remembered to prefix `ENV=testing`.

## Fix

`resolveFromRepoRoot` was already added so host-side `go test` (whose test binaries run from each package's own dir) can find the repo-root `.env.testing`. This finishes that intent: when `ENV` is unset **and** we're running under `go test` (`testing.Testing()`), default to `testing` — the same env `task test` sets explicitly. `testing.Testing()` is true only in test binaries, so `go run` / production are unaffected; everything else still defaults to `development`.

## Verify

`env -u ENV go test ./pkg/chatbot/` (which failed with `required key CHANNEL_NAME missing` before) now passes with no `ENV` prefix and no manual dotenv sourcing. New `TestSetEnvironmentDefaultsToTestingUnderGoTest` locks it in.