### PR TITLE
refactor(chatbot): announce + Chatter onto App methods via a.IRC.Say

### DIFF
--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -6,8 +6,8 @@ import (
 
 // AnnounceNewFollower says a thank-you to a new follower in chat. Wired
 // from pkg/eventsub on channel.follow v2 events.
-func AnnounceNewFollower(username string) {
-	sayFn(fmt.Sprintf("Thank you for the follow, @%s", username))
+func (a *App) AnnounceNewFollower(username string) {
+	a.IRC.Say(fmt.Sprintf("Thank you for the follow, @%s", username))
 }
 
 // AnnounceSubscriber says a thank-you to a new subscriber, gives every
@@ -20,10 +20,19 @@ func AnnounceNewFollower(username string) {
 // resub-with-message handling (channel.subscription.message) are
 // separate event types — wire them through pkg/eventsub.Handlers as
 // they're added.
-func AnnounceSubscriber(username string, isGift bool, tier string) {
+func (a *App) AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = isGift
 	_ = tier
-	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
+	a.IRC.Say(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
 	currentSessions().GiveEveryoneMiles(1.0)
-	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
+	a.IRC.Say(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
+}
+
+// Package-level shims delegating to defaultApp, so cmd's eventsub wiring keeps
+// referencing chatbot.AnnounceNewFollower / chatbot.AnnounceSubscriber as
+// function values. They retire once cmd registers the App's methods directly
+// (later Phase C step).
+func AnnounceNewFollower(username string) { defaultApp.AnnounceNewFollower(username) }
+func AnnounceSubscriber(username string, isGift bool, tier string) {
+	defaultApp.AnnounceSubscriber(username, isGift, tier)
 }

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -183,13 +183,17 @@ func Whisper(username, msg string) {
 
 // Chatter is designed to post a randomized message on a timer.
 // Right now it just posts random "help messages."
-// ctx is forward-compat plumbing — sayFn (the package-level chat-send
-// indirection) doesn't take ctx yet, so it's not propagated into the IRC
-// write.
-func Chatter(_ context.Context) {
+// ctx is forward-compat plumbing — a.IRC.Say doesn't take ctx yet, so it's
+// not propagated into the IRC write.
+func (a *App) Chatter(_ context.Context) {
 	// use twitch emote feature to add some color
-	sayFn("/me " + help())
+	a.IRC.Say("/me " + help())
 }
+
+// Chatter shim delegating to defaultApp, so cmd's cron wiring keeps referencing
+// chatbot.Chatter as a function value. Retires once cmd registers the App's
+// method directly (later Phase C step).
+func Chatter(ctx context.Context) { defaultApp.Chatter(ctx) }
 
 func help() string {
 	text := c.HelpMessages[helpIndex]


### PR DESCRIPTION
**Phase C — PR 3 of the registry/DI refactor.** Retires the last `sayFn` *production* callers.

`AnnounceNewFollower`, `AnnounceSubscriber` (eventsub callbacks) and `Chatter` (cron job) become `*App` methods emitting through `a.IRC.Say` instead of the package-level `sayFn` global. Thin package-level shims delegating to `defaultApp` remain so cmd's wiring (`chatbot.AnnounceNewFollower`, `chatbot.Chatter` as function values) is untouched; they retire once cmd registers the App's methods directly (later step).

**Milestone:** with #766 (social-media closures) + #768 (dispatch path) + this, `sayFn` has **no production callers left** — only its `var sayFn = Say` definition and the `noopIRC`/`captureSay` test seam. That clears the way to delete it once the tests migrate to `recordingIRC`.

**No behavior change:** `defaultApp.IRC` is `realIRC`, so `a.IRC.Say` resolves to the same `Say()`. `go test ./pkg/chatbot/` green.

Independent of #766 (`registry.go`) and #768 (`handlers.go`) — touches `announce.go` + `chatbot.go`.