### PR TITLE
refactor(chatbot): move the command registry onto the App

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -78,6 +78,15 @@ type App struct {
 	// delegates to the pkg/twitch client. The future swap point for an
 	// out-of-process Helix/auth service.
 	Twitch Twitch
+
+	// commands is this App's command registry (built by buildRegistry);
+	// singleWordLookup / multiWordLookup index it by trigger + alias for
+	// dispatch. Populated by indexCommands() — production builds defaultApp's
+	// in init(); tests build a test App's via newTestApp. Replaces the former
+	// package-level globals so the registry travels with the App.
+	commands         []Command
+	singleWordLookup map[string]*Command
+	multiWordLookup  map[string]*Command
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB

--- a/pkg/chatbot/fuzz_test.go
+++ b/pkg/chatbot/fuzz_test.go
@@ -50,7 +50,7 @@ func FuzzFindCommand(f *testing.F) {
 		f.Add(s)
 	}
 	f.Fuzz(func(t *testing.T, s string) {
-		_, _ = findCommand(s)
+		_, _ = defaultApp.findCommand(s)
 	})
 }
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -88,7 +88,7 @@ func (a *App) dispatch(ctx context.Context, cmd *Command, user *users.User, para
 
 // findCommand parses message and returns the matching Command and params.
 // Returns nil if no command matches.
-func findCommand(message string) (*Command, []string) {
+func (a *App) findCommand(message string) (*Command, []string) {
 	msg := normalizeCommandPrefix(strings.TrimSpace(message))
 	split := strings.Split(msg, " ")
 
@@ -112,7 +112,7 @@ func findCommand(message string) (*Command, []string) {
 	}
 
 	// multi-word alias lookup (e.g. "no audio", "no sound")
-	for alias, cmd := range multiWordLookup {
+	for alias, cmd := range a.multiWordLookup {
 		if msg == alias || strings.HasPrefix(msg, alias+" ") {
 			remainder := strings.TrimSpace(strings.TrimPrefix(msg, alias))
 			var mwParams []string
@@ -124,7 +124,7 @@ func findCommand(message string) (*Command, []string) {
 	}
 
 	// single-word lookup
-	if cmd, ok := singleWordLookup[command]; ok {
+	if cmd, ok := a.singleWordLookup[command]; ok {
 		return cmd, params
 	}
 	return nil, nil
@@ -145,7 +145,7 @@ func (a *App) runCommand(ctx context.Context, user *users.User, message string) 
 		trace.SpanFromContext(ctx).SetAttributes(attribute.String("twitch.command", command))
 	}
 
-	cmd, params := findCommand(message)
+	cmd, params := a.findCommand(message)
 	if cmd != nil {
 		a.dispatch(ctx, cmd, user, params)
 		return

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -75,7 +75,7 @@ func TestNormalizeCommandPrefix_DispatchEquivalence(t *testing.T) {
 // --- findCommand routing tests ---
 
 func TestFindCommand_SingleWordTrigger(t *testing.T) {
-	cmd, params := findCommand("!help")
+	cmd, params := defaultApp.findCommand("!help")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -89,7 +89,7 @@ func TestFindCommand_SingleWordTrigger(t *testing.T) {
 
 func TestFindCommand_SingleWordAlias(t *testing.T) {
 	// "hi" is an alias of "hello"
-	cmd, _ := findCommand("hi")
+	cmd, _ := defaultApp.findCommand("hi")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -100,7 +100,7 @@ func TestFindCommand_SingleWordAlias(t *testing.T) {
 
 func TestFindCommand_MultiWordAlias(t *testing.T) {
 	// "no audio" is an alias of !report
-	cmd, params := findCommand("no audio")
+	cmd, params := defaultApp.findCommand("no audio")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -114,7 +114,7 @@ func TestFindCommand_MultiWordAlias(t *testing.T) {
 
 func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
 	// "frozen since yesterday" — starts with the "frozen" alias
-	cmd, params := findCommand("frozen since yesterday")
+	cmd, params := defaultApp.findCommand("frozen since yesterday")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -128,7 +128,7 @@ func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
 
 func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 	// ¡miles should route to the same command as !miles
-	cmd, _ := findCommand("¡miles")
+	cmd, _ := defaultApp.findCommand("¡miles")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -139,7 +139,7 @@ func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 
 func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
 	// "! location" (with a space) should route to !location
-	cmd, _ := findCommand("! location")
+	cmd, _ := defaultApp.findCommand("! location")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -149,7 +149,7 @@ func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
 }
 
 func TestFindCommand_WithParams(t *testing.T) {
-	cmd, params := findCommand("!goto 42")
+	cmd, params := defaultApp.findCommand("!goto 42")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -162,14 +162,14 @@ func TestFindCommand_WithParams(t *testing.T) {
 }
 
 func TestFindCommand_UnknownCommand(t *testing.T) {
-	cmd, _ := findCommand("!doesnotexist99")
+	cmd, _ := defaultApp.findCommand("!doesnotexist99")
 	if cmd != nil {
 		t.Errorf("expected nil for unknown command, got %q", cmd.Trigger)
 	}
 }
 
 func TestFindCommand_EmptyMessage(t *testing.T) {
-	cmd, _ := findCommand("")
+	cmd, _ := defaultApp.findCommand("")
 	if cmd != nil {
 		t.Errorf("expected nil for empty message, got %q", cmd.Trigger)
 	}

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -7,10 +7,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
-var commands []Command
-var singleWordLookup map[string]*Command
-var multiWordLookup map[string]*Command
-
 // buildRegistry constructs the command slice with handlers bound to a.
 func (a *App) buildRegistry() []Command {
 	return []Command{
@@ -239,23 +235,34 @@ func (a *App) buildRegistry() []Command {
 	}
 }
 
-func init() {
-	commands = defaultApp.buildRegistry()
-	singleWordLookup = make(map[string]*Command)
-	multiWordLookup = make(map[string]*Command)
-	for i := range commands {
-		cmd := &commands[i]
-		registerTrigger(cmd.Trigger, cmd)
+// indexCommands builds a.commands from a.buildRegistry() and indexes it into
+// a.singleWordLookup / a.multiWordLookup by trigger and alias. Call once after
+// the App is constructed (its deps don't need to be set — buildRegistry only
+// binds handler method values to a).
+func (a *App) indexCommands() {
+	a.commands = a.buildRegistry()
+	a.singleWordLookup = make(map[string]*Command)
+	a.multiWordLookup = make(map[string]*Command)
+	for i := range a.commands {
+		cmd := &a.commands[i]
+		a.registerTrigger(cmd.Trigger, cmd)
 		for _, alias := range cmd.Aliases {
-			registerTrigger(alias, cmd)
+			a.registerTrigger(alias, cmd)
 		}
 	}
 }
 
-func registerTrigger(trigger string, cmd *Command) {
+func (a *App) registerTrigger(trigger string, cmd *Command) {
 	if strings.Contains(trigger, " ") {
-		multiWordLookup[trigger] = cmd
+		a.multiWordLookup[trigger] = cmd
 	} else {
-		singleWordLookup[trigger] = cmd
+		a.singleWordLookup[trigger] = cmd
 	}
+}
+
+// init builds the package singleton's registry. Once cmd constructs the App and
+// hands it to the message path (later Phase C step), this moves into that
+// constructor and defaultApp goes away.
+func init() {
+	defaultApp.indexCommands()
 }

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
-	for _, cmd := range commands {
+	for _, cmd := range defaultApp.commands {
 		if cmd.Trigger == "" {
 			t.Errorf("command has empty Trigger: %+v", cmd)
 		}
@@ -15,7 +15,7 @@ func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
 
 func TestNoDuplicateTriggersOrAliases(t *testing.T) {
 	seen := map[string]string{} // trigger/alias → owning command's Trigger
-	for _, cmd := range commands {
+	for _, cmd := range defaultApp.commands {
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			if owner, clash := seen[token]; clash {
@@ -27,15 +27,15 @@ func TestNoDuplicateTriggersOrAliases(t *testing.T) {
 }
 
 func TestLookupMapsContainAllTriggers(t *testing.T) {
-	for _, cmd := range commands {
+	for _, cmd := range defaultApp.commands {
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			if strings.Contains(token, " ") {
-				if _, ok := multiWordLookup[token]; !ok {
+				if _, ok := defaultApp.multiWordLookup[token]; !ok {
 					t.Errorf("multi-word trigger %q missing from multiWordLookup", token)
 				}
 			} else {
-				if _, ok := singleWordLookup[token]; !ok {
+				if _, ok := defaultApp.singleWordLookup[token]; !ok {
 					t.Errorf("single-word trigger %q missing from singleWordLookup", token)
 				}
 			}
@@ -44,15 +44,15 @@ func TestLookupMapsContainAllTriggers(t *testing.T) {
 }
 
 func TestLookupMapsPointToCorrectCommand(t *testing.T) {
-	for i := range commands {
-		cmd := &commands[i]
+	for i := range defaultApp.commands {
+		cmd := &defaultApp.commands[i]
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			var got *Command
 			if strings.Contains(token, " ") {
-				got = multiWordLookup[token]
+				got = defaultApp.multiWordLookup[token]
 			} else {
-				got = singleWordLookup[token]
+				got = defaultApp.singleWordLookup[token]
 			}
 			if got != cmd {
 				t.Errorf("trigger %q maps to %q, want %q", token, got.Trigger, cmd.Trigger)


### PR DESCRIPTION
**Phase C — the structural core.** Turns the command registry from a package singleton into per-`App` state.

Previously `commands` / `singleWordLookup` / `multiWordLookup` were package-level globals built in `init()` off `defaultApp`. Now:

- They're **fields on `App`**, built by a new `App.indexCommands()` (`buildRegistry()` + index). `registerTrigger` becomes an `App` method writing `a`'s maps.
- `init()` shrinks to `defaultApp.indexCommands()` — and is explicitly the thing that moves into cmd's App constructor (with `defaultApp` itself) in a later step.
- `findCommand` becomes an `*App` method reading `a.singleWordLookup`/`a.multiWordLookup`; `runCommand` calls `a.findCommand`.

**Why it matters:** this is the prerequisite for cmd building the App and handing it to the message path — the move that ultimately deletes `defaultApp` and the four `Set*` installers (real DI, not "globals with extra steps").

**Tests:** the registry/find tests read `defaultApp`'s registry (built in `init`), so they exercise the real command set unchanged. `go build` / `go vet` / `go test ./pkg/chatbot/` all green; gofmt clean. No behavior change.