### PR TITLE
Release v2.18.2: develop → master

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,42 @@
+name: contract
+
+# Guards the anti-drift contract bridge (pkg/contract): tripbot is the source of
+# truth for the service names / ports / env-var keys the infra cdk8s manifests
+# consume. This catches both failure modes — a constant changed without
+# regenerating contract.json, and contract.json hand-edited away from the
+# constants. pkg/contract is dependency-free (no cgo / libvlc), so this is fast.
+on:
+  pull_request:
+    paths:
+      - 'pkg/contract/**'
+      - '.github/workflows/contract.yml'
+  push:
+    branches:
+      - develop
+      - master
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Go toolchain from .tool-versions, per
+      # vault/decisions/golang-development-with-mise.md.
+      - uses: jdx/mise-action@v4
+
+      # `go generate` must reproduce the committed contract.json byte-for-byte.
+      - name: Regenerate contract.json
+        run: go generate ./pkg/contract
+
+      - name: Assert contract.json is up to date
+        run: |
+          if ! git diff --exit-code pkg/contract/contract.json; then
+            echo "::error::pkg/contract/contract.json is stale — run 'go generate ./pkg/contract' and commit."
+            exit 1
+          fi
+
+      # The test re-asserts constants == committed JSON (defense in depth, and
+      # covers the case where contract.json was hand-edited).
+      - name: Test
+        run: go test ./pkg/contract/...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v6
       # The gofmt hook (and the golang-based gitleaks/actionlint hooks) need
       # the Go toolchain on PATH; mise installs it from .tool-versions.
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
       - uses: pre-commit/action@v3.0.1
         env:
           SKIP: no-commit-to-branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+## [v2.18.2] — 2026-06-01
+
+Patch release, almost entirely internal. The no-globals refactor finishes Phase B and opens Phase C: the last per-package `defaultX` singletons (`pkg/server`, `pkg/video`, `pkg/users`) are retired in favour of constructed structs threaded from cmd, cmd's own globals move into a `Tripbot` struct, and the chatbot's command registry, dispatch path, and event handlers move onto the injectable `App`. NATS phase 2 moves the onscreens command surface (and the admin panel's now-playing) onto pub/sub. Rounded out by a `go test` env-default fix and a CI action bump.
+
+### pubsub
+
+- **NATS phase 2 — onscreens command surface on pub/sub.** The onscreens overlay commands move from direct HTTP calls onto NATS, extending the pub/sub substrate. ([#736])
+
+### refactor
+
+- **Phase B finish — retire the last package `defaultX` singletons.** `pkg/users` session state is encapsulated behind a constructed `*Sessions` with an injected `ChatterSource` ([#753]) and then has its `defaultSessions` global retired ([#764]); `pkg/server` retires `defaultServer`, threading a `*Server` through cmd ([#757]); `pkg/video` retires `defaultPlayer` and sources the admin panel's now-playing from NATS ([#758]).
+- **cmd globals lifted into a `Tripbot` struct (Phase C.1).** The `cmd/tripbot` entrypoint constructs and threads its dependencies instead of reaching for package globals. ([#755])
+- **chatbot Phase C — registry, dispatch, and handlers onto the `App`.** Social-media replies ([#766]), the dispatch path with access-check denials ([#768]), follower/subscriber announcements and the Chatter timer ([#769]), and the command registry with `findCommand` ([#770]) all move off package-level globals onto the injectable `App`, routing chat output through `a.IRC.Say`. Groundwork for retiring `defaultApp` and the `sayFn` global, and for multi-platform chat support.
+
+### CI
+
+- **`go test` defaults `ENV` to testing.** With `ENV` unset under `go test`, `config.SetEnvironment` defaulted to `development` and failed on the absent `.env.development`; it now defaults to `testing` via `testing.Testing()`, so bare `go test ./pkg/...` loads the checked-in `.env.testing` with no prefix — completing the repo-root resolution from v2.18.1. ([#767])
+
+### deps
+
+- **`jdx/mise-action` 2 → 4.** ([#759])
+
 ## [v2.18.1] — 2026-06-01
 
 Patch release. Mostly internals: the Phase B no-globals refactor lands its final package conversions — `pkg/twitch` and `pkg/server` now construct a `*API` / `*Server` instead of mutating package-level globals — alongside extracting reverse-geocoding into an injectable `pkg/geo` and giving chatbot a `App.Twitch` injection seam. Admin-panel polish continues (htmx live updates replacing full-page reloads, a GPS-jump-aware map trail, and an offline-collapsed stream preview), plus dashcam-cv database groundwork (pgvector), a `go test` ergonomics fix, and an OpenTelemetry deps bump.
@@ -1298,3 +1320,15 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#720]: https://github.com/adanalife/tripbot/pull/720
 [#722]: https://github.com/adanalife/tripbot/pull/722
 [#723]: https://github.com/adanalife/tripbot/pull/723
+[#736]: https://github.com/adanalife/tripbot/pull/736
+[#753]: https://github.com/adanalife/tripbot/pull/753
+[#755]: https://github.com/adanalife/tripbot/pull/755
+[#757]: https://github.com/adanalife/tripbot/pull/757
+[#758]: https://github.com/adanalife/tripbot/pull/758
+[#759]: https://github.com/adanalife/tripbot/pull/759
+[#764]: https://github.com/adanalife/tripbot/pull/764
+[#766]: https://github.com/adanalife/tripbot/pull/766
+[#767]: https://github.com/adanalife/tripbot/pull/767
+[#768]: https://github.com/adanalife/tripbot/pull/768
+[#769]: https://github.com/adanalife/tripbot/pull/769
+[#770]: https://github.com/adanalife/tripbot/pull/770

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
-## [v2.18.2] — 2026-06-01
+## [v2.18.2] — 2026-06-02
 
-Patch release, almost entirely internal. The no-globals refactor finishes Phase B and opens Phase C: the last per-package `defaultX` singletons (`pkg/server`, `pkg/video`, `pkg/users`) are retired in favour of constructed structs threaded from cmd, cmd's own globals move into a `Tripbot` struct, and the chatbot's command registry, dispatch path, and event handlers move onto the injectable `App`. NATS phase 2 moves the onscreens command surface (and the admin panel's now-playing) onto pub/sub. Rounded out by a `go test` env-default fix and a CI action bump.
+Patch release, almost entirely internal. The no-globals refactor finishes Phase B and opens Phase C: the last per-package `defaultX` singletons (`pkg/server`, `pkg/video`, `pkg/users`) are retired in favour of constructed structs threaded from cmd, cmd's own globals move into a `Tripbot` struct, and the chatbot's command registry, dispatch path, and event handlers move onto the injectable `App`. NATS phase 2 moves the onscreens command surface (and the admin panel's now-playing) onto pub/sub. Rounded out by a logout-path crash-loop fix, the producer half of the tripbot↔infra anti-drift contract, a `go test` env-default fix, and a CI action bump.
+
+### fix
+
+- **Logged-out users no longer crash-loop `save()`.** A user whose DB row couldn't be found or created (a transient `Find` error returns `ID: 0`) was cached in the session and then failed GORM's `Updates()` on every logout tick with "WHERE conditions required". `save()` now skips a zero-ID user and `login()` won't cache one, so the session self-heals on the next tick. No data lost — the `events` log and monthly scoreboard were unaffected; only the `users.miles` cache missed its increment, and it is recomputable. (TRIPBOT-8D, [#778])
 
 ### pubsub
 
@@ -24,6 +28,10 @@ Patch release, almost entirely internal. The no-globals refactor finishes Phase 
 ### CI
 
 - **`go test` defaults `ENV` to testing.** With `ENV` unset under `go test`, `config.SetEnvironment` defaulted to `development` and failed on the absent `.env.development`; it now defaults to `testing` via `testing.Testing()`, so bare `go test ./pkg/...` loads the checked-in `.env.testing` with no prefix — completing the repo-root resolution from v2.18.1. ([#767])
+
+### tooling
+
+- **tripbot↔infra anti-drift contract (producer half).** `pkg/contract/` holds the canonical service names, ports, and env-var keys as typed Go constants (cross-checked against `pkg/config/tripbot`, `pkg/obs`, `pkg/database`); a `go:generate` tool emits `contract.json` and a test fails on drift in either direction. A new `contract.yml` workflow regenerates in CI and fails if the committed file is stale. The infra cdk8s manifests consume it via `task contract:sync`. Dependency-free, so generate + test stay fast and hermetic. ([#777])
 
 ### deps
 
@@ -1332,3 +1340,5 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#768]: https://github.com/adanalife/tripbot/pull/768
 [#769]: https://github.com/adanalife/tripbot/pull/769
 [#770]: https://github.com/adanalife/tripbot/pull/770
+[#777]: https://github.com/adanalife/tripbot/pull/777
+[#778]: https://github.com/adanalife/tripbot/pull/778

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -104,6 +104,15 @@ type Tripbot struct {
 	// and it publishes video.changed to NATS for the admin panel.
 	player *video.Player
 
+	// sessions tracks who's currently in chat (the login map) + the
+	// lifetime-miles leaderboard — the single process-wide instance,
+	// constructed in NewTripbot. Cron jobs refresh it (UpdateSession /
+	// UpdateLeaderboard); boot hydrates it (InitLeaderboard); gracefulShutdown
+	// flushes it (Shutdown); installed into chatbot (SetSessions) + discord so
+	// they read the same state. One *Sessions per chat provider is the
+	// multi-provider seam.
+	sessions *users.Sessions
+
 	telemetryShutdown telemetry.ShutdownFunc
 
 	// discordSession is set by startDiscord when the Discord bot is enabled
@@ -129,6 +138,7 @@ func NewTripbot(version string) *Tripbot {
 			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
 			vlcClient.New(c.Conf.VlcServerHost),
 		),
+		sessions:   users.NewDefault(),
 		flagClient: feature.NewInMemoryClient(nil),
 	}
 }
@@ -154,7 +164,8 @@ func (t *Tripbot) Run() {
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
 	chatbot.SetVideoPlayer(t.player) // commands read the same Player the cron refreshes
-	users.InitLeaderboard(context.Background())
+	chatbot.SetSessions(t.sessions)  // commands + IRC handlers read the same session state
+	t.sessions.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)
 	t.loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
@@ -228,7 +239,7 @@ func (t *Tripbot) startDiscord(ctx context.Context) {
 		slog.InfoContext(ctx, "discord disabled by feature flag", "flag", discord.FlagKey)
 		return
 	}
-	session, err := discord.New(c.Conf.DiscordBotToken, c.Conf.DiscordGuildID)
+	session, err := discord.New(c.Conf.DiscordBotToken, c.Conf.DiscordGuildID, t.sessions)
 	if err != nil {
 		slog.ErrorContext(ctx, "discord init failed", "err", err)
 		return
@@ -431,8 +442,8 @@ func (t *Tripbot) updateSubscribers() {
 // getCurrentUsers gets the users watching the stream
 func (t *Tripbot) getCurrentUsers() {
 	// fetch initial session
-	users.UpdateSession(context.Background())
-	users.PrintCurrentSession(context.Background())
+	t.sessions.UpdateSession(context.Background())
+	t.sessions.PrintCurrentSession(context.Background())
 }
 
 // connectToTwitch joins Twitch chat and starts listening
@@ -500,7 +511,7 @@ func (t *Tripbot) gracefulShutdown() {
 			slog.Error("discord stop failed", "err", err)
 		}
 	}
-	users.Shutdown(context.Background())
+	t.sessions.Shutdown(context.Background())
 	err := database.Connection().Close()
 	if err != nil {
 		slog.Error("error closing DB connection", "err", err)
@@ -525,10 +536,10 @@ func (t *Tripbot) gracefulShutdown() {
 func (t *Tripbot) scheduleBackgroundJobs() {
 	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)
 	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", t.player.GetCurrentlyPlaying)
-	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
-	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
+	t.addJob(61*time.Second, "users.UpdateSession", t.sessions.UpdateSession)
+	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
 	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
-	t.addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
+	t.addJob(5*time.Minute, "users.PrintCurrentSession", t.sessions.PrintCurrentSession)
 	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
 	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
 	t.addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -29,6 +29,7 @@ import (
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	_ "github.com/dimiro1/banner/autoload"
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/getsentry/sentry-go"
@@ -96,6 +97,13 @@ type Tripbot struct {
 	// the panel's handlers are methods on this instance.
 	srv *server.Server
 
+	// player owns "what's currently playing" — the single process-wide
+	// instance, constructed in NewTripbot. The 60s cron tick refreshes it
+	// (GetCurrentlyPlaying); findInitialVideo + gracefulShutdown read it; it's
+	// installed into chatbot (SetVideoPlayer) so commands read the same state,
+	// and it publishes video.changed to NATS for the admin panel.
+	player *video.Player
+
 	telemetryShutdown telemetry.ShutdownFunc
 
 	// discordSession is set by startDiscord when the Discord bot is enabled
@@ -115,8 +123,12 @@ type Tripbot struct {
 // Postgres-backed flag client) are filled in by the boot-sequence methods.
 func NewTripbot(version string) *Tripbot {
 	return &Tripbot{
-		version:    version,
-		srv:        server.New(),
+		version: version,
+		srv:     server.New(),
+		player: video.NewPlayer(
+			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
+			vlcClient.New(c.Conf.VlcServerHost),
+		),
 		flagClient: feature.NewInMemoryClient(nil),
 	}
 }
@@ -141,6 +153,7 @@ func (t *Tripbot) Run() {
 	t.srv.SetVersion(t.version)
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
+	chatbot.SetVideoPlayer(t.player) // commands read the same Player the cron refreshes
 	users.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)
@@ -151,7 +164,8 @@ func (t *Tripbot) Run() {
 	t.getCurrentUsers()
 	t.startEventSub(shutdownCtx)
 	t.startNATS()
-	t.srv.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
+	t.srv.StartEventHub(shutdownCtx)       // after startNATS: the hub subscribes to the live NATS conn
+	t.player.EmitCurrentVideo(shutdownCtx) // after the hub subscribes: seed its now-playing cache (no NATS replay)
 	t.startDiscord(shutdownCtx)
 	t.startSilentDisconnectWatchdog(shutdownCtx)
 	t.connectToTwitch()
@@ -304,8 +318,8 @@ func (t *Tripbot) startHttpServer(ctx context.Context) {
 // findInitialVideo will determine the vido that is currently-playing
 // we want to run this early, otherwise it will be unset until the first cron job runs
 func (t *Tripbot) findInitialVideo() {
-	video.GetCurrentlyPlaying(context.Background())
-	v := video.CurrentlyPlaying()
+	t.player.GetCurrentlyPlaying(context.Background())
+	v := t.player.Current()
 	_, err := video.LoadOrCreate(context.Background(), v.String())
 	if err != nil {
 		slog.Error("error loading initial video, is there a video playing?", "err", err)
@@ -480,7 +494,7 @@ func (t *Tripbot) gracefulShutdown() {
 	// anything below this probably won't be executed
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
-	slog.Info("last played video", "file", video.CurrentlyPlaying().File())
+	slog.Info("last played video", "file", t.player.Current().File())
 	if t.discordSession != nil {
 		if err := t.discordSession.Stop(); err != nil {
 			slog.Error("discord stop failed", "err", err)
@@ -510,7 +524,7 @@ func (t *Tripbot) gracefulShutdown() {
 // the job-target packages.
 func (t *Tripbot) scheduleBackgroundJobs() {
 	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)
-	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
+	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", t.player.GetCurrentlyPlaying)
 	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
 	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -73,30 +73,54 @@ func tracedJob(name string, fn func(context.Context)) func(context.Context) {
 // version is overridable at build time via -ldflags "-X main.version=...".
 var version = "dev"
 
-var client *twitch.Client
+// Tripbot holds the bot process's runtime dependencies and wiring. The boot
+// sequence (Run) and graceful shutdown are methods on it, so startup ordering
+// is explicit and the deps that used to be package-level globals are fields.
+type Tripbot struct {
+	version string
 
-// scheduler is the background cron scheduler, constructed in startCron and
-// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
-// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
-// can stop it.
-var scheduler *background.Scheduler
+	// irc is the go-twitch-irc client, constructed by setUpTwitchClient
+	// (chatbot.Initialize) and shared by connectToTwitch, pollForTwitchToken
+	// and the token-refresh cron job (SetIRCToken).
+	irc *twitch.Client
 
-var telemetryShutdown telemetry.ShutdownFunc
+	// scheduler is the background cron scheduler, constructed in startCron and
+	// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
+	// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
+	// can stop it.
+	scheduler *background.Scheduler
 
-// discordSession is set by startDiscord when the Discord bot is enabled
-// for this env; gracefulShutdown calls Stop on it to deregister the
-// per-guild slash commands. Nil when Discord stays gated off.
-var discordSession *discord.Session
+	telemetryShutdown telemetry.ShutdownFunc
 
-// flagClient is the process-wide feature flag evaluator. Initialised to an
-// empty in-memory client so unknown keys evaluate to false during the brief
-// startup window before startFeatureFlags swaps in the Postgres-backed
-// client — same fail-closed contract as pkg/feature.
-var flagClient feature.FlagClient = feature.NewInMemoryClient(nil)
+	// discordSession is set by startDiscord when the Discord bot is enabled
+	// for this env; gracefulShutdown calls Stop on it to deregister the
+	// per-guild slash commands. Nil when Discord stays gated off.
+	discordSession *discord.Session
 
-// main performs the various steps to get the bot running
+	// flagClient is the process-wide feature flag evaluator. Initialised to an
+	// empty in-memory client so unknown keys evaluate to false during the brief
+	// startup window before startFeatureFlags swaps in the Postgres-backed
+	// client — same fail-closed contract as pkg/feature.
+	flagClient feature.FlagClient
+}
+
+// NewTripbot constructs a Tripbot with default runtime state. Dependencies
+// that need I/O or ordering (the IRC client, scheduler, Discord session,
+// Postgres-backed flag client) are filled in by the boot-sequence methods.
+func NewTripbot(version string) *Tripbot {
+	return &Tripbot{
+		version:    version,
+		flagClient: feature.NewInMemoryClient(nil),
+	}
+}
+
 func main() {
-	slog.Info("tripbot starting", "version", version)
+	NewTripbot(version).Run()
+}
+
+// Run performs the various steps to get the bot running.
+func (t *Tripbot) Run() {
+	slog.Info("tripbot starting", "version", t.version)
 	createRandomSeed()
 	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
 	// to trigger a graceful shutdown so in-flight requests aren't cut.
@@ -104,26 +128,26 @@ func main() {
 	// the app cleanup off the same signals.
 	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignals()
-	listenForShutdown()
-	initializeTelemetry()
-	initializeErrorLogger()
-	server.SetVersion(version)
-	startHttpServer(shutdownCtx)
-	findInitialVideo()
+	t.listenForShutdown()
+	t.initializeTelemetry()
+	t.initializeErrorLogger()
+	server.SetVersion(t.version)
+	t.startHttpServer(shutdownCtx)
+	t.findInitialVideo()
 	users.InitLeaderboard(context.Background())
-	startCron()
-	startFeatureFlags(shutdownCtx)
-	loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
-	refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
-	setUpTwitchClient()                    // required for the below
-	updateSubscribers()
-	getCurrentUsers()
-	startEventSub(shutdownCtx)
-	startNATS()
+	t.startCron()
+	t.startFeatureFlags(shutdownCtx)
+	t.loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
+	t.refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
+	t.setUpTwitchClient()                    // required for the below
+	t.updateSubscribers()
+	t.getCurrentUsers()
+	t.startEventSub(shutdownCtx)
+	t.startNATS()
 	server.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
-	startDiscord(shutdownCtx)
-	startSilentDisconnectWatchdog(shutdownCtx)
-	connectToTwitch()
+	t.startDiscord(shutdownCtx)
+	t.startSilentDisconnectWatchdog(shutdownCtx)
+	t.connectToTwitch()
 }
 
 // featureFlagRefreshInterval is how often the Postgres-backed flag client
@@ -137,7 +161,7 @@ const featureFlagRefreshInterval = 30 * time.Second
 // empty in-memory client in place — every flag evaluates to its default
 // (false) until the next restart loads cleanly. Mirrors the loadTwitchToken
 // "stay up with limited functionality" pattern.
-func startFeatureFlags(ctx context.Context) {
+func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 	fc, err := feature.NewPostgresClient(ctx, database.GormDB(), featureFlagRefreshInterval)
 	if err != nil {
 		slog.WarnContext(ctx, "feature flag client init failed; flags will default to off",
@@ -145,7 +169,7 @@ func startFeatureFlags(ctx context.Context) {
 			"err", err)
 		return
 	}
-	flagClient = fc
+	t.flagClient = fc
 	chatbot.SetFlagClient(fc)
 	server.SetFlagClient(fc)
 	go fc.Start(ctx)
@@ -156,7 +180,7 @@ func startFeatureFlags(ctx context.Context) {
 // is skipped and publishes no-op silently; chatbot.realOnscreens.
 // ShowMiddleText still mirrors to NATS but the publish becomes a nil
 // check, leaving HTTP as the sole transport.
-func startNATS() {
+func (t *Tripbot) startNATS() {
 	natsclient.Connect(c.Conf.NatsURL, "tripbot")
 }
 
@@ -165,7 +189,7 @@ func startNATS() {
 // API shows the channel offline, and force-restarts the stream after
 // 3 consecutive minute-spaced misalignments. First seen in prod on
 // 2026-05-27, ~30h into an OBS session.
-func startSilentDisconnectWatchdog(ctx context.Context) {
+func (t *Tripbot) startSilentDisconnectWatchdog(ctx context.Context) {
 	go watchdog.WatchSilentDisconnect(ctx, watchdog.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
 }
 
@@ -174,12 +198,12 @@ func startSilentDisconnectWatchdog(ctx context.Context) {
 // flag is on. Every failure path here logs and returns so it can't block
 // (or crash) tripbot startup — Discord is additive to the core IRC /
 // EventSub paths.
-func startDiscord(ctx context.Context) {
+func (t *Tripbot) startDiscord(ctx context.Context) {
 	if ok, reason := discord.ShouldStart(c.Conf); !ok {
 		slog.InfoContext(ctx, "discord disabled", "reason", reason)
 		return
 	}
-	if !flagClient.Bool(ctx, discord.FlagKey, feature.EvalContext{Env: c.Conf.Environment}) {
+	if !t.flagClient.Bool(ctx, discord.FlagKey, feature.EvalContext{Env: c.Conf.Environment}) {
 		slog.InfoContext(ctx, "discord disabled by feature flag", "flag", discord.FlagKey)
 		return
 	}
@@ -192,14 +216,14 @@ func startDiscord(ctx context.Context) {
 		slog.ErrorContext(ctx, "discord start failed", "err", err)
 		return
 	}
-	discordSession = session
+	t.discordSession = session
 }
 
 // startEventSub kicks off the EventSub WebSocket listener in a goroutine
 // so real-time follow/subscribe events fire chat shouts without a 5min
 // polling delay. Skipped (logged, not fatal) when the broadcaster row
 // isn't loaded — the bot still runs without real-time alerts.
-func startEventSub(ctx context.Context) {
+func (t *Tripbot) startEventSub(ctx context.Context) {
 	token := mytwitch.BroadcasterUserAccessToken()
 	if token == "" {
 		slog.WarnContext(ctx, "skipping eventsub: no broadcaster oauth_tokens row; bootstrap with `task tripbot:auth:bootstrap:broadcaster`",
@@ -236,28 +260,28 @@ func createRandomSeed() {
 }
 
 // listenForShutdown creates a background job that listens for a graceful shutdown request
-func listenForShutdown() {
+func (t *Tripbot) listenForShutdown() {
 	helpers.WritePidFile(c.Conf.TripbotPidFile)
 	// start the graceful shutdown listener
-	go gracefulShutdown()
+	go t.gracefulShutdown()
 }
 
 // initializeTelemetry brings up OpenTelemetry providers (traces, metrics,
 // logs). No-ops cleanly if OTEL_SDK_DISABLED is set or no OTLP endpoint
 // is configured — see pkg/telemetry.
-func initializeTelemetry() {
+func (t *Tripbot) initializeTelemetry() {
 	ctx := context.Background()
-	shutdown, err := telemetry.Init(ctx, "tripbot", version)
+	shutdown, err := telemetry.Init(ctx, "tripbot", t.version)
 	if err != nil {
 		// telemetry init failure shouldn't crash the bot — log and continue.
 		slog.WarnContext(ctx, "telemetry init failed", "err", err)
 	}
-	telemetryShutdown = shutdown
+	t.telemetryShutdown = shutdown
 }
 
 // initializeErrorLogger makes sure the logger is configured
-func initializeErrorLogger() {
-	terrors.Initialize(c.Conf, version)
+func (t *Tripbot) initializeErrorLogger() {
+	terrors.Initialize(c.Conf, t.version)
 }
 
 // startHttpServer starts a webserver, which is
@@ -265,14 +289,14 @@ func initializeErrorLogger() {
 // honored by the server for graceful shutdown — when it's canceled,
 // the server stops accepting new connections and drains in-flight
 // requests up to its shutdown timeout.
-func startHttpServer(ctx context.Context) {
+func (t *Tripbot) startHttpServer(ctx context.Context) {
 	// start the HTTP server
 	go server.Start(ctx)
 }
 
 // findInitialVideo will determine the vido that is currently-playing
 // we want to run this early, otherwise it will be unset until the first cron job runs
-func findInitialVideo() {
+func (t *Tripbot) findInitialVideo() {
 	video.GetCurrentlyPlaying(context.Background())
 	v := video.CurrentlyPlaying()
 	_, err := video.LoadOrCreate(context.Background(), v.String())
@@ -282,17 +306,17 @@ func findInitialVideo() {
 }
 
 // startCron starts the background workers
-func startCron() {
+func (t *Tripbot) startCron() {
 	s, err := background.New()
 	if err != nil {
 		slog.Error("error creating background scheduler", "err", err)
 		os.Exit(1)
 	}
-	scheduler = s
-	scheduler.Start()
+	t.scheduler = s
+	t.scheduler.Start()
 	// let !shutdown stop the same scheduler instance
-	chatbot.SetScheduler(scheduler)
-	scheduleBackgroundJobs()
+	chatbot.SetScheduler(t.scheduler)
+	t.scheduleBackgroundJobs()
 }
 
 // loadTwitchToken pulls the bot's OAuth row from the oauth_tokens table.
@@ -305,14 +329,14 @@ func startCron() {
 // no longer gates on Twitch) so the admin panel + /auth/init are reachable
 // to re-auth; "not in chat" is surfaced via the admin panel + the
 // tripbot_twitch_connected gauge instead.
-func loadTwitchToken(ctx context.Context) {
+func (t *Tripbot) loadTwitchToken(ctx context.Context) {
 	if err := mytwitch.LoadFromDB(); err != nil {
 		slog.WarnContext(ctx, "no usable Twitch token at boot; starting without a chat connection and polling",
 			"login_as", c.Conf.BotUsername,
 			"fix", "task tripbot:auth:bootstrap",
 			"reauth_url", mytwitch.AuthInitURL("bot"),
 			"err", err)
-		go pollForTwitchToken(ctx)
+		go t.pollForTwitchToken(ctx)
 	}
 }
 
@@ -320,7 +344,7 @@ func loadTwitchToken(ctx context.Context) {
 // available, then syncs the freshly-loaded IRC token into the client so
 // connectToTwitch's reconnect loop authenticates on its next attempt. Started
 // only when the token was missing at boot; stops on shutdown.
-func pollForTwitchToken(ctx context.Context) {
+func (t *Tripbot) pollForTwitchToken(ctx context.Context) {
 	// Check often so the token is picked up promptly once it lands, but log
 	// the "still waiting" warning at a much slower cadence — boot already
 	// logged the reauth link once, so re-surfacing it every 15s is just noise.
@@ -351,8 +375,8 @@ func pollForTwitchToken(ctx context.Context) {
 			// Push the freshly-loaded token into the (already-constructed)
 			// IRC client so the connect loop's next try uses it instead of
 			// the empty token captured at chatbot.Initialize.
-			if tok := mytwitch.IRCAuthToken(); tok != "" && client != nil {
-				client.SetIRCToken(tok)
+			if tok := mytwitch.IRCAuthToken(); tok != "" && t.irc != nil {
+				t.irc.SetIRCToken(tok)
 			}
 			return
 		}
@@ -366,40 +390,40 @@ func pollForTwitchToken(ctx context.Context) {
 // in-memory token stale until the cron catches up — up to an hour. refreshOne
 // early-returns when the stored token is healthy, so this is a no-op in the
 // common case.
-func refreshTokensIfNearExpiry(ctx context.Context) {
+func (t *Tripbot) refreshTokensIfNearExpiry(ctx context.Context) {
 	mytwitch.RefreshUserAccessToken(ctx)
 }
 
 // setUpTwitchClient sets up the Twitch client,
 // used by many bot features
-func setUpTwitchClient() {
+func (t *Tripbot) setUpTwitchClient() {
 	// set up the Twitch client
-	client = chatbot.Initialize()
+	t.irc = chatbot.Initialize()
 }
 
 // updateSubscribers gets the list of current subscribers
-func updateSubscribers() {
+func (t *Tripbot) updateSubscribers() {
 	// update subscribers list
 	mytwitch.GetSubscribers(context.Background())
 }
 
 // getCurrentUsers gets the users watching the stream
-func getCurrentUsers() {
+func (t *Tripbot) getCurrentUsers() {
 	// fetch initial session
 	users.UpdateSession(context.Background())
 	users.PrintCurrentSession(context.Background())
 }
 
 // connectToTwitch joins Twitch chat and starts listening
-func connectToTwitch() {
-	client.Join(c.Conf.ChannelName)
+func (t *Tripbot) connectToTwitch() {
+	t.irc.Join(c.Conf.ChannelName)
 	slog.Info("joined channel", "channel", c.Conf.ChannelName, "url", fmt.Sprintf("https://twitch.tv/%s", c.Conf.ChannelName))
 
 	// Mark the bot connected to chat once the IRC connection is established.
 	// This drives the admin-panel status row + the tripbot_twitch_connected
 	// gauge — it does NOT gate /health/ready, which stays 200 so the pod keeps
 	// serving the admin panel + /auth/* even while the bot is offline.
-	client.OnConnect(func() {
+	t.irc.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
 		server.SetTwitchConnected(true)
 	})
@@ -411,7 +435,7 @@ func connectToTwitch() {
 		// Connect blocks while connected and returns when the connection
 		// drops; mark not-in-chat so the admin panel + gauge reflect the gap
 		// until the next OnConnect fires.
-		err := client.Connect()
+		err := t.irc.Connect()
 		server.SetTwitchConnected(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
@@ -424,7 +448,7 @@ func connectToTwitch() {
 				// for the next Connect attempt.
 				mytwitch.Reauth(context.Background(), "bot")
 				if tok := mytwitch.IRCAuthToken(); tok != "" {
-					client.SetIRCToken(tok)
+					t.irc.SetIRCToken(tok)
 				} else {
 					// Reauth couldn't produce a token (refresh_token revoked and
 					// no fresh row in the DB yet). Surface the re-bootstrap link
@@ -438,7 +462,7 @@ func connectToTwitch() {
 }
 
 // gracefulShutdown catches CTRL-C and cleans up
-func gracefulShutdown() {
+func (t *Tripbot) gracefulShutdown() {
 	ctrlC := make(chan os.Signal, 1)
 	signal.Notify(ctrlC, os.Interrupt, syscall.SIGTERM)
 
@@ -450,8 +474,8 @@ func gracefulShutdown() {
 	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
 	slog.Info("last played video", "file", video.CurrentlyPlaying().File())
-	if discordSession != nil {
-		if err := discordSession.Stop(); err != nil {
+	if t.discordSession != nil {
+		if err := t.discordSession.Stop(); err != nil {
 			slog.Error("discord stop failed", "err", err)
 		}
 	}
@@ -460,13 +484,13 @@ func gracefulShutdown() {
 	if err != nil {
 		slog.Error("error closing DB connection", "err", err)
 	}
-	if err := scheduler.Stop(); err != nil {
+	if err := t.scheduler.Stop(); err != nil {
 		slog.Error("error shutting down gocron scheduler", "err", err)
 	}
 	sentry.Flush(time.Second * 5)
-	if telemetryShutdown != nil {
+	if t.telemetryShutdown != nil {
 		flushCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-		if err := telemetryShutdown(flushCtx); err != nil {
+		if err := t.telemetryShutdown(flushCtx); err != nil {
 			slog.ErrorContext(flushCtx, "telemetry shutdown failed", "err", err)
 		}
 		cancel()
@@ -477,31 +501,31 @@ func gracefulShutdown() {
 // scheduleBackgroundJobs schedules the various background jobs.
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
-func scheduleBackgroundJobs() {
+func (t *Tripbot) scheduleBackgroundJobs() {
 	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost)
-	addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
-	addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
-	addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
-	addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
-	addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
-	addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
-	addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
-	addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {
+	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
+	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
+	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)
+	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
+	t.addJob(5*time.Minute, "users.PrintCurrentSession", users.PrintCurrentSession)
+	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
+	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
+	t.addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {
 		mytwitch.RefreshUserAccessToken(ctx)
 		// Keep the IRC client's stored token in sync with the rotated credentials.
 		// go-twitch-irc captures the token at construction; without this, any
 		// reconnect after the first rotation replays the original boot-time token.
 		if tok := mytwitch.IRCAuthToken(); tok != "" {
-			client.SetIRCToken(tok)
+			t.irc.SetIRCToken(tok)
 		}
 	})
-	addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", chatbot.Chatter)
+	t.addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", chatbot.Chatter)
 }
 
 // addJob registers a gocron job at the given interval, wrapping fn with
 // tracedJob so each tick opens a span and centralising the error logging.
-func addJob(interval time.Duration, name string, fn func(context.Context)) {
-	_, err := scheduler.NewJob(
+func (t *Tripbot) addJob(interval time.Duration, name string, fn func(context.Context)) {
+	_, err := t.scheduler.NewJob(
 		gocron.DurationJob(interval),
 		gocron.NewTask(tracedJob(name, fn)),
 	)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -90,6 +90,12 @@ type Tripbot struct {
 	// can stop it.
 	scheduler *background.Scheduler
 
+	// srv is the admin-panel / auth / metrics HTTP server, constructed in
+	// NewTripbot. cmd installs runtime state through it (SetVersion,
+	// SetFlagClient, SetTwitchConnected) and starts it (Start, StartEventHub);
+	// the panel's handlers are methods on this instance.
+	srv *server.Server
+
 	telemetryShutdown telemetry.ShutdownFunc
 
 	// discordSession is set by startDiscord when the Discord bot is enabled
@@ -110,6 +116,7 @@ type Tripbot struct {
 func NewTripbot(version string) *Tripbot {
 	return &Tripbot{
 		version:    version,
+		srv:        server.New(),
 		flagClient: feature.NewInMemoryClient(nil),
 	}
 }
@@ -131,7 +138,7 @@ func (t *Tripbot) Run() {
 	t.listenForShutdown()
 	t.initializeTelemetry()
 	t.initializeErrorLogger()
-	server.SetVersion(t.version)
+	t.srv.SetVersion(t.version)
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
 	users.InitLeaderboard(context.Background())
@@ -144,7 +151,7 @@ func (t *Tripbot) Run() {
 	t.getCurrentUsers()
 	t.startEventSub(shutdownCtx)
 	t.startNATS()
-	server.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
+	t.srv.StartEventHub(shutdownCtx) // after startNATS: the hub subscribes to the live NATS conn
 	t.startDiscord(shutdownCtx)
 	t.startSilentDisconnectWatchdog(shutdownCtx)
 	t.connectToTwitch()
@@ -171,7 +178,7 @@ func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 	}
 	t.flagClient = fc
 	chatbot.SetFlagClient(fc)
-	server.SetFlagClient(fc)
+	t.srv.SetFlagClient(fc)
 	go fc.Start(ctx)
 }
 
@@ -291,7 +298,7 @@ func (t *Tripbot) initializeErrorLogger() {
 // requests up to its shutdown timeout.
 func (t *Tripbot) startHttpServer(ctx context.Context) {
 	// start the HTTP server
-	go server.Start(ctx)
+	go t.srv.Start(ctx)
 }
 
 // findInitialVideo will determine the vido that is currently-playing
@@ -425,7 +432,7 @@ func (t *Tripbot) connectToTwitch() {
 	// serving the admin panel + /auth/* even while the bot is offline.
 	t.irc.OnConnect(func() {
 		slog.Info("connected to Twitch chat")
-		server.SetTwitchConnected(true)
+		t.srv.SetTwitchConnected(true)
 	})
 
 	// actually connect to Twitch
@@ -436,7 +443,7 @@ func (t *Tripbot) connectToTwitch() {
 		// drops; mark not-in-chat so the admin panel + gauge reflect the gap
 		// until the next OnConnect fires.
 		err := t.irc.Connect()
-		server.SetTwitchConnected(false)
+		t.srv.SetTwitchConnected(false)
 		if err != nil {
 			slog.Error("unable to connect to twitch", "err", err)
 			if errors.Is(err, twitch.ErrLoginAuthenticationFailed) {

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -502,7 +502,7 @@ func (t *Tripbot) gracefulShutdown() {
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
 func (t *Tripbot) scheduleBackgroundJobs() {
-	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost)
+	onscreensCli := onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)
 	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", video.GetCurrentlyPlaying)
 	t.addJob(61*time.Second, "users.UpdateSession", users.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", users.UpdateLeaderboard)

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -6,8 +6,8 @@ import (
 
 // AnnounceNewFollower says a thank-you to a new follower in chat. Wired
 // from pkg/eventsub on channel.follow v2 events.
-func AnnounceNewFollower(username string) {
-	sayFn(fmt.Sprintf("Thank you for the follow, @%s", username))
+func (a *App) AnnounceNewFollower(username string) {
+	a.IRC.Say(fmt.Sprintf("Thank you for the follow, @%s", username))
 }
 
 // AnnounceSubscriber says a thank-you to a new subscriber, gives every
@@ -20,10 +20,19 @@ func AnnounceNewFollower(username string) {
 // resub-with-message handling (channel.subscription.message) are
 // separate event types — wire them through pkg/eventsub.Handlers as
 // they're added.
-func AnnounceSubscriber(username string, isGift bool, tier string) {
+func (a *App) AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = isGift
 	_ = tier
-	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
+	a.IRC.Say(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
 	currentSessions().GiveEveryoneMiles(1.0)
-	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
+	a.IRC.Say(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
+}
+
+// Package-level shims delegating to defaultApp, so cmd's eventsub wiring keeps
+// referencing chatbot.AnnounceNewFollower / chatbot.AnnounceSubscriber as
+// function values. They retire once cmd registers the App's methods directly
+// (later Phase C step).
+func AnnounceNewFollower(username string) { defaultApp.AnnounceNewFollower(username) }
+func AnnounceSubscriber(username string, isGift bool, tier string) {
+	defaultApp.AnnounceSubscriber(username, isGift, tier)
 }

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -27,5 +27,5 @@ func AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = tier
 	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
 	users.GiveEveryoneMiles(1.0)
-	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", len(users.LoggedIn)))
+	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", users.LoggedInCount()))
 }

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -2,8 +2,6 @@ package chatbot
 
 import (
 	"fmt"
-
-	"github.com/adanalife/tripbot/pkg/users"
 )
 
 // AnnounceNewFollower says a thank-you to a new follower in chat. Wired
@@ -26,6 +24,6 @@ func AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = isGift
 	_ = tier
 	sayFn(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
-	users.GiveEveryoneMiles(1.0)
-	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", users.LoggedInCount()))
+	currentSessions().GiveEveryoneMiles(1.0)
+	sayFn(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
 }

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -78,6 +78,15 @@ type App struct {
 	// delegates to the pkg/twitch client. The future swap point for an
 	// out-of-process Helix/auth service.
 	Twitch Twitch
+
+	// commands is this App's command registry (built by buildRegistry);
+	// singleWordLookup / multiWordLookup index it by trigger + alias for
+	// dispatch. Populated by indexCommands() — production builds defaultApp's
+	// in init(); tests build a test App's via newTestApp. Replaces the former
+	// package-level globals so the registry travels with the App.
+	commands         []Command
+	singleWordLookup map[string]*Command
+	multiWordLookup  map[string]*Command
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -183,13 +183,17 @@ func Whisper(username, msg string) {
 
 // Chatter is designed to post a randomized message on a timer.
 // Right now it just posts random "help messages."
-// ctx is forward-compat plumbing — sayFn (the package-level chat-send
-// indirection) doesn't take ctx yet, so it's not propagated into the IRC
-// write.
-func Chatter(_ context.Context) {
+// ctx is forward-compat plumbing — a.IRC.Say doesn't take ctx yet, so it's
+// not propagated into the IRC write.
+func (a *App) Chatter(_ context.Context) {
 	// use twitch emote feature to add some color
-	sayFn("/me " + help())
+	a.IRC.Say("/me " + help())
 }
+
+// Chatter shim delegating to defaultApp, so cmd's cron wiring keeps referencing
+// chatbot.Chatter as a function value. Retires once cmd registers the App's
+// method directly (later Phase C step).
+func Chatter(ctx context.Context) { defaultApp.Chatter(ctx) }
 
 func help() string {
 	text := c.HelpMessages[helpIndex]

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/geo"
+	"github.com/adanalife/tripbot/pkg/natsclient"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
@@ -91,7 +92,7 @@ func (a *App) db() *gorm.DB {
 
 var defaultApp = &App{
 	// DB stays nil; commands use a.db() which falls back to database.GormDB().
-	Onscreens:  realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost), nats: realNATS{}, env: c.Conf.Environment},
+	Onscreens:  realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)},
 	VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},
 	Video:      realVideo{},
 	IRC:        realIRC{},

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -67,7 +67,7 @@ func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {
 	msg += punctuation[rand.Intn(len(punctuation))]
 
 	// give a little help message if the user is new
-	if user.CurrentMiles(ctx) < 2.0 {
+	if a.Sessions.CurrentMiles(ctx, *user) < 2.0 {
 		msg += " I'm Tripbot, your adventure companion. Try using !commands to interact with me."
 	}
 
@@ -153,8 +153,8 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 	// check to see if an arg was provided
 	if len(params) == 0 {
 		username = user.Username
-		lifetimeMiles = user.CurrentMiles(ctx)
-		monthlyMiles = user.CurrentMonthlyMiles(ctx)
+		lifetimeMiles = a.Sessions.CurrentMiles(ctx, *user)
+		monthlyMiles = a.Sessions.CurrentMonthlyMiles(ctx, *user)
 	} else {
 		username = helpers.StripAtSign(params[0])
 		u := a.Sessions.Find(ctx, username)
@@ -165,8 +165,8 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 			return
 		}
 
-		lifetimeMiles = u.CurrentMiles(ctx)
-		monthlyMiles = u.CurrentMonthlyMiles(ctx)
+		lifetimeMiles = a.Sessions.CurrentMiles(ctx, u)
+		monthlyMiles = a.Sessions.CurrentMonthlyMiles(ctx, u)
 	}
 
 	msg := "@%s has %.2fmi this month"
@@ -195,7 +195,7 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 
 func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !kilometres", "username", user.Username)
-	km := user.CurrentMiles(ctx) * 1.609344
+	km := a.Sessions.CurrentMiles(ctx, *user) * 1.609344
 	msg := "@%s has %.2f kilometres."
 	msg = fmt.Sprintf(msg, user.Username, km)
 	a.IRC.Say(msg)
@@ -485,7 +485,7 @@ func postReportToDiscord(webhookURL, username, message string) {
 
 func (a *App) bonusMilesCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !bonusmiles", "username", user.Username)
-	bonus := user.BonusMiles()
+	bonus := a.Sessions.BonusMiles(*user)
 	msg := fmt.Sprintf("%s has earned %.4f bonus miles this session", user.Username, bonus)
 	a.IRC.Say(msg)
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -20,7 +20,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/database"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
-	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
 	"github.com/hako/durafmt"
 	"gorm.io/gorm"
@@ -497,7 +496,7 @@ func (a *App) secretInfoCmd(ctx context.Context, user *users.User, _ []string) {
 		return
 	}
 	vid := a.Video.Current()
-	msg := fmt.Sprintf("currently playing: %s, playtime: %s", vid, video.CurrentProgress())
+	msg := fmt.Sprintf("currently playing: %s, playtime: %s", vid, a.Video.CurrentProgress())
 	lat, lng, err := vid.Location()
 	if err != nil {
 		msg = fmt.Sprintf("%s, err: %s", msg, err)

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1168,17 +1169,10 @@ func TestMilesCmd_OtherUser_NotInDB(t *testing.T) {
 }
 
 func TestMilesCmd_Self_WithMiles(t *testing.T) {
-	mock := installMockDB(t)
 	app := newTestApp(video.Video{})
-
-	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
-		WithArgs("viewer1").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
-	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "miles_2026_05"))
-	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
-			AddRow(99, 42, 7, 8.0))
+	// Stage the miles via the Sessions seam; the GetScore math behind
+	// CurrentMonthlyMiles is covered in pkg/users / pkg/scoreboards.
+	app.Sessions = &recordingSessions{Miles: 50.0, MonthlyMiles: 8.0}
 
 	out, restore := captureSay(t)
 	defer restore()
@@ -1193,24 +1187,12 @@ func TestMilesCmd_Self_WithMiles(t *testing.T) {
 	if !strings.Contains(msg, "(50mi total)") {
 		t.Errorf("expected lifetime total in self-lookup, got %q", msg)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
 }
 
 func TestMilesCmd_Self_NewcomerHint(t *testing.T) {
-	mock := installMockDB(t)
 	app := newTestApp(video.Video{})
-
 	// Brand-new user: monthly = 0, lifetime = 0 → triggers both newcomer hints.
-	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
-		WithArgs("newbie").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(99))
-	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "miles_2026_05"))
-	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
-			AddRow(100, 99, 7, 0.0))
+	app.Sessions = &recordingSessions{Miles: 0.0, MonthlyMiles: 0.0}
 
 	out, restore := captureSay(t)
 	defer restore()
@@ -1225,35 +1207,19 @@ func TestMilesCmd_Self_NewcomerHint(t *testing.T) {
 	if !strings.Contains(msg, "takes a bit for me to notice you") {
 		t.Errorf("expected zero-miles-specific hint, got %q", msg)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
 }
 
 func TestMilesCmd_OtherUser_Found(t *testing.T) {
-	mock := installMockDB(t)
 	app := newTestApp(video.Video{})
 
-	// Stage Sessions.Find to return a known user (replaces the old
-	// sqlmock SELECT * FROM users expectation).
+	// Stage Sessions.Find to return a known user, plus the miles the seam
+	// reports for them (the GetScore math is covered in pkg/users).
 	rec := &recordingSessions{
-		FindResult: users.User{ID: 42, Username: "viewer1", Miles: 120.0},
+		FindResult:   users.User{ID: 42, Username: "viewer1", Miles: 120.0},
+		Miles:        120.0,
+		MonthlyMiles: 15.5,
 	}
 	app.Sessions = rec
-
-	// 1. scoreboards.getUserIDByName — raw SELECT id by username
-	mock.ExpectQuery(`SELECT id FROM users WHERE username = `).
-		WithArgs("viewer1").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
-
-	// 2. scoreboards.findOrCreateScoreboard — FirstOrCreate SELECT
-	mock.ExpectQuery(`SELECT \* FROM "scoreboards" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(7, "miles_2026_05"))
-
-	// 3. scoreboards.findOrCreateScore — FirstOrCreate SELECT for the score row
-	mock.ExpectQuery(`SELECT \* FROM "scores" WHERE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "scoreboard_id", "value"}).
-			AddRow(99, 42, 7, 15.5))
 
 	out, restore := captureSay(t)
 	defer restore()
@@ -1268,11 +1234,11 @@ func TestMilesCmd_OtherUser_Found(t *testing.T) {
 	if !strings.Contains(msg, "(120mi total)") {
 		t.Errorf("expected lifetime miles in parens, got %q", msg)
 	}
-	if len(rec.Calls) != 1 || rec.Calls[0] != `Find("viewer1")` {
-		t.Errorf("expected Sessions.Find(\"viewer1\") call, got %v", rec.Calls)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	// the other-user path looks the user up via Sessions.Find, then reads
+	// their miles through the same seam.
+	want := []string{`Find("viewer1")`, `CurrentMiles("viewer1")`, `CurrentMonthlyMiles("viewer1")`}
+	if !slices.Equal(rec.Calls, want) {
+		t.Errorf("expected %v, got %v", want, rec.Calls)
 	}
 }
 

--- a/pkg/chatbot/fuzz_test.go
+++ b/pkg/chatbot/fuzz_test.go
@@ -50,7 +50,7 @@ func FuzzFindCommand(f *testing.F) {
 		f.Add(s)
 	}
 	f.Fuzz(func(t *testing.T, s string) {
-		_, _ = findCommand(s)
+		_, _ = defaultApp.findCommand(s)
 	})
 }
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -42,14 +42,14 @@ type chatUser interface {
 }
 
 // checkAccess returns true when the user is allowed to run cmd.
-// It calls sayFn with the appropriate denial message when access is denied.
-func (cmd *Command) checkAccess(ctx context.Context, user chatUser, sayFn func(string)) bool {
+// It calls say with the appropriate denial message when access is denied.
+func (cmd *Command) checkAccess(ctx context.Context, user chatUser, say func(string)) bool {
 	if followerGatingEnabled && cmd.RequiresFollow && !user.HasCommandAvailable(ctx) {
-		sayFn(followerMsg)
+		say(followerMsg)
 		return false
 	}
 	if cmd.RequiresSubscriber && !user.IsSubscriber() {
-		sayFn(subscriberMsg)
+		say(subscriberMsg)
 		return false
 	}
 	return true
@@ -68,9 +68,9 @@ func (su sessionUser) HasCommandAvailable(ctx context.Context) bool {
 }
 func (su sessionUser) IsSubscriber() bool { return su.s.IsSubscriber(*su.u) }
 
-func dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
+func (a *App) dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)
-	if !cmd.checkAccess(ctx, sessionUser{currentSessions(), user}, sayFn) {
+	if !cmd.checkAccess(ctx, sessionUser{currentSessions(), user}, a.IRC.Say) {
 		return
 	}
 	// Start a child span under the chatbot.handle_message span from
@@ -130,7 +130,7 @@ func findCommand(message string) (*Command, []string) {
 	return nil, nil
 }
 
-func runCommand(ctx context.Context, user *users.User, message string) {
+func (a *App) runCommand(ctx context.Context, user *users.User, message string) {
 	// parse for otel span attribute (only set for !-prefixed commands)
 	msg := normalizeCommandPrefix(strings.TrimSpace(message))
 	split := strings.Split(msg, " ")
@@ -147,7 +147,7 @@ func runCommand(ctx context.Context, user *users.User, message string) {
 
 	cmd, params := findCommand(message)
 	if cmd != nil {
-		dispatch(ctx, cmd, user, params)
+		a.dispatch(ctx, cmd, user, params)
 		return
 	}
 
@@ -184,7 +184,10 @@ func PrivateMessage(msg twitch.PrivateMessage) {
 	// log in the user
 	user := currentSessions().LoginIfNecessary(ctx, username)
 
-	runCommand(ctx, user, message)
+	// defaultApp is the package singleton; PrivateMessage is still a
+	// free-function Twitch callback (registered in Initialize). It becomes a
+	// thin adapter onto a cmd-constructed *App in the later Phase C steps.
+	defaultApp.runCommand(ctx, user, message)
 }
 
 // this event fires when a user joins the channel

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -88,7 +88,7 @@ func (a *App) dispatch(ctx context.Context, cmd *Command, user *users.User, para
 
 // findCommand parses message and returns the matching Command and params.
 // Returns nil if no command matches.
-func findCommand(message string) (*Command, []string) {
+func (a *App) findCommand(message string) (*Command, []string) {
 	msg := normalizeCommandPrefix(strings.TrimSpace(message))
 	split := strings.Split(msg, " ")
 
@@ -112,7 +112,7 @@ func findCommand(message string) (*Command, []string) {
 	}
 
 	// multi-word alias lookup (e.g. "no audio", "no sound")
-	for alias, cmd := range multiWordLookup {
+	for alias, cmd := range a.multiWordLookup {
 		if msg == alias || strings.HasPrefix(msg, alias+" ") {
 			remainder := strings.TrimSpace(strings.TrimPrefix(msg, alias))
 			var mwParams []string
@@ -124,7 +124,7 @@ func findCommand(message string) (*Command, []string) {
 	}
 
 	// single-word lookup
-	if cmd, ok := singleWordLookup[command]; ok {
+	if cmd, ok := a.singleWordLookup[command]; ok {
 		return cmd, params
 	}
 	return nil, nil
@@ -145,7 +145,7 @@ func (a *App) runCommand(ctx context.Context, user *users.User, message string) 
 		trace.SpanFromContext(ctx).SetAttributes(attribute.String("twitch.command", command))
 	}
 
-	cmd, params := findCommand(message)
+	cmd, params := a.findCommand(message)
 	if cmd != nil {
 		a.dispatch(ctx, cmd, user, params)
 		return

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -55,9 +55,22 @@ func (cmd *Command) checkAccess(ctx context.Context, user chatUser, sayFn func(s
 	return true
 }
 
+// sessionUser adapts a *users.User plus the installed *Sessions to the
+// chatUser access-check seam — the follower/subscriber + command-availability
+// checks now live on Sessions (per-provider state), not on User.
+type sessionUser struct {
+	s *users.Sessions
+	u *users.User
+}
+
+func (su sessionUser) HasCommandAvailable(ctx context.Context) bool {
+	return su.s.HasCommandAvailable(ctx, su.u)
+}
+func (su sessionUser) IsSubscriber() bool { return su.s.IsSubscriber(*su.u) }
+
 func dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)
-	if !cmd.checkAccess(ctx, user, sayFn) {
+	if !cmd.checkAccess(ctx, sessionUser{currentSessions(), user}, sayFn) {
 		return
 	}
 	// Start a child span under the chatbot.handle_message span from
@@ -169,19 +182,19 @@ func PrivateMessage(msg twitch.PrivateMessage) {
 	// check to see if the message is a command
 	//TODO: also include ones prefixed with whitespace?
 	// log in the user
-	user := users.LoginIfNecessary(ctx, username)
+	user := currentSessions().LoginIfNecessary(ctx, username)
 
 	runCommand(ctx, user, message)
 }
 
 // this event fires when a user joins the channel
 func UserJoin(joinMessage twitch.UserJoinMessage) {
-	users.LoginIfNecessary(context.Background(), joinMessage.User)
+	currentSessions().LoginIfNecessary(context.Background(), joinMessage.User)
 }
 
 // this event fires when a user leaves the channel
 func UserPart(partMessage twitch.UserPartMessage) {
-	users.LogoutIfNecessary(context.Background(), partMessage.User)
+	currentSessions().LogoutIfNecessary(context.Background(), partMessage.User)
 }
 
 // send message to chat if someone subs

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -75,7 +75,7 @@ func TestNormalizeCommandPrefix_DispatchEquivalence(t *testing.T) {
 // --- findCommand routing tests ---
 
 func TestFindCommand_SingleWordTrigger(t *testing.T) {
-	cmd, params := findCommand("!help")
+	cmd, params := defaultApp.findCommand("!help")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -89,7 +89,7 @@ func TestFindCommand_SingleWordTrigger(t *testing.T) {
 
 func TestFindCommand_SingleWordAlias(t *testing.T) {
 	// "hi" is an alias of "hello"
-	cmd, _ := findCommand("hi")
+	cmd, _ := defaultApp.findCommand("hi")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -100,7 +100,7 @@ func TestFindCommand_SingleWordAlias(t *testing.T) {
 
 func TestFindCommand_MultiWordAlias(t *testing.T) {
 	// "no audio" is an alias of !report
-	cmd, params := findCommand("no audio")
+	cmd, params := defaultApp.findCommand("no audio")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -114,7 +114,7 @@ func TestFindCommand_MultiWordAlias(t *testing.T) {
 
 func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
 	// "frozen since yesterday" — starts with the "frozen" alias
-	cmd, params := findCommand("frozen since yesterday")
+	cmd, params := defaultApp.findCommand("frozen since yesterday")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -128,7 +128,7 @@ func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
 
 func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 	// ¡miles should route to the same command as !miles
-	cmd, _ := findCommand("¡miles")
+	cmd, _ := defaultApp.findCommand("¡miles")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -139,7 +139,7 @@ func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 
 func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
 	// "! location" (with a space) should route to !location
-	cmd, _ := findCommand("! location")
+	cmd, _ := defaultApp.findCommand("! location")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -149,7 +149,7 @@ func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
 }
 
 func TestFindCommand_WithParams(t *testing.T) {
-	cmd, params := findCommand("!goto 42")
+	cmd, params := defaultApp.findCommand("!goto 42")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -162,14 +162,14 @@ func TestFindCommand_WithParams(t *testing.T) {
 }
 
 func TestFindCommand_UnknownCommand(t *testing.T) {
-	cmd, _ := findCommand("!doesnotexist99")
+	cmd, _ := defaultApp.findCommand("!doesnotexist99")
 	if cmd != nil {
 		t.Errorf("expected nil for unknown command, got %q", cmd.Trigger)
 	}
 }
 
 func TestFindCommand_EmptyMessage(t *testing.T) {
-	cmd, _ := findCommand("")
+	cmd, _ := defaultApp.findCommand("")
 	if cmd != nil {
 		t.Errorf("expected nil for empty message, got %q", cmd.Trigger)
 	}

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -3,8 +3,6 @@ package chatbot
 import (
 	"context"
 	"testing"
-
-	"github.com/adanalife/tripbot/pkg/users"
 )
 
 func TestNormalizeCommandPrefix(t *testing.T) {
@@ -188,9 +186,9 @@ type fakeUser struct {
 func (f *fakeUser) HasCommandAvailable(_ context.Context) bool { return f.follower }
 func (f *fakeUser) IsSubscriber() bool                         { return f.subscriber }
 
-// realUserAsChat wraps *users.User so it satisfies chatUser in tests
-// where we want to pass a struct with known field values.
-var _ chatUser = (*users.User)(nil)
+// sessionUser (a *users.User + the installed *Sessions) is the production
+// chatUser; this asserts it satisfies the seam.
+var _ chatUser = sessionUser{}
 
 func TestCheckAccess_NoRestrictions(t *testing.T) {
 	cmd := &Command{Trigger: "!test"}

--- a/pkg/chatbot/nats_test.go
+++ b/pkg/chatbot/nats_test.go
@@ -2,9 +2,7 @@ package chatbot
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
-	"testing"
 )
 
 // noopNATS satisfies NATS for tests that don't care whether anything
@@ -15,7 +13,7 @@ func (noopNATS) Publish(_ context.Context, _ string, _ []byte) {}
 
 // recordingNATS captures every publish call so tests can assert on the
 // subject + payload pair. Goroutine-safe so concurrent commands don't
-// race the slice.
+// race the slice. Reused by say_test.go (it satisfies eventbus.Publisher).
 type recordingNATS struct {
 	mu        sync.Mutex
 	Publishes []recordedPublish
@@ -32,60 +30,4 @@ func (r *recordingNATS) Publish(_ context.Context, subject string, payload []byt
 	cp := make([]byte, len(payload))
 	copy(cp, payload)
 	r.Publishes = append(r.Publishes, recordedPublish{Subject: subject, Payload: cp})
-}
-
-// TestRealOnscreens_ShowMiddleText_PublishesToNATS asserts realOnscreens
-// fires the right subject + envelope shape on every ShowMiddleText call,
-// regardless of what the HTTP path does.
-func TestRealOnscreens_ShowMiddleText_PublishesToNATS(t *testing.T) {
-	rec := &recordingNATS{}
-	r := realOnscreens{c: nil, nats: rec, env: "stage"}
-
-	// Calling with a nil HTTP client panics — but we want to assert the
-	// publish happened *before* the HTTP call. Catch the panic and proceed.
-	func() {
-		defer func() { _ = recover() }()
-		_ = r.ShowMiddleText(context.Background(), "hello world")
-	}()
-
-	if len(rec.Publishes) != 1 {
-		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
-	}
-	pub := rec.Publishes[0]
-	if pub.Subject != "tripbot.stage.onscreens.middle.show" {
-		t.Errorf("subject = %q, want tripbot.stage.onscreens.middle.show", pub.Subject)
-	}
-
-	var ev middleTextEvent
-	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
-		t.Fatalf("payload not valid JSON: %v", err)
-	}
-	if ev.Msg != "hello world" {
-		t.Errorf("msg = %q, want hello world", ev.Msg)
-	}
-	if ev.EmittedAt == "" {
-		t.Errorf("emitted_at empty")
-	}
-}
-
-// TestRealOnscreens_ShowMiddleText_TopicReflectsEnv covers prod, dev,
-// any non-stage env wires through correctly.
-func TestRealOnscreens_ShowMiddleText_TopicReflectsEnv(t *testing.T) {
-	for _, env := range []string{"prod", "development", "test"} {
-		t.Run(env, func(t *testing.T) {
-			rec := &recordingNATS{}
-			r := realOnscreens{c: nil, nats: rec, env: env}
-			func() {
-				defer func() { _ = recover() }()
-				_ = r.ShowMiddleText(context.Background(), "x")
-			}()
-			if len(rec.Publishes) != 1 {
-				t.Fatalf("expected 1 publish")
-			}
-			want := "tripbot." + env + ".onscreens.middle.show"
-			if rec.Publishes[0].Subject != want {
-				t.Errorf("subject = %q, want %q", rec.Publishes[0].Subject, want)
-			}
-		})
-	}
 }

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -2,9 +2,6 @@ package chatbot
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"log/slog"
 	"time"
 
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
@@ -25,13 +22,10 @@ type Onscreens interface {
 // concrete Client instance is owned by the App (wired up in defaultApp),
 // not read off a package-level global in pkg/onscreens-client.
 //
-// nats + env are used by ShowMiddleText to mirror the call to NATS
-// alongside the HTTP request — phase 1 of the pubsub migration. Other
-// methods stay HTTP-only until phase 2 peels them off.
+// The NATS mirror lives in the client itself now (it talks to NATS + HTTP
+// for every command), so this adapter is a thin pass-through.
 type realOnscreens struct {
-	c    *onscreensClient.Client
-	nats NATS
-	env  string
+	c *onscreensClient.Client
 }
 
 func (r realOnscreens) ShowFlag(ctx context.Context, dur time.Duration) error {
@@ -43,32 +37,9 @@ func (r realOnscreens) ShowLeaderboard(ctx context.Context, title string, lb [][
 func (r realOnscreens) HideMiddleText(ctx context.Context) error {
 	return r.c.HideMiddleText(ctx)
 }
-
-// middleTextEvent is the wire format published to
-// tripbot.<env>.onscreens.middle.show. Snake_case so a future protobuf
-// schema maps 1-1.
-type middleTextEvent struct {
-	Msg       string `json:"msg"`
-	EmittedAt string `json:"emitted_at"`
-}
-
 func (r realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
-	// Parallel publish: NATS first (cheap, fire-and-forget) so a slow
-	// HTTP call doesn't delay it. HTTP remains the source of truth for
-	// phase 1; the NATS subscriber on onscreens-server acts on the same
-	// payload but its actions are presently redundant with the HTTP path.
-	payload, err := json.Marshal(middleTextEvent{
-		Msg:       msg,
-		EmittedAt: time.Now().UTC().Format(time.RFC3339Nano),
-	})
-	if err != nil {
-		slog.ErrorContext(ctx, "marshal middle-text event", "err", err)
-	} else {
-		r.nats.Publish(ctx, fmt.Sprintf("tripbot.%s.onscreens.middle.show", r.env), payload)
-	}
 	return r.c.ShowMiddleText(ctx, msg)
 }
-
 func (r realOnscreens) ShowTimewarp(ctx context.Context) error {
 	return r.c.ShowTimewarp(ctx)
 }

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -7,10 +7,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
-var commands []Command
-var singleWordLookup map[string]*Command
-var multiWordLookup map[string]*Command
-
 // buildRegistry constructs the command slice with handlers bound to a.
 func (a *App) buildRegistry() []Command {
 	return []Command{
@@ -239,23 +235,34 @@ func (a *App) buildRegistry() []Command {
 	}
 }
 
-func init() {
-	commands = defaultApp.buildRegistry()
-	singleWordLookup = make(map[string]*Command)
-	multiWordLookup = make(map[string]*Command)
-	for i := range commands {
-		cmd := &commands[i]
-		registerTrigger(cmd.Trigger, cmd)
+// indexCommands builds a.commands from a.buildRegistry() and indexes it into
+// a.singleWordLookup / a.multiWordLookup by trigger and alias. Call once after
+// the App is constructed (its deps don't need to be set — buildRegistry only
+// binds handler method values to a).
+func (a *App) indexCommands() {
+	a.commands = a.buildRegistry()
+	a.singleWordLookup = make(map[string]*Command)
+	a.multiWordLookup = make(map[string]*Command)
+	for i := range a.commands {
+		cmd := &a.commands[i]
+		a.registerTrigger(cmd.Trigger, cmd)
 		for _, alias := range cmd.Aliases {
-			registerTrigger(alias, cmd)
+			a.registerTrigger(alias, cmd)
 		}
 	}
 }
 
-func registerTrigger(trigger string, cmd *Command) {
+func (a *App) registerTrigger(trigger string, cmd *Command) {
 	if strings.Contains(trigger, " ") {
-		multiWordLookup[trigger] = cmd
+		a.multiWordLookup[trigger] = cmd
 	} else {
-		singleWordLookup[trigger] = cmd
+		a.singleWordLookup[trigger] = cmd
 	}
+}
+
+// init builds the package singleton's registry. Once cmd constructs the App and
+// hands it to the message path (later Phase C step), this moves into that
+// constructor and defaultApp goes away.
+func init() {
+	defaultApp.indexCommands()
 }

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -70,60 +70,60 @@ func (a *App) buildRegistry() []Command {
 			Trigger: "!socialmedia",
 			Aliases: []string{"!social", "!socials"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Find me outside of Twitch: !youtube, !tiktok, !instagram, !bluesky")
+				a.IRC.Say("Find me outside of Twitch: !youtube, !tiktok, !instagram, !bluesky")
 			},
 		},
 		{
 			Trigger: "!discord",
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Join us on Discord: https://discord.gg/hKvNgZrk52")
+				a.IRC.Say("Join us on Discord: https://discord.gg/hKvNgZrk52")
 			},
 		},
 		{
 			Trigger: "!twitter",
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Follow on Twitter: https://twitter.com/adanalife_")
+				a.IRC.Say("Follow on Twitter: https://twitter.com/adanalife_")
 			},
 		},
 		{
 			Trigger: "!instagram",
 			Aliases: []string{"!ig", "!insta"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Follow on Instagram: https://instagram.com/adanalife_")
+				a.IRC.Say("Follow on Instagram: https://instagram.com/adanalife_")
 			},
 		},
 		{
 			Trigger: "!facebook",
 			Aliases: []string{"!fb"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Follow on Facebook: https://www.facebook.com/adanalifeblog")
+				a.IRC.Say("Follow on Facebook: https://www.facebook.com/adanalifeblog")
 			},
 		},
 		{
 			Trigger: "!youtube",
 			Aliases: []string{"!yt"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Subscribe on YouTube: https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg")
+				a.IRC.Say("Subscribe on YouTube: https://www.youtube.com/channel/UC8Q7uFC1Xyr2ZnTWOk9Aizg")
 			},
 		},
 		{
 			Trigger: "!tiktok",
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Follow on TikTok: https://tiktok.com/@adanalife")
+				a.IRC.Say("Follow on TikTok: https://tiktok.com/@adanalife")
 			},
 		},
 		{
 			Trigger: "!bluesky",
 			Aliases: []string{"!bsky"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Follow on Bluesky: https://bsky.app/profile/dana.lol")
+				a.IRC.Say("Follow on Bluesky: https://bsky.app/profile/dana.lol")
 			},
 		},
 		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, !song, and many other hidden commands!")
+				a.IRC.Say("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, !song, and many other hidden commands!")
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func (a *App) buildRegistry() []Command {
 			Trigger: "!gas",
 			Aliases: []string{"!fuel", "!petrol"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("About full, thanks for asking")
+				a.IRC.Say("About full, thanks for asking")
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!somafm",
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				sayFn("Stream music by SomaFM — https://somafm.com")
+				a.IRC.Say("Stream music by SomaFM — https://somafm.com")
 			},
 		},
 	}

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
-	for _, cmd := range commands {
+	for _, cmd := range defaultApp.commands {
 		if cmd.Trigger == "" {
 			t.Errorf("command has empty Trigger: %+v", cmd)
 		}
@@ -15,7 +15,7 @@ func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
 
 func TestNoDuplicateTriggersOrAliases(t *testing.T) {
 	seen := map[string]string{} // trigger/alias → owning command's Trigger
-	for _, cmd := range commands {
+	for _, cmd := range defaultApp.commands {
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			if owner, clash := seen[token]; clash {
@@ -27,15 +27,15 @@ func TestNoDuplicateTriggersOrAliases(t *testing.T) {
 }
 
 func TestLookupMapsContainAllTriggers(t *testing.T) {
-	for _, cmd := range commands {
+	for _, cmd := range defaultApp.commands {
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			if strings.Contains(token, " ") {
-				if _, ok := multiWordLookup[token]; !ok {
+				if _, ok := defaultApp.multiWordLookup[token]; !ok {
 					t.Errorf("multi-word trigger %q missing from multiWordLookup", token)
 				}
 			} else {
-				if _, ok := singleWordLookup[token]; !ok {
+				if _, ok := defaultApp.singleWordLookup[token]; !ok {
 					t.Errorf("single-word trigger %q missing from singleWordLookup", token)
 				}
 			}
@@ -44,15 +44,15 @@ func TestLookupMapsContainAllTriggers(t *testing.T) {
 }
 
 func TestLookupMapsPointToCorrectCommand(t *testing.T) {
-	for i := range commands {
-		cmd := &commands[i]
+	for i := range defaultApp.commands {
+		cmd := &defaultApp.commands[i]
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			var got *Command
 			if strings.Contains(token, " ") {
-				got = multiWordLookup[token]
+				got = defaultApp.multiWordLookup[token]
 			} else {
-				got = singleWordLookup[token]
+				got = defaultApp.singleWordLookup[token]
 			}
 			if got != cmd {
 				t.Errorf("trigger %q maps to %q, want %q", token, got.Trigger, cmd.Trigger)

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -2,30 +2,38 @@ package chatbot
 
 import (
 	"context"
+	"sync"
 
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
 // Sessions is the subset of the pkg/users surface that chatbot commands
 // depend on at command-time (user lookups, lifetime-leaderboard reads,
-// graceful shutdown of in-memory session state). Tests inject a fake;
-// production uses the package-backed realSessions adapter wired in
-// defaultApp. Mirrors the Onscreens/VLC/Video/IRC injection pattern.
+// miles computations, graceful shutdown of in-memory session state). Tests
+// inject a fake; production uses the realSessions adapter wired in defaultApp.
+// Mirrors the Onscreens/VLC/Video/IRC injection pattern.
 //
-// The IRC-side session lifecycle (LoginIfNecessary / LogoutIfNecessary)
-// is intentionally NOT on this interface — those are called from the
-// free-function handlers in handlers.go (PrivateMessage / UserJoin /
-// UserPart), which aren't App methods yet. They'll move onto App (and
-// onto this interface) in a follow-up.
+// The IRC-side session lifecycle (LoginIfNecessary / LogoutIfNecessary) and the
+// follower/subscriber + login-count reads are intentionally NOT on this
+// interface — they're called from the free-function handlers in handlers.go /
+// announce.go, which aren't App methods yet, so they reach the installed
+// *Sessions through currentSessions() directly. They'll move onto App (and onto
+// this interface) when those handlers do.
 type Sessions interface {
 	// Find looks up a user by username. Returns User{ID: 0} for an
 	// unknown user (mirrors pkg/users.Find's existing contract).
 	Find(ctx context.Context, username string) users.User
 	// LifetimeLeaderboard returns the current snapshot of the
 	// lifetime-miles leaderboard, a slice of [username, miles] pairs
-	// hydrated at startup by users.InitLeaderboard. Read-only from the
+	// hydrated at startup by InitLeaderboard. Read-only from the
 	// chatbot's perspective.
 	LifetimeLeaderboard() [][]string
+	// CurrentMiles / CurrentMonthlyMiles / BonusMiles compute a user's miles
+	// including the live session bonus, which depends on the session's login
+	// map — hence they live on Sessions and take the User.
+	CurrentMiles(ctx context.Context, u users.User) float32
+	CurrentMonthlyMiles(ctx context.Context, u users.User) float32
+	BonusMiles(u users.User) float32
 	// Shutdown logs out every in-memory session, flushing each user's
 	// state to the DB. Called by !shutdown before the process exits.
 	Shutdown(ctx context.Context)
@@ -34,7 +42,32 @@ type Sessions interface {
 	SetBot(ctx context.Context, username string, isBot bool) error
 }
 
-// realSessions delegates to pkg/users.
+// sessions is the *users.Sessions realSessions (and the free-function IRC
+// handlers) delegate to. cmd/tripbot installs the single process-wide instance
+// via SetSessions once it's constructed. nil until then (brief startup window)
+// and in tests, which inject their own Sessions fake rather than realSessions —
+// so the nil guards below only ever fire pre-install. Mirrors SetVideoPlayer.
+var (
+	sessionsMu sync.RWMutex
+	sessions   *users.Sessions
+)
+
+// SetSessions installs the Sessions that realSessions and the IRC handlers
+// delegate to. Called from cmd/tripbot once Sessions is constructed.
+func SetSessions(s *users.Sessions) {
+	sessionsMu.Lock()
+	sessions = s
+	sessionsMu.Unlock()
+}
+
+func currentSessions() *users.Sessions {
+	sessionsMu.RLock()
+	defer sessionsMu.RUnlock()
+	return sessions
+}
+
+// realSessions delegates to the installed *users.Sessions, plus pkg/users'
+// standalone DB helper (Find, which is not session state).
 type realSessions struct{}
 
 func (realSessions) Find(ctx context.Context, username string) users.User {
@@ -42,13 +75,47 @@ func (realSessions) Find(ctx context.Context, username string) users.User {
 }
 
 func (realSessions) LifetimeLeaderboard() [][]string {
-	return users.LifetimeMilesLeaderboard()
+	s := currentSessions()
+	if s == nil {
+		return nil
+	}
+	return s.LifetimeLeaderboard()
+}
+
+func (realSessions) CurrentMiles(ctx context.Context, u users.User) float32 {
+	s := currentSessions()
+	if s == nil {
+		return u.Miles
+	}
+	return s.CurrentMiles(ctx, u)
+}
+
+func (realSessions) CurrentMonthlyMiles(ctx context.Context, u users.User) float32 {
+	s := currentSessions()
+	if s == nil {
+		return 0
+	}
+	return s.CurrentMonthlyMiles(ctx, u)
+}
+
+func (realSessions) BonusMiles(u users.User) float32 {
+	s := currentSessions()
+	if s == nil {
+		return 0
+	}
+	return s.BonusMiles(u)
 }
 
 func (realSessions) Shutdown(ctx context.Context) {
-	users.Shutdown(ctx)
+	if s := currentSessions(); s != nil {
+		s.Shutdown(ctx)
+	}
 }
 
 func (realSessions) SetBot(ctx context.Context, username string, isBot bool) error {
-	return users.SetBot(ctx, username, isBot)
+	s := currentSessions()
+	if s == nil {
+		return nil
+	}
+	return s.SetBot(ctx, username, isBot)
 }

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -42,7 +42,7 @@ func (realSessions) Find(ctx context.Context, username string) users.User {
 }
 
 func (realSessions) LifetimeLeaderboard() [][]string {
-	return users.LifetimeMilesLeaderboard
+	return users.LifetimeMilesLeaderboard()
 }
 
 func (realSessions) Shutdown(ctx context.Context) {

--- a/pkg/chatbot/sessions_test.go
+++ b/pkg/chatbot/sessions_test.go
@@ -12,10 +12,13 @@ import (
 // reads as empty, and Shutdown is a no-op.
 type noopSessions struct{}
 
-func (noopSessions) Find(_ context.Context, _ string) users.User      { return users.User{} }
-func (noopSessions) LifetimeLeaderboard() [][]string                  { return nil }
-func (noopSessions) Shutdown(_ context.Context)                       {}
-func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error { return nil }
+func (noopSessions) Find(_ context.Context, _ string) users.User                 { return users.User{} }
+func (noopSessions) LifetimeLeaderboard() [][]string                             { return nil }
+func (noopSessions) Shutdown(_ context.Context)                                  {}
+func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error            { return nil }
+func (noopSessions) CurrentMiles(_ context.Context, u users.User) float32        { return u.Miles }
+func (noopSessions) CurrentMonthlyMiles(_ context.Context, _ users.User) float32 { return 0 }
+func (noopSessions) BonusMiles(_ users.User) float32                             { return 0 }
 
 // recordingSessions captures every call made to it so tests can assert
 // the chatbot queried the expected user / leaderboard surfaces.
@@ -28,6 +31,8 @@ type recordingSessions struct {
 	Leaderboard [][]string
 	// SetBotErr is the error SetBot will return for every call.
 	SetBotErr error
+	// Miles / MonthlyMiles / Bonus stage what the miles methods return.
+	Miles, MonthlyMiles, Bonus float32
 }
 
 func (r *recordingSessions) Find(_ context.Context, username string) users.User {
@@ -47,4 +52,19 @@ func (r *recordingSessions) Shutdown(_ context.Context) {
 func (r *recordingSessions) SetBot(_ context.Context, username string, isBot bool) error {
 	r.Calls = append(r.Calls, fmt.Sprintf("SetBot(%q, %t)", username, isBot))
 	return r.SetBotErr
+}
+
+func (r *recordingSessions) CurrentMiles(_ context.Context, u users.User) float32 {
+	r.Calls = append(r.Calls, fmt.Sprintf("CurrentMiles(%q)", u.Username))
+	return r.Miles
+}
+
+func (r *recordingSessions) CurrentMonthlyMiles(_ context.Context, u users.User) float32 {
+	r.Calls = append(r.Calls, fmt.Sprintf("CurrentMonthlyMiles(%q)", u.Username))
+	return r.MonthlyMiles
+}
+
+func (r *recordingSessions) BonusMiles(u users.User) float32 {
+	r.Calls = append(r.Calls, fmt.Sprintf("BonusMiles(%q)", u.Username))
+	return r.Bonus
 }

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -2,34 +2,83 @@ package chatbot
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
 // Video is the subset of the pkg/video surface that chatbot commands depend
-// on. Tests inject a fake; production uses the package-backed realVideo
-// adapter wired in defaultApp. Mirrors the Onscreens/VLC injection pattern.
+// on. Tests inject a fake; production uses the realVideo adapter wired in
+// defaultApp. Mirrors the Onscreens/VLC injection pattern.
 type Video interface {
 	// Current returns the video the system believes is currently playing,
-	// without making any I/O calls. Reads pkg/video's package-level state.
+	// without making any I/O calls.
 	Current() video.Video
-	// GetCurrentlyPlaying refreshes pkg/video's notion of what's currently
-	// playing (an HTTP call to vlc-server in production), updates the
-	// package-level state, and returns the resulting Video.
+	// GetCurrentlyPlaying refreshes the Player's notion of what's currently
+	// playing (an HTTP call to vlc-server in production) and returns it.
 	GetCurrentlyPlaying(ctx context.Context) video.Video
+	// CurrentProgress reports how long the current clip has been playing.
+	CurrentProgress() time.Duration
 	// FindRandomByState returns a random video filmed in the given US state.
 	// Returns *terrors.NoFootageForStateError when no rows match.
 	FindRandomByState(ctx context.Context, state string) (video.Video, error)
 }
 
-// realVideo delegates to pkg/video.
+// videoPlayer is the *video.Player realVideo delegates to. cmd/tripbot installs
+// the single process-wide instance via SetVideoPlayer once it's constructed, so
+// commands read the same playback state the cron tick refreshes. nil until then
+// (brief startup window) and in tests, which inject their own Video fake rather
+// than realVideo — so the nil guards below only ever fire pre-install.
+var (
+	videoMu     sync.RWMutex
+	videoPlayer *video.Player
+)
+
+// SetVideoPlayer installs the Player that realVideo delegates to. Called from
+// cmd/tripbot once the Player is constructed. Mirrors SetScheduler.
+func SetVideoPlayer(p *video.Player) {
+	videoMu.Lock()
+	videoPlayer = p
+	videoMu.Unlock()
+}
+
+func currentPlayer() *video.Player {
+	videoMu.RLock()
+	defer videoMu.RUnlock()
+	return videoPlayer
+}
+
+// realVideo delegates to the installed *video.Player (Current /
+// GetCurrentlyPlaying) and to pkg/video's standalone DB helper
+// (FindRandomByState, which is not Player state).
 type realVideo struct{}
 
-func (realVideo) Current() video.Video { return video.CurrentlyPlaying() }
-func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
-	video.GetCurrentlyPlaying(ctx)
-	return video.CurrentlyPlaying()
+func (realVideo) Current() video.Video {
+	p := currentPlayer()
+	if p == nil {
+		return video.Video{}
+	}
+	return p.Current()
 }
+
+func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
+	p := currentPlayer()
+	if p == nil {
+		return video.Video{}
+	}
+	p.GetCurrentlyPlaying(ctx)
+	return p.Current()
+}
+
+func (realVideo) CurrentProgress() time.Duration {
+	p := currentPlayer()
+	if p == nil {
+		return 0
+	}
+	return p.CurrentProgress()
+}
+
 func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
 	return video.FindRandomByState(ctx, state)
 }

--- a/pkg/chatbot/video_test.go
+++ b/pkg/chatbot/video_test.go
@@ -3,6 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/adanalife/tripbot/pkg/video"
 )
@@ -13,6 +14,7 @@ type noopVideo struct{}
 
 func (noopVideo) Current() video.Video                              { return video.Video{} }
 func (noopVideo) GetCurrentlyPlaying(_ context.Context) video.Video { return video.Video{} }
+func (noopVideo) CurrentProgress() time.Duration                    { return 0 }
 func (noopVideo) FindRandomByState(_ context.Context, _ string) (video.Video, error) {
 	return video.Video{}, nil
 }
@@ -36,6 +38,10 @@ func (r *recordingVideo) Current() video.Video {
 func (r *recordingVideo) GetCurrentlyPlaying(_ context.Context) video.Video {
 	r.Calls = append(r.Calls, "GetCurrentlyPlaying()")
 	return r.Vid
+}
+func (r *recordingVideo) CurrentProgress() time.Duration {
+	r.Calls = append(r.Calls, "CurrentProgress()")
+	return 0
 }
 func (r *recordingVideo) FindRandomByState(_ context.Context, state string) (video.Video, error) {
 	r.Calls = append(r.Calls, fmt.Sprintf("FindRandomByState(%q)", state))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/joho/godotenv"
 )
@@ -23,8 +24,18 @@ func SetEnvironment() {
 
 	envVar, ok := os.LookupEnv("ENV")
 	if !ok {
-		envVar = "development"
-		slog.Warn("ENV not set, defaulting to development")
+		// Host-side `go test ./pkg/...` runs with ENV unset; default those to
+		// testing so the repo-root .env.testing (located via resolveFromRepoRoot
+		// below) loads instead of the absent .env.development — the same env
+		// `task test` sets explicitly. testing.Testing() is true only in test
+		// binaries, so `go run` / production are unaffected. Everything else
+		// defaults to development.
+		if testing.Testing() {
+			envVar = "testing"
+		} else {
+			envVar = "development"
+			slog.Warn("ENV not set, defaulting to development")
+		}
 		// envconfig.Process reads from the process env; the defaulted
 		// value has to be visible to the required:"true" field on
 		// TripbotConfig.Environment / VlcServerConfig.Environment.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,6 +44,28 @@ func TestResolveFromRepoRootFallsBackWithoutGoMod(t *testing.T) {
 	}
 }
 
+// With ENV unset under `go test`, SetEnvironment should default to testing (so
+// the repo-root .env.testing loads), not development — otherwise host-side
+// `go test ./pkg/...` fails on the absent .env.development + missing required
+// config keys.
+func TestSetEnvironmentDefaultsToTestingUnderGoTest(t *testing.T) {
+	orig, had := os.LookupEnv("ENV")
+	os.Unsetenv("ENV")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("ENV", orig)
+		} else {
+			os.Unsetenv("ENV")
+		}
+	})
+
+	SetEnvironment()
+
+	if got := os.Getenv("ENV"); got != "testing" {
+		t.Errorf("SetEnvironment() with ENV unset under go test: ENV=%q, want %q", got, "testing")
+	}
+}
+
 // chdir switches into dir for the duration of the test, restoring the original
 // working directory afterward. t.TempDir()s used here have no go.mod ancestor
 // outside themselves, so the resolver's walk terminates at the filesystem root.

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -1,0 +1,205 @@
+// Package contract is the anti-drift bridge between tripbot (the consumer and
+// source of truth) and the infra/cdk8s manifests (the producer of k8s objects).
+// It holds the canonical service names, ports, and env-var keys shared across
+// the two repos as typed Go values, and emits them as contract.json via
+// `go generate`. A sibling test asserts the committed contract.json matches
+// these constants, so any drift fails CI here in tripbot.
+//
+// The committed pkg/contract/contract.json is the canonical copy; the infra
+// side syncs FROM it (`task contract:sync`). Edit the constants below, run
+// `go generate ./pkg/contract`, and commit the regenerated JSON together.
+//
+// Where tripbot already owns a value (the obs-websocket addr default, the
+// VLC RTSP port, the env-var keys behind pkg/config/tripbot's envconfig tags),
+// the constant here is cross-checked against that definition rather than being
+// an independent literal. Values with no prior Go home (the logical service
+// names, the various pod ports, the stream env keys read only by shell/docker)
+// are declared here as their new canonical home.
+//
+// JSON key order is fixed (it matches the hand-authored infra contract.json):
+// Current() returns ordered key/value slices, and Marshal renders them in that
+// order so the generated file is stable and reviewable.
+package contract
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// comment is the leading "_comment" field stamped into contract.json. It tells
+// a reader of the JSON which repo owns the file and how the two sides stay in
+// sync.
+const comment = "Anti-drift contract between tripbot (consumer, source of truth) and infra/cdk8s (producer). Canonical service names, ports, and env-var keys. Generated from Go constants in tripbot's pkg/contract via `go generate ./pkg/contract`; the infra side syncs from it via `task contract:sync`. Edit pkg/contract/contract.go and regenerate — do not hand-edit this file."
+
+// Logical service names → their Kubernetes Service name. These are the names
+// tripbot clients dial (VLC_SERVER_HOST, ONSCREENS_SERVER_HOST, the
+// obs-websocket addr) and the names cdk8s must stamp onto the matching
+// Service objects.
+const (
+	// ServiceTripbot is the chatbot / admin-panel service.
+	ServiceTripbot = "tripbot"
+	// ServiceVLCServer is the vlc-server (dashcam playback + RTSP) service.
+	ServiceVLCServer = "vlc-server"
+	// ServiceOnscreensServer is the onscreens-server (overlay render) service.
+	ServiceOnscreensServer = "onscreens-server"
+	// ServiceOBSTwitch is the OBS instance streaming to Twitch. This matches
+	// the obs-websocket addr default baked into pkg/obs (obs-twitch:4455).
+	ServiceOBSTwitch = "obs-twitch"
+	// ServiceOBSYouTube is the OBS instance streaming to YouTube.
+	ServiceOBSYouTube = "obs-youtube"
+	// ServicePostgres is the Postgres service (DATABASE_HOST in cluster).
+	ServicePostgres = "postgres"
+)
+
+// Pod ports. Several services co-locate on 8080 for their HTTP API but expose
+// other ports (VNC, websocket, RTSP) on their own pods, so the keys are
+// per-(service, role) rather than per-number.
+const (
+	// PortOBSVNC is the raw VNC port exposed by the OBS pods.
+	PortOBSVNC = 5900
+	// PortOBSWebsocket is the OBS WebSocket control port. Matches the
+	// obs-twitch:4455 default in pkg/obs.
+	PortOBSWebsocket = 4455
+	// PortOBSNoVNC is the noVNC (browser VNC) port on the OBS pods.
+	PortOBSNoVNC = 6080
+	// PortOBSServer is the obs-server (Flask health/version/shutdown) port.
+	PortOBSServer = 8080
+	// PortVLCHTTP is the vlc-server HTTP API port.
+	PortVLCHTTP = 8080
+	// PortVLCOnscreensLegacy is the legacy onscreens port vlc-server used to
+	// serve before onscreens-server split out.
+	PortVLCOnscreensLegacy = 8081
+	// PortVLCRTSP is the vlc-server RTSP output port. Matches the :8554 RTSP
+	// chain baked into pkg/vlc-server.
+	PortVLCRTSP = 8554
+	// PortVLCVNC is the VNC port on the vlc-server pod.
+	PortVLCVNC = 5900
+	// PortOnscreensHTTP is the onscreens-server HTTP API port.
+	PortOnscreensHTTP = 8080
+	// PortTripbotHTTP is the tripbot chatbot/admin HTTP port.
+	PortTripbotHTTP = 8080
+	// PortPostgres is the Postgres port.
+	PortPostgres = 5432
+)
+
+// Env-var keys shared between tripbot (which reads them) and cdk8s (which
+// stamps them into ConfigMaps/Secrets). The host/server keys mirror the
+// envconfig struct tags in pkg/config/tripbot/type.go and pkg/database; the
+// obs-websocket key mirrors pkg/obs; the stream keys have no Go consumer
+// (read only by the OBS image's shell entrypoint) and are owned here.
+const (
+	// EnvKeyOBSWebsocketAddr is the host:port pkg/obs dials for OBS control.
+	EnvKeyOBSWebsocketAddr = "OBS_WEBSOCKET_ADDR"
+	// EnvKeyOBSServerHost mirrors TripbotConfig.ObsServerHost.
+	EnvKeyOBSServerHost = "OBS_SERVER_HOST"
+	// EnvKeyVLCServerHost mirrors TripbotConfig.VlcServerHost.
+	EnvKeyVLCServerHost = "VLC_SERVER_HOST"
+	// EnvKeyOnscreensServerHost mirrors TripbotConfig.OnscreensServerHost.
+	EnvKeyOnscreensServerHost = "ONSCREENS_SERVER_HOST"
+	// EnvKeyDatabaseHost is the Postgres host pkg/database requires.
+	EnvKeyDatabaseHost = "DATABASE_HOST"
+	// EnvKeyStreamPlatform selects which platform OBS streams to. Read by the
+	// OBS image entrypoint, not by Go.
+	EnvKeyStreamPlatform = "STREAM_PLATFORM"
+	// EnvKeyStreamKey is the per-platform stream key. Read by the OBS image
+	// entrypoint, not by Go.
+	EnvKeyStreamKey = "STREAM_KEY"
+)
+
+// pair is one ordered key/value entry in a contract section.
+type pair struct {
+	Key   string
+	Value any
+}
+
+// Contract holds the canonical contract sections in their on-disk order.
+type Contract struct {
+	Comment  string
+	Services []pair
+	Ports    []pair
+	EnvKeys  []pair
+}
+
+// Current returns the contract built from the canonical Go constants, with the
+// section keys in the same order as the hand-authored infra contract.json.
+func Current() Contract {
+	return Contract{
+		Comment: comment,
+		Services: []pair{
+			{"tripbot", ServiceTripbot},
+			{"vlc_server", ServiceVLCServer},
+			{"onscreens_server", ServiceOnscreensServer},
+			{"obs_twitch", ServiceOBSTwitch},
+			{"obs_youtube", ServiceOBSYouTube},
+			{"postgres", ServicePostgres},
+		},
+		Ports: []pair{
+			{"obs_vnc", PortOBSVNC},
+			{"obs_websocket", PortOBSWebsocket},
+			{"obs_novnc", PortOBSNoVNC},
+			{"obs_server", PortOBSServer},
+			{"vlc_http", PortVLCHTTP},
+			{"vlc_onscreens_legacy", PortVLCOnscreensLegacy},
+			{"vlc_rtsp", PortVLCRTSP},
+			{"vlc_vnc", PortVLCVNC},
+			{"onscreens_http", PortOnscreensHTTP},
+			{"tripbot_http", PortTripbotHTTP},
+			{"postgres", PortPostgres},
+		},
+		EnvKeys: []pair{
+			{"obs_websocket_addr", EnvKeyOBSWebsocketAddr},
+			{"obs_server_host", EnvKeyOBSServerHost},
+			{"vlc_server_host", EnvKeyVLCServerHost},
+			{"onscreens_server_host", EnvKeyOnscreensServerHost},
+			{"database_host", EnvKeyDatabaseHost},
+			{"stream_platform", EnvKeyStreamPlatform},
+			{"stream_key", EnvKeyStreamKey},
+		},
+	}
+}
+
+// Marshal renders the contract as pretty-printed JSON with stable key order
+// (2-space indent, trailing newline) — the exact bytes the generator writes to
+// pkg/contract/contract.json and the test compares against.
+func (c Contract) Marshal() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+
+	commentJSON, err := json.Marshal(c.Comment)
+	if err != nil {
+		return nil, fmt.Errorf("marshal _comment: %w", err)
+	}
+	fmt.Fprintf(&buf, "  %q: %s,\n", "_comment", commentJSON)
+
+	sections := []struct {
+		name  string
+		pairs []pair
+	}{
+		{"services", c.Services},
+		{"ports", c.Ports},
+		{"env_keys", c.EnvKeys},
+	}
+	for i, section := range sections {
+		fmt.Fprintf(&buf, "  %q: {\n", section.name)
+		for j, p := range section.pairs {
+			valJSON, err := json.Marshal(p.Value)
+			if err != nil {
+				return nil, fmt.Errorf("marshal %s.%s: %w", section.name, p.Key, err)
+			}
+			fmt.Fprintf(&buf, "    %q: %s", p.Key, valJSON)
+			if j < len(section.pairs)-1 {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString("  }")
+		if i < len(sections)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString("}\n")
+	return buf.Bytes(), nil
+}

--- a/pkg/contract/contract.json
+++ b/pkg/contract/contract.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Anti-drift contract between tripbot (consumer, source of truth) and infra/cdk8s (producer). Canonical service names, ports, and env-var keys. Generated from Go constants in tripbot's pkg/contract via `go generate ./pkg/contract`; the infra side syncs from it via `task contract:sync`. Edit pkg/contract/contract.go and regenerate — do not hand-edit this file.",
+  "services": {
+    "tripbot": "tripbot",
+    "vlc_server": "vlc-server",
+    "onscreens_server": "onscreens-server",
+    "obs_twitch": "obs-twitch",
+    "obs_youtube": "obs-youtube",
+    "postgres": "postgres"
+  },
+  "ports": {
+    "obs_vnc": 5900,
+    "obs_websocket": 4455,
+    "obs_novnc": 6080,
+    "obs_server": 8080,
+    "vlc_http": 8080,
+    "vlc_onscreens_legacy": 8081,
+    "vlc_rtsp": 8554,
+    "vlc_vnc": 5900,
+    "onscreens_http": 8080,
+    "tripbot_http": 8080,
+    "postgres": 5432
+  },
+  "env_keys": {
+    "obs_websocket_addr": "OBS_WEBSOCKET_ADDR",
+    "obs_server_host": "OBS_SERVER_HOST",
+    "vlc_server_host": "VLC_SERVER_HOST",
+    "onscreens_server_host": "ONSCREENS_SERVER_HOST",
+    "database_host": "DATABASE_HOST",
+    "stream_platform": "STREAM_PLATFORM",
+    "stream_key": "STREAM_KEY"
+  }
+}

--- a/pkg/contract/contract_test.go
+++ b/pkg/contract/contract_test.go
@@ -1,0 +1,27 @@
+package contract
+
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed contract.json
+var committed []byte
+
+// TestContractMatchesCommitted is the anti-drift guard: it regenerates the
+// contract from the in-code constants and asserts the result is byte-identical
+// to the committed contract.json. If a service name, port, or env-var key
+// changes in contract.go without regenerating, this fails CI.
+func TestContractMatchesCommitted(t *testing.T) {
+	got, err := Current().Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if string(got) != string(committed) {
+		t.Errorf("contract.json is out of date with pkg/contract constants.\n"+
+			"Run `go generate ./pkg/contract` and commit the result.\n\n"+
+			"--- committed contract.json ---\n%s\n--- generated from constants ---\n%s",
+			committed, got)
+	}
+}

--- a/pkg/contract/generate.go
+++ b/pkg/contract/generate.go
@@ -1,0 +1,6 @@
+package contract
+
+// Regenerate the committed contract.json from the Go constants in this package.
+// Run after editing any service name, port, or env-var key here.
+//
+//go:generate go run ./internal/gen

--- a/pkg/contract/internal/gen/main.go
+++ b/pkg/contract/internal/gen/main.go
@@ -1,0 +1,36 @@
+// Command gen marshals the canonical pkg/contract constants to
+// pkg/contract/contract.json. It is invoked by the //go:generate directive in
+// pkg/contract/generate.go; run `go generate ./pkg/contract` after editing the
+// constants.
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/adanalife/tripbot/pkg/contract"
+)
+
+func main() {
+	data, err := contract.Current().Marshal()
+	if err != nil {
+		log.Fatalf("marshal contract: %v", err)
+	}
+
+	// Resolve the output path relative to this source file so the generator
+	// writes to pkg/contract/contract.json regardless of the working directory
+	// `go generate` runs from.
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("could not determine generator source path")
+	}
+	// self = pkg/contract/internal/gen/main.go → pkg/contract/contract.json
+	out := filepath.Join(filepath.Dir(self), "..", "..", "contract.json")
+
+	if err := os.WriteFile(out, data, 0o644); err != nil {
+		log.Fatalf("write %s: %v", out, err)
+	}
+	log.Printf("wrote %s", out)
+}

--- a/pkg/discord/commands.go
+++ b/pkg/discord/commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	"github.com/adanalife/tripbot/pkg/scoreboards"
-	"github.com/adanalife/tripbot/pkg/users"
 )
 
 const leaderboardSize = 10
@@ -119,7 +118,7 @@ func (s *Session) runLifetimeLeaderboard(ctx context.Context, i *discordgo.Inter
 		slog.ErrorContext(ctx, "discord defer reply failed", "err", err, "command", "totalleaderboard")
 		return
 	}
-	entries := users.LifetimeMilesLeaderboard()
+	entries := s.sessions.LifetimeLeaderboard()
 	if len(entries) > leaderboardSize {
 		entries = entries[:leaderboardSize]
 	}

--- a/pkg/discord/commands.go
+++ b/pkg/discord/commands.go
@@ -119,7 +119,7 @@ func (s *Session) runLifetimeLeaderboard(ctx context.Context, i *discordgo.Inter
 		slog.ErrorContext(ctx, "discord defer reply failed", "err", err, "command", "totalleaderboard")
 		return
 	}
-	entries := users.LifetimeMilesLeaderboard
+	entries := users.LifetimeMilesLeaderboard()
 	if len(entries) > leaderboardSize {
 		entries = entries[:leaderboardSize]
 	}

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/users"
 )
 
 // FlagKey is the feature flag that gates Discord bot startup. cmd/tripbot
@@ -50,11 +51,14 @@ type Session struct {
 	s              *discordgo.Session
 	guildID        string
 	registeredCmds []*discordgo.ApplicationCommand
+	// sessions backs the /totalleaderboard command's in-memory read. Supplied
+	// by cmd/tripbot so discord shares the bot's one *users.Sessions instance.
+	sessions *users.Sessions
 }
 
 // New constructs the underlying discordgo session. Does not open the
 // gateway — call Start for that.
-func New(token, guildID string) (*Session, error) {
+func New(token, guildID string, sessions *users.Sessions) (*Session, error) {
 	s, err := discordgo.New("Bot " + token)
 	if err != nil {
 		return nil, fmt.Errorf("discordgo.New: %w", err)
@@ -66,7 +70,7 @@ func New(token, guildID string) (*Session, error) {
 	// INTERACTION_CREATE is reaching us. Bump to LogDebug if even
 	// informational chatter doesn't surface the interaction dispatch.
 	s.LogLevel = discordgo.LogInformational
-	return &Session{s: s, guildID: guildID}, nil
+	return &Session{s: s, guildID: guildID, sessions: sessions}, nil
 }
 
 // Start opens the gateway, registers the slash commands against the

--- a/pkg/natsclient/publisher.go
+++ b/pkg/natsclient/publisher.go
@@ -1,0 +1,38 @@
+package natsclient
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Publisher is the fire-and-forget publish seam consumers inject so they
+// depend on an interface rather than reaching for the package singleton
+// directly. The shape is identical to the publishers already embedded in
+// pkg/eventbus and pkg/chatbot; new code takes a natsclient.Publisher so
+// those can eventually collapse onto this one definition.
+type Publisher interface {
+	// Publish sends payload on subject. Errors are logged, never returned —
+	// every publish is fire-and-forget by design. A no-op when NATS is
+	// disabled (the singleton conn is nil).
+	Publish(ctx context.Context, subject string, payload []byte)
+}
+
+// connPublisher delegates to the package singleton, read lazily on each
+// call so a connection that lands after the caller is constructed (always —
+// main runs after package vars) is still picked up.
+type connPublisher struct{}
+
+func (connPublisher) Publish(ctx context.Context, subject string, payload []byte) {
+	c := Conn()
+	if c == nil {
+		return
+	}
+	if err := c.Publish(subject, payload); err != nil {
+		slog.ErrorContext(ctx, "nats publish failed", "err", err, "subject", subject)
+	}
+}
+
+// DefaultPublisher returns a Publisher backed by the package singleton.
+// Callers that don't need their own seam (the video Player, background
+// jobs) wire this in; tests inject a fake instead.
+func DefaultPublisher() Publisher { return connPublisher{} }

--- a/pkg/onscreens-client/nats_test.go
+++ b/pkg/onscreens-client/nats_test.go
@@ -1,0 +1,187 @@
+package onscreensClient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
+)
+
+// recordingPublisher captures every publish so tests can assert on the
+// subject + payload. Goroutine-safe. Satisfies natsclient.Publisher.
+type recordingPublisher struct {
+	mu        sync.Mutex
+	Publishes []recordedPublish
+}
+
+type recordedPublish struct {
+	Subject string
+	Payload []byte
+}
+
+func (r *recordingPublisher) Publish(_ context.Context, subject string, payload []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	r.Publishes = append(r.Publishes, recordedPublish{Subject: subject, Payload: cp})
+}
+
+// okServer stands up an httptest.Server that 200s everything, so the
+// client's HTTP path succeeds and tests can focus on the NATS mirror.
+func okServer(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// TestShowMiddleText_PublishesToNATS asserts the client fires the right
+// subject + envelope on every ShowMiddleText, alongside the HTTP call.
+func TestShowMiddleText_PublishesToNATS(t *testing.T) {
+	rec := &recordingPublisher{}
+	c := New(okServer(t), rec, "stage")
+
+	if err := c.ShowMiddleText(context.Background(), "hello world"); err != nil {
+		t.Fatalf("ShowMiddleText: %v", err)
+	}
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	pub := rec.Publishes[0]
+	if pub.Subject != "tripbot.stage.onscreens.middle.show" {
+		t.Errorf("subject = %q, want tripbot.stage.onscreens.middle.show", pub.Subject)
+	}
+
+	var ev oe.MiddleShow
+	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Msg != "hello world" {
+		t.Errorf("msg = %q, want hello world", ev.Msg)
+	}
+	if ev.EmittedAt == "" {
+		t.Error("emitted_at empty")
+	}
+}
+
+// TestShowMiddleText_TopicReflectsEnv covers the subject scoping per env.
+func TestShowMiddleText_TopicReflectsEnv(t *testing.T) {
+	host := okServer(t)
+	for _, env := range []string{"prod", "development", "test"} {
+		t.Run(env, func(t *testing.T) {
+			rec := &recordingPublisher{}
+			c := New(host, rec, env)
+			if err := c.ShowMiddleText(context.Background(), "x"); err != nil {
+				t.Fatalf("ShowMiddleText: %v", err)
+			}
+			if len(rec.Publishes) != 1 {
+				t.Fatalf("expected 1 publish")
+			}
+			want := "tripbot." + env + ".onscreens.middle.show"
+			if rec.Publishes[0].Subject != want {
+				t.Errorf("subject = %q, want %q", rec.Publishes[0].Subject, want)
+			}
+		})
+	}
+}
+
+// TestShowLeaderboard_PublishesStructured asserts the leaderboard publish
+// carries the structured {title, rows} payload (the server renders it).
+func TestShowLeaderboard_PublishesToNATS(t *testing.T) {
+	rec := &recordingPublisher{}
+	c := New(okServer(t), rec, "prod")
+
+	rows := [][]string{{"alice", "100"}, {"bob", "50"}}
+	if err := c.ShowLeaderboard(context.Background(), "Monthly Miles", rows); err != nil {
+		t.Fatalf("ShowLeaderboard: %v", err)
+	}
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	pub := rec.Publishes[0]
+	if pub.Subject != "tripbot.prod.onscreens.leaderboard.show" {
+		t.Errorf("subject = %q, want tripbot.prod.onscreens.leaderboard.show", pub.Subject)
+	}
+
+	var ev oe.LeaderboardShow
+	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Title != "Monthly Miles" {
+		t.Errorf("title = %q, want Monthly Miles", ev.Title)
+	}
+	if len(ev.Rows) != 2 || ev.Rows[0][0] != "alice" || ev.Rows[1][1] != "50" {
+		t.Errorf("rows = %v, want [[alice 100] [bob 50]]", ev.Rows)
+	}
+}
+
+// TestEmptyPayloadCommandsPublish covers the mirror for the no-payload
+// commands: each fires exactly one publish on its subject with an envelope
+// that carries emitted_at.
+func TestEmptyPayloadCommandsPublish(t *testing.T) {
+	host := okServer(t)
+	cases := []struct {
+		name    string
+		call    func(c *Client) error
+		subject string
+	}{
+		{"middle.hide", func(c *Client) error { return c.HideMiddleText(context.Background()) }, "tripbot.stage.onscreens.middle.hide"},
+		{"timewarp.show", func(c *Client) error { return c.ShowTimewarp(context.Background()) }, "tripbot.stage.onscreens.timewarp.show"},
+		{"gps.show", func(c *Client) error { return c.ShowGPSImage(context.Background(), 60) }, "tripbot.stage.onscreens.gps.show"},
+		{"gps.hide", func(c *Client) error { return c.HideGPSImage(context.Background()) }, "tripbot.stage.onscreens.gps.hide"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingPublisher{}
+			c := New(host, rec, "stage")
+			if err := tc.call(c); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+			if len(rec.Publishes) != 1 {
+				t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+			}
+			if rec.Publishes[0].Subject != tc.subject {
+				t.Errorf("subject = %q, want %q", rec.Publishes[0].Subject, tc.subject)
+			}
+			var env oe.Command
+			if err := json.Unmarshal(rec.Publishes[0].Payload, &env); err != nil {
+				t.Fatalf("payload not valid JSON: %v", err)
+			}
+			if env.EmittedAt == "" {
+				t.Error("emitted_at empty")
+			}
+		})
+	}
+}
+
+// TestShowFlagDoesNotPublish asserts the disabled flag.show stays a no-op
+// (no subject in the taxonomy, so nothing is published).
+func TestShowFlagDoesNotPublish(t *testing.T) {
+	rec := &recordingPublisher{}
+	c := New(okServer(t), rec, "stage")
+	if err := c.ShowFlag(context.Background(), 10); err != nil {
+		t.Fatalf("ShowFlag: %v", err)
+	}
+	if len(rec.Publishes) != 0 {
+		t.Errorf("expected 0 publishes for disabled flag.show, got %d", len(rec.Publishes))
+	}
+}
+
+// TestNilPublisher_NoPublishNoPanic asserts a nil publisher disables the
+// mirror without panicking (the path used by HTTP-only test rigs).
+func TestNilPublisher_NoPublishNoPanic(t *testing.T) {
+	c := New(okServer(t), nil, "test")
+	if err := c.ShowMiddleText(context.Background(), "x"); err != nil {
+		t.Fatalf("ShowMiddleText: %v", err)
+	}
+}

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -2,6 +2,7 @@ package onscreensClient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log/slog"
@@ -10,28 +11,56 @@ import (
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
-	"github.com/adanalife/tripbot/pkg/users"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// Client talks to the onscreens-server HTTP API. Construct via New(host).
+// Client talks to the onscreens-server HTTP API and mirrors each command
+// onto NATS. Construct via New(host, nats, env).
+//
+// The NATS publish is the HTTP→NATS migration (phase 2): commands publish to
+// NATS alongside the HTTP call, with HTTP still the source of truth, and the
+// onscreens-server subscriber acts on the same payload. nats may be nil
+// (tests that don't exercise pubsub) — publishes no-op then.
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
+	nats       natsclient.Publisher
+	env        string
 }
 
 // New returns a Client pointed at the given onscreens-server host. The HTTP
 // transport is OTel-instrumented so outbound calls produce spans and
-// propagate W3C tracecontext headers.
-func New(host string) *Client {
+// propagate W3C tracecontext headers. nats + env drive the NATS mirror; pass
+// natsclient.DefaultPublisher() in production, or a nil publisher to disable
+// the mirror (tests).
+func New(host string, nats natsclient.Publisher, env string) *Client {
 	return &Client{
 		serverURL:  "http://" + host,
 		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
+		nats:       nats,
+		env:        env,
 	}
 }
 
+// publish marshals ev and fires it on subject. Fire-and-forget: marshal
+// errors are logged, and a nil publisher (or a nil underlying conn) no-ops.
+func (c *Client) publish(ctx context.Context, subject string, ev any) {
+	if c.nats == nil {
+		return
+	}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal onscreens event", "err", err, "subject", subject)
+		return
+	}
+	c.nats.Publish(ctx, subject, payload)
+}
+
 func (c *Client) HideMiddleText(ctx context.Context) error {
+	c.publish(ctx, oe.MiddleHideSubject(c.env), oe.Command{Envelope: oe.NewEnvelope()})
 	_, err := c.get(ctx, c.serverURL+"/onscreens/middle/hide")
 	if err != nil {
 		slog.ErrorContext(ctx, "error hiding middle onscreen", "err", err)
@@ -41,6 +70,12 @@ func (c *Client) HideMiddleText(ctx context.Context) error {
 }
 
 func (c *Client) ShowMiddleText(ctx context.Context, msg string) error {
+	// Publish NATS first (cheap, fire-and-forget) so a slow HTTP call doesn't
+	// delay it; HTTP remains the source of truth during the mirror period.
+	c.publish(ctx, oe.MiddleShowSubject(c.env), oe.MiddleShow{
+		Envelope: oe.NewEnvelope(),
+		Msg:      msg,
+	})
 	url := c.serverURL + "/onscreens/middle/show"
 	url = fmt.Sprintf("%s?msg=%s", url, helpers.Base64Encode(msg))
 	_, err := c.get(ctx, url)
@@ -52,12 +87,25 @@ func (c *Client) ShowMiddleText(ctx context.Context, msg string) error {
 }
 
 func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error {
-	content := users.LeaderboardContent(title, leaderboard)
+	// onscreens-server renders the HTML now, so both transports carry the
+	// structured {title, rows} payload. Build it once and reuse it for the
+	// NATS publish and the base64-JSON HTTP query param.
+	ev := oe.LeaderboardShow{
+		Envelope: oe.NewEnvelope(),
+		Title:    title,
+		Rows:     leaderboard,
+	}
+	c.publish(ctx, oe.LeaderboardShowSubject(c.env), ev)
 
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal leaderboard event", "err", err)
+		return err
+	}
 	url := c.serverURL + "/onscreens/leaderboard/show"
-	url = fmt.Sprintf("%s?content=%s", url, helpers.Base64Encode(content))
+	url = fmt.Sprintf("%s?content=%s", url, helpers.Base64Encode(string(payload)))
 
-	_, err := c.get(ctx, url)
+	_, err = c.get(ctx, url)
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing leaderboard onscreen", "err", err)
 		return err
@@ -96,6 +144,7 @@ func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
 }
 
 func (c *Client) ShowTimewarp(ctx context.Context) error {
+	c.publish(ctx, oe.TimewarpShowSubject(c.env), oe.Command{Envelope: oe.NewEnvelope()})
 	_, err := c.get(ctx, c.serverURL+"/onscreens/timewarp/show")
 	if err != nil {
 		slog.ErrorContext(ctx, "error showing timewarp onscreen", "err", err)
@@ -117,6 +166,9 @@ func (c *Client) ShowFlag(ctx context.Context, dur time.Duration) error {
 }
 
 func (c *Client) ShowGPSImage(ctx context.Context, dur time.Duration) error {
+	// dur isn't transported — the server owns the GPS overlay's duration
+	// (gpsDuration); the HTTP query param is vestigial and ignored there too.
+	c.publish(ctx, oe.GPSShowSubject(c.env), oe.Command{Envelope: oe.NewEnvelope()})
 	url := c.serverURL + "/onscreens/gps/show"
 	url = fmt.Sprintf("%s?duration=%s", url, helpers.Base64Encode(string(rune(dur))))
 	_, err := c.get(ctx, url)
@@ -128,6 +180,7 @@ func (c *Client) ShowGPSImage(ctx context.Context, dur time.Duration) error {
 }
 
 func (c *Client) HideGPSImage(ctx context.Context) error {
+	c.publish(ctx, oe.GPSHideSubject(c.env), oe.Command{Envelope: oe.NewEnvelope()})
 	_, err := c.get(ctx, c.serverURL+"/onscreens/gps/hide")
 	if err != nil {
 		slog.ErrorContext(ctx, "error hiding gps onscreen", "err", err)

--- a/pkg/onscreens-events/events.go
+++ b/pkg/onscreens-events/events.go
@@ -1,0 +1,48 @@
+// Package onscreensEvents holds the wire format for the onscreens command
+// events published over NATS (subjects of the form
+// tripbot.<env>.onscreens.<overlay>.<verb>).
+//
+// It is imported by both the publisher (cmd/tripbot, via
+// pkg/onscreens-client) and the subscriber (cmd/onscreens-server). To stay
+// safe as a shared package it is stdlib-only and side-effect-free: no
+// init(), no pkg/config import, env is always a parameter rather than read
+// from config here. See vault/decisions/package-boundary-init-discipline.md.
+package onscreensEvents
+
+import "time"
+
+// Envelope is embedded in every onscreens command event. EmittedAt is an
+// RFC3339Nano UTC timestamp, useful for latency/debugging. Snake_case JSON
+// so a future protobuf schema maps 1-1.
+type Envelope struct {
+	EmittedAt string `json:"emitted_at"`
+}
+
+// NewEnvelope returns an Envelope stamped with the current UTC time.
+func NewEnvelope() Envelope {
+	return Envelope{EmittedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+}
+
+// MiddleShow is the payload for the middle.show subject.
+type MiddleShow struct {
+	Envelope
+	Msg string `json:"msg"`
+}
+
+// LeaderboardShow is the payload for the leaderboard.show subject. The
+// server renders Rows into the on-screen HTML, so the wire carries
+// structured data rather than a pre-rendered blob.
+type LeaderboardShow struct {
+	Envelope
+	Title string     `json:"title"`
+	Rows  [][]string `json:"rows"`
+}
+
+// Command is the payload for events that carry no data beyond the
+// envelope: every hide, plus timewarp.show and gps.show (the server
+// supplies their content and duration). A single type rather than a swarm
+// of identical empty structs — the subject distinguishes them, and any
+// event that grows a field graduates to its own named type then.
+type Command struct {
+	Envelope
+}

--- a/pkg/onscreens-events/events_test.go
+++ b/pkg/onscreens-events/events_test.go
@@ -1,0 +1,75 @@
+package onscreensEvents
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSubjects(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"middle.show", MiddleShowSubject("staging"), "tripbot.staging.onscreens.middle.show"},
+		{"middle.hide", MiddleHideSubject("staging"), "tripbot.staging.onscreens.middle.hide"},
+		{"leaderboard.show", LeaderboardShowSubject("prod"), "tripbot.prod.onscreens.leaderboard.show"},
+		{"leaderboard.hide", LeaderboardHideSubject("prod"), "tripbot.prod.onscreens.leaderboard.hide"},
+		{"timewarp.show", TimewarpShowSubject("development"), "tripbot.development.onscreens.timewarp.show"},
+		{"timewarp.hide", TimewarpHideSubject("development"), "tripbot.development.onscreens.timewarp.hide"},
+		{"gps.show", GPSShowSubject("staging"), "tripbot.staging.onscreens.gps.show"},
+		{"gps.hide", GPSHideSubject("staging"), "tripbot.staging.onscreens.gps.hide"},
+		{"flag.hide", FlagHideSubject("prod"), "tripbot.prod.onscreens.flag.hide"},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestMiddleShowRoundTrip(t *testing.T) {
+	in := MiddleShow{Envelope: NewEnvelope(), Msg: "hello"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out MiddleShow
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Msg != in.Msg {
+		t.Errorf("msg: got %q, want %q", out.Msg, in.Msg)
+	}
+	if out.EmittedAt == "" {
+		t.Error("emitted_at empty after round-trip")
+	}
+}
+
+func TestLeaderboardShowRoundTrip(t *testing.T) {
+	in := LeaderboardShow{
+		Envelope: NewEnvelope(),
+		Title:    "Monthly Miles",
+		Rows:     [][]string{{"alice", "42"}, {"bob", "17"}},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out LeaderboardShow
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Title != in.Title {
+		t.Errorf("title: got %q, want %q", out.Title, in.Title)
+	}
+	if len(out.Rows) != 2 || out.Rows[0][0] != "alice" || out.Rows[1][1] != "17" {
+		t.Errorf("rows round-trip mismatch: %v", out.Rows)
+	}
+}
+
+func TestNewEnvelopeStampsTime(t *testing.T) {
+	if NewEnvelope().EmittedAt == "" {
+		t.Error("NewEnvelope did not stamp EmittedAt")
+	}
+}

--- a/pkg/onscreens-events/subjects.go
+++ b/pkg/onscreens-events/subjects.go
@@ -1,0 +1,29 @@
+package onscreensEvents
+
+import "fmt"
+
+// domain is the fixed segment between <env> and <overlay> in every
+// onscreens subject: tripbot.<env>.onscreens.<overlay>.<verb>.
+const domain = "onscreens"
+
+// subject builds tripbot.<env>.onscreens.<overlay>.<verb>. Unexported so
+// callers go through the typed constructors below — that keeps the
+// overlay/verb strings in one place and out of reach of typos at the call
+// site.
+func subject(env, overlay, verb string) string {
+	return fmt.Sprintf("tripbot.%s.%s.%s.%s", env, domain, overlay, verb)
+}
+
+func MiddleShowSubject(env string) string      { return subject(env, "middle", "show") }
+func MiddleHideSubject(env string) string      { return subject(env, "middle", "hide") }
+func LeaderboardShowSubject(env string) string { return subject(env, "leaderboard", "show") }
+func LeaderboardHideSubject(env string) string { return subject(env, "leaderboard", "hide") }
+func TimewarpShowSubject(env string) string    { return subject(env, "timewarp", "show") }
+func TimewarpHideSubject(env string) string    { return subject(env, "timewarp", "hide") }
+func GPSShowSubject(env string) string         { return subject(env, "gps", "show") }
+func GPSHideSubject(env string) string         { return subject(env, "gps", "hide") }
+
+// FlagHideSubject is the only flag subject. flag.show is intentionally
+// absent — the feature is disabled (the HTTP route 501s and the client
+// method is a no-op), so publishing it would be dead surface.
+func FlagHideSubject(env string) string { return subject(env, "flag", "hide") }

--- a/pkg/onscreens-server/browser.go
+++ b/pkg/onscreens-server/browser.go
@@ -70,7 +70,7 @@ var onscreenRegistry = map[string]onscreenStyle{
 		Name: SlugMiddleText, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",
 	},
 	SlugLeaderboard: {
-		// Server emits an HTML grid (see users.LeaderboardContent) so the
+		// Server emits an HTML grid (see renderLeaderboard) so the
 		// score column aligns via CSS rather than space-padding — any font
 		// works.
 		Name: SlugLeaderboard, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",

--- a/pkg/onscreens-server/handlers.go
+++ b/pkg/onscreens-server/handlers.go
@@ -1,11 +1,13 @@
 package onscreensServer
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/adanalife/tripbot/pkg/helpers"
+	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/mux"
 )
@@ -113,14 +115,22 @@ func (s *Server) onscreensLeaderboardHandler(w http.ResponseWriter, r *http.Requ
 			http.Error(w, "417 expectation failed", http.StatusExpectationFailed)
 			return
 		}
-		content, err := helpers.Base64Decode(base64content[0])
+		raw, err := helpers.Base64Decode(base64content[0])
 		if err != nil {
 			slog.ErrorContext(r.Context(), "unable to decode string", "err", err)
 			http.Error(w, "422 unprocessable entity", http.StatusUnprocessableEntity)
 			return
 		}
+		// content is base64(JSON {title, rows}); the server renders the HTML
+		// (same path the NATS leaderboard.show handler takes).
+		var ev oe.LeaderboardShow
+		if err := json.Unmarshal([]byte(raw), &ev); err != nil {
+			slog.ErrorContext(r.Context(), "unable to decode leaderboard payload", "err", err)
+			http.Error(w, "422 unprocessable entity", http.StatusUnprocessableEntity)
+			return
+		}
 
-		s.Leaderboard.ShowFor(content, leaderboardDuration)
+		s.Leaderboard.ShowFor(renderLeaderboard(ev.Title, ev.Rows), leaderboardDuration)
 		fmt.Fprintf(w, "OK")
 	case "hide":
 		s.Leaderboard.Hide()

--- a/pkg/onscreens-server/leaderboard_content.go
+++ b/pkg/onscreens-server/leaderboard_content.go
@@ -1,0 +1,40 @@
+package onscreensServer
+
+import (
+	"fmt"
+	"html"
+	"strings"
+)
+
+// renderLeaderboard renders the leaderboard onscreen as a CSS-grid HTML
+// fragment. The score column auto-sizes to the widest entry via
+// grid-template-columns, so digits line up across rows regardless of font.
+// The leaderboard onscreen is registered with RenderAsHTML so the
+// browser-source template injects this via innerHTML.
+//
+// Moved here from pkg/users.LeaderboardContent: onscreens-server now owns
+// presentation, so the wire (NATS + HTTP) carries structured {title, rows}
+// rather than a pre-rendered blob, and the renderer lives next to the
+// overlay it feeds. Kept dependency-free (fmt/html/strings) so it doesn't
+// drag pkg/users' DB/config init into this binary.
+func renderLeaderboard(title string, leaderboard [][]string) string {
+	size := 5
+	if len(leaderboard) < size {
+		size = len(leaderboard)
+	}
+	leaderboard = leaderboard[:size]
+
+	var b strings.Builder
+	b.WriteString(`<div class="lb-grid">`)
+	fmt.Fprintf(&b, `<div class="lb-title">%s</div>`, html.EscapeString(strings.Title(title)))
+	for _, row := range leaderboard {
+		fmt.Fprintf(
+			&b,
+			`<span class="lb-score">%s</span><span class="lb-user">(%s)</span>`,
+			html.EscapeString(row[1]),
+			html.EscapeString(row[0]),
+		)
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}

--- a/pkg/onscreens-server/leaderboard_content_test.go
+++ b/pkg/onscreens-server/leaderboard_content_test.go
@@ -1,0 +1,104 @@
+package onscreensServer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderLeaderboard(t *testing.T) {
+	board := [][]string{
+		{"alice", "100.5"},
+		{"bob", "75.2"},
+		{"carol", "50.0"},
+	}
+	got := renderLeaderboard("monthly miles", board)
+
+	if !strings.Contains(got, `<div class="lb-title">Monthly Miles</div>`) {
+		t.Fatalf("expected title-cased header, got %q", got)
+	}
+	for _, name := range []string{"alice", "bob", "carol"} {
+		if !strings.Contains(got, `<span class="lb-user">(`+name+`)</span>`) {
+			t.Fatalf("expected user span for %q, got %q", name, got)
+		}
+	}
+	if !strings.Contains(got, `<span class="lb-score">100.5</span><span class="lb-user">(alice)</span>`) {
+		t.Fatalf("expected adjacent score+user spans for alice, got %q", got)
+	}
+}
+
+func TestRenderLeaderboardTruncatesToFive(t *testing.T) {
+	board := [][]string{
+		{"u1", "10"}, {"u2", "9"}, {"u3", "8"}, {"u4", "7"},
+		{"u5", "6"}, {"u6", "5"}, {"u7", "4"},
+	}
+	got := renderLeaderboard("top", board)
+
+	if strings.Contains(got, "u6") || strings.Contains(got, "u7") {
+		t.Fatalf("expected truncation to 5 entries, got %q", got)
+	}
+	for _, name := range []string{"u1", "u2", "u3", "u4", "u5"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("expected %q in top-5, got %q", name, got)
+		}
+	}
+}
+
+func TestRenderLeaderboardSmallerThanFive(t *testing.T) {
+	board := [][]string{
+		{"alice", "100"},
+		{"bob", "50"},
+	}
+	got := renderLeaderboard("tiny", board)
+	if !strings.Contains(got, "alice") || !strings.Contains(got, "bob") {
+		t.Fatalf("expected both names, got %q", got)
+	}
+}
+
+func TestRenderLeaderboardEmpty(t *testing.T) {
+	got := renderLeaderboard("nobody", nil)
+	want := `<div class="lb-grid"><div class="lb-title">Nobody</div></div>`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// Scores render in their own span (no space-padding) so the CSS grid can
+// auto-size the column.
+func TestRenderLeaderboardNoSpacePadding(t *testing.T) {
+	board := [][]string{
+		{"alice", "123"},
+		{"bob", "15"},
+		{"carol", "7"},
+	}
+	got := renderLeaderboard("guesses", board)
+
+	wantSpans := []string{
+		`<span class="lb-score">123</span><span class="lb-user">(alice)</span>`,
+		`<span class="lb-score">15</span><span class="lb-user">(bob)</span>`,
+		`<span class="lb-score">7</span><span class="lb-user">(carol)</span>`,
+	}
+	for _, want := range wantSpans {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in output, got %q", want, got)
+		}
+	}
+	// No padding spaces between score and user spans.
+	if strings.Contains(got, "</span> <span") {
+		t.Fatalf("did not expect padding space between score/user spans, got %q", got)
+	}
+}
+
+// Defensive: usernames are normally [a-zA-Z0-9_] from Twitch, but the
+// renderer escapes anything that would break out of the surrounding HTML.
+func TestRenderLeaderboardEscapesHTML(t *testing.T) {
+	board := [][]string{
+		{"<script>", "1"},
+	}
+	got := renderLeaderboard("xss", board)
+	if strings.Contains(got, "<script>") {
+		t.Fatalf("expected HTML-escaped username, got %q", got)
+	}
+	if !strings.Contains(got, "&lt;script&gt;") {
+		t.Fatalf("expected &lt;script&gt; escape, got %q", got)
+	}
+}

--- a/pkg/onscreens-server/nats.go
+++ b/pkg/onscreens-server/nats.go
@@ -3,55 +3,90 @@ package onscreensServer
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 	"github.com/adanalife/tripbot/pkg/natsclient"
+	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
 	"github.com/nats-io/nats.go"
 )
 
-// middleTextEvent mirrors the chatbot-side wire format for
-// tripbot.<env>.onscreens.middle.show. Mirror, not import, to keep the
-// chatbot/onscreens-server package boundary clean — the wire format
-// will live in its own pkg/events module once a second event lands.
-type middleTextEvent struct {
-	Msg       string `json:"msg"`
-	EmittedAt string `json:"emitted_at"`
-}
-
 // StartNATSSubscribers attaches the server's NATS subscriptions to the
-// package-singleton *nats.Conn (initialized by main via
-// natsclient.Connect). No-op when the conn is nil (NATS_URL unset).
-// Returns the subscription so callers can Unsubscribe on shutdown if
-// they want — phase 1 lets the process exit do that work.
+// package-singleton *nats.Conn (initialized by main via natsclient.Connect).
+// No-op when the conn is nil (NATS_URL unset); HTTP remains the sole
+// transport then.
 //
-// Phase 1: a single subject — tripbot.<env>.onscreens.middle.show. Phase
-// 2 peels the rest of the onscreens-client surface onto NATS.
+// Phase 2: the onscreens command surface moves onto NATS. Each handler maps
+// 1-1 to the matching HTTP handler body, calling the same overlay method.
+// The publisher mirrors every command alongside HTTP with HTTP still the
+// source of truth, so acting here is presently redundant — but lets us burn
+// in NATS delivery before peeling HTTP off. Subscribers are registered
+// explicitly (not via an onscreens.> wildcard) so each gets its own
+// subscribe log line and the dispatch stays readable.
 func (s *Server) StartNATSSubscribers(ctx context.Context) {
 	conn := natsclient.Conn()
 	if conn == nil {
 		slog.InfoContext(ctx, "nats subscriber skipped (NATS_URL unset)")
 		return
 	}
-	subject := fmt.Sprintf("tripbot.%s.onscreens.middle.show", c.Conf.Environment)
-	sub, err := conn.Subscribe(subject, s.handleMiddleTextShow)
-	if err != nil {
-		slog.ErrorContext(ctx, "nats subscribe failed", "err", err, "subject", subject)
-		return
+	env := c.Conf.Environment
+	subs := []struct {
+		subject string
+		handler nats.MsgHandler
+	}{
+		{oe.MiddleShowSubject(env), s.handleMiddleShow},
+		{oe.MiddleHideSubject(env), s.handleMiddleHide},
+		{oe.LeaderboardShowSubject(env), s.handleLeaderboardShow},
+		{oe.LeaderboardHideSubject(env), s.handleLeaderboardHide},
+		{oe.TimewarpShowSubject(env), s.handleTimewarpShow},
+		{oe.TimewarpHideSubject(env), s.handleTimewarpHide},
+		{oe.GPSShowSubject(env), s.handleGPSShow},
+		{oe.GPSHideSubject(env), s.handleGPSHide},
+		{oe.FlagHideSubject(env), s.handleFlagHide},
 	}
-	slog.InfoContext(ctx, "nats subscribed", "subject", subject, "queue", sub.Queue)
+	for _, sb := range subs {
+		// Best-effort: one bad subject shouldn't stop the rest from binding.
+		if _, err := conn.Subscribe(sb.subject, sb.handler); err != nil {
+			slog.ErrorContext(ctx, "nats subscribe failed", "err", err, "subject", sb.subject)
+			continue
+		}
+		slog.InfoContext(ctx, "nats subscribed", "subject", sb.subject)
+	}
 }
 
-func (s *Server) handleMiddleTextShow(m *nats.Msg) {
-	var ev middleTextEvent
+// handleMiddleShow shows the middle text. Strict: a missing msg or malformed
+// body is dropped — a show with no content is a publisher bug, not an intent.
+func (s *Server) handleMiddleShow(m *nats.Msg) {
+	var ev oe.MiddleShow
 	if err := json.Unmarshal(m.Data, &ev); err != nil {
-		slog.Error("nats: decode middle-text event", "err", err, "subject", m.Subject)
+		slog.Error("nats: decode middle.show", "err", err, "subject", m.Subject)
 		return
 	}
 	if ev.Msg == "" {
-		slog.Warn("nats: middle-text event missing msg field", "subject", m.Subject)
+		slog.Warn("nats: middle.show missing msg", "subject", m.Subject)
 		return
 	}
 	s.MiddleText.Show(ev.Msg)
 }
+
+// handleLeaderboardShow renders the {title, rows} payload server-side and
+// shows it for the standard duration — the same path the HTTP handler takes.
+func (s *Server) handleLeaderboardShow(m *nats.Msg) {
+	var ev oe.LeaderboardShow
+	if err := json.Unmarshal(m.Data, &ev); err != nil {
+		slog.Error("nats: decode leaderboard.show", "err", err, "subject", m.Subject)
+		return
+	}
+	s.Leaderboard.ShowFor(renderLeaderboard(ev.Title, ev.Rows), leaderboardDuration)
+}
+
+// The hide + empty-payload show handlers below take no data beyond the
+// envelope, so the body isn't inspected: the subject is the whole intent.
+// Hides are lenient by construction (nothing to reject).
+func (s *Server) handleMiddleHide(_ *nats.Msg)      { s.MiddleText.Hide() }
+func (s *Server) handleLeaderboardHide(_ *nats.Msg) { s.Leaderboard.Hide() }
+func (s *Server) handleTimewarpShow(_ *nats.Msg)    { s.Timewarp.ShowFor("Timewarp!", timewarpDuration) }
+func (s *Server) handleTimewarpHide(_ *nats.Msg)    { s.Timewarp.Hide() }
+func (s *Server) handleGPSShow(_ *nats.Msg)         { s.GPS.Show("") }
+func (s *Server) handleGPSHide(_ *nats.Msg)         { s.GPS.Hide() }
+func (s *Server) handleFlagHide(_ *nats.Msg)        { s.Flag.Hide() }

--- a/pkg/onscreens-server/nats_test.go
+++ b/pkg/onscreens-server/nats_test.go
@@ -1,22 +1,23 @@
 package onscreensServer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nats-io/nats.go"
 )
 
-// TestHandleMiddleTextShow_DecodesAndShows asserts a well-formed NATS
-// message lands on the MiddleText overlay the same way the HTTP handler
-// would (s.MiddleText.Show is the shared path).
-func TestHandleMiddleTextShow_DecodesAndShows(t *testing.T) {
+// TestHandleMiddleShow_DecodesAndShows asserts a well-formed NATS message
+// lands on the MiddleText overlay the same way the HTTP handler would
+// (s.MiddleText.Show is the shared path).
+func TestHandleMiddleShow_DecodesAndShows(t *testing.T) {
 	s := &Server{MiddleText: newMiddleText()}
 
 	msg := &nats.Msg{
 		Subject: "tripbot.test.onscreens.middle.show",
 		Data:    []byte(`{"msg":"hello from nats","emitted_at":"2026-05-28T16:00:00Z"}`),
 	}
-	s.handleMiddleTextShow(msg)
+	s.handleMiddleShow(msg)
 
 	if !s.MiddleText.IsShowing {
 		t.Errorf("MiddleText.IsShowing = false, want true")
@@ -26,11 +27,11 @@ func TestHandleMiddleTextShow_DecodesAndShows(t *testing.T) {
 	}
 }
 
-// TestHandleMiddleTextShow_RejectsEmptyMsg covers the defensive check
-// for a malformed publisher that omits the msg field. The overlay's
-// existing Content must not change. (MiddleText starts IsShowing=true by
-// design — it carries pre-restart text — so this asserts on Content.)
-func TestHandleMiddleTextShow_RejectsEmptyMsg(t *testing.T) {
+// TestHandleMiddleShow_RejectsEmptyMsg covers the defensive check for a
+// malformed publisher that omits the msg field. The overlay's existing
+// Content must not change. (MiddleText starts IsShowing=true by design — it
+// carries pre-restart text — so this asserts on Content.)
+func TestHandleMiddleShow_RejectsEmptyMsg(t *testing.T) {
 	s := &Server{MiddleText: newMiddleText()}
 	s.MiddleText.Content = "pre-existing"
 
@@ -38,15 +39,15 @@ func TestHandleMiddleTextShow_RejectsEmptyMsg(t *testing.T) {
 		Subject: "tripbot.test.onscreens.middle.show",
 		Data:    []byte(`{"emitted_at":"2026-05-28T16:00:00Z"}`),
 	}
-	s.handleMiddleTextShow(msg)
+	s.handleMiddleShow(msg)
 
 	if s.MiddleText.Content != "pre-existing" {
 		t.Errorf("MiddleText.Content = %q, want pre-existing (empty msg should be a no-op)", s.MiddleText.Content)
 	}
 }
 
-// TestHandleMiddleTextShow_RejectsBadJSON covers a non-JSON payload.
-func TestHandleMiddleTextShow_RejectsBadJSON(t *testing.T) {
+// TestHandleMiddleShow_RejectsBadJSON covers a non-JSON payload.
+func TestHandleMiddleShow_RejectsBadJSON(t *testing.T) {
 	s := &Server{MiddleText: newMiddleText()}
 	s.MiddleText.Content = "pre-existing"
 
@@ -54,9 +55,120 @@ func TestHandleMiddleTextShow_RejectsBadJSON(t *testing.T) {
 		Subject: "tripbot.test.onscreens.middle.show",
 		Data:    []byte(`not json at all`),
 	}
-	s.handleMiddleTextShow(msg)
+	s.handleMiddleShow(msg)
 
 	if s.MiddleText.Content != "pre-existing" {
 		t.Errorf("MiddleText.Content = %q, want pre-existing (bad JSON should be a no-op)", s.MiddleText.Content)
+	}
+}
+
+// emptyMsg is an envelope-only payload — the shape every hide + the
+// empty-payload shows arrive as.
+func emptyMsg(subject string) *nats.Msg {
+	return &nats.Msg{Subject: subject, Data: []byte(`{"emitted_at":"2026-05-28T16:00:00Z"}`)}
+}
+
+func TestHandleMiddleHide(t *testing.T) {
+	s := &Server{MiddleText: newMiddleText()}
+	s.MiddleText.Show("something")
+	s.handleMiddleHide(emptyMsg("tripbot.test.onscreens.middle.hide"))
+	if s.MiddleText.IsShowing {
+		t.Error("MiddleText.IsShowing = true, want false after hide")
+	}
+}
+
+func TestHandleLeaderboardShow(t *testing.T) {
+	s := &Server{Leaderboard: newLeaderboardOnscreen()}
+
+	msg := &nats.Msg{
+		Subject: "tripbot.test.onscreens.leaderboard.show",
+		Data:    []byte(`{"emitted_at":"2026-05-28T16:00:00Z","title":"monthly miles","rows":[["alice","100"]]}`),
+	}
+	s.handleLeaderboardShow(msg)
+
+	if !s.Leaderboard.IsShowing {
+		t.Error("Leaderboard.IsShowing = false, want true")
+	}
+	// Server renders the HTML from {title, rows}.
+	if !strings.Contains(s.Leaderboard.Content, `<div class="lb-title">Monthly Miles</div>`) {
+		t.Errorf("Leaderboard.Content missing rendered title, got %q", s.Leaderboard.Content)
+	}
+	if !strings.Contains(s.Leaderboard.Content, "(alice)") {
+		t.Errorf("Leaderboard.Content missing user, got %q", s.Leaderboard.Content)
+	}
+}
+
+func TestHandleLeaderboardShow_RejectsBadJSON(t *testing.T) {
+	s := &Server{Leaderboard: newLeaderboardOnscreen()}
+	s.Leaderboard.Content = "pre-existing"
+
+	s.handleLeaderboardShow(&nats.Msg{
+		Subject: "tripbot.test.onscreens.leaderboard.show",
+		Data:    []byte(`not json`),
+	})
+
+	if s.Leaderboard.Content != "pre-existing" {
+		t.Errorf("Leaderboard.Content = %q, want pre-existing (bad JSON should be a no-op)", s.Leaderboard.Content)
+	}
+}
+
+func TestHandleLeaderboardHide(t *testing.T) {
+	s := &Server{Leaderboard: newLeaderboardOnscreen()}
+	s.Leaderboard.ShowFor("x", leaderboardDuration)
+	s.handleLeaderboardHide(emptyMsg("tripbot.test.onscreens.leaderboard.hide"))
+	if s.Leaderboard.IsShowing {
+		t.Error("Leaderboard.IsShowing = true, want false after hide")
+	}
+}
+
+func TestHandleTimewarpShow(t *testing.T) {
+	s := &Server{Timewarp: newTimewarp()}
+	s.handleTimewarpShow(emptyMsg("tripbot.test.onscreens.timewarp.show"))
+	if !s.Timewarp.IsShowing {
+		t.Error("Timewarp.IsShowing = false, want true")
+	}
+	if s.Timewarp.Content != "Timewarp!" {
+		t.Errorf("Timewarp.Content = %q, want Timewarp!", s.Timewarp.Content)
+	}
+}
+
+func TestHandleTimewarpHide(t *testing.T) {
+	s := &Server{Timewarp: newTimewarp()}
+	s.Timewarp.ShowFor("Timewarp!", timewarpDuration)
+	s.handleTimewarpHide(emptyMsg("tripbot.test.onscreens.timewarp.hide"))
+	if s.Timewarp.IsShowing {
+		t.Error("Timewarp.IsShowing = true, want false after hide")
+	}
+}
+
+func TestHandleGPSShowHide(t *testing.T) {
+	s := &Server{GPS: newGPSOnscreen()}
+	s.handleGPSShow(emptyMsg("tripbot.test.onscreens.gps.show"))
+	if !s.GPS.IsShowing {
+		t.Error("GPS.IsShowing = false, want true after show")
+	}
+	s.handleGPSHide(emptyMsg("tripbot.test.onscreens.gps.hide"))
+	if s.GPS.IsShowing {
+		t.Error("GPS.IsShowing = true, want false after hide")
+	}
+}
+
+func TestHandleFlagHide(t *testing.T) {
+	s := &Server{Flag: newFlagOnscreen()}
+	s.Flag.Show("")
+	s.handleFlagHide(emptyMsg("tripbot.test.onscreens.flag.hide"))
+	if s.Flag.IsShowing {
+		t.Error("Flag.IsShowing = true, want false after hide")
+	}
+}
+
+// TestHideLenientOnEmptyBody asserts a hide with a nil/garbage body still
+// hides — the subject is the whole intent.
+func TestHideLenientOnEmptyBody(t *testing.T) {
+	s := &Server{MiddleText: newMiddleText()}
+	s.MiddleText.Show("x")
+	s.handleMiddleHide(&nats.Msg{Subject: "tripbot.test.onscreens.middle.hide", Data: nil})
+	if s.MiddleText.IsShowing {
+		t.Error("hide should act regardless of body")
 	}
 }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -17,7 +17,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/obs"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
-	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/gorilla/mux"
 )
 
@@ -29,12 +28,7 @@ var startedAt = time.Now()
 // ping. 2s keeps a slow or hung vlc-server from stalling the panel render.
 var healthClient = &http.Client{Timeout: 2 * time.Second}
 
-// currentlyPlaying / currentProgress are overridable in tests; by default they
-// read pkg/video's in-process state (refreshed by a 60s cron tick), so the
-// admin panel costs nothing to show "now playing".
 var (
-	currentlyPlaying = video.CurrentlyPlaying
-	currentProgress  = video.CurrentProgress
 	// chatterCount is the in-memory count of users in chat, refreshed ~60s by
 	// the UpdateSession cron. Overridable in tests.
 	chatterCount = mytwitch.ChatterCount
@@ -235,7 +229,7 @@ func (s *Server) adminHandler(w http.ResponseWriter, r *http.Request) {
 		Uptime:         time.Since(startedAt).Round(time.Second).String(),
 		Chatters:       chatterCount(),
 		Services:       s.gatherStatus(buildSHA(), vlc, onscreens, obs),
-		Now:            currentVideo(vlc.OK),
+		Now:            s.currentVideo(vlc.OK),
 		Audio:          nowPlayingFetcher(r.Context()),
 		Stream:         gatherStream(r.Context()),
 		PanelHost:      panelHost(r),
@@ -484,22 +478,24 @@ func (s *Server) refreshHandler(w http.ResponseWriter, r *http.Request) {
 
 // currentVideo summarizes the currently-playing video for the page, but only
 // when vlc is healthy (a stale value while vlc is down would be misleading).
-// Reads pkg/video's in-process value — no extra call. Returns nil when nothing
-// is playing yet (empty slug).
-func currentVideo(vlcOK bool) *nowPlaying {
+// Reads the last video.changed cached by the hub from NATS — no in-process
+// pkg/video dependency — so the panel can later be lifted into its own service.
+// Returns nil when no video.changed has arrived yet. Progress is derived from
+// the event's emitted_at (the clip start), matching the live SSE ticker.
+func (s *Server) currentVideo(vlcOK bool) *nowPlaying {
 	if !vlcOK {
 		return nil
 	}
-	v := currentlyPlaying()
-	if v.Slug == "" {
+	ev, ok := s.hub.snapshotNowPlaying()
+	if !ok || ev.File == "" {
 		return nil
 	}
-	progress := currentProgress()
+	started := parseEmitted(ev.EmittedAt)
 	return &nowPlaying{
-		File:      v.File(),
-		State:     v.State,
-		Progress:  progress.Round(time.Second).String(),
-		SinceUnix: time.Now().Add(-progress).Unix(),
+		File:      ev.File,
+		State:     ev.State,
+		Progress:  time.Since(started).Round(time.Second).String(),
+		SinceUnix: started.Unix(),
 	}
 }
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -222,7 +222,7 @@ type adminData struct {
 // pings, each version linking to its changelog), the currently-playing video
 // when vlc is up, the broadcaster/bot accounts, and links to the OBS / Grafana
 // / Traefik / Hubble dashboards. Replaces the bare 404 that used to sit on "/".
-func adminHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) adminHandler(w http.ResponseWriter, r *http.Request) {
 	vlc := siblingStatus(r.Context(), "vlc", c.Conf.VlcServerHost)
 	onscreens := siblingStatus(r.Context(), "onscreens", c.Conf.OnscreensServerHost)
 	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
@@ -234,17 +234,17 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 		Env:            c.Conf.Environment,
 		Uptime:         time.Since(startedAt).Round(time.Second).String(),
 		Chatters:       chatterCount(),
-		Services:       gatherStatus(buildSHA(), vlc, onscreens, obs),
+		Services:       s.gatherStatus(buildSHA(), vlc, onscreens, obs),
 		Now:            currentVideo(vlc.OK),
 		Audio:          nowPlayingFetcher(r.Context()),
 		Stream:         gatherStream(r.Context()),
 		PanelHost:      panelHost(r),
 		Links:          gatherLinks(),
-		Flags:          gatherFlags(r.Context()),
+		Flags:          s.gatherFlags(r.Context()),
 		Reauth:         accountsNeedingReauth(),
 		AuthStatuses:   authStatuses(),
-		ChatHistory:    defaultServer.hub.snapshotChat(),
-		MapTrailJSON:   mapTrailJSON(),
+		ChatHistory:    s.hub.snapshotChat(),
+		MapTrailJSON:   s.mapTrailJSON(),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -264,11 +264,11 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 // gatherStatus reports tripbot's own readiness (in-memory, free) and folds in
 // the already-probed sibling-service rows. Each row carries its build tag in a
 // version column linking to that build's changelog at the deployed sha.
-func gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
+func (s *Server) gatherStatus(sha string, siblings ...serviceStatus) []serviceStatus {
 	tripbot := serviceStatus{
 		Name:       "tripbot",
-		OK:         defaultServer.twitchConnected.Load(),
-		Version:    defaultServer.versionTag,
+		OK:         s.twitchConnected.Load(),
+		Version:    s.versionTag,
 		VersionURL: changelogURL(sha),
 		Uptime:     uptimeSince(startedAt),
 	}
@@ -319,8 +319,8 @@ func uptimeSince(t time.Time) string {
 // flag into the small display row the template renders. Returns nil when
 // no flags are loaded yet (startup window before SetFlagClient) so the
 // template's {{if .Flags}} hides the section cleanly.
-func gatherFlags(ctx context.Context) []featureFlag {
-	flags := defaultServer.flagSnapshot(ctx)
+func (s *Server) gatherFlags(ctx context.Context) []featureFlag {
+	flags := s.flagSnapshot(ctx)
 	if len(flags) == 0 {
 		return nil
 	}
@@ -464,7 +464,7 @@ func obsStreamActionHandler(w http.ResponseWriter, r *http.Request) {
 // in the DOM is fragile, and those values are low-volatility — they refresh on
 // the next full page load. Same sibling-ping cost as the root render; fine at
 // 15s for a single-operator panel.
-func refreshHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) refreshHandler(w http.ResponseWriter, r *http.Request) {
 	vlc := siblingStatus(r.Context(), "vlc", c.Conf.VlcServerHost)
 	onscreens := siblingStatus(r.Context(), "onscreens", c.Conf.OnscreensServerHost)
 	obs := siblingStatus(r.Context(), "obs", c.Conf.ObsServerHost)
@@ -474,7 +474,7 @@ func refreshHandler(w http.ResponseWriter, r *http.Request) {
 
 	var sb strings.Builder
 	sb.WriteString(`<ul id="status-list" hx-swap-oob="true">`)
-	sb.WriteString(renderStatusRows(gatherStatus(buildSHA(), vlc, onscreens, obs)))
+	sb.WriteString(renderStatusRows(s.gatherStatus(buildSHA(), vlc, onscreens, obs)))
 	sb.WriteString(`</ul>`)
 	sb.WriteString(renderStreamControl(gatherStream(r.Context()), true))
 	if _, err := w.Write([]byte(sb.String())); err != nil {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/feature"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/adanalife/tripbot/pkg/video"
@@ -405,7 +406,7 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		c.Conf.ExternalURL = "https://tripbot.prod.whereisdana.today"
 		c.Conf.Environment = "production"
 	})
-	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
+	withCurrentlyPlaying(t, srv, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
 	withChatterCount(t, 12)
 
 	srv.SetVersion("v1.2.3")
@@ -470,7 +471,7 @@ func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	})
 	// even with a video loaded, an unhealthy vlc hides "now playing" rather
 	// than showing a possibly-stale value.
-	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
+	withCurrentlyPlaying(t, srv, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
 	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -508,14 +509,17 @@ func withConf(t *testing.T, set func()) {
 	set()
 }
 
-// withCurrentlyPlaying swaps the currentlyPlaying / currentProgress seams so
-// the admin handler sees a fixed video + progress without driving the player.
-func withCurrentlyPlaying(t *testing.T, v video.Video, progress time.Duration) {
+// withCurrentlyPlaying seeds srv's hub with a video.changed so the admin
+// handler renders a fixed "now playing" — mirroring how it reads now-playing
+// from the NATS hub cache in production. progress maps to the event's
+// emitted_at (clip start = now - progress).
+func withCurrentlyPlaying(t *testing.T, srv *Server, v video.Video, progress time.Duration) {
 	t.Helper()
-	savedV, savedP := currentlyPlaying, currentProgress
-	currentlyPlaying = func() video.Video { return v }
-	currentProgress = func() time.Duration { return progress }
-	t.Cleanup(func() { currentlyPlaying, currentProgress = savedV, savedP })
+	srv.hub.setNowPlaying(eventbus.VideoChanged{
+		File:      v.File(),
+		State:     v.State,
+		EmittedAt: time.Now().Add(-progress).Format(time.RFC3339Nano),
+	})
 }
 
 // withChatterCount swaps the chatterCount seam to a fixed value.

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -303,8 +303,8 @@ func TestRestartActionHandler_UnknownServiceIs400(t *testing.T) {
 }
 
 func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 
 	// stream active → the OOB widget should offer "stop"
 	savedStatus := obsStreamStatus
@@ -335,7 +335,7 @@ func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
 	c.Conf.ObsServerHost = "" // skip the obs sibling ping
 
 	rec := httptest.NewRecorder()
-	refreshHandler(rec, httptest.NewRequest(http.MethodGet, "/admin/refresh", nil))
+	srv.refreshHandler(rec, httptest.NewRequest(http.MethodGet, "/admin/refresh", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -361,8 +361,8 @@ func TestRefreshHandler_RendersOOBStatusAndStreamControl(t *testing.T) {
 }
 
 func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withReauth(t, nil) // healthy tokens — no re-auth callout
 	withAuthStatuses(t, []mytwitch.AccountTokenStatus{
 		{Account: "bot", LoginAs: "tripbot4000", ExpiresAt: time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)},
@@ -408,12 +408,10 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, 3*time.Minute+12*time.Second)
 	withChatterCount(t, 12)
 
-	saved := defaultServer.versionTag
-	defer func() { defaultServer.versionTag = saved }()
-	SetVersion("v1.2.3")
+	srv.SetVersion("v1.2.3")
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -460,8 +458,8 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 
 func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	withNowPlaying(t, nowPlayingTrack{}) // no audio info — keeps assertion on "now playing" absence valid
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(false)
+	srv := New()
+	srv.SetTwitchConnected(false)
 	withReauth(t, nil)
 
 	withConf(t, func() {
@@ -475,7 +473,7 @@ func TestAdminHandler_DegradedAndVlcUnreachable(t *testing.T) {
 	withCurrentlyPlaying(t, video.Video{Slug: "wy_0042", State: "Wyoming"}, time.Minute)
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
@@ -558,8 +556,8 @@ func withNowPlaying(t *testing.T, track nowPlayingTrack) {
 }
 
 func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(false)
+	srv := New()
+	srv.SetTwitchConnected(false)
 	withNowPlaying(t, nowPlayingTrack{})
 
 	withConf(t, func() {
@@ -574,7 +572,7 @@ func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -595,8 +593,8 @@ func TestAdminHandler_RendersReauthPrompt(t *testing.T) {
 
 func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	withNowPlaying(t, nowPlayingTrack{})
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
 	withReauth(t, nil) // all tokens healthy
@@ -605,31 +603,25 @@ func TestAdminHandler_NoReauthPromptWhenHealthy(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if strings.Contains(rec.Body.String(), "re-authenticate") {
 		t.Errorf("re-auth prompt should be hidden when no account needs re-auth")
 	}
 }
 
-func withFlags(t *testing.T, flags map[string]feature.Flag) {
+func withFlags(t *testing.T, srv *Server, flags map[string]feature.Flag) {
 	t.Helper()
-	saved := defaultServer.flagClient
-	SetFlagClient(feature.NewInMemoryClient(flags))
-	t.Cleanup(func() {
-		defaultServer.flagMu.Lock()
-		defaultServer.flagClient = saved
-		defaultServer.flagMu.Unlock()
-	})
+	srv.SetFlagClient(feature.NewInMemoryClient(flags))
 }
 
 func TestAdminHandler_RendersFeatureFlagsWhenLoaded(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withFlags(t, map[string]feature.Flag{
+	withFlags(t, srv, map[string]feature.Flag{
 		"discord.bot_enabled": {
 			Key:               "discord.bot_enabled",
 			Description:       "Gates pkg/discord startup.",
@@ -645,7 +637,7 @@ func TestAdminHandler_RendersFeatureFlagsWhenLoaded(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -671,47 +663,44 @@ func TestAdminHandler_RendersFeatureFlagsWhenLoaded(t *testing.T) {
 }
 
 func TestAdminHandler_HidesFeatureFlagsSectionWhenEmpty(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withFlags(t, nil) // no flags loaded
+	withFlags(t, srv, nil) // no flags loaded
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if strings.Contains(rec.Body.String(), "feature flags") {
 		t.Errorf("feature flags section should be hidden when no flags are loaded")
 	}
 }
 
-// withChatHistory swaps the process hub for a fresh one seeded with lines,
-// restoring the original after the test.
-func withChatHistory(t *testing.T, lines []ChatLine) {
+// withChatHistory seeds srv's hub with a fresh ring containing the given lines.
+func withChatHistory(t *testing.T, srv *Server, lines []ChatLine) {
 	t.Helper()
-	saved := defaultServer.hub
 	h := NewHub()
 	for _, l := range lines {
 		h.appendChat(l)
 	}
-	defaultServer.hub = h
-	t.Cleanup(func() { defaultServer.hub = saved })
+	srv.hub = h
 }
 
 func TestAdminHandler_RendersChatHistoryAndSSEWiring(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withChatHistory(t, []ChatLine{
+	withChatHistory(t, srv, []ChatLine{
 		{Username: "alice", Text: "hello", At: time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC)},
 		{Username: "bob", Text: "<b>hi</b>", At: time.Date(2026, 5, 29, 13, 6, 0, 0, time.UTC)},
 	})
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -730,15 +719,15 @@ func TestAdminHandler_RendersChatHistoryAndSSEWiring(t *testing.T) {
 }
 
 func TestAdminHandler_ChatEmptyPlaceholder(t *testing.T) {
-	defer SetTwitchConnected(false)
-	SetTwitchConnected(true)
+	srv := New()
+	srv.SetTwitchConnected(true)
 	withNowPlaying(t, nowPlayingTrack{})
 	withReauth(t, nil)
 	withConf(t, func() { c.Conf.VlcServerHost = "" })
-	withChatHistory(t, nil) // empty ring
+	withChatHistory(t, srv, nil) // empty ring
 
 	rec := httptest.NewRecorder()
-	adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if !strings.Contains(rec.Body.String(), "waiting for chat") {
 		t.Errorf("expected empty-chat placeholder when no history")

--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -16,7 +16,7 @@ const sseHeartbeat = 20 * time.Second
 // eventsHandler streams live-console events to the browser over Server-Sent
 // Events. HTMX's sse extension connects here (sse-connect="/admin/events") and
 // routes each named event to its sse-swap target.
-func eventsHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	rc := http.NewResponseController(w)
 
@@ -41,8 +41,8 @@ func eventsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ch := defaultServer.hub.register()
-	defer defaultServer.hub.unregister(ch)
+	ch := s.hub.register()
+	defer s.hub.unregister(ch)
 
 	heartbeat := time.NewTicker(sseHeartbeat)
 	defer heartbeat.Stop()

--- a/pkg/server/events_test.go
+++ b/pkg/server/events_test.go
@@ -66,6 +66,7 @@ func waitFor(t *testing.T, cond func() bool) {
 }
 
 func TestEventsHandler_streamsChatEvent(t *testing.T) {
+	srv := New()
 	rec := newFlushRecorder()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -73,15 +74,15 @@ func TestEventsHandler_streamsChatEvent(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		eventsHandler(rec, req)
+		srv.eventsHandler(rec, req)
 		close(done)
 	}()
 
 	// Wait until the handler has registered with the hub, so our broadcast
 	// isn't dropped before the client channel exists.
-	waitFor(t, func() bool { return defaultServer.hub.numSubscribers() >= 1 })
+	waitFor(t, func() bool { return srv.hub.numSubscribers() >= 1 })
 
-	defaultServer.hub.broadcast(sseEvent{Name: "chat", Data: `<div class="chat-line">hi</div>`})
+	srv.hub.broadcast(sseEvent{Name: "chat", Data: `<div class="chat-line">hi</div>`})
 
 	select {
 	case <-rec.writes:
@@ -105,14 +106,15 @@ func TestEventsHandler_streamsChatEvent(t *testing.T) {
 	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
 		t.Errorf("Cache-Control = %q, want no-store", cc)
 	}
-	if defaultServer.hub.numSubscribers() != 0 {
-		t.Errorf("subscriber not cleaned up after disconnect: %d", defaultServer.hub.numSubscribers())
+	if srv.hub.numSubscribers() != 0 {
+		t.Errorf("subscriber not cleaned up after disconnect: %d", srv.hub.numSubscribers())
 	}
 }
 
 // TestEventsHandler_flattensNewlines guards SSE framing: a data fragment with a
 // stray newline must not break the "event:/data:" framing.
 func TestEventsHandler_flattensNewlines(t *testing.T) {
+	srv := New()
 	rec := newFlushRecorder()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -120,12 +122,12 @@ func TestEventsHandler_flattensNewlines(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		eventsHandler(rec, req)
+		srv.eventsHandler(rec, req)
 		close(done)
 	}()
-	waitFor(t, func() bool { return defaultServer.hub.numSubscribers() >= 1 })
+	waitFor(t, func() bool { return srv.hub.numSubscribers() >= 1 })
 
-	defaultServer.hub.broadcast(sseEvent{Name: "chat", Data: "line1\nline2"})
+	srv.hub.broadcast(sseEvent{Name: "chat", Data: "line1\nline2"})
 	select {
 	case <-rec.writes:
 	case <-time.After(2 * time.Second):

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -32,8 +32,6 @@ var helixClient = mytwitch.Client
 
 // SetVersion lets cmd/tripbot inject its build-time version string
 // before the HTTP server starts.
-func SetVersion(v string) { defaultServer.SetVersion(v) }
-
 func (s *Server) SetVersion(v string) {
 	if v != "" {
 		s.versionTag = v
@@ -52,8 +50,6 @@ func (s *Server) SetVersion(v string) {
 
 // SetTwitchConnected updates the chat-connection signal: the in-memory flag
 // the admin panel reads and the tripbot_twitch_connected gauge.
-func SetTwitchConnected(connected bool) { defaultServer.SetTwitchConnected(connected) }
-
 func (s *Server) SetTwitchConnected(connected bool) {
 	s.twitchConnected.Store(connected)
 	instrumentation.TwitchConnection.Set(connected)
@@ -61,8 +57,6 @@ func (s *Server) SetTwitchConnected(connected bool) {
 
 // TwitchConnected reports the last-known chat-connection state, for the
 // admin panel's status row.
-func TwitchConnected() bool { return defaultServer.TwitchConnected() }
-
 func (s *Server) TwitchConnected() bool {
 	return s.twitchConnected.Load()
 }
@@ -74,8 +68,6 @@ func (s *Server) TwitchConnected() bool {
 
 // SetFlagClient lets cmd/tripbot install the Postgres-backed FlagClient
 // once startFeatureFlags has loaded the initial snapshot.
-func SetFlagClient(fc feature.FlagClient) { defaultServer.SetFlagClient(fc) }
-
 func (s *Server) SetFlagClient(fc feature.FlagClient) {
 	s.flagMu.Lock()
 	s.flagClient = fc
@@ -94,13 +86,13 @@ func (s *Server) flagSnapshot(ctx context.Context) []feature.Flag {
 // build-time ldflag; sha + built_at are read from the binary's embedded
 // VCS info (Go's automatic -buildvcs). started_at is when the process
 // began (admin.startedAt) so callers can derive uptime themselves.
-func versionHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
 		Tag       string `json:"tag"`
 		Sha       string `json:"sha"`
 		BuiltAt   string `json:"built_at"`
 		StartedAt string `json:"started_at"`
-	}{Tag: defaultServer.versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
+	}{Tag: s.versionTag, StartedAt: startedAt.UTC().Format(time.RFC3339)}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -16,28 +16,27 @@ import (
 // probe. The probe itself (httpmw.ReadinessHandler with no checks → always
 // 200) is covered in pkg/httpmw; here we just guard the signal accessors.
 func TestTwitchConnectedSignal(t *testing.T) {
-	defer SetTwitchConnected(false) // reset package state for other tests
+	srv := New()
 
-	SetTwitchConnected(false)
-	if TwitchConnected() {
+	srv.SetTwitchConnected(false)
+	if srv.TwitchConnected() {
 		t.Fatalf("after SetTwitchConnected(false), TwitchConnected() = true, want false")
 	}
 
-	SetTwitchConnected(true)
-	if !TwitchConnected() {
+	srv.SetTwitchConnected(true)
+	if !srv.TwitchConnected() {
 		t.Fatalf("after SetTwitchConnected(true), TwitchConnected() = false, want true")
 	}
 }
 
 func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
-	saved := defaultServer.versionTag
-	defer func() { defaultServer.versionTag = saved }()
-	SetVersion("v9.9.9-test")
+	srv := New()
+	srv.SetVersion("v9.9.9-test")
 
 	req := httptest.NewRequest(http.MethodGet, "/version", nil)
 	rec := httptest.NewRecorder()
 
-	versionHandler(rec, req)
+	srv.versionHandler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -75,6 +75,13 @@ type Hub struct {
 	// mapTrail is the recent GPS breadcrumb trail (bounded by mapTrailSize),
 	// appended on each video.changed that carries a real fix.
 	mapTrail []mapPoint
+
+	// nowPlaying is the last video.changed seen, cached so the initial page
+	// render can show "now playing" from NATS instead of reaching into
+	// pkg/video in-process. nowPlayingKnown gates it (nothing seen yet → the
+	// panel hides the card). Populated by handleVideoChanged.
+	nowPlaying      eventbus.VideoChanged
+	nowPlayingKnown bool
 }
 
 // NewHub returns an unstarted hub. Safe to construct at package-init time — it
@@ -173,15 +180,16 @@ func (h *Hub) updateViewers(count int) string {
 	return dir
 }
 
-// handleVideoChanged forwards a video switch to the panel's "now playing"
-// card. There's no ring to keep — the page renders the current video on load
-// and this just refreshes it; the hub holds no video state.
+// handleVideoChanged caches the switch as the current "now playing" (so the
+// initial page render reads it from here instead of pkg/video in-process) and
+// forwards it to connected panels' "now playing" card.
 func (h *Hub) handleVideoChanged(ctx context.Context, data []byte) {
 	var ev eventbus.VideoChanged
 	if err := json.Unmarshal(data, &ev); err != nil {
 		slog.ErrorContext(ctx, "live-console hub: bad video payload", "err", err)
 		return
 	}
+	h.setNowPlaying(ev)
 	h.broadcast(sseEvent{Name: "video", Data: renderVideoLine(ev)})
 
 	// Drop a breadcrumb for the live map when the clip has a real GPS fix.
@@ -190,6 +198,22 @@ func (h *Hub) handleVideoChanged(ctx context.Context, data []byte) {
 		h.appendMapPoint(p)
 		h.broadcast(sseEvent{Name: "map", Data: renderMapPoint(p)})
 	}
+}
+
+// setNowPlaying caches the latest video.changed as the current clip.
+func (h *Hub) setNowPlaying(ev eventbus.VideoChanged) {
+	h.mu.Lock()
+	h.nowPlaying = ev
+	h.nowPlayingKnown = true
+	h.mu.Unlock()
+}
+
+// snapshotNowPlaying returns the last video.changed seen and whether one has
+// arrived yet, for the initial page render.
+func (h *Hub) snapshotNowPlaying() (eventbus.VideoChanged, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.nowPlaying, h.nowPlayingKnown
 }
 
 // hasFix reports whether a video.changed carries usable coordinates — flagged

--- a/pkg/server/hub.go
+++ b/pkg/server/hub.go
@@ -224,11 +224,11 @@ func renderMapPoint(p mapPoint) string {
 	return fmt.Sprintf(`<span data-lat="%.6f" data-lng="%.6f"></span>`, p.Lat, p.Lng)
 }
 
-// mapTrailJSON returns the process hub's breadcrumb trail as a JSON
+// mapTrailJSON returns the server hub's breadcrumb trail as a JSON
 // [[lat,lng],…] string for the page's map data attribute (empty "[]" when
 // there's no trail yet).
-func mapTrailJSON() string {
-	trail := defaultServer.hub.snapshotMapTrail()
+func (s *Server) mapTrailJSON() string {
+	trail := s.hub.snapshotMapTrail()
 	pts := make([][2]float64, len(trail))
 	for i, p := range trail {
 		pts[i] = [2]float64{p.Lat, p.Lng}
@@ -384,6 +384,4 @@ func renderVideoLine(ev eventbus.VideoChanged) string {
 
 // StartEventHub begins the hub's NATS subscription. Call from main() AFTER
 // natsclient.Connect — at server.Start time NATS isn't connected yet.
-func StartEventHub(ctx context.Context) { defaultServer.StartEventHub(ctx) }
-
 func (s *Server) StartEventHub(ctx context.Context) { s.hub.Start(ctx) }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,11 +31,10 @@ import (
 
 // Server holds the web server's mutable runtime state — the live-console hub,
 // the Twitch chat-connection flag, the build version tag, and the feature-flag
-// client the admin panel reads. cmd/tripbot installs values via the setter
-// methods (SetVersion / SetTwitchConnected / SetFlagClient) before and while
-// Start runs. The package-level functions below delegate to a process-wide
-// defaultServer so existing callers stay unchanged during the no-globals
-// transition.
+// client the admin panel reads. cmd/tripbot constructs one via New, installs
+// values through the setter methods (SetVersion / SetTwitchConnected /
+// SetFlagClient) before and while Start runs, and the HTTP handlers are
+// methods on it so the panel reads this instance's state — no package global.
 type Server struct {
 	hub             *Hub
 	twitchConnected atomic.Bool
@@ -56,18 +55,11 @@ func New() *Server {
 	}
 }
 
-// defaultServer is the process-wide Server backing the package-level shims and
-// the free-function HTTP handlers (which read defaultServer's fields).
-var defaultServer = New()
-
 // shutdownTimeout is how long Shutdown waits for in-flight requests to
 // finish before forcing connections closed. 15s is the typical sweet spot:
 // long enough that healthy requests complete, short enough that a stuck
 // handler doesn't block process exit indefinitely.
 const shutdownTimeout = 15 * time.Second
-
-// Start is the package-level shim delegating to defaultServer.
-func Start(ctx context.Context) { defaultServer.Start(ctx) }
 
 // Start starts the web server. When ctx is canceled (e.g. SIGINT/SIGTERM
 // via signal.NotifyContext) the server stops accepting new connections and
@@ -88,7 +80,7 @@ func (s *Server) Start(ctx context.Context) {
 	hp.Handle("/ready", tagged("/health/ready", httpmw.ReadinessHandler()))
 
 	// version endpoint — returns build metadata as JSON
-	r.Handle("/version", tagged("/version", versionHandler)).Methods("GET", "HEAD")
+	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")
 
 	// auth endpoints
 	auth := r.PathPrefix("/auth").Methods("GET").Subrouter()
@@ -102,15 +94,15 @@ func (s *Server) Start(ctx context.Context) {
 	r.Path("/metrics").Handler(tagged("/metrics", promhttp.Handler().ServeHTTP))
 
 	// admin panel (status overview + links) on the root path
-	r.Handle("/", tagged("/", adminHandler)).Methods("GET", "HEAD")
+	r.Handle("/", tagged("/", s.adminHandler)).Methods("GET", "HEAD")
 
 	// live console: SSE stream the panel subscribes to (GET, long-lived) +
 	// the vendored htmx assets it loads. The /admin POST subrouter below is
 	// POST-only, so the GET stream registers on r directly.
-	r.Handle("/admin/events", tagged("/admin/events", eventsHandler)).Methods("GET")
+	r.Handle("/admin/events", tagged("/admin/events", s.eventsHandler)).Methods("GET")
 	// live panel refresh: hidden poller OOB-swaps the always-present status rows
 	// + stream toggle so they stay current without a full reload.
-	r.Handle("/admin/refresh", tagged("/admin/refresh", refreshHandler)).Methods("GET")
+	r.Handle("/admin/refresh", tagged("/admin/refresh", s.refreshHandler)).Methods("GET")
 	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -3,7 +3,6 @@ package users
 import (
 	"context"
 	"fmt"
-	"html"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -102,33 +101,6 @@ func (s *Sessions) printLeaderboard() {
 	for i, pair := range s.lifetimeLeaderboard {
 		fmt.Printf("%d: %s - %s\n", i+1, pair[1], aurora.Magenta(pair[0]))
 	}
-}
-
-// LeaderboardContent renders the leaderboard onscreen as a CSS-grid HTML
-// fragment. The score column auto-sizes to the widest entry via
-// grid-template-columns, so digits line up across rows regardless of font.
-// The onscreen is registered with RenderAsHTML in onscreenRegistry so the
-// browser-source template injects this via innerHTML.
-func LeaderboardContent(title string, leaderboard [][]string) string {
-	size := 5
-	if len(leaderboard) < size {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
-
-	var b strings.Builder
-	b.WriteString(`<div class="lb-grid">`)
-	fmt.Fprintf(&b, `<div class="lb-title">%s</div>`, html.EscapeString(strings.Title(title)))
-	for _, row := range leaderboard {
-		fmt.Fprintf(
-			&b,
-			`<span class="lb-score">%s</span><span class="lb-user">(%s)</span>`,
-			html.EscapeString(row[1]),
-			html.EscapeString(row[0]),
-		)
-	}
-	b.WriteString(`</div>`)
-	return b.String()
 }
 
 // LifetimeMilesLeaderboard returns the cached lifetime-miles leaderboard from

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -13,12 +13,11 @@ import (
 	"github.com/logrusorgru/aurora/v3"
 )
 
-var LifetimeMilesLeaderboard [][]string
 var initLeaderboardSize = 25
 var maxLeaderboardSize = 50
 
 // InitLeaderboard creates the initial leaderboard
-func InitLeaderboard(ctx context.Context) {
+func (s *Sessions) InitLeaderboard(ctx context.Context) {
 	var users []User
 
 	result := database.GormDB().WithContext(ctx).
@@ -33,24 +32,24 @@ func InitLeaderboard(ctx context.Context) {
 	for _, user := range users {
 		miles := fmt.Sprintf("%.1f", user.Miles)
 		pair := []string{user.Username, miles}
-		LifetimeMilesLeaderboard = append(LifetimeMilesLeaderboard, pair)
+		s.lifetimeLeaderboard = append(s.lifetimeLeaderboard, pair)
 	}
 }
 
 // UpdateLeaderboard rebuilds the lifetime-miles leaderboard from the
-// LoggedIn map. The work is in-memory (no DB hits), so ctx only carries
-// the cron-tick span for log correlation.
-func UpdateLeaderboard(ctx context.Context) {
-	for _, user := range LoggedIn {
+// session's logged-in users. The work is in-memory (no DB hits), so ctx
+// only carries the cron-tick span for log correlation.
+func (s *Sessions) UpdateLeaderboard(ctx context.Context) {
+	for _, user := range s.loggedIn {
 		// skip adding this user if they're a bot or the channel owner
 		if user.IsBot || c.UserIsAdmin(user.Username) {
 			continue
 		}
-		insertIntoLeaderboard(ctx, *user)
+		s.insertIntoLeaderboard(ctx, *user)
 	}
-	// truncate LifetimeMilesLeaderboard if it gets too big
-	if len(LifetimeMilesLeaderboard) > maxLeaderboardSize {
-		LifetimeMilesLeaderboard = LifetimeMilesLeaderboard[:maxLeaderboardSize]
+	// truncate the leaderboard if it gets too big
+	if len(s.lifetimeLeaderboard) > maxLeaderboardSize {
+		s.lifetimeLeaderboard = s.lifetimeLeaderboard[:maxLeaderboardSize]
 	}
 }
 
@@ -64,44 +63,43 @@ func strToFloat32(ctx context.Context, str string) float32 {
 	return float32(value)
 }
 
-func insertIntoLeaderboard(ctx context.Context, user User) {
+func (s *Sessions) insertIntoLeaderboard(ctx context.Context, user User) {
 	// first we remove this user from the board
-	removeFromLeaderboard(user.Username)
+	s.removeFromLeaderboard(user.Username)
 
 	// get the current miles as a float
 	miles := user.CurrentMiles(ctx)
 
-	for i, pair := range LifetimeMilesLeaderboard {
+	for i, pair := range s.lifetimeLeaderboard {
 		val := strToFloat32(ctx, pair[1])
 		// see if our miles are higher
 		if miles >= val {
 			milesStr := fmt.Sprintf("%.1f", miles)
 			newPair := []string{user.Username, milesStr}
 
-			// insert into LifetimeMilesLeaderboard
+			// insert into the leaderboard
 			// https://github.com/golang/go/wiki/SliceTricks#insert
-			LifetimeMilesLeaderboard = append(LifetimeMilesLeaderboard[:i], append([][]string{newPair}, LifetimeMilesLeaderboard[i:]...)...)
+			s.lifetimeLeaderboard = append(s.lifetimeLeaderboard[:i], append([][]string{newPair}, s.lifetimeLeaderboard[i:]...)...)
 			return
 		}
 	}
 }
 
-// removeFromLeaderboard searches the LifetimeMilesLeaderboard for
-// a username and removes it
-func removeFromLeaderboard(username string) {
-	for i, pair := range LifetimeMilesLeaderboard {
+// removeFromLeaderboard searches the leaderboard for a username and removes it
+func (s *Sessions) removeFromLeaderboard(username string) {
+	for i, pair := range s.lifetimeLeaderboard {
 		if pair[0] == username {
-			// delete from LifetimeMilesLeaderboard
+			// delete from the leaderboard
 			// https://github.com/golang/go/wiki/SliceTricks#delete
-			LifetimeMilesLeaderboard = append(LifetimeMilesLeaderboard[:i], LifetimeMilesLeaderboard[i+1:]...)
+			s.lifetimeLeaderboard = append(s.lifetimeLeaderboard[:i], s.lifetimeLeaderboard[i+1:]...)
 			return
 		}
 	}
 }
 
 // this was used for development
-func printLeaderboard() {
-	for i, pair := range LifetimeMilesLeaderboard {
+func (s *Sessions) printLeaderboard() {
+	for i, pair := range s.lifetimeLeaderboard {
 		fmt.Printf("%d: %s - %s\n", i+1, pair[1], aurora.Magenta(pair[0]))
 	}
 }
@@ -132,3 +130,12 @@ func LeaderboardContent(title string, leaderboard [][]string) string {
 	b.WriteString(`</div>`)
 	return b.String()
 }
+
+// LifetimeMilesLeaderboard returns the cached lifetime-miles leaderboard from
+// the default session. Was a package-level slice; now an accessor over the
+// session-owned state.
+func LifetimeMilesLeaderboard() [][]string { return defaultSessions.lifetimeLeaderboard }
+
+func InitLeaderboard(ctx context.Context) { defaultSessions.InitLeaderboard(ctx) }
+
+func UpdateLeaderboard(ctx context.Context) { defaultSessions.UpdateLeaderboard(ctx) }

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -67,7 +67,7 @@ func (s *Sessions) insertIntoLeaderboard(ctx context.Context, user User) {
 	s.removeFromLeaderboard(user.Username)
 
 	// get the current miles as a float
-	miles := user.CurrentMiles(ctx)
+	miles := s.CurrentMiles(ctx, user)
 
 	for i, pair := range s.lifetimeLeaderboard {
 		val := strToFloat32(ctx, pair[1])
@@ -103,11 +103,7 @@ func (s *Sessions) printLeaderboard() {
 	}
 }
 
-// LifetimeMilesLeaderboard returns the cached lifetime-miles leaderboard from
-// the default session. Was a package-level slice; now an accessor over the
-// session-owned state.
-func LifetimeMilesLeaderboard() [][]string { return defaultSessions.lifetimeLeaderboard }
-
-func InitLeaderboard(ctx context.Context) { defaultSessions.InitLeaderboard(ctx) }
-
-func UpdateLeaderboard(ctx context.Context) { defaultSessions.UpdateLeaderboard(ctx) }
+// LifetimeLeaderboard returns the cached lifetime-miles leaderboard (a slice of
+// [username, miles] pairs), hydrated by InitLeaderboard and rebuilt by
+// UpdateLeaderboard.
+func (s *Sessions) LifetimeLeaderboard() [][]string { return s.lifetimeLeaderboard }

--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -2,7 +2,6 @@ package users
 
 import (
 	"context"
-	"strings"
 	"testing"
 )
 
@@ -23,104 +22,6 @@ func TestStrToFloat32Valid(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestLeaderboardContent(t *testing.T) {
-	board := [][]string{
-		{"alice", "100.5"},
-		{"bob", "75.2"},
-		{"carol", "50.0"},
-	}
-	got := LeaderboardContent("monthly miles", board)
-
-	if !strings.Contains(got, `<div class="lb-title">Monthly Miles</div>`) {
-		t.Fatalf("expected title-cased header, got %q", got)
-	}
-	for _, name := range []string{"alice", "bob", "carol"} {
-		if !strings.Contains(got, `<span class="lb-user">(`+name+`)</span>`) {
-			t.Fatalf("expected user span for %q, got %q", name, got)
-		}
-	}
-	if !strings.Contains(got, `<span class="lb-score">100.5</span><span class="lb-user">(alice)</span>`) {
-		t.Fatalf("expected adjacent score+user spans for alice, got %q", got)
-	}
-}
-
-func TestLeaderboardContentTruncatesToFive(t *testing.T) {
-	board := [][]string{
-		{"u1", "10"}, {"u2", "9"}, {"u3", "8"}, {"u4", "7"},
-		{"u5", "6"}, {"u6", "5"}, {"u7", "4"},
-	}
-	got := LeaderboardContent("top", board)
-
-	if strings.Contains(got, "u6") || strings.Contains(got, "u7") {
-		t.Fatalf("expected truncation to 5 entries, got %q", got)
-	}
-	for _, name := range []string{"u1", "u2", "u3", "u4", "u5"} {
-		if !strings.Contains(got, name) {
-			t.Fatalf("expected %q in top-5, got %q", name, got)
-		}
-	}
-}
-
-func TestLeaderboardContentSmallerThanFive(t *testing.T) {
-	board := [][]string{
-		{"alice", "100"},
-		{"bob", "50"},
-	}
-	got := LeaderboardContent("tiny", board)
-	if !strings.Contains(got, "alice") || !strings.Contains(got, "bob") {
-		t.Fatalf("expected both names, got %q", got)
-	}
-}
-
-func TestLeaderboardContentEmpty(t *testing.T) {
-	got := LeaderboardContent("nobody", nil)
-	want := `<div class="lb-grid"><div class="lb-title">Nobody</div></div>`
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-}
-
-// Scores render in their own span (no space-padding) so the CSS grid can
-// auto-size the column.
-func TestLeaderboardContentNoSpacePadding(t *testing.T) {
-	board := [][]string{
-		{"alice", "123"},
-		{"bob", "15"},
-		{"carol", "7"},
-	}
-	got := LeaderboardContent("guesses", board)
-
-	wantSpans := []string{
-		`<span class="lb-score">123</span><span class="lb-user">(alice)</span>`,
-		`<span class="lb-score">15</span><span class="lb-user">(bob)</span>`,
-		`<span class="lb-score">7</span><span class="lb-user">(carol)</span>`,
-	}
-	for _, want := range wantSpans {
-		if !strings.Contains(got, want) {
-			t.Fatalf("expected %q in output, got %q", want, got)
-		}
-	}
-	// No padding spaces between score and user spans.
-	if strings.Contains(got, "</span> <span") {
-		t.Fatalf("did not expect padding space between score/user spans, got %q", got)
-	}
-}
-
-// Defensive: usernames are normally [a-zA-Z0-9_] from Twitch, but the
-// renderer escapes anything that would break out of the surrounding HTML.
-func TestLeaderboardContentEscapesHTML(t *testing.T) {
-	board := [][]string{
-		{"<script>", "1"},
-	}
-	got := LeaderboardContent("xss", board)
-	if strings.Contains(got, "<script>") {
-		t.Fatalf("expected HTML-escaped username, got %q", got)
-	}
-	if !strings.Contains(got, "&lt;script&gt;") {
-		t.Fatalf("expected &lt;script&gt; escape, got %q", got)
 	}
 }
 

--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -124,26 +124,18 @@ func TestLeaderboardContentEscapesHTML(t *testing.T) {
 	}
 }
 
-// snapshotLeaderboard saves the global LifetimeMilesLeaderboard and returns a
-// restore func. Use with defer to keep tests from contaminating each other.
-func snapshotLeaderboard() func() {
-	saved := make([][]string, len(LifetimeMilesLeaderboard))
-	copy(saved, LifetimeMilesLeaderboard)
-	return func() { LifetimeMilesLeaderboard = saved }
-}
-
 func TestRemoveFromLeaderboard(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"alice", "100"}, {"bob", "75"}, {"carol", "50"},
 	}
 
-	removeFromLeaderboard("bob")
+	s.removeFromLeaderboard("bob")
 
-	if len(LifetimeMilesLeaderboard) != 2 {
-		t.Fatalf("expected 2 entries after remove, got %d", len(LifetimeMilesLeaderboard))
+	if len(s.lifetimeLeaderboard) != 2 {
+		t.Fatalf("expected 2 entries after remove, got %d", len(s.lifetimeLeaderboard))
 	}
-	for _, pair := range LifetimeMilesLeaderboard {
+	for _, pair := range s.lifetimeLeaderboard {
 		if pair[0] == "bob" {
 			t.Fatal("bob still present after remove")
 		}
@@ -151,77 +143,67 @@ func TestRemoveFromLeaderboard(t *testing.T) {
 }
 
 func TestRemoveFromLeaderboardMissing(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"alice", "100"}, {"bob", "75"},
 	}
 
-	removeFromLeaderboard("nobody")
+	s.removeFromLeaderboard("nobody")
 
-	if len(LifetimeMilesLeaderboard) != 2 {
-		t.Fatalf("expected unchanged length after missing remove, got %d", len(LifetimeMilesLeaderboard))
+	if len(s.lifetimeLeaderboard) != 2 {
+		t.Fatalf("expected unchanged length after missing remove, got %d", len(s.lifetimeLeaderboard))
 	}
 }
 
 func TestRemoveFromLeaderboardEmpty(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = nil
+	s := New(noopChatterSource{})
 
-	removeFromLeaderboard("alice")
+	s.removeFromLeaderboard("alice")
 
-	if len(LifetimeMilesLeaderboard) != 0 {
-		t.Fatalf("expected empty leaderboard, got %v", LifetimeMilesLeaderboard)
+	if len(s.lifetimeLeaderboard) != 0 {
+		t.Fatalf("expected empty leaderboard, got %v", s.lifetimeLeaderboard)
 	}
 }
 
-// insertIntoLeaderboard pulls miles from User.CurrentMiles, which uses the
-// global LoggedIn map. We seed the map with a session snapshot so the math is
-// deterministic.
+// insertIntoLeaderboard pulls miles from User.CurrentMiles. The user isn't in
+// the default session, so CurrentMiles returns User.Miles directly (no session
+// bonus) — making the math deterministic.
 func TestInsertIntoLeaderboardOrdersByMilesDesc(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"existing-1", "100"},
 		{"existing-2", "50"},
 		{"existing-3", "10"},
 	}
 
-	savedLoggedIn := LoggedIn
-	defer func() { LoggedIn = savedLoggedIn }()
-	LoggedIn = map[string]*User{}
-
-	// Miles=75 from User.Miles directly (no session bonus, since not in LoggedIn).
 	u := User{Username: "newcomer", Miles: 75}
-	insertIntoLeaderboard(context.Background(), u)
+	s.insertIntoLeaderboard(context.Background(), u)
 
-	if len(LifetimeMilesLeaderboard) != 4 {
+	if len(s.lifetimeLeaderboard) != 4 {
 		t.Fatalf("expected 4 entries after insert, got %d: %v",
-			len(LifetimeMilesLeaderboard), LifetimeMilesLeaderboard)
+			len(s.lifetimeLeaderboard), s.lifetimeLeaderboard)
 	}
-	if LifetimeMilesLeaderboard[1][0] != "newcomer" {
-		t.Fatalf("expected newcomer at index 1 (between 100 and 50), got order %v", LifetimeMilesLeaderboard)
+	if s.lifetimeLeaderboard[1][0] != "newcomer" {
+		t.Fatalf("expected newcomer at index 1 (between 100 and 50), got order %v", s.lifetimeLeaderboard)
 	}
 }
 
 func TestInsertIntoLeaderboardReplacesExistingUser(t *testing.T) {
-	defer snapshotLeaderboard()()
-	LifetimeMilesLeaderboard = [][]string{
+	s := New(noopChatterSource{})
+	s.lifetimeLeaderboard = [][]string{
 		{"alice", "100"},
 		{"bob", "50"},
 	}
 
-	savedLoggedIn := LoggedIn
-	defer func() { LoggedIn = savedLoggedIn }()
-	LoggedIn = map[string]*User{}
-
 	// Bob's miles increased to 200 — should jump above alice and replace his old row.
 	u := User{Username: "bob", Miles: 200}
-	insertIntoLeaderboard(context.Background(), u)
+	s.insertIntoLeaderboard(context.Background(), u)
 
-	if len(LifetimeMilesLeaderboard) != 2 {
+	if len(s.lifetimeLeaderboard) != 2 {
 		t.Fatalf("expected length unchanged after replace, got %d: %v",
-			len(LifetimeMilesLeaderboard), LifetimeMilesLeaderboard)
+			len(s.lifetimeLeaderboard), s.lifetimeLeaderboard)
 	}
-	if LifetimeMilesLeaderboard[0][0] != "bob" {
-		t.Fatalf("expected bob to be #1 with 200 miles, got %v", LifetimeMilesLeaderboard)
+	if s.lifetimeLeaderboard[0][0] != "bob" {
+		t.Fatalf("expected bob to be #1 with 200 miles, got %v", s.lifetimeLeaderboard)
 	}
 }

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -41,10 +41,10 @@ func New(source ChatterSource) *Sessions {
 	}
 }
 
-// defaultSessions is the process-wide Sessions used by the package-level
-// shims below and by User value-method reads of session state. Production
-// wires it to the Twitch-backed source; tests build their own *Sessions.
-var defaultSessions = New(twitchSource{})
+// NewDefault constructs the production Sessions, wired to the Twitch-backed
+// chatter source. cmd/tripbot constructs one and threads it through the boot
+// sequence + into chatbot/discord; tests build their own *Sessions via New.
+func NewDefault() *Sessions { return New(twitchSource{}) }
 
 // UpdateSession uses the chatter source to maintain the list of
 // currently-logged-in users.
@@ -129,7 +129,7 @@ func (s *Sessions) login(ctx context.Context, username string) *User {
 // logout removes the user from the list of currently-logged in users,
 // and updates the DB with their most up-to-date values
 func (s *Sessions) logout(ctx context.Context, u *User) {
-	sessionMiles := u.sessionMiles(ctx)
+	sessionMiles := s.sessionMiles(ctx, *u)
 
 	// print logout message if they're human
 	if !u.IsBot {
@@ -138,13 +138,13 @@ func (s *Sessions) logout(ctx context.Context, u *User) {
 			"user", u.String(),
 			"duration", durafmt.ParseShort(loggedInDur).String(),
 			"session_miles", sessionMiles,
-			"monthly_miles", u.CurrentMonthlyMiles(ctx),
+			"monthly_miles", s.CurrentMonthlyMiles(ctx, *u),
 			"guess_score", u.GetScore(ctx, scoreboards.CurrentGuessScoreboard()),
 		)
 	}
 
 	// update miles
-	u.Miles = u.CurrentMiles(ctx)
+	u.Miles = s.CurrentMiles(ctx, *u)
 	// update the last seen date
 	u.LastSeen = time.Now()
 	// store the user in the db
@@ -257,26 +257,5 @@ func (s *Sessions) PrintCurrentSession(ctx context.Context) {
 	)
 }
 
-// Package-level shims delegate to defaultSessions so existing callers
-// (cmd/tripbot, pkg/chatbot, ...) stay unchanged while the package's session
-// state moves onto Sessions. Threading a constructed *Sessions through those
-// callers (and dropping these shims) is a later stage of the no-globals work.
-
-func UpdateSession(ctx context.Context) { defaultSessions.UpdateSession(ctx) }
-
-func LoginIfNecessary(ctx context.Context, username string) *User {
-	return defaultSessions.LoginIfNecessary(ctx, username)
-}
-
-func LogoutIfNecessary(ctx context.Context, username string) {
-	defaultSessions.LogoutIfNecessary(ctx, username)
-}
-
-func Shutdown(ctx context.Context) { defaultSessions.Shutdown(ctx) }
-
-func GiveEveryoneMiles(gift float32) { defaultSessions.GiveEveryoneMiles(gift) }
-
-func PrintCurrentSession(ctx context.Context) { defaultSessions.PrintCurrentSession(ctx) }
-
-// LoggedInCount returns the number of users currently in the default session.
-func LoggedInCount() int { return len(defaultSessions.loggedIn) }
+// LoggedInCount returns the number of users currently in chat.
+func (s *Sessions) LoggedInCount() int { return len(s.loggedIn) }

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -97,6 +97,14 @@ func (s *Sessions) login(ctx context.Context, username string) *User {
 	now := time.Now()
 
 	user := FindOrCreate(ctx, username)
+	// A zero ID means FindOrCreate couldn't get a DB row (transient Find error
+	// or a failed create). Don't cache an un-saveable user in the session, or
+	// every later logout tick would fail save(). Return without logging them in;
+	// the next tick retries FindOrCreate and self-heals once the DB recovers.
+	if user.ID == 0 {
+		slog.WarnContext(ctx, "could not find or create user, skipping login", "username", username)
+		return &user
+	}
 	// increment the number of visits
 	user.NumVisits = user.NumVisits + 1
 	// set the login time

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -14,72 +14,86 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
 	"github.com/hako/durafmt"
-
-	"github.com/adanalife/tripbot/pkg/twitch"
-	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 )
 
 //TODO: consider moving this whole thing elsewhere (to background perhaps?)
 
-// LoggedIn is a map that contains all the currently logged-in users,
-// mapping their username to a User
-var LoggedIn = make(map[string]*User)
+// Sessions tracks the users currently logged in to one platform's chat plus
+// the derived lifetime-miles leaderboard. It owns what used to be the
+// package-level LoggedIn map and LifetimeMilesLeaderboard slice, so a single
+// process holds exactly one Sessions and a per-platform bot instance gets its
+// own (the prerequisite for running, e.g., a YouTube bot beside the Twitch
+// one). Its view of who is in chat comes from an injected ChatterSource.
+type Sessions struct {
+	source ChatterSource
+	// loggedIn maps username -> User for everyone currently in chat.
+	loggedIn map[string]*User
+	// lifetimeLeaderboard is the cached [username, miles] leaderboard,
+	// hydrated by InitLeaderboard and rebuilt by UpdateLeaderboard.
+	lifetimeLeaderboard [][]string
+}
 
-// UpdateSession will use the data from the Twitch API to maintain a list
-// of currently-logged-in users
-func UpdateSession(ctx context.Context) {
-	// fetch the latest chatters from Twitch
-	twitch.UpdateChatters()
-	currentChatters := twitch.Chatters()
+// New constructs a Sessions backed by the given ChatterSource.
+func New(source ChatterSource) *Sessions {
+	return &Sessions{
+		source:   source,
+		loggedIn: make(map[string]*User),
+	}
+}
+
+// defaultSessions is the process-wide Sessions used by the package-level
+// shims below and by User value-method reads of session state. Production
+// wires it to the Twitch-backed source; tests build their own *Sessions.
+var defaultSessions = New(twitchSource{})
+
+// UpdateSession uses the chatter source to maintain the list of
+// currently-logged-in users.
+func (s *Sessions) UpdateSession(ctx context.Context) {
+	// fetch the latest chatters from the platform
+	s.source.UpdateChatters()
+	currentChatters := s.source.Chatters()
 
 	// Publish the authoritative chatter total so the admin panel's live console
 	// updates the "in chat" number (and flashes it on a change) without a reload.
-	eventbus.EmitViewerCount(ctx, c.Conf.Environment, twitch.ChatterCount())
+	eventbus.EmitViewerCount(ctx, c.Conf.Environment, s.source.ChatterCount())
 
 	// log out the people who aren't present
-	for username, user := range LoggedIn {
+	for username, user := range s.loggedIn {
 		if _, ok := currentChatters[username]; ok {
 			// they're logged in and a current chatter, do nothing
 			continue
-		} else {
-			// they're logged in and NOT a current chatter, so log them out
-			user.logout(ctx)
-			continue
 		}
+		// they're logged in and NOT a current chatter, so log them out
+		s.logout(ctx, user)
 	}
 
 	// log in everybody else
 	//TODO: this could get slow, maybe make a list of users that need to be logged in?
-	for chatter, _ := range currentChatters {
-		LoginIfNecessary(ctx, chatter)
+	for chatter := range currentChatters {
+		s.LoginIfNecessary(ctx, chatter)
 	}
-
-	// PrintCurrentSession()
-	// twitch.PrintCurrentChatters()
 }
 
 // LoginIfNecessary checks the list of currently-logged in users and will
 // run login() if this user isn't currently logged in
-func LoginIfNecessary(ctx context.Context, username string) *User {
-	// check if the user is currently logged in
-	if isLoggedIn(username) {
-		return LoggedIn[username]
+func (s *Sessions) LoginIfNecessary(ctx context.Context, username string) *User {
+	if s.isLoggedIn(username) {
+		return s.loggedIn[username]
 	}
 	// they weren't logged in, so note in the DB
-	return login(ctx, username)
+	return s.login(ctx, username)
 }
 
 // LogoutIfNecessary will log out the user if it finds them in the session
-func LogoutIfNecessary(ctx context.Context, username string) {
-	if isLoggedIn(username) {
-		user := *LoggedIn[username]
-		user.logout(ctx)
+func (s *Sessions) LogoutIfNecessary(ctx context.Context, username string) {
+	if s.isLoggedIn(username) {
+		s.logout(ctx, s.loggedIn[username])
 	}
 }
 
 // login will record the users presence in the DB
 // TODO: do we want to make a DB update here? we could do it on logout()
-func login(ctx context.Context, username string) *User {
+func (s *Sessions) login(ctx context.Context, username string) *User {
 	now := time.Now()
 
 	user := FindOrCreate(ctx, username)
@@ -98,12 +112,12 @@ func login(ctx context.Context, username string) *User {
 	user.save(ctx)
 
 	// just a silly message to confirm subscriber feature is working
-	if mytwitch.UserIsSubscriber(username) {
+	if s.source.IsSubscriber(username) {
 		slog.InfoContext(ctx, "subscriber logged in", "username", username)
 	}
 
 	// add them to the session
-	LoggedIn[username] = &user
+	s.loggedIn[username] = &user
 
 	if err := events.Login(ctx, username, user.sessionID); err != nil {
 		slog.ErrorContext(ctx, "error creating login event", "err", err)
@@ -112,9 +126,9 @@ func login(ctx context.Context, username string) *User {
 	return &user
 }
 
-// User.logout() removes the user from the list of currently-logged in users,
+// logout removes the user from the list of currently-logged in users,
 // and updates the DB with their most up-to-date values
-func (u User) logout(ctx context.Context) {
+func (s *Sessions) logout(ctx context.Context, u *User) {
 	sessionMiles := u.sessionMiles(ctx)
 
 	// print logout message if they're human
@@ -144,40 +158,38 @@ func (u User) logout(ctx context.Context) {
 	}
 
 	// remove them from the session
-	delete(LoggedIn, u.Username)
+	delete(s.loggedIn, u.Username)
 }
 
 // isLoggedIn checks if the user is currently logged in
-func isLoggedIn(username string) bool {
-	if _, ok := LoggedIn[username]; ok {
-		return true
-	}
-	return false
+func (s *Sessions) isLoggedIn(username string) bool {
+	_, ok := s.loggedIn[username]
+	return ok
 }
 
-// ShutDown loops through all of the logged-in users and logs them out
-func Shutdown(ctx context.Context) {
+// Shutdown loops through all of the logged-in users and logs them out
+func (s *Sessions) Shutdown(ctx context.Context) {
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "logged-in users at shutdown")
-		spew.Dump(LoggedIn)
+		spew.Dump(s.loggedIn)
 	}
-	for _, user := range LoggedIn {
-		user.logout(ctx)
+	for _, user := range s.loggedIn {
+		s.logout(ctx, user)
 	}
 }
 
 // GiveEveryoneMiles gives all logged-in users miles
-func GiveEveryoneMiles(gift float32) {
+func (s *Sessions) GiveEveryoneMiles(gift float32) {
 	slog.Info("giving all logged-in users gift miles", "gift", gift)
-	for _, user := range LoggedIn {
+	for _, user := range s.loggedIn {
 		user.Miles += gift
 	}
 }
 
 // sortedUsernameList creates a list of only usernames, and sort it
-func sortedUsernameList() []string {
-	usernames := make([]string, 0, len(LoggedIn))
-	for username, _ := range LoggedIn {
+func (s *Sessions) sortedUsernameList() []string {
+	usernames := make([]string, 0, len(s.loggedIn))
+	for username := range s.loggedIn {
 		usernames = append(usernames, username)
 	}
 	sort.Sort(sort.StringSlice(usernames))
@@ -185,10 +197,10 @@ func sortedUsernameList() []string {
 }
 
 // colorizeUsernames loops over the sorted names and colorizes them
-func colorizeUsernames(usernames []string) []string {
+func (s *Sessions) colorizeUsernames(usernames []string) []string {
 	coloredUsernames := make([]string, 0, len(usernames))
 	for _, username := range usernames {
-		user := *LoggedIn[username]
+		user := *s.loggedIn[username]
 		if user.IsBot {
 			// don't add them to the output
 			continue
@@ -200,9 +212,9 @@ func colorizeUsernames(usernames []string) []string {
 }
 
 // humans returns the users in the session who are not bots
-func humans() []*User {
+func (s *Sessions) humans() []*User {
 	var humans []*User
-	for _, user := range LoggedIn {
+	for _, user := range s.loggedIn {
 		if !user.IsBot {
 			humans = append(humans, user)
 		}
@@ -211,14 +223,14 @@ func humans() []*User {
 }
 
 // countHumans returns the number of humans in the session
-func countHumans() int {
-	return len(humans())
+func (s *Sessions) countHumans() int {
+	return len(s.humans())
 }
 
 // bots returns the users in the session who are known bots
-func bots() []*User {
+func (s *Sessions) bots() []*User {
 	var bots []*User
-	for _, user := range LoggedIn {
+	for _, user := range s.loggedIn {
 		if user.IsBot {
 			bots = append(bots, user)
 		}
@@ -227,21 +239,44 @@ func bots() []*User {
 }
 
 // countBots returns the number of bots in the session
-func countBots() int {
-	return len(bots())
+func (s *Sessions) countBots() int {
+	return len(s.bots())
 }
 
 // PrintCurrentSession simply prints info about the current session.
-// ctx links the snapshot log line to the parent cron-tick span;
-// twitch.ChatterCount doesn't take ctx yet.
-func PrintCurrentSession(ctx context.Context) {
-	usernames := sortedUsernameList()
-	coloredUsernames := colorizeUsernames(usernames)
+// ctx links the snapshot log line to the parent cron-tick span.
+func (s *Sessions) PrintCurrentSession(ctx context.Context) {
+	usernames := s.sortedUsernameList()
+	coloredUsernames := s.colorizeUsernames(usernames)
 
 	slog.InfoContext(ctx, "session snapshot",
-		"chatters", twitch.ChatterCount(),
-		"humans", countHumans(),
-		"bots", countBots(),
+		"chatters", s.source.ChatterCount(),
+		"humans", s.countHumans(),
+		"bots", s.countBots(),
 		"logged_in", strings.Join(coloredUsernames, ", "),
 	)
 }
+
+// Package-level shims delegate to defaultSessions so existing callers
+// (cmd/tripbot, pkg/chatbot, ...) stay unchanged while the package's session
+// state moves onto Sessions. Threading a constructed *Sessions through those
+// callers (and dropping these shims) is a later stage of the no-globals work.
+
+func UpdateSession(ctx context.Context) { defaultSessions.UpdateSession(ctx) }
+
+func LoginIfNecessary(ctx context.Context, username string) *User {
+	return defaultSessions.LoginIfNecessary(ctx, username)
+}
+
+func LogoutIfNecessary(ctx context.Context, username string) {
+	defaultSessions.LogoutIfNecessary(ctx, username)
+}
+
+func Shutdown(ctx context.Context) { defaultSessions.Shutdown(ctx) }
+
+func GiveEveryoneMiles(gift float32) { defaultSessions.GiveEveryoneMiles(gift) }
+
+func PrintCurrentSession(ctx context.Context) { defaultSessions.PrintCurrentSession(ctx) }
+
+// LoggedInCount returns the number of users currently in the default session.
+func LoggedInCount() int { return len(defaultSessions.loggedIn) }

--- a/pkg/users/source.go
+++ b/pkg/users/source.go
@@ -1,0 +1,42 @@
+package users
+
+import "github.com/adanalife/tripbot/pkg/twitch"
+
+// ChatterSource supplies the platform-specific view of who is currently in
+// chat and each viewer's relationship to the channel. It is the seam between
+// session tracking (platform-agnostic) and the chat transport (per-platform).
+//
+// Today the only implementation is twitchSource, backed by Twitch Helix via
+// pkg/twitch. When the multi-platform chat-transport work lands, a YouTube or
+// TikTok adapter drops in here so a per-platform bot instance
+// (PLATFORM=youtube, etc.) tracks its own audience without Sessions changing.
+// See vault/sessions/2026-05-31-multi-platform-streaming-arch.md.
+type ChatterSource interface {
+	// UpdateChatters refreshes the source's notion of who is in chat.
+	UpdateChatters()
+	// Chatters returns the set of usernames currently in chat.
+	Chatters() map[string]struct{}
+	// ChatterCount is the authoritative in-chat total. It can exceed the
+	// number of logged-in users (e.g. lurkers the source counts but that
+	// never appear in chat).
+	ChatterCount() int
+	// IsSubscriber reports whether the user is a paid subscriber/member.
+	IsSubscriber(username string) bool
+	// IsFollower reports whether the user follows the channel.
+	IsFollower(username string) bool
+}
+
+// twitchSource is the Twitch-backed ChatterSource. Its methods delegate to
+// pkg/twitch's package surface; this adapter is the single point of
+// users->twitch coupling, isolating it for the future per-platform split.
+type twitchSource struct{}
+
+func (twitchSource) UpdateChatters()               { twitch.UpdateChatters() }
+func (twitchSource) Chatters() map[string]struct{} { return twitch.Chatters() }
+func (twitchSource) ChatterCount() int             { return twitch.ChatterCount() }
+func (twitchSource) IsSubscriber(username string) bool {
+	return twitch.UserIsSubscriber(username)
+}
+func (twitchSource) IsFollower(username string) bool {
+	return twitch.UserIsFollower(username)
+}

--- a/pkg/users/source_test.go
+++ b/pkg/users/source_test.go
@@ -1,0 +1,70 @@
+package users
+
+import "testing"
+
+// noopChatterSource is a ChatterSource that reports nobody in chat and nobody
+// followed/subscribed. Used by tests that build a *Sessions but don't exercise
+// the source.
+type noopChatterSource struct{}
+
+func (noopChatterSource) UpdateChatters()               {}
+func (noopChatterSource) Chatters() map[string]struct{} { return map[string]struct{}{} }
+func (noopChatterSource) ChatterCount() int             { return 0 }
+func (noopChatterSource) IsSubscriber(_ string) bool    { return false }
+func (noopChatterSource) IsFollower(_ string) bool      { return false }
+
+// recordingChatterSource answers from canned maps and counts calls, so tests
+// can assert the seam actually routes through the injected source.
+type recordingChatterSource struct {
+	subscribers map[string]bool
+	followers   map[string]bool
+	subCalls    int
+	followCalls int
+}
+
+func (recordingChatterSource) UpdateChatters()               {}
+func (recordingChatterSource) Chatters() map[string]struct{} { return map[string]struct{}{} }
+func (recordingChatterSource) ChatterCount() int             { return 0 }
+func (r *recordingChatterSource) IsSubscriber(username string) bool {
+	r.subCalls++
+	return r.subscribers[username]
+}
+func (r *recordingChatterSource) IsFollower(username string) bool {
+	r.followCalls++
+	return r.followers[username]
+}
+
+// User.IsSubscriber routes through the injected ChatterSource — the seam a
+// future YouTube/TikTok adapter swaps into.
+func TestUserIsSubscriberUsesChatterSource(t *testing.T) {
+	prev := defaultSessions.source
+	defer func() { defaultSessions.source = prev }()
+	rec := &recordingChatterSource{subscribers: map[string]bool{"alice": true}}
+	defaultSessions.source = rec
+
+	if !(User{Username: "alice"}).IsSubscriber() {
+		t.Fatal("expected alice to be a subscriber via the injected source")
+	}
+	if (User{Username: "bob"}).IsSubscriber() {
+		t.Fatal("expected bob not to be a subscriber")
+	}
+	if rec.subCalls != 2 {
+		t.Fatalf("expected 2 IsSubscriber calls on the source, got %d", rec.subCalls)
+	}
+}
+
+// Two *Sessions hold independent state — the prerequisite for running a
+// per-platform bot instance (e.g. YouTube) beside the Twitch one without them
+// sharing a global session map.
+func TestSessionsHoldIndependentState(t *testing.T) {
+	a := New(noopChatterSource{})
+	b := New(noopChatterSource{})
+
+	a.lifetimeLeaderboard = [][]string{{"x", "1"}}
+	a.loggedIn["x"] = &User{Username: "x"}
+
+	if len(b.lifetimeLeaderboard) != 0 || len(b.loggedIn) != 0 {
+		t.Fatalf("expected independent *Sessions, but b saw a's state: lb=%v loggedIn=%v",
+			b.lifetimeLeaderboard, b.loggedIn)
+	}
+}

--- a/pkg/users/source_test.go
+++ b/pkg/users/source_test.go
@@ -34,18 +34,17 @@ func (r *recordingChatterSource) IsFollower(username string) bool {
 	return r.followers[username]
 }
 
-// User.IsSubscriber routes through the injected ChatterSource — the seam a
-// future YouTube/TikTok adapter swaps into.
-func TestUserIsSubscriberUsesChatterSource(t *testing.T) {
-	prev := defaultSessions.source
-	defer func() { defaultSessions.source = prev }()
+// Sessions.IsSubscriber routes through the injected ChatterSource — the seam a
+// future YouTube/TikTok adapter swaps into (each provider gets its own
+// *Sessions + source).
+func TestSessionsIsSubscriberUsesChatterSource(t *testing.T) {
 	rec := &recordingChatterSource{subscribers: map[string]bool{"alice": true}}
-	defaultSessions.source = rec
+	s := New(rec)
 
-	if !(User{Username: "alice"}).IsSubscriber() {
+	if !s.IsSubscriber(User{Username: "alice"}) {
 		t.Fatal("expected alice to be a subscriber via the injected source")
 	}
-	if (User{Username: "bob"}).IsSubscriber() {
+	if s.IsSubscriber(User{Username: "bob"}) {
 		t.Fatal("expected bob not to be a subscriber")
 	}
 	if rec.subCalls != 2 {

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -87,6 +87,14 @@ func (s *Sessions) CurrentMonthlyMiles(ctx context.Context, u User) float32 {
 
 // User.save() will take the given user and store it in the DB
 func (u User) save(ctx context.Context) {
+	// A zero ID means we never found or created a DB row for this user (e.g. a
+	// transient DB error in Find). Model(&u).Updates() would build an UPDATE
+	// with no WHERE clause, which GORM refuses ("WHERE conditions required").
+	// Skip rather than emit that misleading error every tick.
+	if u.ID == 0 {
+		slog.WarnContext(ctx, "refusing to save user with no ID", "username", u.Username)
+		return
+	}
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "saving user", "username", u.Username)
 	}

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -36,25 +36,30 @@ type User struct {
 // this is how long they have before they can guess again
 var guessCooldown = 3 * time.Minute
 
-func (u User) loggedInDur() time.Duration {
+// The miles + follower/subscriber computations below are *Sessions methods
+// (not User methods) because they read the session's live login map + chatter
+// source. They take the User as a parameter so the session state and the
+// per-user data stay explicitly separate.
+
+func (s *Sessions) loggedInDur(u User) time.Duration {
 	// exit early if they're not logged in
-	if !defaultSessions.isLoggedIn(u.Username) {
+	if !s.isLoggedIn(u.Username) {
 		return 0 * time.Second
 	}
 	// lookup the user in the session so the LoggedIn value is current
-	return time.Now().Sub(defaultSessions.loggedIn[u.Username].LoggedIn)
+	return time.Now().Sub(s.loggedIn[u.Username].LoggedIn)
 }
 
-func (u User) sessionMiles(ctx context.Context) float32 {
+func (s *Sessions) sessionMiles(ctx context.Context, u User) float32 {
 	// exit early if they're not logged in
-	if !defaultSessions.isLoggedIn(u.Username) {
+	if !s.isLoggedIn(u.Username) {
 		return 0.0
 	}
-	loggedInDur := u.loggedInDur()
+	loggedInDur := s.loggedInDur(u)
 	sessionMiles := helpers.DurationToMiles(loggedInDur)
 	// give subscribers a miles bonus
-	if u.IsSubscriber() {
-		bonusMiles := u.BonusMiles()
+	if s.IsSubscriber(u) {
+		bonusMiles := s.BonusMiles(u)
 		if c.Conf.Verbose {
 			slog.InfoContext(ctx, "subscriber will get bonus miles", "username", u.Username, "bonus_miles", bonusMiles)
 		}
@@ -63,21 +68,21 @@ func (u User) sessionMiles(ctx context.Context) float32 {
 	return sessionMiles
 }
 
-func (u User) CurrentMiles(ctx context.Context) float32 {
-	return u.Miles + u.sessionMiles(ctx)
+func (s *Sessions) CurrentMiles(ctx context.Context, u User) float32 {
+	return u.Miles + s.sessionMiles(ctx, u)
 }
 
-func (u User) BonusMiles() float32 {
-	if defaultSessions.isLoggedIn(u.Username) {
-		loggedInDur := u.loggedInDur()
+func (s *Sessions) BonusMiles(u User) float32 {
+	if s.isLoggedIn(u.Username) {
+		loggedInDur := s.loggedInDur(u)
 		sessionMiles := helpers.DurationToMiles(loggedInDur)
 		return sessionMiles * 0.05
 	}
 	return 0.0
 }
 
-func (u User) CurrentMonthlyMiles(ctx context.Context) float32 {
-	return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard()) + u.sessionMiles(ctx)
+func (s *Sessions) CurrentMonthlyMiles(ctx context.Context, u User) float32 {
+	return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard()) + s.sessionMiles(ctx, u)
 }
 
 // User.save() will take the given user and store it in the DB
@@ -98,27 +103,27 @@ func (u User) save(ctx context.Context) {
 
 // SetBot flips users.is_bot for a username. Returns gorm.ErrRecordNotFound
 // if the user doesn't exist in the DB.
-func SetBot(ctx context.Context, username string, isBot bool) error {
+func (s *Sessions) SetBot(ctx context.Context, username string, isBot bool) error {
 	user := Find(ctx, username)
 	if user.ID == 0 {
 		return gorm.ErrRecordNotFound
 	}
 	user.IsBot = isBot
 	user.save(ctx)
-	if loggedIn, ok := defaultSessions.loggedIn[username]; ok {
+	if loggedIn, ok := s.loggedIn[username]; ok {
 		loggedIn.IsBot = isBot
 	}
 	return nil
 }
 
 // IsFollower returns true if the user is a follower
-func (u User) IsFollower() bool {
-	return defaultSessions.source.IsFollower(u.Username)
+func (s *Sessions) IsFollower(u User) bool {
+	return s.source.IsFollower(u.Username)
 }
 
 // IsSubscriber returns true if the user is a subscriber
-func (u User) IsSubscriber() bool {
-	return defaultSessions.source.IsSubscriber(u.Username)
+func (s *Sessions) IsSubscriber(u User) bool {
+	return s.source.IsSubscriber(u.Username)
 }
 
 // User.String prints a colored version of the user
@@ -163,9 +168,9 @@ func Find(ctx context.Context, username string) User {
 // HasCommandAvailable lets users run a command once a day,
 // unless they are a follower in which case they can run
 // as many as they like
-func (u *User) HasCommandAvailable(ctx context.Context) bool {
+func (s *Sessions) HasCommandAvailable(ctx context.Context, u *User) bool {
 	// followers get unlimited commands
-	if u.IsFollower() {
+	if s.IsFollower(*u) {
 		return true
 	}
 	// check if they ran a command in the last 24 hrs

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
-	"github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/google/uuid"
 	"github.com/logrusorgru/aurora/v3"
 	"gorm.io/gorm"
@@ -39,16 +38,16 @@ var guessCooldown = 3 * time.Minute
 
 func (u User) loggedInDur() time.Duration {
 	// exit early if they're not logged in
-	if !isLoggedIn(u.Username) {
+	if !defaultSessions.isLoggedIn(u.Username) {
 		return 0 * time.Second
 	}
 	// lookup the user in the session so the LoggedIn value is current
-	return time.Now().Sub(LoggedIn[u.Username].LoggedIn)
+	return time.Now().Sub(defaultSessions.loggedIn[u.Username].LoggedIn)
 }
 
 func (u User) sessionMiles(ctx context.Context) float32 {
 	// exit early if they're not logged in
-	if !isLoggedIn(u.Username) {
+	if !defaultSessions.isLoggedIn(u.Username) {
 		return 0.0
 	}
 	loggedInDur := u.loggedInDur()
@@ -69,7 +68,7 @@ func (u User) CurrentMiles(ctx context.Context) float32 {
 }
 
 func (u User) BonusMiles() float32 {
-	if isLoggedIn(u.Username) {
+	if defaultSessions.isLoggedIn(u.Username) {
 		loggedInDur := u.loggedInDur()
 		sessionMiles := helpers.DurationToMiles(loggedInDur)
 		return sessionMiles * 0.05
@@ -106,7 +105,7 @@ func SetBot(ctx context.Context, username string, isBot bool) error {
 	}
 	user.IsBot = isBot
 	user.save(ctx)
-	if loggedIn, ok := LoggedIn[username]; ok {
+	if loggedIn, ok := defaultSessions.loggedIn[username]; ok {
 		loggedIn.IsBot = isBot
 	}
 	return nil
@@ -114,12 +113,12 @@ func SetBot(ctx context.Context, username string, isBot bool) error {
 
 // IsFollower returns true if the user is a follower
 func (u User) IsFollower() bool {
-	return twitch.UserIsFollower(u.Username)
+	return defaultSessions.source.IsFollower(u.Username)
 }
 
 // IsSubscriber returns true if the user is a subscriber
 func (u User) IsSubscriber() bool {
-	return twitch.UserIsSubscriber(u.Username)
+	return defaultSessions.source.IsSubscriber(u.Username)
 }
 
 // User.String prints a colored version of the user

--- a/pkg/video/setup_test.go
+++ b/pkg/video/setup_test.go
@@ -1,14 +1,15 @@
 package video
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/adanalife/tripbot/pkg/database"
-	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -43,12 +44,22 @@ func installMockDB(t *testing.T) sqlmock.Sqlmock {
 	return mock
 }
 
-// recordedCalls captures URL paths hit on a fake server.
-type recordedCalls struct {
-	paths []string
+// recordingOnscreens is an interface fake satisfying the Player's onscreens
+// dependency, capturing each GPS overlay call by method name. Replaces the
+// old httptest-backed rig now that Player takes an interface.
+type recordingOnscreens struct {
+	calls []string
 }
 
-func (r *recordedCalls) add(p string) { r.paths = append(r.paths, p) }
+func (r *recordingOnscreens) ShowGPSImage(_ context.Context, _ time.Duration) error {
+	r.calls = append(r.calls, "ShowGPSImage")
+	return nil
+}
+
+func (r *recordingOnscreens) HideGPSImage(_ context.Context) error {
+	r.calls = append(r.calls, "HideGPSImage")
+	return nil
+}
 
 // fakeVLCServer stands up an httptest.Server that responds to /vlc/current
 // with the value pointed to by current. Tests mutate *current to change what
@@ -68,26 +79,6 @@ func fakeVLCServer(t *testing.T, current *string) *vlcClient.Client {
 	// vlcClient.New(host) builds the URL as "http://" + host, so strip the
 	// scheme from the httptest URL before handing it over.
 	return vlcClient.New(strings.TrimPrefix(srv.URL, "http://"))
-}
-
-// fakeOnscreensServer stands up an httptest.Server that records calls to the
-// GPS show/hide endpoints. Tests assert on rec.paths to verify which overlay
-// transitions fired.
-//
-// Returns a *onscreens-client.Client configured to talk to the fake and a
-// pointer to the recorded-calls struct.
-func fakeOnscreensServer(t *testing.T) (*onscreensClient.Client, *recordedCalls) {
-	t.Helper()
-	rec := &recordedCalls{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/onscreens/gps/show", "/onscreens/gps/hide":
-			rec.add(r.URL.Path)
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-	return onscreensClient.New(strings.TrimPrefix(srv.URL, "http://")), rec
 }
 
 // expectLoadHit queues a sqlmock expectation for a successful load() — i.e.

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -11,8 +11,6 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/helpers"
-	"github.com/adanalife/tripbot/pkg/natsclient"
-	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
@@ -27,10 +25,9 @@ type onscreens interface {
 
 // Player owns the state of "what's currently playing" and the clients that
 // drive the VLC playback + onscreens overlays. Construct via NewPlayer; the
-// package-level defaultPlayer is wired up at init for callers that still hit
-// the free-function shims below.
+// single process-wide instance lives on cmd/tripbot's Tripbot struct.
 type Player struct {
-	CurrentlyPlaying Video // exported because external callers used to read video.CurrentlyPlaying
+	CurrentlyPlaying Video // exported because external callers read the current video off it
 	curVid, preVid   string
 	timeStarted      time.Time
 	onscreens        onscreens
@@ -41,15 +38,6 @@ type Player struct {
 func NewPlayer(onscreens onscreens, vlc *vlcClient.Client) *Player {
 	return &Player{onscreens: onscreens, vlc: vlc}
 }
-
-// defaultPlayer is the package-level Player used by the free-function shims
-// below. Exists so callers that aren't constructor-injected (cmd/tripbot
-// bootstrap, script/collect-gps) keep working. New consumers should construct
-// their own *Player via NewPlayer().
-var defaultPlayer = NewPlayer(
-	onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
-	vlcClient.New(c.Conf.VlcServerHost),
-)
 
 // GetCurrentlyPlaying will use lsof to figure out
 // which dashcam video is currently playing (seriously).
@@ -116,6 +104,21 @@ func (p *Player) CurrentProgress() time.Duration {
 // Current returns the currently-playing video.
 func (p *Player) Current() Video { return p.CurrentlyPlaying }
 
+// EmitCurrentVideo re-publishes the current clip as a video.changed without a
+// transition. cmd calls this once right after the live-console hub subscribes
+// to NATS, so a freshly-started hub shows "now playing" immediately instead of
+// waiting for the next clip change (NATS core has no replay). No-op when
+// nothing is playing yet. A periodic re-emit for a separately-started console
+// is the tripbot-console split's concern, not this.
+func (p *Player) EmitCurrentVideo(ctx context.Context) {
+	if p.CurrentlyPlaying.Slug == "" {
+		return
+	}
+	eventbus.EmitVideoChanged(ctx, c.Conf.Environment,
+		p.CurrentlyPlaying.File(), p.CurrentlyPlaying.State, p.CurrentlyPlaying.Flagged,
+		p.CurrentlyPlaying.Lat, p.CurrentlyPlaying.Lng)
+}
+
 func (p *Player) figureOutCurrentVideo(ctx context.Context) string {
 	if helpers.RunningOnWindows() {
 		slog.ErrorContext(ctx, "can't run script on windows")
@@ -131,12 +134,3 @@ func (p *Player) figureOutCurrentVideo(ctx context.Context) string {
 	}
 	return outString
 }
-
-// ---- package-level shims (transitional) ----
-// Each free function calls the corresponding method on defaultPlayer. These
-// preserve the existing public surface for unmigrated callers. New consumers
-// should construct their own *Player via NewPlayer().
-
-func GetCurrentlyPlaying(ctx context.Context) { defaultPlayer.GetCurrentlyPlaying(ctx) }
-func CurrentProgress() time.Duration          { return defaultPlayer.CurrentProgress() }
-func CurrentlyPlaying() Video                 { return defaultPlayer.Current() }

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -11,9 +11,19 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/natsclient"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
+
+// onscreens is the subset of the onscreens-client surface the Player drives
+// (GPS overlay toggles on flagged-video transitions). Tests inject a
+// recording fake; production uses *onscreensClient.Client, which mirrors
+// each call to NATS + HTTP.
+type onscreens interface {
+	ShowGPSImage(ctx context.Context, dur time.Duration) error
+	HideGPSImage(ctx context.Context) error
+}
 
 // Player owns the state of "what's currently playing" and the clients that
 // drive the VLC playback + onscreens overlays. Construct via NewPlayer; the
@@ -23,12 +33,12 @@ type Player struct {
 	CurrentlyPlaying Video // exported because external callers used to read video.CurrentlyPlaying
 	curVid, preVid   string
 	timeStarted      time.Time
-	onscreens        *onscreensClient.Client
+	onscreens        onscreens
 	vlc              *vlcClient.Client
 }
 
 // NewPlayer returns a Player with its own Onscreens + VLC clients.
-func NewPlayer(onscreens *onscreensClient.Client, vlc *vlcClient.Client) *Player {
+func NewPlayer(onscreens onscreens, vlc *vlcClient.Client) *Player {
 	return &Player{onscreens: onscreens, vlc: vlc}
 }
 
@@ -37,7 +47,7 @@ func NewPlayer(onscreens *onscreensClient.Client, vlc *vlcClient.Client) *Player
 // bootstrap, script/collect-gps) keep working. New consumers should construct
 // their own *Player via NewPlayer().
 var defaultPlayer = NewPlayer(
-	onscreensClient.New(c.Conf.OnscreensServerHost),
+	onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
 	vlcClient.New(c.Conf.VlcServerHost),
 )
 

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -30,10 +30,10 @@ func skipIfDarwin(t *testing.T) {
 }
 
 func TestPlayer_Current_ZeroBeforeAnyCall(t *testing.T) {
-	onscreens, _ := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := ""
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	got := p.Current()
 	if got != (Video{}) {
@@ -44,10 +44,10 @@ func TestPlayer_Current_ZeroBeforeAnyCall(t *testing.T) {
 func TestPlayer_GetCurrentlyPlaying_FirstCall_FlaggedShowsGPS(t *testing.T) {
 	skipIfDarwin(t)
 	mock := installMockDB(t)
-	onscreens, rec := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	// DB returns a flagged video for the slug derived from vlcCurrent.
 	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
@@ -60,8 +60,8 @@ func TestPlayer_GetCurrentlyPlaying_FirstCall_FlaggedShowsGPS(t *testing.T) {
 	if !p.Current().Flagged {
 		t.Error("expected CurrentlyPlaying.Flagged = true (staged in mock rows)")
 	}
-	if len(rec.paths) != 1 || rec.paths[0] != "/onscreens/gps/show" {
-		t.Errorf("expected single ShowGPSImage call (/onscreens/gps/show), got %v", rec.paths)
+	if len(rec.calls) != 1 || rec.calls[0] != "ShowGPSImage" {
+		t.Errorf("expected single ShowGPSImage call, got %v", rec.calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
@@ -71,10 +71,10 @@ func TestPlayer_GetCurrentlyPlaying_FirstCall_FlaggedShowsGPS(t *testing.T) {
 func TestPlayer_GetCurrentlyPlaying_FirstCall_NotFlaggedHidesGPS(t *testing.T) {
 	skipIfDarwin(t)
 	mock := installMockDB(t)
-	onscreens, rec := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := "2019_0615_183000_001.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	expectLoadHit(mock, 7, "2019_0615_183000_001", false)
 
@@ -83,8 +83,8 @@ func TestPlayer_GetCurrentlyPlaying_FirstCall_NotFlaggedHidesGPS(t *testing.T) {
 	if p.Current().Flagged {
 		t.Error("expected CurrentlyPlaying.Flagged = false (staged in mock rows)")
 	}
-	if len(rec.paths) != 1 || rec.paths[0] != "/onscreens/gps/hide" {
-		t.Errorf("expected single HideGPSImage call (/onscreens/gps/hide), got %v", rec.paths)
+	if len(rec.calls) != 1 || rec.calls[0] != "HideGPSImage" {
+		t.Errorf("expected single HideGPSImage call, got %v", rec.calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
@@ -94,10 +94,10 @@ func TestPlayer_GetCurrentlyPlaying_FirstCall_NotFlaggedHidesGPS(t *testing.T) {
 func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 	skipIfDarwin(t)
 	mock := installMockDB(t)
-	onscreens, rec := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	// Only one DB hit expected — the second GetCurrentlyPlaying call sees
 	// curVid == preVid and short-circuits before reaching LoadOrCreate.
@@ -114,8 +114,8 @@ func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 	if p.timeStarted != timeStartedAfterFirst {
 		t.Error("expected timeStarted unchanged across same-vid calls; got a reset")
 	}
-	if len(rec.paths) != 1 {
-		t.Errorf("expected exactly one onscreens call (from first transition), got %d: %v", len(rec.paths), rec.paths)
+	if len(rec.calls) != 1 {
+		t.Errorf("expected exactly one onscreens call (from first transition), got %d: %v", len(rec.calls), rec.calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
@@ -125,10 +125,10 @@ func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *testing.T) {
 	skipIfDarwin(t)
 	mock := installMockDB(t)
-	onscreens, rec := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	// First vid: flagged → ShowGPSImage.
 	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
@@ -158,13 +158,13 @@ func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *
 	if p.Current().Slug == firstSlug {
 		t.Errorf("CurrentlyPlaying.Slug unchanged after transition (still %q)", firstSlug)
 	}
-	wantOverlay := []string{"/onscreens/gps/show", "/onscreens/gps/hide"}
-	if len(rec.paths) != len(wantOverlay) {
-		t.Fatalf("expected overlay sequence %v, got %v", wantOverlay, rec.paths)
+	wantOverlay := []string{"ShowGPSImage", "HideGPSImage"}
+	if len(rec.calls) != len(wantOverlay) {
+		t.Fatalf("expected overlay sequence %v, got %v", wantOverlay, rec.calls)
 	}
 	for i, want := range wantOverlay {
-		if rec.paths[i] != want {
-			t.Errorf("overlay call %d: want %q, got %q", i, want, rec.paths[i])
+		if rec.calls[i] != want {
+			t.Errorf("overlay call %d: want %q, got %q", i, want, rec.calls[i])
 		}
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -175,10 +175,10 @@ func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *
 func TestPlayer_CurrentProgress_TracksTimeSinceStart(t *testing.T) {
 	skipIfDarwin(t)
 	mock := installMockDB(t)
-	onscreens, _ := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
 
@@ -200,18 +200,18 @@ func TestPlayer_GetCurrentlyPlaying_EmptyVlcResult_NoTransition(t *testing.T) {
 	// curVid stays "" and equals preVid (also ""), so LoadOrCreate is
 	// never invoked. installMockDB-less SetGormDB is left at nil; any
 	// DB hit would NPE and fail the test loudly.
-	onscreens, rec := fakeOnscreensServer(t)
+	rec := &recordingOnscreens{}
 	vlcCurrent := ""
 	vlc := fakeVLCServer(t, &vlcCurrent)
-	p := NewPlayer(onscreens, vlc)
+	p := NewPlayer(rec, vlc)
 
 	p.GetCurrentlyPlaying(context.Background())
 
 	if p.curVid != "" || p.preVid != "" {
 		t.Errorf("curVid/preVid after empty-vlc first call = (%q, %q); want (\"\",\"\")", p.curVid, p.preVid)
 	}
-	if len(rec.paths) != 0 {
-		t.Errorf("expected no overlay calls on no-transition path, got %v", rec.paths)
+	if len(rec.calls) != 0 {
+		t.Errorf("expected no overlay calls on no-transition path, got %v", rec.calls)
 	}
 	if p.Current() != (Video{}) {
 		t.Errorf("Current() after empty-vlc first call = %+v, want zero Video", p.Current())

--- a/script/collect-gps/collect-gps.go
+++ b/script/collect-gps/collect-gps.go
@@ -12,7 +12,10 @@ import (
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/geo"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	"github.com/adanalife/tripbot/pkg/video"
+	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
 // this will hold the filename passed in via the CLI
@@ -41,9 +44,14 @@ func main() {
 		if videoFile != "" {
 			log.Fatal("you cannot use -current and -file at the same time")
 		}
-		// preload the currently-playing vid
-		video.GetCurrentlyPlaying(context.Background())
-		videoFile = video.CurrentlyPlaying().String()
+		// preload the currently-playing vid via a constructed Player (no
+		// package-level defaultPlayer anymore).
+		player := video.NewPlayer(
+			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
+			vlcClient.New(c.Conf.VlcServerHost),
+		)
+		player.GetCurrentlyPlaying(context.Background())
+		videoFile = player.Current().String()
 	}
 
 	// a file was passed in via the CLI


### PR DESCRIPTION
Patch release — **v2.18.2** (auto-tag bumps patch; no `#minor`/`#major` in the payload).

Almost entirely internal. The no-globals refactor finishes Phase B and opens Phase C; NATS phase 2 moves the onscreens command surface onto pub/sub; plus a `go test` env-default fix and a CI action bump. Full notes: `CHANGELOG.md` → **[v2.18.2]**.

### Payload (12 PRs since v2.18.1)
- **pubsub:** NATS phase 2 — onscreens command surface on pub/sub (#736)
- **refactor (no-globals):** retire `defaultSessions` (#753, #764), `defaultServer` (#757), `defaultPlayer` + admin now-playing via NATS (#758); lift cmd globals into a `Tripbot` struct (#755); chatbot Phase C — social-media (#766), dispatch path (#768), announce + Chatter (#769), command registry (#770) onto the `App`
- **CI:** `go test` defaults `ENV` to testing (#767)
- **deps:** `jdx/mise-action` 2 → 4 (#759)

No user-visible behavior change.

---
⚠️ **Merge with a _merge commit_, not squash** (per the [merge-strategy-by-target-branch ADR](https://github.com/adanalife/tripbot)) — preserves develop's commits as ancestors of master so future releases merge cleanly. Merging triggers auto-tag → `v2.18.2` → multi-arch build + deploy.