### PR TITLE
refactor(chatbot): New() constructor + ConnectIRC method (keystone prep)

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -99,20 +99,31 @@ func (a *App) db() *gorm.DB {
 	return database.GormDB()
 }
 
-var defaultApp = &App{
-	// DB stays nil; commands use a.db() which falls back to database.GormDB().
-	Onscreens:  realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)},
-	VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},
-	Video:      realVideo{},
-	IRC:        realIRC{},
-	Sessions:   realSessions{},
-	NowPlaying: newRealNowPlaying(),
-	Flags:      realFlags{},
-	NATS:       realNATS{},
-	Cron:       realCron{},
-	Geocoder:   realGeocoder{},
-	Twitch:     realTwitch{},
+// New constructs an App wired with the production (realX) dependency adapters,
+// with its command registry built and indexed. cmd builds the live App with
+// this; the package singleton defaultApp is built from it for the package-level
+// Twitch adapters / eventsub shims and the tests. Construction touches no
+// network or DB — the realX adapters are lazy.
+func New() *App {
+	a := &App{
+		// DB stays nil; commands use a.db() which falls back to database.GormDB().
+		Onscreens:  realOnscreens{c: onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)},
+		VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost)},
+		Video:      realVideo{},
+		IRC:        realIRC{},
+		Sessions:   realSessions{},
+		NowPlaying: newRealNowPlaying(),
+		Flags:      realFlags{},
+		NATS:       realNATS{},
+		Cron:       realCron{},
+		Geocoder:   realGeocoder{},
+		Twitch:     realTwitch{},
+	}
+	a.indexCommands()
+	return a
 }
+
+var defaultApp = New()
 
 // used to determine which help message to display
 // randomized so it starts with a new one every restart
@@ -126,9 +137,17 @@ const subscriberMsg = "You must be a subscriber to run that command :)"
 // follow before they can try commands. Flip back to true to re-enable.
 var followerGatingEnabled = false
 
-// Initialize returns a Twitch client struct with all of the various configuration in place.
+// Initialize builds the package singleton's Twitch client. Thin wrapper over
+// defaultApp.ConnectIRC kept so cmd/tripbot is unchanged during the migration;
+// it goes away once cmd constructs its own App and calls ConnectIRC directly.
 func Initialize() *twitch.Client {
-	var err error
+	return defaultApp.ConnectIRC()
+}
+
+// ConnectIRC builds the Twitch IRC client, wires this App's inbound adapters to
+// it, and returns it. Also does the process-wide geocoder + Twitch-API warmup.
+// The returned client is connected by the caller (cmd/tripbot).
+func (a *App) ConnectIRC() *twitch.Client {
 	Uptime = time.Now()
 
 	// set up the process-wide geocoder (coords -> places). realGeocoder and
@@ -139,7 +158,7 @@ func Initialize() *twitch.Client {
 	// at boot, log and continue so the process stays up (readiness reports
 	// not-ready until the IRC connection lands). mytwitch.Client() doesn't
 	// cache on failure, so callers retry once Twitch is back.
-	if _, err = mytwitch.Client(); err != nil {
+	if _, err := mytwitch.Client(); err != nil {
 		slog.Error("twitch API client unavailable at startup; continuing", "err", err)
 	}
 
@@ -147,12 +166,12 @@ func Initialize() *twitch.Client {
 	// cmd/auth-bootstrap; cmd/tripbot calls mytwitch.LoadFromDB before this.
 	client = twitch.NewClient(c.Conf.BotUsername, mytwitch.IRCAuthToken())
 
-	// attach handlers
-	client.OnUserJoinMessage(UserJoin)
-	client.OnUserPartMessage(UserPart)
-	// client.OnUserNoticeMessage(chatbot.UserNotice)
-	client.OnWhisperMessage(GetWhisper)
-	client.OnPrivateMessage(PrivateMessage)
+	// attach this App's Twitch inbound adapters
+	client.OnUserJoinMessage(a.onTwitchJoin)
+	client.OnUserPartMessage(a.onTwitchPart)
+	// client.OnUserNoticeMessage(...)
+	client.OnWhisperMessage(a.onTwitchWhisper)
+	client.OnPrivateMessage(a.onTwitchMessage)
 
 	return client
 }

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -215,22 +215,22 @@ func (a *App) HandleWhisper(msg IncomingMessage) {
 // --- Twitch inbound adapters ---
 //
 // These translate go-twitch-irc event types into neutral Handle* calls on the
-// package singleton. They stay registered in Initialize until cmd constructs
-// the App and registers its methods directly (later Phase C step); a future
-// YouTube/etc. transport adds its own adapters feeding the same Handle* methods.
+// App, and are wired to the IRC client in ConnectIRC. A future YouTube/etc.
+// transport adds its own adapters feeding the same Handle* methods, so the
+// command path never learns about platforms.
 
-func PrivateMessage(msg twitch.PrivateMessage) {
-	defaultApp.HandleMessage(context.Background(), IncomingMessage{User: msg.User.Name, Text: msg.Message})
+func (a *App) onTwitchMessage(msg twitch.PrivateMessage) {
+	a.HandleMessage(context.Background(), IncomingMessage{User: msg.User.Name, Text: msg.Message})
 }
 
-func UserJoin(joinMessage twitch.UserJoinMessage) {
-	defaultApp.HandleJoin(joinMessage.User)
+func (a *App) onTwitchJoin(joinMessage twitch.UserJoinMessage) {
+	a.HandleJoin(joinMessage.User)
 }
 
-func UserPart(partMessage twitch.UserPartMessage) {
-	defaultApp.HandlePart(partMessage.User)
+func (a *App) onTwitchPart(partMessage twitch.UserPartMessage) {
+	a.HandlePart(partMessage.User)
 }
 
-func GetWhisper(message twitch.WhisperMessage) {
-	defaultApp.HandleWhisper(IncomingMessage{User: message.User.Name, Text: message.Message})
+func (a *App) onTwitchWhisper(message twitch.WhisperMessage) {
+	a.HandleWhisper(IncomingMessage{User: message.User.Name, Text: message.Message})
 }

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -259,10 +259,3 @@ func (a *App) registerTrigger(trigger string, cmd *Command) {
 		a.singleWordLookup[trigger] = cmd
 	}
 }
-
-// init builds the package singleton's registry. Once cmd constructs the App and
-// hands it to the message path (later Phase C step), this moves into that
-// constructor and defaultApp goes away.
-func init() {
-	defaultApp.indexCommands()
-}


### PR DESCRIPTION
**Phase C — keystone prep.** Makes the `App` constructible + self-wiring, setting up cmd to own it.

- **`New() *App`** — extracts the `defaultApp` literal into a constructor that also calls `indexCommands()`, so the registry build moves out of `init()` (deleted) into construction. `var defaultApp = New()`.
- **`(a *App) ConnectIRC()`** — `Initialize()`'s body becomes a method that builds the Twitch client and wires *this App's* inbound adapters. `Initialize()` stays as a thin `defaultApp.ConnectIRC()` wrapper so **cmd/tripbot is unchanged**.
- The four Twitch adapters (`PrivateMessage`/…) become unexported `*App` methods (`onTwitchMessage`/`onTwitchJoin`/`onTwitchPart`/`onTwitchWhisper`) registered in `ConnectIRC`, instead of package free funcs bound to `defaultApp`.

**Next:** cmd calls `chatbot.New()` + `ConnectIRC()` directly and registers the App's eventsub/cron methods, after which `defaultApp` + the `Initialize` wrapper + the announce/Chatter shims retire.

**No behavior change:** `Initialize()` still builds `defaultApp`'s client and wires the same adapters. `go build ./pkg/chatbot/... ./cmd/tripbot/...`, `go vet`, `go test ./pkg/chatbot/` all green; gofmt clean.