### PR TITLE
refactor(chatbot): cmd owns the App; retire the package free-func shims

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -80,8 +80,15 @@ var version = "dev"
 type Tripbot struct {
 	version string
 
+	// app is the chatbot App that owns the command registry and runs chat
+	// commands + inbound handlers. Constructed in NewTripbot; setUpTwitchClient
+	// wires its Twitch adapters to the IRC client (ConnectIRC), and eventsub /
+	// cron register its methods. Replaces the package-level defaultApp on the
+	// live path.
+	app *chatbot.App
+
 	// irc is the go-twitch-irc client, constructed by setUpTwitchClient
-	// (chatbot.Initialize) and shared by connectToTwitch, pollForTwitchToken
+	// (app.ConnectIRC) and shared by connectToTwitch, pollForTwitchToken
 	// and the token-refresh cron job (SetIRCToken).
 	irc *twitch.Client
 
@@ -133,6 +140,7 @@ type Tripbot struct {
 func NewTripbot(version string) *Tripbot {
 	return &Tripbot{
 		version: version,
+		app:     chatbot.New(),
 		srv:     server.New(),
 		player: video.NewPlayer(
 			onscreensClient.New(c.Conf.OnscreensServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
@@ -168,7 +176,7 @@ func (t *Tripbot) Run() {
 	t.sessions.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)
-	t.loadTwitchToken(shutdownCtx)           // must precede chatbot.Initialize — provides the IRC token
+	t.loadTwitchToken(shutdownCtx)           // must precede setUpTwitchClient — provides the IRC token
 	t.refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
 	t.setUpTwitchClient()                    // required for the below
 	t.updateSubscribers()
@@ -276,8 +284,8 @@ func (t *Tripbot) startEventSub(ctx context.Context) {
 			BroadcasterToken:  token,
 			BroadcasterUserID: mytwitch.ChannelID(),
 		}, eventsub.Handlers{
-			OnFollow:    chatbot.AnnounceNewFollower,
-			OnSubscribe: chatbot.AnnounceSubscriber,
+			OnFollow:    t.app.AnnounceNewFollower,
+			OnSubscribe: t.app.AnnounceSubscriber,
 		})
 		if err != nil && !errors.Is(err, context.Canceled) {
 			slog.ErrorContext(ctx, "eventsub run terminated", "err", err)
@@ -406,7 +414,7 @@ func (t *Tripbot) pollForTwitchToken(ctx context.Context) {
 			slog.InfoContext(ctx, "Twitch token loaded; bot will connect on next attempt")
 			// Push the freshly-loaded token into the (already-constructed)
 			// IRC client so the connect loop's next try uses it instead of
-			// the empty token captured at chatbot.Initialize.
+			// the empty token captured at ConnectIRC.
 			if tok := mytwitch.IRCAuthToken(); tok != "" && t.irc != nil {
 				t.irc.SetIRCToken(tok)
 			}
@@ -429,8 +437,8 @@ func (t *Tripbot) refreshTokensIfNearExpiry(ctx context.Context) {
 // setUpTwitchClient sets up the Twitch client,
 // used by many bot features
 func (t *Tripbot) setUpTwitchClient() {
-	// set up the Twitch client
-	t.irc = chatbot.Initialize()
+	// build the Twitch IRC client and wire the App's inbound adapters to it
+	t.irc = t.app.ConnectIRC()
 }
 
 // updateSubscribers gets the list of current subscribers
@@ -551,7 +559,7 @@ func (t *Tripbot) scheduleBackgroundJobs() {
 			t.irc.SetIRCToken(tok)
 		}
 	})
-	t.addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", chatbot.Chatter)
+	t.addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", t.app.Chatter)
 }
 
 // addJob registers a gocron job at the given interval, wrapping fn with

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -27,12 +27,3 @@ func (a *App) AnnounceSubscriber(username string, isGift bool, tier string) {
 	currentSessions().GiveEveryoneMiles(1.0)
 	a.IRC.Say(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
 }
-
-// Package-level shims delegating to defaultApp, so cmd's eventsub wiring keeps
-// referencing chatbot.AnnounceNewFollower / chatbot.AnnounceSubscriber as
-// function values. They retire once cmd registers the App's methods directly
-// (later Phase C step).
-func AnnounceNewFollower(username string) { defaultApp.AnnounceNewFollower(username) }
-func AnnounceSubscriber(username string, isGift bool, tier string) {
-	defaultApp.AnnounceSubscriber(username, isGift, tier)
-}

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -71,7 +71,7 @@ type App struct {
 	Cron Cron
 	// Geocoder turns GPS coords into a place name for !location. Tests inject
 	// a recordingGeocoder / noopGeocoder; production uses realGeocoder which
-	// delegates to the pkg/geo default configured in Initialize.
+	// delegates to the pkg/geo default configured in ConnectIRC.
 	Geocoder Geocoder
 	// Twitch is the command-time Twitch Helix surface (follow lookups today).
 	// Tests inject a recordingTwitch; production uses realTwitch which
@@ -81,9 +81,9 @@ type App struct {
 
 	// commands is this App's command registry (built by buildRegistry);
 	// singleWordLookup / multiWordLookup index it by trigger + alias for
-	// dispatch. Populated by indexCommands() — production builds defaultApp's
-	// in init(); tests build a test App's via newTestApp. Replaces the former
-	// package-level globals so the registry travels with the App.
+	// dispatch. Built by indexCommands(), called from New() at construction.
+	// Replaces the former package-level globals so the registry travels with
+	// the App.
 	commands         []Command
 	singleWordLookup map[string]*Command
 	multiWordLookup  map[string]*Command
@@ -136,13 +136,6 @@ const subscriberMsg = "You must be a subscriber to run that command :)"
 // checkAccess. Disabled for launch so first-time viewers aren't told to
 // follow before they can try commands. Flip back to true to re-enable.
 var followerGatingEnabled = false
-
-// Initialize builds the package singleton's Twitch client. Thin wrapper over
-// defaultApp.ConnectIRC kept so cmd/tripbot is unchanged during the migration;
-// it goes away once cmd constructs its own App and calls ConnectIRC directly.
-func Initialize() *twitch.Client {
-	return defaultApp.ConnectIRC()
-}
 
 // ConnectIRC builds the Twitch IRC client, wires this App's inbound adapters to
 // it, and returns it. Also does the process-wide geocoder + Twitch-API warmup.
@@ -217,11 +210,6 @@ func (a *App) Chatter(_ context.Context) {
 	// use twitch emote feature to add some color
 	a.IRC.Say("/me " + help())
 }
-
-// Chatter shim delegating to defaultApp, so cmd's cron wiring keeps referencing
-// chatbot.Chatter as a function value. Retires once cmd registers the App's
-// method directly (later Phase C step).
-func Chatter(ctx context.Context) { defaultApp.Chatter(ctx) }
 
 func help() string {
 	text := c.HelpMessages[helpIndex]


### PR DESCRIPTION
**Phase C — the keystone.** cmd/tripbot now owns a constructed `*App` instead of routing through the package singleton.

- `NewTripbot` builds `app: chatbot.New()`.
- `setUpTwitchClient` → `t.irc = t.app.ConnectIRC()` (was `chatbot.Initialize()`).
- eventsub registers `t.app.AnnounceNewFollower` / `t.app.AnnounceSubscriber` (method values).
- the Chatter cron registers `t.app.Chatter`.
- The package-level shims those replaced — `Initialize()`, `AnnounceNewFollower`/`AnnounceSubscriber`, `Chatter` — are **deleted**.

`defaultApp` now survives **only as the test fixture** — production no longer references it. Retiring it (migrating the registry/command tests to a constructed test App) plus the four `Set*` installers is the remaining Phase C work (the capstone).

**Behavior-preserving:** `t.app` uses the same `realX` adapters reading the same `Set*`-installed globals, so the live path is identical — it just runs through cmd's App instead of `defaultApp`. `go build ./cmd/tripbot/... ./pkg/chatbot/...`, `go vet`, `go test ./pkg/chatbot/` all green; gofmt clean.

⚠️ **First slice that changes bot startup wiring** — build-verified here, but wants a **stage smoke-test** (watch it connect to IRC + run a command) before the release that carries it ships to prod.