### PR TITLE
obs: parametrize streaming target via STREAM_PLATFORM

### DIFF
--- a/infra/docker/obs/config/service.json.tmpl
+++ b/infra/docker/obs/config/service.json.tmpl
@@ -2,8 +2,8 @@
   "settings": {
     "bwtest": false,
     "key": "${STREAM_KEY}",
-    "server": "auto",
-    "service": "Twitch"
+    "server": "${OBS_STREAM_SERVER}",
+    "service": "${OBS_STREAM_SERVICE}"
   },
   "type": "rtmp_common"
 }

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -52,6 +52,25 @@ esac
 export OBS_STREAM_ENCODER="${OBS_STREAM_ENCODER:-obs_x264}"
 echo "OBS stream encoder: ${OBS_STREAM_ENCODER}"
 
+# Streaming target platform. Default `twitch` preserves the original
+# hardcoded behavior exactly (service "Twitch", server "auto" — OBS
+# resolves "auto" via Twitch's ingest API at connect time). Set
+# STREAM_PLATFORM=youtube (k8s configmap in the obs-youtube overlay) to
+# point the same canvas/encoder at YouTube's RTMPS ingest. service.json.tmpl
+# consumes OBS_STREAM_SERVICE / OBS_STREAM_SERVER via envsubst below.
+case "${STREAM_PLATFORM:-twitch}" in
+  youtube)
+    export OBS_STREAM_SERVICE="YouTube - RTMPS"
+    export OBS_STREAM_SERVER="rtmps://a.rtmps.youtube.com:443/live2"
+    echo "OBS stream platform: youtube (YouTube - RTMPS)"
+    ;;
+  *)
+    export OBS_STREAM_SERVICE="Twitch"
+    export OBS_STREAM_SERVER="auto"
+    echo "OBS stream platform: twitch (server auto)"
+    ;;
+esac
+
 # OBS 32 split the legacy global.ini in two: app-level settings stayed in
 # global.ini (BrowserHWAccel etc.) and user-preference settings moved to
 # user.ini. Seed both so OBS sees a complete config and never prompts about
@@ -101,7 +120,7 @@ envsubst < /opt/obs/config/obs-websocket.json.tmpl > "$OBS_HOME/plugin_config/ob
 # Render service.json only when STREAM_KEY is set. start-obs.sh keys off
 # this file's existence to decide whether to pass --startstreaming.
 if [[ -n "${STREAM_KEY:-}" ]]; then
-  echo "STREAM_KEY set; configuring Twitch and starting stream."
+  echo "STREAM_KEY set; configuring ${OBS_STREAM_SERVICE} and starting stream."
   envsubst < /opt/obs/config/service.json.tmpl \
     > "$OBS_HOME/basic/profiles/ADanaLife/service.json"
 else


### PR DESCRIPTION
## What

Make the OBS image's streaming target configurable so the same image can stream to Twitch **or** YouTube. Previously `config/service.json.tmpl` hardcoded `"service": "Twitch"`, so the image was Twitch-only.

## How

- `entrypoint.sh` gains a `STREAM_PLATFORM` case (default `twitch`) that exports `OBS_STREAM_SERVICE` / `OBS_STREAM_SERVER`, matching the existing `OBS_QUALITY_PRESET` / `OBS_STREAM_ENCODER` convention.
  - `twitch`  → service `Twitch`, server `auto` (unchanged)
  - `youtube` → service `YouTube - RTMPS`, server `rtmps://a.rtmps.youtube.com:443/live2`
- `service.json.tmpl` consumes those via `envsubst`.

## Why

First step toward a separate `obs-youtube` OBS instance (streaming side of the YouTube chatbot work). OBS is just the compositor/encoder — content comes from vlc-server — so a second instance can reuse the same canvas and only differ in ingest target.

## No-op for Twitch

With `STREAM_PLATFORM` unset, the rendered `service.json` is byte-identical to the previous hardcoded file (verified). The existing Twitch path is unaffected.

## Follow-ups (separate PRs)

- infra: rename `obs` → `obs-twitch`; add `obs-youtube` stage-1 overlay (off by default).