### PR TITLE
obs: point OBS host references at obs-twitch

### DIFF
--- a/pkg/obs/control.go
+++ b/pkg/obs/control.go
@@ -16,7 +16,7 @@ import (
 func dial(_ context.Context) (*goobs.Client, error) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
-		addr = "obs:4455"
+		addr = "obs-twitch:4455"
 	}
 	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
 	if passwd == "" {

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -17,7 +17,7 @@ import (
 func PollStreamingActive(ctx context.Context, interval time.Duration) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
-		addr = "obs:4455"
+		addr = "obs-twitch:4455"
 	}
 	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
 	if passwd == "" {

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -554,8 +554,8 @@ func pingHealthy(ctx context.Context, rawURL string) bool {
 // neither appears here. Entries whose URL can't be derived are dropped.
 func gatherLinks() []navLink {
 	links := []navLink{}
-	if obs := tailnetServiceURL("obs"); obs != "" {
-		links = append(links, navLink{Label: "obs", URL: obs})
+	if obs := tailnetServiceURL("obs-twitch"); obs != "" {
+		links = append(links, navLink{Label: "obs-twitch", URL: obs})
 	}
 	links = append(links,
 		navLink{Label: "grafana", URL: grafanaURL},
@@ -603,7 +603,7 @@ func changelogURL(sha string) string {
 }
 
 // tailnetServiceURL returns the Tailscale K8s-operator URL for a sibling
-// service in this env's namespace, e.g. obs-prod.tail020deb.ts.net for
+// service in this env's namespace, e.g. obs-twitch-prod.tail020deb.ts.net for
 // production. Tailnet (CGNAT 100.x) URLs are preferred over the LAN-IP-backed
 // *.whereisdana.today URLs because the latter silently fail on client
 // networks that overlap the home LAN's 192.168.1.0/24 range. Returns "" for

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -42,11 +42,11 @@ func TestTailnetServiceURL(t *testing.T) {
 	cases := []struct {
 		env, service, want string
 	}{
-		{"production", "obs", "https://obs-prod.tail020deb.ts.net"},
+		{"production", "obs-twitch", "https://obs-twitch-prod.tail020deb.ts.net"},
 		{"production", "vlc-server", "https://vlc-server-prod.tail020deb.ts.net"},
-		{"staging", "obs", "https://obs-stage.tail020deb.ts.net"},
-		{"development", "obs", ""}, // not served by the operator
-		{"testing", "obs", ""},
+		{"staging", "obs-twitch", "https://obs-twitch-stage.tail020deb.ts.net"},
+		{"development", "obs-twitch", ""}, // not served by the operator
+		{"testing", "obs-twitch", ""},
 	}
 	for _, tc := range cases {
 		c.Conf.Environment = tc.env
@@ -441,11 +441,11 @@ func TestAdminHandler_RendersReadyStatusAndLinks(t *testing.T) {
 		"Wyoming",                                        // current video state
 		`class="now-elapsed" data-since=`,                // elapsed span the JS ticker counts up
 		"3m12s",                                          // clip progress (initial server render)
-		`>obs</a>`,                                       // one-word OBS link
+		`>obs-twitch</a>`,                                // one-word OBS link
 		`>grafana</a>`,                                   // one-word grafana link
 		`>traefik</a>`,                                   // one-word traefik link
 		`>hubble</a>`,                                    // one-word hubble link
-		"https://obs-prod.tail020deb.ts.net",             // tailnet OBS href
+		"https://obs-twitch-prod.tail020deb.ts.net",      // tailnet OBS href
 		grafanaURL,                                       // grafana href
 		traefikURL,                                       // traefik href
 		// Environment is "production" above → hubble link carries ?namespace=prod-1


### PR DESCRIPTION
## What

The OBS Deployment/Service was renamed `obs → obs-twitch` ([infra#629](https://github.com/adanalife/infra/pull/629)). Update the bot's in-code references to match.

## Changes

- `pkg/obs/{control,streaming}.go`: default OBS websocket addr `obs:4455 → obs-twitch:4455`. (infra#629 also sets `OBS_WEBSOCKET_ADDR` explicitly in the tripbot configmap, so prod is correct regardless of deploy ordering — this just keeps the in-code default from going stale.)
- `pkg/server/admin.go`: admin-panel tailnet nav link now targets `obs-twitch` (host `obs-twitch-prod`/`-stage`); label + doc-comment example updated.
- `admin_test.go`: expectations updated.

The internal status-display key + restart-endpoint case `"obs"` are left as-is — they're a self-contained admin-panel contract keyed off `ObsServerHost`, not the k8s name, and renaming them would couple in template changes for no functional gain.

## Verification

`go test ./pkg/obs/... ./pkg/server/...` passes.

## Pairs with

[infra#629](https://github.com/adanalife/infra/pull/629) (the rename). Deploy together so the admin panel's OBS link/status resolve.