### PR TITLE
fix(users): stop zero-ID users failing save() every tick (TRIPBOT-8D)

### DIFF
--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -83,6 +83,14 @@ func login(ctx context.Context, username string) *User {
 	now := time.Now()
 
 	user := FindOrCreate(ctx, username)
+	// A zero ID means FindOrCreate couldn't get a DB row (transient Find error
+	// or a failed create). Don't cache an un-saveable user in the session, or
+	// every later logout tick would fail save(). Return without logging them in;
+	// the next tick retries FindOrCreate and self-heals once the DB recovers.
+	if user.ID == 0 {
+		slog.WarnContext(ctx, "could not find or create user, skipping login", "username", username)
+		return &user
+	}
 	// increment the number of visits
 	user.NumVisits = user.NumVisits + 1
 	// set the login time

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -83,6 +83,14 @@ func (u User) CurrentMonthlyMiles(ctx context.Context) float32 {
 
 // User.save() will take the given user and store it in the DB
 func (u User) save(ctx context.Context) {
+	// A zero ID means we never found or created a DB row for this user (e.g. a
+	// transient DB error in Find). Model(&u).Updates() would build an UPDATE
+	// with no WHERE clause, which GORM refuses ("WHERE conditions required").
+	// Skip rather than emit that misleading error every tick.
+	if u.ID == 0 {
+		slog.WarnContext(ctx, "refusing to save user with no ID", "username", u.Username)
+		return
+	}
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "saving user", "username", u.Username)
 	}


### PR DESCRIPTION
Fixes [TRIPBOT-8D](https://a-dana-life.sentry.io/issues/TRIPBOT-8D) — `*errors.errorString: WHERE conditions required`.

## Root cause

`User.save()` runs `Model(&u).Updates(...)`, which GORM builds a `WHERE` from the primary key. When `User.ID == 0`, there is no `WHERE`, so GORM refuses with `ErrMissingWhereClause` ("WHERE conditions required") rather than risk a global `UPDATE`.

A zero-ID user reaches the session because `Find()` returns `User{ID: 0}` on **any** DB error (not just not-found), and `create()` returns whatever `Find()` gives back. A transient DB blip during login therefore caches an un-saveable `*User` in `LoggedIn`, which then fails `save()` on every logout tick (`UpdateSession → logout → save`). 0 users impacted, repeated occurrences = a few poisoned session entries retrying.

Not a 2.18.x regression — `save()` is unchanged since #674. It became *visible* once error logging moved to the slog→Sentry handler (#573); before that it went through `terrors.Log`.

## Fix (two layers)

1. **`save()` guards against `ID == 0`** — logs at Warn and returns instead of issuing a doomed `UPDATE`. Correct regardless of cause.
2. **`login()` skips caching a zero-ID user** — the next session tick retries `FindOrCreate` and self-heals once the DB recovers, so the poison never persists.

Both log at Warn, which the telemetry handler treats as a breadcrumb (only `Error+` becomes a Sentry event), so no new noise. The genuine underlying DB error is still captured at Error inside `Find`/`create`.

## Repercussions / data impact

No permanent data loss. `save()` logs its error and returns normally (no panic — the gocron frames in the trace are just the scheduled-job wrapper), so logout continues past it:

- **`events` table** (login/logout) — recorded normally. Per the events-table-design ADR this is the source of truth, so affected lifetime miles are recomputable via `cmd/backfill-miles`.
- **Monthly miles scoreboard** (`AddToScore`) — keyed by username, ran after `save()`, unaffected.
- **Only casualty:** the `users.miles` lifetime-total *cache* column did not get its increment for affected sessions. It is stale-low for those users but reconstructable from `events`.

## Follow-up (not in this PR)

`Find()` conflates not-found with DB-error (both return `ID: 0`), so `FindOrCreate` will attempt a create during a transient DB outage. Giving `Find()` an error-returning contract is a larger change touching many callers — left out to keep this surgical and avoid churn against the in-flight 2.18.2 refactors.

## Test

`go test ./pkg/users/` passes; package builds and vets clean.