### PR TITLE
refactor(chatbot): retire SetScheduler; cmd assigns App.Cron directly

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -94,8 +94,8 @@ type Tripbot struct {
 
 	// scheduler is the background cron scheduler, constructed in startCron and
 	// shared by scheduleBackgroundJobs (job registration) and gracefulShutdown
-	// (Stop). Also installed into chatbot via chatbot.SetScheduler so !shutdown
-	// can stop it.
+	// (Stop). Also assigned onto t.app.Cron so the !shutdown command can stop
+	// it.
 	scheduler *background.Scheduler
 
 	// srv is the admin-panel / auth / metrics HTTP server, constructed in
@@ -354,8 +354,9 @@ func (t *Tripbot) startCron() {
 	}
 	t.scheduler = s
 	t.scheduler.Start()
-	// let !shutdown stop the same scheduler instance
-	chatbot.SetScheduler(t.scheduler)
+	// let !shutdown stop the same scheduler instance (*background.Scheduler
+	// satisfies chatbot.Cron directly)
+	t.app.Cron = t.scheduler
 	t.scheduleBackgroundJobs()
 }
 

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -64,10 +64,10 @@ type App struct {
 	// which delegates to the pkg/natsclient singleton (no-op when
 	// NATS_URL is empty).
 	NATS NATS
-	// Cron stops the background scheduler during !shutdown. Tests inject
-	// noopCron{}; production uses realCron which delegates to the
-	// constructed *background.Scheduler cmd/tripbot installs via
-	// SetScheduler once cron has started.
+	// Cron stops the background scheduler during !shutdown. Defaults to
+	// noopCron{} (set in New(), also what tests use); cmd/tripbot assigns the
+	// constructed *background.Scheduler — which satisfies Cron directly — once
+	// cron has started.
 	Cron Cron
 	// Geocoder turns GPS coords into a place name for !location. Tests inject
 	// a recordingGeocoder / noopGeocoder; production uses realGeocoder which
@@ -115,7 +115,7 @@ func New() *App {
 		NowPlaying: newRealNowPlaying(),
 		Flags:      realFlags{},
 		NATS:       realNATS{},
-		Cron:       realCron{},
+		Cron:       noopCron{},
 		Geocoder:   realGeocoder{},
 		Twitch:     realTwitch{},
 	}

--- a/pkg/chatbot/cron.go
+++ b/pkg/chatbot/cron.go
@@ -1,43 +1,15 @@
 package chatbot
 
-import "sync"
-
 // Cron is the background-scheduler surface the chatbot needs: stopping the
-// scheduler during !shutdown. *background.Scheduler satisfies it directly.
+// scheduler during !shutdown. *background.Scheduler satisfies it directly, so
+// cmd/tripbot assigns the constructed scheduler straight onto App.Cron.
 type Cron interface {
 	Stop() error
 }
 
-// realCron is the production Cron adapter the App is wired with at package
-// init. Delegates to scheduler, which cmd/tripbot replaces with the
-// constructed *background.Scheduler via SetScheduler once cron has started.
-// Mirrors the realFlags shape.
-type realCron struct{}
-
-func (realCron) Stop() error {
-	cronMu.RLock()
-	s := scheduler
-	cronMu.RUnlock()
-	return s.Stop()
-}
-
-// scheduler is the Cron realCron delegates to. Initialised to a no-op so the
-// brief startup window before cmd/tripbot installs the real scheduler — and
-// every test App — has a safe Stop().
-var (
-	cronMu    sync.RWMutex
-	scheduler Cron = noopCron{}
-)
-
-// noopCron swallows Stop. Used before SetScheduler runs and in tests.
+// noopCron swallows Stop. It's the App's Cron default (set in New()), covering
+// the brief startup window before cmd/tripbot installs the real scheduler — and
+// every test App.
 type noopCron struct{}
 
 func (noopCron) Stop() error { return nil }
-
-// SetScheduler installs the Cron that realCron delegates to. Called from
-// cmd/tripbot once the background scheduler is constructed and started.
-func SetScheduler(s Cron) {
-	cronMu.Lock()
-	scheduler = s
-	cronMu.Unlock()
-}

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -36,7 +36,7 @@ var (
 )
 
 // SetVideoPlayer installs the Player that realVideo delegates to. Called from
-// cmd/tripbot once the Player is constructed. Mirrors SetScheduler.
+// cmd/tripbot once the Player is constructed.
 func SetVideoPlayer(p *video.Player) {
 	videoMu.Lock()
 	videoPlayer = p


### PR DESCRIPTION
**Phase C — step 7 of the Set\* installer retirements.** First of four; the cleanest, so it sets the template for `SetVideoPlayer` / `SetSessions` / `SetFlagClient`.

Now that cmd owns the `App` (#774), it can wire the scheduler straight onto the App field instead of routing through the package-level `SetScheduler` setter + global. `*background.Scheduler` satisfies the `Cron` interface directly, so the `realCron` adapter and its mutex-guarded `scheduler` global were pure indirection.

- `App.Cron` defaults to `noopCron{}` in `New()` (safe `Stop()` for the startup window + every test App); `startCron` does `t.app.Cron = t.scheduler`.
- Deleted `realCron`, the `scheduler` package global, `cronMu`, and `SetScheduler`.
- **No mutex needed:** the assignment happens in `startCron`, which completes before `setUpTwitchClient` connects the IRC client — so it happens-before any `!shutdown` read of `a.Cron`. Same explicit-startup-ordering pattern as the other App fields.

**No behavior change.** `go build ./pkg/chatbot/... ./cmd/tripbot/...`, `go vet`, `go test ./pkg/chatbot/` all green; gofmt clean.

**Remaining Phase C:** `SetVideoPlayer` / `SetSessions` / `SetFlagClient` (same shape, independent of each other), then the capstone — delete `defaultApp` / `sayFn` / package `client` / init, migrating the registry/command tests to a constructed test App.