### PR TITLE
refactor(chatbot): retire SetVideoPlayer; realVideo holds its own Player

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -107,8 +107,8 @@ type Tripbot struct {
 	// player owns "what's currently playing" — the single process-wide
 	// instance, constructed in NewTripbot. The 60s cron tick refreshes it
 	// (GetCurrentlyPlaying); findInitialVideo + gracefulShutdown read it; it's
-	// installed into chatbot (SetVideoPlayer) so commands read the same state,
-	// and it publishes video.changed to NATS for the admin panel.
+	// wrapped into the chatbot Video adapter (NewVideoAdapter) so commands read
+	// the same state, and it publishes video.changed to NATS for the admin panel.
 	player *video.Player
 
 	// sessions tracks who's currently in chat (the login map) + the
@@ -171,8 +171,8 @@ func (t *Tripbot) Run() {
 	t.srv.SetVersion(t.version)
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
-	chatbot.SetVideoPlayer(t.player) // commands read the same Player the cron refreshes
-	chatbot.SetSessions(t.sessions)  // commands + IRC handlers read the same session state
+	t.app.Video = chatbot.NewVideoAdapter(t.player) // commands read the same Player the cron refreshes
+	chatbot.SetSessions(t.sessions)                 // commands + IRC handlers read the same session state
 	t.sessions.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -46,7 +46,7 @@ type Sessions interface {
 // handlers) delegate to. cmd/tripbot installs the single process-wide instance
 // via SetSessions once it's constructed. nil until then (brief startup window)
 // and in tests, which inject their own Sessions fake rather than realSessions —
-// so the nil guards below only ever fire pre-install. Mirrors SetVideoPlayer.
+// so the nil guards below only ever fire pre-install.
 var (
 	sessionsMu sync.RWMutex
 	sessions   *users.Sessions

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -2,15 +2,15 @@ package chatbot
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
 // Video is the subset of the pkg/video surface that chatbot commands depend
-// on. Tests inject a fake; production uses the realVideo adapter wired in
-// defaultApp. Mirrors the Onscreens/VLC injection pattern.
+// on. Tests inject a fake; production uses the realVideo adapter, which
+// cmd/tripbot builds around the process-wide *video.Player via NewVideoAdapter.
+// Mirrors the Onscreens/VLC injection pattern.
 type Video interface {
 	// Current returns the video the system believes is currently playing,
 	// without making any I/O calls.
@@ -25,60 +25,42 @@ type Video interface {
 	FindRandomByState(ctx context.Context, state string) (video.Video, error)
 }
 
-// videoPlayer is the *video.Player realVideo delegates to. cmd/tripbot installs
-// the single process-wide instance via SetVideoPlayer once it's constructed, so
-// commands read the same playback state the cron tick refreshes. nil until then
-// (brief startup window) and in tests, which inject their own Video fake rather
-// than realVideo — so the nil guards below only ever fire pre-install.
-var (
-	videoMu     sync.RWMutex
-	videoPlayer *video.Player
-)
+// realVideo delegates to its *video.Player (Current / GetCurrentlyPlaying /
+// CurrentProgress) and to pkg/video's standalone DB helper (FindRandomByState,
+// which is not Player state). cmd/tripbot installs the process-wide Player via
+// NewVideoAdapter so commands read the same playback state the cron tick
+// refreshes. player is nil in New()'s default adapter — the brief startup
+// window before cmd assigns App.Video, and the defaultApp test fixture — so the
+// nil guards below cover that. Tests inject their own Video fake rather than
+// realVideo, so the guards only ever fire pre-install.
+type realVideo struct{ player *video.Player }
 
-// SetVideoPlayer installs the Player that realVideo delegates to. Called from
-// cmd/tripbot once the Player is constructed.
-func SetVideoPlayer(p *video.Player) {
-	videoMu.Lock()
-	videoPlayer = p
-	videoMu.Unlock()
-}
+// NewVideoAdapter builds the production Video adapter around p. cmd/tripbot
+// assigns the result onto App.Video once the Player is constructed.
+func NewVideoAdapter(p *video.Player) Video { return realVideo{player: p} }
 
-func currentPlayer() *video.Player {
-	videoMu.RLock()
-	defer videoMu.RUnlock()
-	return videoPlayer
-}
-
-// realVideo delegates to the installed *video.Player (Current /
-// GetCurrentlyPlaying) and to pkg/video's standalone DB helper
-// (FindRandomByState, which is not Player state).
-type realVideo struct{}
-
-func (realVideo) Current() video.Video {
-	p := currentPlayer()
-	if p == nil {
+func (r realVideo) Current() video.Video {
+	if r.player == nil {
 		return video.Video{}
 	}
-	return p.Current()
+	return r.player.Current()
 }
 
-func (realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
-	p := currentPlayer()
-	if p == nil {
+func (r realVideo) GetCurrentlyPlaying(ctx context.Context) video.Video {
+	if r.player == nil {
 		return video.Video{}
 	}
-	p.GetCurrentlyPlaying(ctx)
-	return p.Current()
+	r.player.GetCurrentlyPlaying(ctx)
+	return r.player.Current()
 }
 
-func (realVideo) CurrentProgress() time.Duration {
-	p := currentPlayer()
-	if p == nil {
+func (r realVideo) CurrentProgress() time.Duration {
+	if r.player == nil {
 		return 0
 	}
-	return p.CurrentProgress()
+	return r.player.CurrentProgress()
 }
 
-func (realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
+func (r realVideo) FindRandomByState(ctx context.Context, state string) (video.Video, error) {
 	return video.FindRandomByState(ctx, state)
 }


### PR DESCRIPTION
**Phase C — step 8 of the Set\* installer retirements** (after #779's `SetScheduler`).

Now that cmd owns the `App` (#774), it builds the Video adapter around the process-wide `*video.Player` and assigns it onto `App.Video`, instead of routing through the package-level `SetVideoPlayer` setter + mutex-guarded global.

Unlike `Cron`, `*video.Player` doesn't satisfy the `Video` interface directly (signature adaptation on `GetCurrentlyPlaying`, plus the standalone `FindRandomByState` helper that isn't Player state), so the adapter stays — it just holds its own `player` field now instead of reading a package global.

- `realVideo` gains a `player` field; `NewVideoAdapter(p)` builds the production adapter for cmd to assign (the adapter type itself stays unexported).
- `New()`'s default `Video: realVideo{}` keeps a nil player (startup window + `defaultApp` test fixture); the existing nil guards cover that.
- cmd does `t.app.Video = chatbot.NewVideoAdapter(t.player)` in `Run()`, before `startCron`/`setUpTwitchClient` — so it happens-before any command read. No mutex needed.
- Deleted the `videoPlayer` global, `videoMu`, `currentPlayer()`, and `SetVideoPlayer`.

**No behavior change.** `go build ./pkg/chatbot/... ./cmd/tripbot/...`, `go vet`, `go test ./pkg/chatbot/` all green; gofmt clean.

**Remaining Phase C:** `SetSessions` / `SetFlagClient` (same shape), then the capstone — delete `defaultApp` / `sayFn` / package `client` / init, migrating the registry/command tests to a constructed test App.