### PR TITLE
refactor(chatbot): retire SetSessions; App holds Sessions + UserSessions

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -115,9 +115,9 @@ type Tripbot struct {
 	// lifetime-miles leaderboard — the single process-wide instance,
 	// constructed in NewTripbot. Cron jobs refresh it (UpdateSession /
 	// UpdateLeaderboard); boot hydrates it (InitLeaderboard); gracefulShutdown
-	// flushes it (Shutdown); installed into chatbot (SetSessions) + discord so
-	// they read the same state. One *Sessions per chat provider is the
-	// multi-provider seam.
+	// flushes it (Shutdown); assigned onto the chatbot App (Sessions adapter +
+	// UserSessions) and into discord so they read the same state. One *Sessions
+	// per chat provider is the multi-provider seam.
 	sessions *users.Sessions
 
 	telemetryShutdown telemetry.ShutdownFunc
@@ -171,8 +171,9 @@ func (t *Tripbot) Run() {
 	t.srv.SetVersion(t.version)
 	t.startHttpServer(shutdownCtx)
 	t.findInitialVideo()
-	t.app.Video = chatbot.NewVideoAdapter(t.player) // commands read the same Player the cron refreshes
-	chatbot.SetSessions(t.sessions)                 // commands + IRC handlers read the same session state
+	t.app.Video = chatbot.NewVideoAdapter(t.player)         // commands read the same Player the cron refreshes
+	t.app.Sessions = chatbot.NewSessionsAdapter(t.sessions) // command-time queries
+	t.app.UserSessions = t.sessions                         // inbound IRC handlers + access checks read the same session state
 	t.sessions.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)

--- a/pkg/chatbot/announce.go
+++ b/pkg/chatbot/announce.go
@@ -24,6 +24,6 @@ func (a *App) AnnounceSubscriber(username string, isGift bool, tier string) {
 	_ = isGift
 	_ = tier
 	a.IRC.Say(fmt.Sprintf("Thank you for the sub, @%s; enjoy your !bonusmiles bleedPurple", username))
-	currentSessions().GiveEveryoneMiles(1.0)
-	a.IRC.Say(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", currentSessions().LoggedInCount()))
+	a.UserSessions.GiveEveryoneMiles(1.0)
+	a.IRC.Say(fmt.Sprintf("The %d current viewers have been given a bonus mile, too HolidayPresent", a.UserSessions.LoggedInCount()))
 }

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/natsclient"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+	"github.com/adanalife/tripbot/pkg/users"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 	"github.com/gempir/go-twitch-irc/v4"
 	"gorm.io/gorm"
@@ -48,8 +49,15 @@ type App struct {
 	// Sessions wraps the user-lookup / lifetime-leaderboard / shutdown
 	// surface of pkg/users for command-time queries. Tests inject a
 	// recordingSessions to assert lookups and stage results; production
-	// uses the realSessions adapter.
+	// uses the realSessions adapter built by NewSessionsAdapter.
 	Sessions Sessions
+	// UserSessions is the concrete process-wide session state the inbound IRC
+	// handlers (HandleMessage / Join / Part) and dispatch's access check use
+	// directly — the login/logout lifecycle + follower/subscriber + login-count
+	// reads that are intentionally off the narrow Sessions interface. cmd/tripbot
+	// assigns the same *users.Sessions it wraps into Sessions. nil in tests and
+	// the brief startup window before cmd assigns it.
+	UserSessions *users.Sessions
 	// NowPlaying reports the currently-playing track on the stream's
 	// background audio source. Tests inject a fake; production uses
 	// realNowPlaying which polls SomaFM.

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -70,7 +70,7 @@ func (su sessionUser) IsSubscriber() bool { return su.s.IsSubscriber(*su.u) }
 
 func (a *App) dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)
-	if !cmd.checkAccess(ctx, sessionUser{currentSessions(), user}, a.IRC.Say) {
+	if !cmd.checkAccess(ctx, sessionUser{a.UserSessions, user}, a.IRC.Say) {
 		return
 	}
 	// Start a child span under the chatbot.handle_message span from
@@ -189,18 +189,18 @@ func (a *App) HandleMessage(ctx context.Context, msg IncomingMessage) {
 	// log in the user, then run any command (lowercased for matching)
 	//TODO: we lose capitalization here, is that okay?
 	//TODO: also handle commands prefixed with whitespace?
-	user := currentSessions().LoginIfNecessary(ctx, msg.User)
+	user := a.UserSessions.LoginIfNecessary(ctx, msg.User)
 	a.runCommand(ctx, user, strings.ToLower(msg.Text))
 }
 
 // HandleJoin records that a user joined the channel.
 func (a *App) HandleJoin(username string) {
-	currentSessions().LoginIfNecessary(context.Background(), username)
+	a.UserSessions.LoginIfNecessary(context.Background(), username)
 }
 
 // HandlePart records that a user left the channel.
 func (a *App) HandlePart(username string) {
-	currentSessions().LogoutIfNecessary(context.Background(), username)
+	a.UserSessions.LogoutIfNecessary(context.Background(), username)
 }
 
 // HandleWhisper lets an admin remote-say into chat by whispering the bot.

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -2,7 +2,6 @@ package chatbot
 
 import (
 	"context"
-	"sync"
 
 	"github.com/adanalife/tripbot/pkg/users"
 )
@@ -10,15 +9,15 @@ import (
 // Sessions is the subset of the pkg/users surface that chatbot commands
 // depend on at command-time (user lookups, lifetime-leaderboard reads,
 // miles computations, graceful shutdown of in-memory session state). Tests
-// inject a fake; production uses the realSessions adapter wired in defaultApp.
-// Mirrors the Onscreens/VLC/Video/IRC injection pattern.
+// inject a fake; production uses the realSessions adapter built by
+// NewSessionsAdapter. Mirrors the Onscreens/VLC/Video/IRC injection pattern.
 //
 // The IRC-side session lifecycle (LoginIfNecessary / LogoutIfNecessary) and the
 // follower/subscriber + login-count reads are intentionally NOT on this
-// interface — they're called from the free-function handlers in handlers.go /
-// announce.go, which aren't App methods yet, so they reach the installed
-// *Sessions through currentSessions() directly. They'll move onto App (and onto
-// this interface) when those handlers do.
+// interface — they're called from the inbound handlers (HandleMessage / Join /
+// Part) and dispatch's access check, which reach the concrete *users.Sessions
+// through App.UserSessions directly. Keeping them off this interface keeps the
+// command-time fake surface (noopSessions / recordingSessions) minimal.
 type Sessions interface {
 	// Find looks up a user by username. Returns User{ID: 0} for an
 	// unknown user (mirrors pkg/users.Find's existing contract).
@@ -42,80 +41,61 @@ type Sessions interface {
 	SetBot(ctx context.Context, username string, isBot bool) error
 }
 
-// sessions is the *users.Sessions realSessions (and the free-function IRC
-// handlers) delegate to. cmd/tripbot installs the single process-wide instance
-// via SetSessions once it's constructed. nil until then (brief startup window)
-// and in tests, which inject their own Sessions fake rather than realSessions —
-// so the nil guards below only ever fire pre-install.
-var (
-	sessionsMu sync.RWMutex
-	sessions   *users.Sessions
-)
+// realSessions delegates to its *users.Sessions, plus pkg/users' standalone DB
+// helper (Find, which is not session state). cmd/tripbot builds it around the
+// process-wide *users.Sessions via NewSessionsAdapter so commands read the same
+// session state the IRC handlers mutate. s is nil in New()'s default adapter —
+// the brief startup window before cmd assigns App.Sessions, and the defaultApp
+// test fixture — so the nil guards below cover that. Tests inject their own
+// Sessions fake rather than realSessions, so the guards only ever fire
+// pre-install.
+type realSessions struct{ s *users.Sessions }
 
-// SetSessions installs the Sessions that realSessions and the IRC handlers
-// delegate to. Called from cmd/tripbot once Sessions is constructed.
-func SetSessions(s *users.Sessions) {
-	sessionsMu.Lock()
-	sessions = s
-	sessionsMu.Unlock()
-}
+// NewSessionsAdapter builds the production Sessions adapter around s. cmd/tripbot
+// assigns the result onto App.Sessions once Sessions is constructed.
+func NewSessionsAdapter(s *users.Sessions) Sessions { return realSessions{s: s} }
 
-func currentSessions() *users.Sessions {
-	sessionsMu.RLock()
-	defer sessionsMu.RUnlock()
-	return sessions
-}
-
-// realSessions delegates to the installed *users.Sessions, plus pkg/users'
-// standalone DB helper (Find, which is not session state).
-type realSessions struct{}
-
-func (realSessions) Find(ctx context.Context, username string) users.User {
+func (r realSessions) Find(ctx context.Context, username string) users.User {
 	return users.Find(ctx, username)
 }
 
-func (realSessions) LifetimeLeaderboard() [][]string {
-	s := currentSessions()
-	if s == nil {
+func (r realSessions) LifetimeLeaderboard() [][]string {
+	if r.s == nil {
 		return nil
 	}
-	return s.LifetimeLeaderboard()
+	return r.s.LifetimeLeaderboard()
 }
 
-func (realSessions) CurrentMiles(ctx context.Context, u users.User) float32 {
-	s := currentSessions()
-	if s == nil {
+func (r realSessions) CurrentMiles(ctx context.Context, u users.User) float32 {
+	if r.s == nil {
 		return u.Miles
 	}
-	return s.CurrentMiles(ctx, u)
+	return r.s.CurrentMiles(ctx, u)
 }
 
-func (realSessions) CurrentMonthlyMiles(ctx context.Context, u users.User) float32 {
-	s := currentSessions()
-	if s == nil {
+func (r realSessions) CurrentMonthlyMiles(ctx context.Context, u users.User) float32 {
+	if r.s == nil {
 		return 0
 	}
-	return s.CurrentMonthlyMiles(ctx, u)
+	return r.s.CurrentMonthlyMiles(ctx, u)
 }
 
-func (realSessions) BonusMiles(u users.User) float32 {
-	s := currentSessions()
-	if s == nil {
+func (r realSessions) BonusMiles(u users.User) float32 {
+	if r.s == nil {
 		return 0
 	}
-	return s.BonusMiles(u)
+	return r.s.BonusMiles(u)
 }
 
-func (realSessions) Shutdown(ctx context.Context) {
-	if s := currentSessions(); s != nil {
-		s.Shutdown(ctx)
+func (r realSessions) Shutdown(ctx context.Context) {
+	if r.s != nil {
+		r.s.Shutdown(ctx)
 	}
 }
 
-func (realSessions) SetBot(ctx context.Context, username string, isBot bool) error {
-	s := currentSessions()
-	if s == nil {
+func (r realSessions) SetBot(ctx context.Context, username string, isBot bool) error {
+	if r.s == nil {
 		return nil
 	}
-	return s.SetBot(ctx, username, isBot)
+	return r.s.SetBot(ctx, username, isBot)
 }


### PR DESCRIPTION
**Phase C — step 9 of the Set\* installer retirements** (after #779 `SetScheduler`, #780 `SetVideoPlayer`).

Now that cmd owns the `App` (#774), it builds the Sessions adapter and assigns the session state onto the App, instead of routing through the package-level `SetSessions` setter + mutex-guarded global.

The wrinkle here: the command-time surface and the inbound-handler surface have different needs, so they get **two fields** (as the Phase C plan called for):

- **`App.Sessions`** (narrow `Sessions` interface) — command bodies + tests. `realSessions` now holds its own `*users.Sessions`; `NewSessionsAdapter(s)` builds it for cmd (adapter type stays unexported).
- **`App.UserSessions`** (concrete `*users.Sessions`) — the login/logout lifecycle (`HandleMessage` / `HandleJoin` / `HandlePart`), `AnnounceSubscriber`'s bonus-mile grant, and dispatch's access check (`sessionUser`). These need the full `*users.Sessions` API (`LoginIfNecessary`, `LogoutIfNecessary`, `GiveEveryoneMiles`, `LoggedInCount`, `HasCommandAvailable`, `IsSubscriber`) that's intentionally off the narrow interface — widening it (and every test fake) would be the wrong trade, so a second concrete field is cheaper.

cmd assigns both in `Run()` before `startCron`/`setUpTwitchClient`, so the writes happen-before any command or inbound read — no mutex needed. Deleted the `sessions` global, `sessionsMu`, `currentSessions()`, and `SetSessions`.

**No behavior change** (the 6 swapped call sites read `nil` in tests exactly as `currentSessions()` did). `go build ./pkg/chatbot/... ./cmd/tripbot/...`, `go vet`, `go test ./pkg/chatbot/` all green; gofmt clean.

**Remaining Phase C:** `SetFlagClient` (last of the four), then the capstone — delete `defaultApp` / `sayFn` / package `client` / init, migrating the registry/command tests to a constructed test App.