### PR TITLE
refactor(chatbot): retire defaultApp; tests build their own App

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -84,8 +84,8 @@ type Tripbot struct {
 	// app is the chatbot App that owns the command registry and runs chat
 	// commands + inbound handlers. Constructed in NewTripbot; setUpTwitchClient
 	// wires its Twitch adapters to the IRC client (ConnectIRC), and eventsub /
-	// cron register its methods. Replaces the package-level defaultApp on the
-	// live path.
+	// cron register its methods. cmd owns this App; the package holds no
+	// singleton.
 	app *chatbot.App
 
 	// irc is the go-twitch-irc client, constructed by setUpTwitchClient

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -26,8 +26,8 @@ var googleMapsAPIKey string
 var client *twitch.Client
 var Uptime time.Time
 
-// App holds injectable dependencies for the chatbot.
-// Tests instantiate it directly with fakes; production uses defaultApp.
+// App holds injectable dependencies for the chatbot. cmd/tripbot constructs the
+// live one with New(); tests instantiate it directly with fakes.
 type App struct {
 	// DB is the GORM handle used by commands that need to read or write the
 	// database. nil in tests that don't exercise the DB; otherwise either the
@@ -64,9 +64,9 @@ type App struct {
 	NowPlaying NowPlaying
 	// Flags evaluates feature flag values for command-time gating. Tests
 	// inject noopFlags{} (every key false); New() defaults it to an empty
-	// in-memory client (same fail-closed contract) for the startup window +
-	// defaultApp, and cmd/tripbot assigns the Postgres-backed client once the
-	// DB connection is up.
+	// in-memory client (same fail-closed contract) for the startup window
+	// before cmd/tripbot assigns the Postgres-backed client once the DB
+	// connection is up.
 	Flags feature.FlagClient
 	// NATS is the fire-and-forget pubsub surface. Tests inject a
 	// recordingNATS to assert on publishes; production uses realNATS
@@ -109,10 +109,9 @@ func (a *App) db() *gorm.DB {
 }
 
 // New constructs an App wired with the production (realX) dependency adapters,
-// with its command registry built and indexed. cmd builds the live App with
-// this; the package singleton defaultApp is built from it for the package-level
-// Twitch adapters / eventsub shims and the tests. Construction touches no
-// network or DB — the realX adapters are lazy.
+// with its command registry built and indexed. cmd/tripbot builds the live App
+// with this and owns it; nothing in the package holds a singleton. Construction
+// touches no network or DB — the realX adapters are lazy.
 func New() *App {
 	a := &App{
 		// DB stays nil; commands use a.db() which falls back to database.GormDB().
@@ -131,8 +130,6 @@ func New() *App {
 	a.indexCommands()
 	return a
 }
-
-var defaultApp = New()
 
 // used to determine which help message to display
 // randomized so it starts with a new one every restart

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -48,7 +48,7 @@ func newTestVideo(state string, lat, lng float64, date time.Time) video.Video {
 // (recordingOnscreens / recordingVLC / recordingVideo / recordingIRC /
 // recordingSessions).
 func newTestApp(vid video.Video) *App {
-	return &App{
+	a := &App{
 		Onscreens:  noopOnscreens{},
 		VLC:        noopVLC{},
 		Video:      &recordingVideo{Vid: vid},
@@ -61,7 +61,15 @@ func newTestApp(vid video.Video) *App {
 		Geocoder:   noopGeocoder{},
 		Twitch:     noopTwitch{},
 	}
+	a.indexCommands() // build the registry, same as New() does in production
+	return a
 }
+
+// builtTestApp is a fake-wired App with the command registry indexed, shared by
+// the registry-inspection and findCommand-routing tests (read-only — they
+// inspect command definitions / routing, never dispatch). It replaces the
+// production defaultApp singleton those tests used to read.
+var builtTestApp = newTestApp(video.Video{})
 
 // --- App.IRC seam ---
 //

--- a/pkg/chatbot/fuzz_test.go
+++ b/pkg/chatbot/fuzz_test.go
@@ -50,7 +50,7 @@ func FuzzFindCommand(f *testing.F) {
 		f.Add(s)
 	}
 	f.Fuzz(func(t *testing.T, s string) {
-		_, _ = defaultApp.findCommand(s)
+		_, _ = builtTestApp.findCommand(s)
 	})
 }
 

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -75,7 +75,7 @@ func TestNormalizeCommandPrefix_DispatchEquivalence(t *testing.T) {
 // --- findCommand routing tests ---
 
 func TestFindCommand_SingleWordTrigger(t *testing.T) {
-	cmd, params := defaultApp.findCommand("!help")
+	cmd, params := builtTestApp.findCommand("!help")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -89,7 +89,7 @@ func TestFindCommand_SingleWordTrigger(t *testing.T) {
 
 func TestFindCommand_SingleWordAlias(t *testing.T) {
 	// "hi" is an alias of "hello"
-	cmd, _ := defaultApp.findCommand("hi")
+	cmd, _ := builtTestApp.findCommand("hi")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -100,7 +100,7 @@ func TestFindCommand_SingleWordAlias(t *testing.T) {
 
 func TestFindCommand_MultiWordAlias(t *testing.T) {
 	// "no audio" is an alias of !report
-	cmd, params := defaultApp.findCommand("no audio")
+	cmd, params := builtTestApp.findCommand("no audio")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -114,7 +114,7 @@ func TestFindCommand_MultiWordAlias(t *testing.T) {
 
 func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
 	// "frozen since yesterday" — starts with the "frozen" alias
-	cmd, params := defaultApp.findCommand("frozen since yesterday")
+	cmd, params := builtTestApp.findCommand("frozen since yesterday")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -128,7 +128,7 @@ func TestFindCommand_MultiWordAliasWithTrailingText(t *testing.T) {
 
 func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 	// ¡miles should route to the same command as !miles
-	cmd, _ := defaultApp.findCommand("¡miles")
+	cmd, _ := builtTestApp.findCommand("¡miles")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -139,7 +139,7 @@ func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 
 func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
 	// "! location" (with a space) should route to !location
-	cmd, _ := defaultApp.findCommand("! location")
+	cmd, _ := builtTestApp.findCommand("! location")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -149,7 +149,7 @@ func TestFindCommand_SpaceSeparatedBang(t *testing.T) {
 }
 
 func TestFindCommand_WithParams(t *testing.T) {
-	cmd, params := defaultApp.findCommand("!goto 42")
+	cmd, params := builtTestApp.findCommand("!goto 42")
 	if cmd == nil {
 		t.Fatal("expected a command, got nil")
 	}
@@ -162,14 +162,14 @@ func TestFindCommand_WithParams(t *testing.T) {
 }
 
 func TestFindCommand_UnknownCommand(t *testing.T) {
-	cmd, _ := defaultApp.findCommand("!doesnotexist99")
+	cmd, _ := builtTestApp.findCommand("!doesnotexist99")
 	if cmd != nil {
 		t.Errorf("expected nil for unknown command, got %q", cmd.Trigger)
 	}
 }
 
 func TestFindCommand_EmptyMessage(t *testing.T) {
-	cmd, _ := defaultApp.findCommand("")
+	cmd, _ := builtTestApp.findCommand("")
 	if cmd != nil {
 		t.Errorf("expected nil for empty message, got %q", cmd.Trigger)
 	}

--- a/pkg/chatbot/irc.go
+++ b/pkg/chatbot/irc.go
@@ -2,7 +2,7 @@ package chatbot
 
 // IRC is the subset of the IRC client surface chatbot commands depend on
 // to send chat output. Tests inject a fake; production uses the package-backed
-// realIRC adapter wired in defaultApp. Mirrors the Onscreens/VLC pattern.
+// realIRC adapter wired in New(). Mirrors the Onscreens/VLC pattern.
 type IRC interface {
 	Say(msg string)               // post a message in chat
 	Whisper(username, msg string) // whisper to a specific user

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -9,7 +9,7 @@ import (
 
 // Onscreens is the subset of the onscreens-client surface that chatbot
 // commands depend on. Tests inject a fake; production uses the
-// realOnscreens adapter wired in defaultApp.
+// realOnscreens adapter wired in New().
 type Onscreens interface {
 	ShowFlag(ctx context.Context, dur time.Duration) error
 	ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error
@@ -19,7 +19,7 @@ type Onscreens interface {
 }
 
 // realOnscreens delegates to a constructed *onscreensClient.Client. The
-// concrete Client instance is owned by the App (wired up in defaultApp),
+// concrete Client instance is owned by the App (wired up in New()),
 // not read off a package-level global in pkg/onscreens-client.
 //
 // The NATS mirror lives in the client itself now (it talks to NATS + HTTP

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
-	for _, cmd := range defaultApp.commands {
+	for _, cmd := range builtTestApp.commands {
 		if cmd.Trigger == "" {
 			t.Errorf("command has empty Trigger: %+v", cmd)
 		}
@@ -15,7 +15,7 @@ func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
 
 func TestNoDuplicateTriggersOrAliases(t *testing.T) {
 	seen := map[string]string{} // trigger/alias → owning command's Trigger
-	for _, cmd := range defaultApp.commands {
+	for _, cmd := range builtTestApp.commands {
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			if owner, clash := seen[token]; clash {
@@ -27,15 +27,15 @@ func TestNoDuplicateTriggersOrAliases(t *testing.T) {
 }
 
 func TestLookupMapsContainAllTriggers(t *testing.T) {
-	for _, cmd := range defaultApp.commands {
+	for _, cmd := range builtTestApp.commands {
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			if strings.Contains(token, " ") {
-				if _, ok := defaultApp.multiWordLookup[token]; !ok {
+				if _, ok := builtTestApp.multiWordLookup[token]; !ok {
 					t.Errorf("multi-word trigger %q missing from multiWordLookup", token)
 				}
 			} else {
-				if _, ok := defaultApp.singleWordLookup[token]; !ok {
+				if _, ok := builtTestApp.singleWordLookup[token]; !ok {
 					t.Errorf("single-word trigger %q missing from singleWordLookup", token)
 				}
 			}
@@ -44,15 +44,15 @@ func TestLookupMapsContainAllTriggers(t *testing.T) {
 }
 
 func TestLookupMapsPointToCorrectCommand(t *testing.T) {
-	for i := range defaultApp.commands {
-		cmd := &defaultApp.commands[i]
+	for i := range builtTestApp.commands {
+		cmd := &builtTestApp.commands[i]
 		all := append([]string{cmd.Trigger}, cmd.Aliases...)
 		for _, token := range all {
 			var got *Command
 			if strings.Contains(token, " ") {
-				got = defaultApp.multiWordLookup[token]
+				got = builtTestApp.multiWordLookup[token]
 			} else {
-				got = defaultApp.singleWordLookup[token]
+				got = builtTestApp.singleWordLookup[token]
 			}
 			if got != cmd {
 				t.Errorf("trigger %q maps to %q, want %q", token, got.Trigger, cmd.Trigger)

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -44,11 +44,10 @@ type Sessions interface {
 // realSessions delegates to its *users.Sessions, plus pkg/users' standalone DB
 // helper (Find, which is not session state). cmd/tripbot builds it around the
 // process-wide *users.Sessions via NewSessionsAdapter so commands read the same
-// session state the IRC handlers mutate. s is nil in New()'s default adapter —
-// the brief startup window before cmd assigns App.Sessions, and the defaultApp
-// test fixture — so the nil guards below cover that. Tests inject their own
-// Sessions fake rather than realSessions, so the guards only ever fire
-// pre-install.
+// session state the IRC handlers mutate. s is nil in New()'s default adapter
+// until cmd assigns App.Sessions, so the nil guards below cover that brief
+// startup window. Tests inject their own Sessions fake rather than realSessions,
+// so the guards only ever fire pre-install.
 type realSessions struct{ s *users.Sessions }
 
 // NewSessionsAdapter builds the production Sessions adapter around s. cmd/tripbot

--- a/pkg/chatbot/video.go
+++ b/pkg/chatbot/video.go
@@ -29,10 +29,10 @@ type Video interface {
 // CurrentProgress) and to pkg/video's standalone DB helper (FindRandomByState,
 // which is not Player state). cmd/tripbot installs the process-wide Player via
 // NewVideoAdapter so commands read the same playback state the cron tick
-// refreshes. player is nil in New()'s default adapter — the brief startup
-// window before cmd assigns App.Video, and the defaultApp test fixture — so the
-// nil guards below cover that. Tests inject their own Video fake rather than
-// realVideo, so the guards only ever fire pre-install.
+// refreshes. player is nil in New()'s default adapter until cmd assigns
+// App.Video, so the nil guards below cover that brief startup window. Tests
+// inject their own Video fake rather than realVideo, so the guards only ever
+// fire pre-install.
 type realVideo struct{ player *video.Player }
 
 // NewVideoAdapter builds the production Video adapter around p. cmd/tripbot

--- a/pkg/chatbot/vlc.go
+++ b/pkg/chatbot/vlc.go
@@ -8,7 +8,7 @@ import (
 
 // VLC is the subset of the vlc-client surface that chatbot commands depend
 // on (timewarp, jump, skip, back). Tests inject a fake; production uses the
-// realVLC adapter wired in defaultApp. Mirrors the Onscreens injection
+// realVLC adapter wired in New(). Mirrors the Onscreens injection
 // pattern.
 type VLC interface {
 	PlayRandom(ctx context.Context) error
@@ -18,7 +18,7 @@ type VLC interface {
 }
 
 // realVLC delegates to a constructed *vlcClient.Client. The concrete Client
-// instance is owned by the App (wired up in defaultApp), not read off a
+// instance is owned by the App (wired up in New()), not read off a
 // package-level global in pkg/vlc-client.
 type realVLC struct {
 	c *vlcClient.Client


### PR DESCRIPTION
**Phase C capstone — PR 1 of 3.** Retires the `defaultApp` package singleton.

`defaultApp` was the App built at package init. After #774 (cmd owns the live App), it had **no production callers left** — only the registry / findCommand / fuzz tests still read it as a built-registry fixture.

- `newTestApp` now calls `indexCommands()`, so every test App has the registry built (same as `New()` does in production).
- A shared, read-only `builtTestApp` fixture replaces `defaultApp` for the registry-inspection (`registry_test`), findCommand-routing (`handlers_test`), and fuzz (`fuzz_test`) tests — all of which only inspect command definitions / routing, never dispatch.
- Deleted `var defaultApp = New()` and refreshed the adapter doc comments that named it as the wiring home (now `New()`).

Removing the init-time singleton means `New()` only runs when cmd or a test calls it — no App constructed at package import.

**No behavior change.** `go build ./pkg/chatbot/... ./cmd/tripbot/...`, `go vet`, `go test ./pkg/chatbot/` all green; gofmt clean.

**Remaining capstone:**
- **PR 2** — collapse the `sayFn`/`captureSay` test seam onto the injected `recordingIRC` (rewrite the ~57 sites, make `noopIRC` a true no-op), delete `sayFn`.
- **PR 3** — outbound `ChatClient` seam: rename `IRC`→`ChatClient`, the adapter holds its own `*twitch.Client` + a provider-neutral console-mirror wrapper, delete the package `client` global + `Say`/`Whisper`. This is the multi-provider-shaped finale.