### PR TITLE
feat(contract): add per-platform service names for the cdk8s app factory

### DIFF
--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -52,6 +52,22 @@ const (
 	ServicePostgres = "postgres"
 )
 
+// Per-platform service names. Each streaming platform runs its own full stack
+// (tripbot + vlc + onscreens + obs); the names carry the platform suffix so a
+// Service only ever selects its own platform's pods. obs has been per-platform
+// since #629; the cdk8s app factory brings the other three onto the same shape.
+// The bare ServiceTripbot/ServiceVLCServer/ServiceOnscreensServer above remain
+// the app-identity prefixes (Secret/ConfigMap names) — only the workload
+// Services carry the suffix.
+const (
+	ServiceTripbotTwitch    = "tripbot-twitch"
+	ServiceTripbotYouTube   = "tripbot-youtube"
+	ServiceVLCTwitch        = "vlc-twitch"
+	ServiceVLCYouTube       = "vlc-youtube"
+	ServiceOnscreensTwitch  = "onscreens-twitch"
+	ServiceOnscreensYouTube = "onscreens-youtube"
+)
+
 // Pod ports. Several services co-locate on 8080 for their HTTP API but expose
 // other ports (VNC, websocket, RTSP) on their own pods, so the keys are
 // per-(service, role) rather than per-number.
@@ -132,6 +148,12 @@ func Current() Contract {
 			{"onscreens_server", ServiceOnscreensServer},
 			{"obs_twitch", ServiceOBSTwitch},
 			{"obs_youtube", ServiceOBSYouTube},
+			{"tripbot_twitch", ServiceTripbotTwitch},
+			{"tripbot_youtube", ServiceTripbotYouTube},
+			{"vlc_twitch", ServiceVLCTwitch},
+			{"vlc_youtube", ServiceVLCYouTube},
+			{"onscreens_twitch", ServiceOnscreensTwitch},
+			{"onscreens_youtube", ServiceOnscreensYouTube},
 			{"postgres", ServicePostgres},
 		},
 		Ports: []pair{

--- a/pkg/contract/contract.json
+++ b/pkg/contract/contract.json
@@ -6,6 +6,12 @@
     "onscreens_server": "onscreens-server",
     "obs_twitch": "obs-twitch",
     "obs_youtube": "obs-youtube",
+    "tripbot_twitch": "tripbot-twitch",
+    "tripbot_youtube": "tripbot-youtube",
+    "vlc_twitch": "vlc-twitch",
+    "vlc_youtube": "vlc-youtube",
+    "onscreens_twitch": "onscreens-twitch",
+    "onscreens_youtube": "onscreens-youtube",
     "postgres": "postgres"
   },
   "ports": {


### PR DESCRIPTION
## What

Adds per-platform service-name constants for **tripbot / vlc / onscreens**, mirroring what obs has had since [#629](https://github.com/adanalife/tripbot/pull/629) (`obs-twitch`/`obs-youtube`):

```
tripbot_twitch    → tripbot-twitch       vlc_twitch        → vlc-twitch
tripbot_youtube   → tripbot-youtube      vlc_youtube       → vlc-youtube
onscreens_twitch  → onscreens-twitch     onscreens_youtube → onscreens-youtube
```

Regenerated `contract.json` via `go generate ./pkg/contract`; the drift test passes.

## Why

This is the source-of-truth half of the **unified per-platform app factory** (cdk8s). The factory emits a full stack per streaming platform (tripbot + vlc + onscreens + obs), every name routed through the contract. The bare `tripbot`/`vlc-server`/`onscreens-server` keys stay — they remain the app-identity prefixes for Secret/ConfigMap names; only the workload Services carry the platform suffix.

## Companion

Infra picks this up via `task contract:sync` and converts the three constructs to factories — infra PR to follow (linked here once open).