### PR TITLE
feat: live enable/disable toggle for feature flags in the admin panel

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -28,6 +28,20 @@ type FlagClient interface {
 	Snapshot(ctx context.Context) []Flag
 }
 
+// FlagToggler is the admin write surface: flip a flag's global default on or
+// off and make the change live immediately. It's kept separate from
+// FlagClient so the read path stays OpenFeature-shaped (a future SDK swap
+// only has to satisfy Bool/Snapshot); only the Postgres-backed client
+// implements it. Callers that want the toggle surface type-assert their
+// FlagClient to FlagToggler and degrade gracefully when it's absent (e.g.
+// the in-memory fallback used before the DB client is wired).
+type FlagToggler interface {
+	// SetEnabled persists the new global-default state for key and refreshes
+	// the in-memory snapshot so the change takes effect without waiting for
+	// the next background poll. Returns an error if key doesn't exist.
+	SetEnabled(ctx context.Context, key string, enabled bool) error
+}
+
 // EvalContext carries the targeting attributes a flag is evaluated against.
 // The App is responsible for populating it (Channel, Env from config;
 // Username and Roles from the user being acted on, if any).

--- a/pkg/feature/postgres.go
+++ b/pkg/feature/postgres.go
@@ -2,6 +2,7 @@ package feature
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -61,6 +62,23 @@ func (r *repository) LoadAll(ctx context.Context) (map[string]Flag, error) {
 	return out, nil
 }
 
+// SetEnabled flips the enabled column for one flag. RowsAffected == 0 means
+// the key doesn't exist — surfaced as an error so an admin toggle of an
+// unknown key fails loudly rather than silently no-op'ing.
+func (r *repository) SetEnabled(ctx context.Context, key string, enabled bool) error {
+	res := r.db.WithContext(ctx).
+		Model(&flagRow{}).
+		Where("key = ?", key).
+		Updates(map[string]any{"enabled": enabled, "updated_at": time.Now()})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("feature flag %q not found", key)
+	}
+	return nil
+}
+
 // PostgresClient is a FlagClient backed by a Postgres-loaded snapshot
 // refreshed in a background goroutine. The hot path (Bool) is a map read
 // under an RWMutex — no DB hit per evaluation.
@@ -118,6 +136,24 @@ func (c *PostgresClient) refresh(ctx context.Context) error {
 	c.mu.Lock()
 	c.flags = next
 	c.mu.Unlock()
+	return nil
+}
+
+// SetEnabled persists the new global-default state for key, then force-loads
+// the snapshot so the change is live immediately — both this client's Bool
+// evaluations and its Snapshot reflect it without waiting for the next poll.
+// Implements FlagToggler.
+func (c *PostgresClient) SetEnabled(ctx context.Context, key string, enabled bool) error {
+	if err := c.repo.SetEnabled(ctx, key, enabled); err != nil {
+		return err
+	}
+	// Pull the fresh state in immediately. A refresh error here is unexpected
+	// (the write just succeeded), but if it happens the next poll reconciles;
+	// the DB is already authoritative, so we don't fail the toggle.
+	if err := c.refresh(ctx); err != nil {
+		slog.WarnContext(ctx, "flag toggle persisted but immediate refresh failed; next poll will reconcile",
+			"err", err, "key", key)
+	}
 	return nil
 }
 

--- a/pkg/feature/postgres_test.go
+++ b/pkg/feature/postgres_test.go
@@ -154,6 +154,61 @@ func TestPostgresClient_RefreshFailureRetainsCache(t *testing.T) {
 	}
 }
 
+func TestPostgresClient_SetEnabled(t *testing.T) {
+	db, mock := newMockDB(t)
+	expectFlags(mock, flagRow{
+		Key:               "chatbot.weather",
+		Description:       "weather command",
+		Enabled:           false,
+		TargetRemovalDate: time.Now().Add(30 * 24 * time.Hour),
+	})
+	c, err := NewPostgresClient(context.Background(), db, time.Minute)
+	if err != nil {
+		t.Fatalf("NewPostgresClient: %v", err)
+	}
+	if c.Bool(context.Background(), "chatbot.weather", EvalContext{}) {
+		t.Fatal("flag should start disabled")
+	}
+
+	// The write, then the immediate force-refresh that pulls the new state in.
+	mock.ExpectExec(`UPDATE "feature_flags" SET`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectFlags(mock, flagRow{
+		Key:               "chatbot.weather",
+		Description:       "weather command",
+		Enabled:           true,
+		TargetRemovalDate: time.Now().Add(30 * 24 * time.Hour),
+	})
+
+	if err := c.SetEnabled(context.Background(), "chatbot.weather", true); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	if !c.Bool(context.Background(), "chatbot.weather", EvalContext{}) {
+		t.Error("flag should be live-enabled immediately after SetEnabled, no poll wait")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestPostgresClient_SetEnabledUnknownKey(t *testing.T) {
+	db, mock := newMockDB(t)
+	expectFlags(mock) // empty table
+	c, err := NewPostgresClient(context.Background(), db, time.Minute)
+	if err != nil {
+		t.Fatalf("NewPostgresClient: %v", err)
+	}
+	// Zero rows matched → error, and no force-refresh SELECT is issued.
+	mock.ExpectExec(`UPDATE "feature_flags" SET`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	if err := c.SetEnabled(context.Background(), "nope.missing", true); err == nil {
+		t.Error("expected an error when toggling a key that doesn't exist")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
 func TestPostgresClient_EmptyTable(t *testing.T) {
 	db, mock := newMockDB(t)
 	expectFlags(mock) // zero rows

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -151,6 +151,39 @@ func renderStreamControl(sc streamControl, oob bool) string {
 	return sb.String()
 }
 
+// flagRowTmpl renders one feature-flag <li>. It's the swap target for the
+// toggle POSTs (hx-target="closest .flag-row", hx-swap="outerHTML") and is
+// rendered identically on the initial page load (via the flagRow template
+// func) and by flagActionHandler's response, so a live toggle matches a fresh
+// page render. The toggle button only renders when .Toggleable — a read-only
+// client (startup window, tests) keeps the bare on/off status. The button is a
+// "molly" button (data-arm-label) so an accidental tap arms rather than fires,
+// matching the stream/restart toggles.
+var flagRowTmpl = template.Must(template.New("flagrow").Parse(
+	`<li class="row flag-row">` +
+		`<span class="dot {{if .Enabled}}up{{else}}down{{end}}"></span>` +
+		`<span class="name"><code>{{.Key}}</code>{{if .Description}}<span class="state"> · {{.Description}}</span>{{end}}</span>` +
+		`<span class="status">{{if .Enabled}}on{{else}}off{{end}}</span>` +
+		`{{- if .Toggleable}}` +
+		`{{- if .Enabled}}` +
+		`<button type="button" class="flag-toggle on" hx-post="/admin/flags/{{.Key}}/disable" hx-target="closest .flag-row" hx-swap="outerHTML" hx-disabled-elt="this" data-arm-label="click again to disable" data-original-label="disable">disable</button>` +
+		`{{- else}}` +
+		`<button type="button" class="flag-toggle off" hx-post="/admin/flags/{{.Key}}/enable" hx-target="closest .flag-row" hx-swap="outerHTML" hx-disabled-elt="this" data-arm-label="click again to enable" data-original-label="enable">enable</button>` +
+		`{{- end}}` +
+		`{{- end}}` +
+		`</li>`))
+
+// renderFlagRow executes flagRowTmpl to a string, shared by the initial page
+// render (via the flagRow template func) and flagActionHandler's swap response.
+func renderFlagRow(f featureFlag) string {
+	var sb strings.Builder
+	if err := flagRowTmpl.Execute(&sb, f); err != nil {
+		slog.Error("couldn't render flag row", "err", err)
+		return ""
+	}
+	return sb.String()
+}
+
 // statusRowsTmpl renders the <li> service-status rows. Extracted so the initial
 // page render (via the statusRows template func) and the /admin/refresh poll
 // produce identical markup, mirroring the streamControl/authCard pattern.
@@ -188,6 +221,10 @@ type featureFlag struct {
 	Key         string
 	Enabled     bool
 	Description string
+	// Toggleable is true when the installed flag client supports writes (the
+	// Postgres-backed client in prod). When false — the in-memory fallback
+	// during startup, or in tests — the row renders read-only with no button.
+	Toggleable bool
 }
 
 // adminData is the template payload.
@@ -318,12 +355,14 @@ func (s *Server) gatherFlags(ctx context.Context) []featureFlag {
 	if len(flags) == 0 {
 		return nil
 	}
+	_, toggleable := s.flagToggler()
 	out := make([]featureFlag, 0, len(flags))
 	for _, f := range flags {
 		out = append(out, featureFlag{
 			Key:         f.Key,
 			Enabled:     f.Enabled,
 			Description: f.Description,
+			Toggleable:  toggleable,
 		})
 	}
 	return out
@@ -446,6 +485,58 @@ func obsStreamActionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if _, werr := w.Write([]byte(renderStreamControl(streamControl{Reachable: true, Active: active}, false))); werr != nil {
 		slog.ErrorContext(r.Context(), "couldn't write stream control", "err", werr)
+	}
+}
+
+// flagActionHandler handles POST /admin/flags/{key}/{action} (action =
+// "enable" or "disable") from the feature-flags section's toggle buttons.
+// It writes the new global default through the flag client's toggle surface —
+// which force-refreshes the in-memory snapshot, so the change is live for both
+// this panel and the bot's command gating immediately — then swaps in the
+// flag's row to reflect the new state.
+func (s *Server) flagActionHandler(w http.ResponseWriter, r *http.Request) {
+	key := mux.Vars(r)["key"]
+	action := mux.Vars(r)["action"]
+	var enabled bool
+	switch action {
+	case "enable":
+		enabled = true
+	case "disable":
+		enabled = false
+	default:
+		http.Error(w, "unknown action", http.StatusBadRequest)
+		return
+	}
+
+	toggler, ok := s.flagToggler()
+	if !ok {
+		// The in-memory fallback (startup window) has no write surface. The UI
+		// gates the button on the same condition, so this is the defensive path
+		// for a stale page posting before the Postgres client is wired.
+		slog.ErrorContext(r.Context(), "flag toggle unavailable: client is read-only", "key", key)
+		http.Error(w, "feature flags are read-only right now", http.StatusServiceUnavailable)
+		return
+	}
+	if err := toggler.SetEnabled(r.Context(), key, enabled); err != nil {
+		slog.ErrorContext(r.Context(), "flag toggle failed", "key", key, "action", action, "err", err)
+		http.Error(w, "couldn't toggle flag", http.StatusBadGateway)
+		return
+	}
+	slog.InfoContext(r.Context(), "feature flag toggled from admin panel", "key", key, "enabled", enabled)
+
+	// Re-render the row from the freshly-refreshed snapshot so the swapped-in
+	// markup matches a full page render exactly (carrying the description back).
+	row := featureFlag{Key: key, Enabled: enabled, Toggleable: true}
+	for _, f := range s.flagSnapshot(r.Context()) {
+		if f.Key == key {
+			row.Description = f.Description
+			row.Enabled = f.Enabled
+			break
+		}
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if _, werr := w.Write([]byte(renderFlagRow(row))); werr != nil {
+		slog.ErrorContext(r.Context(), "couldn't write flag row", "err", werr)
 	}
 }
 
@@ -698,6 +789,9 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
 	"streamControl": func(sc streamControl) template.HTML { return template.HTML(renderStreamControl(sc, false)) },
 	// statusRows renders the service-status <li> rows, shared with /admin/refresh.
 	"statusRows": func(s []serviceStatus) template.HTML { return template.HTML(renderStatusRows(s)) },
+	// flagRow renders one feature-flag <li>, shared with flagActionHandler so a
+	// live toggle's swapped-in row matches the initial render byte-for-byte.
+	"flagRow": func(f featureFlag) template.HTML { return template.HTML(renderFlagRow(f)) },
 }).Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -800,6 +894,13 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   /* feature-flags rows reuse .row but the name column carries the flag key
      in monospace; description trails after a separator dot like elsewhere. */
   .row.flag-row .name code { font-family:var(--mono); font-size:.95em; }
+  /* per-flag enable/disable toggle — same small, unobtrusive shape as .restart;
+     a green tint when the action will enable, and a molly button (arms on first
+     tap, fires on the second) like the stream/restart controls. */
+  button.flag-toggle { font:inherit; font-size:.8em; padding:3px 9px; border-radius:4px; border:1px solid #2a2a2a; background:#1a1a1a; color:#888; cursor:pointer; transition:background .15s, color .15s, border-color .15s; min-width:4.5em; }
+  button.flag-toggle:hover { background:#252525; color:#ccc; border-color:#3a3a3a; }
+  button.flag-toggle.off:hover { color:#7fc296; border-color:#2f6f43; }
+  button.flag-toggle.armed { background:#f85149; color:#fff; border-color:#f85149; box-shadow:0 0 0 2px #f8514980; }
   .stream-frame { aspect-ratio:16 / 9; width:100%; margin-top:10px; background:#000; border-radius:6px; overflow:hidden; }
   .stream-frame iframe { width:100%; height:100%; border:none; display:block; }
   a { color:#58a6ff; text-decoration:none; }
@@ -841,7 +942,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
      hx-post is in flight, and hx-disabled-elt also sets :disabled. Dim it + show
      a progress cursor so a tap reads as "working" and a double-tap is visibly
      inert until the request settles. */
-  button.htmx-request, button.stream:disabled, button.restart:disabled { opacity:.55; cursor:progress; }
+  button.htmx-request, button.stream:disabled, button.restart:disabled, button.flag-toggle:disabled { opacity:.55; cursor:progress; }
   /* live chat console — recent history rendered server-side, live lines stream
      in via SSE (sse-swap="chat", beforeend). Same disclosure look as the others. */
   details.chat { margin:24px 0 0; }
@@ -968,13 +1069,7 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   <details class="feature-flags">
     <summary>feature flags</summary>
     <ul class="flags">
-      {{range .Flags}}
-      <li class="row flag-row">
-        <span class="dot {{if .Enabled}}up{{else}}down{{end}}"></span>
-        <span class="name"><code>{{.Key}}</code>{{if .Description}}<span class="state"> · {{.Description}}</span>{{end}}</span>
-        <span class="status">{{if .Enabled}}on{{else}}off{{end}}</span>
-      </li>
-      {{end}}
+      {{range .Flags}}{{flagRow .}}{{end}}
     </ul>
   </details>
   {{end}}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -790,5 +792,172 @@ func TestAdminHandler_ChatEmptyPlaceholder(t *testing.T) {
 
 	if !strings.Contains(rec.Body.String(), "waiting for chat") {
 		t.Errorf("expected empty-chat placeholder when no history")
+	}
+}
+
+// fakeToggler is an in-memory FlagClient that also implements
+// feature.FlagToggler, so the admin toggle handler's write path can be
+// exercised without a database. SetEnabled mutates the in-memory flag and
+// records the call for assertions.
+type fakeToggler struct {
+	flags map[string]feature.Flag
+	calls []string // one "key=true"/"key=false" per SetEnabled
+}
+
+func newFakeToggler(flags map[string]feature.Flag) *fakeToggler {
+	if flags == nil {
+		flags = map[string]feature.Flag{}
+	}
+	return &fakeToggler{flags: flags}
+}
+
+func (f *fakeToggler) Bool(_ context.Context, key string, _ feature.EvalContext) bool {
+	return f.flags[key].Enabled
+}
+
+func (f *fakeToggler) Snapshot(_ context.Context) []feature.Flag {
+	out := make([]feature.Flag, 0, len(f.flags))
+	for _, fl := range f.flags {
+		out = append(out, fl)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func (f *fakeToggler) SetEnabled(_ context.Context, key string, enabled bool) error {
+	fl, ok := f.flags[key]
+	if !ok {
+		return fmt.Errorf("unknown flag %q", key)
+	}
+	fl.Enabled = enabled
+	f.flags[key] = fl
+	f.calls = append(f.calls, fmt.Sprintf("%s=%t", key, enabled))
+	return nil
+}
+
+func flagRouter(srv *Server) *mux.Router {
+	r := mux.NewRouter()
+	r.Handle("/admin/flags/{key}/{action}", http.HandlerFunc(srv.flagActionHandler)).Methods("POST")
+	return r
+}
+
+func TestFlagActionHandler_EnableTogglesAndSwapsRow(t *testing.T) {
+	srv := New()
+	tog := newFakeToggler(map[string]feature.Flag{
+		"chatbot.weather": {Key: "chatbot.weather", Description: "weather command", Enabled: false},
+	})
+	srv.SetFlagClient(tog)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/flags/chatbot.weather/enable", nil)
+	rec := httptest.NewRecorder()
+	flagRouter(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body %q", rec.Code, rec.Body.String())
+	}
+	if len(tog.calls) != 1 || tog.calls[0] != "chatbot.weather=true" {
+		t.Fatalf("SetEnabled calls = %v, want [chatbot.weather=true]", tog.calls)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `<code>chatbot.weather</code>`) {
+		t.Errorf("response should be the flag row; got %q", body)
+	}
+	// Now enabled, the swapped-in row offers the opposite (disable) action.
+	if !strings.Contains(body, `hx-post="/admin/flags/chatbot.weather/disable"`) {
+		t.Errorf("enabled row should now offer disable; got %q", body)
+	}
+	if !strings.Contains(body, `class="status">on<`) {
+		t.Errorf("row status should read on; got %q", body)
+	}
+	if !strings.Contains(body, "weather command") {
+		t.Errorf("row should carry the description back; got %q", body)
+	}
+}
+
+func TestFlagActionHandler_DisableTogglesOff(t *testing.T) {
+	srv := New()
+	tog := newFakeToggler(map[string]feature.Flag{
+		"chatbot.weather": {Key: "chatbot.weather", Description: "weather command", Enabled: true},
+	})
+	srv.SetFlagClient(tog)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/flags/chatbot.weather/disable", nil)
+	rec := httptest.NewRecorder()
+	flagRouter(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body %q", rec.Code, rec.Body.String())
+	}
+	if len(tog.calls) != 1 || tog.calls[0] != "chatbot.weather=false" {
+		t.Fatalf("SetEnabled calls = %v, want [chatbot.weather=false]", tog.calls)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `hx-post="/admin/flags/chatbot.weather/enable"`) {
+		t.Errorf("disabled row should now offer enable; got %q", body)
+	}
+	if !strings.Contains(body, `class="status">off<`) {
+		t.Errorf("row status should read off; got %q", body)
+	}
+}
+
+func TestFlagActionHandler_ReadOnlyClientIs503(t *testing.T) {
+	srv := New()
+	// The in-memory client has no write surface (doesn't implement FlagToggler).
+	srv.SetFlagClient(feature.NewInMemoryClient(map[string]feature.Flag{
+		"chatbot.weather": {Key: "chatbot.weather", Enabled: false},
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/flags/chatbot.weather/enable", nil)
+	rec := httptest.NewRecorder()
+	flagRouter(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d, want 503", rec.Code)
+	}
+}
+
+func TestFlagActionHandler_UnknownActionIs400(t *testing.T) {
+	srv := New()
+	srv.SetFlagClient(newFakeToggler(map[string]feature.Flag{
+		"chatbot.weather": {Key: "chatbot.weather", Enabled: false},
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/flags/chatbot.weather/bogus", nil)
+	rec := httptest.NewRecorder()
+	flagRouter(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+}
+
+func TestFlagActionHandler_UnknownKeyIsBadGateway(t *testing.T) {
+	srv := New()
+	srv.SetFlagClient(newFakeToggler(nil)) // empty — every key unknown
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/flags/nope.missing/enable", nil)
+	rec := httptest.NewRecorder()
+	flagRouter(srv).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status %d, want 502", rec.Code)
+	}
+}
+
+func TestAdminHandler_RendersToggleButtonsWhenClientWritable(t *testing.T) {
+	srv := New()
+	srv.SetTwitchConnected(true)
+	withNowPlaying(t, nowPlayingTrack{})
+	withReauth(t, nil)
+	withConf(t, func() { c.Conf.VlcServerHost = "" })
+	srv.SetFlagClient(newFakeToggler(map[string]feature.Flag{
+		"chatbot.weather": {Key: "chatbot.weather", Description: "weather command", Enabled: false},
+	}))
+
+	rec := httptest.NewRecorder()
+	srv.adminHandler(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !strings.Contains(rec.Body.String(), `hx-post="/admin/flags/chatbot.weather/enable"`) {
+		t.Errorf("writable client should render a toggle button in the flag row")
 	}
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -82,6 +82,18 @@ func (s *Server) flagSnapshot(ctx context.Context) []feature.Flag {
 	return client.Snapshot(ctx)
 }
 
+// flagToggler returns the installed flag client's write surface, if it has
+// one. The Postgres-backed client does; the in-memory fallback (startup
+// window, tests) doesn't — so the admin toggle UI and the toggle action
+// both gate on the ok result, degrading to read-only when absent.
+func (s *Server) flagToggler() (feature.FlagToggler, bool) {
+	s.flagMu.RLock()
+	client := s.flagClient
+	s.flagMu.RUnlock()
+	t, ok := client.(feature.FlagToggler)
+	return t, ok
+}
+
 // versionHandler returns build metadata as JSON. The tag comes from the
 // build-time ldflag; sha + built_at are read from the binary's embedded
 // VCS info (Go's automatic -buildvcs). started_at is when the process

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -111,6 +111,7 @@ func (s *Server) Start(ctx context.Context) {
 	// exposed; no app-layer auth gate (see CLAUDE.md / vault decisions).
 	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
 	admin.Handle("/obs/stream/{action}", tagged("/admin/obs/stream/{action}", obsStreamActionHandler))
+	admin.Handle("/flags/{key}/{action}", tagged("/admin/flags/{key}/{action}", s.flagActionHandler))
 	admin.Handle("/shutdown", tagged("/admin/shutdown", httpmw.ShutdownHandler()))
 	admin.Handle("/restart/{service}", tagged("/admin/restart/{service}", restartActionHandler))
 


### PR DESCRIPTION
## Summary
Answers "can we toggle flags live?" — yes, and now from the admin panel instead of editing Postgres by hand.

- **New `feature.FlagToggler` write surface** (`SetEnabled`), kept separate from the OpenFeature-shaped `FlagClient` read interface so a future SDK swap stays mechanical. The Postgres-backed client implements it: writes the `enabled` column, then **force-refreshes its in-memory snapshot** so the change is live immediately for every holder of the shared client — both the admin panel and the bot's command-time gating — with no wait for the 30s poll.
- **Admin panel toggle.** Each row in the feature-flags section gets an enable/disable button (a "molly" button — arms on first tap, fires on the second, matching the existing stream/restart toggles). `POST /admin/flags/{key}/{action}` flips the flag and swaps the row back in to reflect the new state.
- **Degrades cleanly.** The button only renders when the installed client supports writes; the in-memory startup fallback keeps the section read-only, exactly as before.
- Toggling an unknown key fails loudly (errors / 502) rather than silently no-op'ing.

## Test plan
- [x] `pkg/feature` + `pkg/server` suites green; `go vet` + `gofmt` clean; `cmd/tripbot` builds
- [x] Unit tests: `SetEnabled` write-through + force-refresh; unknown-key error; handler enable/disable row swap; read-only client → 503; unknown action → 400; unknown key → 502; panel renders the button only when writable
- [ ] CI green
- [ ] Dana: toggle a flag in the panel, confirm chat behavior flips without a redeploy

Pairs with #799, which seeds the first command-gating flag (`chatbot.weather`) this panel can now flip.