### PR TITLE
fix(obs): derive default websocket addr from the contract

### DIFF
--- a/pkg/obs/control.go
+++ b/pkg/obs/control.go
@@ -3,11 +3,22 @@ package obs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
+	"github.com/adanalife/tripbot/pkg/contract"
 	goobs "github.com/andreykaipov/goobs"
 )
+
+// defaultOBSWebsocketAddr is the fallback dialed when OBS_WEBSOCKET_ADDR is
+// unset. Derived from the shared contract so it tracks the canonical
+// obs-twitch service name + websocket port instead of drifting when OBS is
+// renamed (it was left as the pre-per-platform "obs:4455" once and broke the
+// watchdog on stage). In-cluster, cdk8s stamps OBS_WEBSOCKET_ADDR per platform
+// so the YouTube stack dials obs-youtube; this default only covers the
+// env-unset case.
+var defaultOBSWebsocketAddr = fmt.Sprintf("%s:%d", contract.ServiceOBSTwitch, contract.PortOBSWebsocket)
 
 // dial opens a fresh OBS WebSocket connection using the same env vars
 // PollStreamingActive reads. Callers are responsible for client.Disconnect().
@@ -16,7 +27,7 @@ import (
 func dial(_ context.Context) (*goobs.Client, error) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
-		addr = "obs:4455"
+		addr = defaultOBSWebsocketAddr
 	}
 	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
 	if passwd == "" {

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -17,7 +17,7 @@ import (
 func PollStreamingActive(ctx context.Context, interval time.Duration) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
-		addr = "obs:4455"
+		addr = defaultOBSWebsocketAddr
 	}
 	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
 	if passwd == "" {


### PR DESCRIPTION
## Problem

On stage the OBS silent-disconnect watchdog logs `WARN watchdog: obs status unavailable err="obs websocket unreachable\ndial tcp: lookup obs"`.

`pkg/obs` reads `OBS_WEBSOCKET_ADDR` from the env with a hardcoded fallback of `obs:4455` — the pre-per-platform service name. Once OBS went per-platform (`obs` → `obs-twitch`) there's no `obs` Service to resolve, so every code path that hits the default (the watchdog's `GetStreamActiveSteady`, `StartStream`/`StopStream`, `PollStreamingActive`) fails with `lookup obs`.

cdk8s never stamps `OBS_WEBSOCKET_ADDR` onto tripbot (it sets `OBS_SERVER_HOST` for the :8080 Flask server, but not the :4455 websocket addr), so the in-code default is load-bearing — and it was stale.

## Fix

Build the default from `pkg/contract` (`ServiceOBSTwitch` + `PortOBSWebsocket`) instead of a literal, so it tracks the canonical service name and can't silently drift on the next rename. `contract.go` already *claimed* this default matched `obs-twitch:4455`; now it actually does.

`pkg/contract` is a stdlib-only leaf with no `init()` side effects, so importing it from `pkg/obs` keeps vlc-server's import chain clean (verified with `go list -deps`).

## The load-bearing half is in infra

For correct **per-platform** behavior the YouTube stack must dial `obs-youtube`, which a single default can't cover. The companion change stamps `OBS_WEBSOCKET_ADDR` per-platform in cdk8s's `config_data()`, on the `feat/prod-cutover-prep` branch of adanalife/infra. This PR makes the env-unset fallback correct (and resilient to the next rename); the infra change makes the in-cluster value correct for both platforms.

## Test

`go test ./pkg/obs/... ./pkg/contract/...` passes.