### PR TITLE
Release v3.0.1: develop → master

### DIFF
--- a/.github/workflows/obs-base.yml
+++ b/.github/workflows/obs-base.yml
@@ -1,11 +1,20 @@
 name: OBS CEF Base Image
 # Bakes adanalife/obs-cef-base:arm64-<OBS>-<CEF> + arm64-latest, which
-# Dockerfile.arm64 then COPYs the OBS install tree out of. Re-runs only when
-# the base Dockerfile or this workflow file changes; manual dispatch
-# available for re-bakes (e.g., chasing a CEF tarball mirror change).
+# Dockerfile.arm64 then COPYs the OBS install tree out of. This is a 90-min
+# arm64 CEF compile, so it must only run when it has to.
+#
+# Scoped to develop/master pushes that touch the base Dockerfile or this
+# workflow. The branches filter is load-bearing: GitHub ignores `paths`
+# filters on tag pushes, so without it every `v*` release tag bypassed the
+# path filter and triggered a full rebake (even though the base hadn't
+# changed). Manual dispatch stays available for re-bakes (e.g., chasing a
+# CEF tarball mirror change).
 on:
   workflow_dispatch:
   push:
+    branches:
+      - develop
+      - master
     paths:
       - 'infra/docker/obs/Dockerfile.arm64-base'
       - '.github/workflows/obs-base.yml'

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -11,6 +11,13 @@ on:
     tags:
       - v*
 
+# Supersede an in-flight run when new commits land on the same PR/branch —
+# a superseded build's image is immediately stale, and this keeps concurrent
+# Docker Hub traffic down (rate-limit avoidance).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect whether this PR touches OBS image inputs. arm64 is the slow
   # lane (CEF compile, ~30+ min); skipping it on PRs that only touch Go
@@ -60,6 +67,17 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+
+    # Authenticate base-image (CEF base, etc.) pulls so they count against
+    # our Docker Hub account limit rather than the shared GitHub-runner-IP
+    # anonymous limit (the usual toomanyrequests source). Covers both the
+    # amd64 buildx path and the arm64 `docker compose build` path. Push
+    # stays false.
+    - name: Login to DockerHub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     # Cached buildx path for amd64. arm64 keeps `docker compose build` —
     # the CEF compile dominates wall time and isn't helped meaningfully

--- a/.github/workflows/tripbot.yml
+++ b/.github/workflows/tripbot.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - develop
 
+# Supersede an in-flight run when new commits land on the same PR/branch —
+# a superseded build's image is immediately stale, and this keeps concurrent
+# Docker Hub traffic down (rate-limit avoidance).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,6 +25,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      # Authenticate base-image pulls so they count against our Docker Hub
+      # account limit rather than the shared GitHub-runner-IP anonymous
+      # limit (the usual toomanyrequests source). Push stays false.
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build tripbot image
         uses: docker/build-push-action@v7

--- a/.github/workflows/vlc.yml
+++ b/.github/workflows/vlc.yml
@@ -27,6 +27,13 @@ on:
       - 'go.mod'
       - 'go.sum'
 
+# Supersede an in-flight run when new commits land on the same PR/branch —
+# a superseded build's image is immediately stale, and this keeps concurrent
+# Docker Hub traffic down (rate-limit avoidance).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,6 +47,15 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
+
+    # Authenticate base-image pulls so they count against our Docker Hub
+    # account limit rather than the shared GitHub-runner-IP anonymous
+    # limit (the usual toomanyrequests source). Push stays false.
+    - name: Login to DockerHub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build VLC container 🤖
       uses: docker/build-push-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### admin
+
+- **Send chat messages from the admin console.** The chat pane gains a send box: type a message and post it to Twitch chat **as the bot** or **as the broadcaster**, with a toggle that only offers accounts currently logged in (and hides itself when just one is). The line renders optimistically (greyed) and confirms when it round-trips back on the live chat stream, reddening as "not delivered" if a send fails. Routed as a `chat.send` NATS command (console publishes, tripbot sends) so it's split-ready. **Broadcaster sends need a re-auth** — `user:write:chat` is new on the broadcaster scopes. ([#803])
+
 ### pubsub
 
 - **NATS phase 2 peel — onscreens commands are NATS-only now.** With the command surface burned in on NATS (and phase 3 running on top of it), the redundant HTTP command path is removed: the client publishes its subject and returns, and `onscreens-server` drops the `middle`/`leaderboard`/`timewarp`/`gps`/`flag` handlers and routes (the overlays are driven by the existing NATS subscribers). The browser-source feeds, health, version, metrics, and admin endpoints stay on HTTP, so `ONSCREENS_SERVER_HOST` is unchanged. With `NATS_URL` unset there's no longer an HTTP fallback — every live env runs NATS. ([#788])
@@ -1369,4 +1373,5 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#744]: https://github.com/adanalife/tripbot/pull/744
 [#788]: https://github.com/adanalife/tripbot/pull/788
 [#789]: https://github.com/adanalife/tripbot/pull/789
+[#803]: https://github.com/adanalife/tripbot/pull/803
 [infra #623]: https://github.com/adanalife/infra/pull/623

--- a/cmd/tripbot/chatsend.go
+++ b/cmd/tripbot/chatsend.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	chatEvents "github.com/adanalife/tripbot/pkg/chat-events"
+	"github.com/adanalife/tripbot/pkg/chatsend"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+	"github.com/nats-io/nats.go"
+)
+
+// startChatSendSubscriber wires the admin console's "send a chat message"
+// command. The console (pkg/server) publishes chatEvents.Send on
+// tripbot.<env>.chat.send; tripbot owns the Twitch identities, so it's the
+// thing that actually sends. This keeps the console split-ready: post-split it
+// publishes the same command and this subscriber relocates to whichever service
+// ends up owning the Twitch tokens, with no change to the console or the wire.
+//
+// No-op when NATS is unconfigured (the singleton conn is nil) — the same
+// fire-and-forget posture as the rest of the NATS surface. Must run after
+// startNATS (conn) and setUpTwitchClient (which wires t.app.Chat via ConnectIRC).
+func (t *Tripbot) startChatSendSubscriber(ctx context.Context) {
+	conn := natsclient.Conn()
+	if conn == nil {
+		slog.InfoContext(ctx, "chat.send subscriber skipped (NATS_URL unset)")
+		return
+	}
+	subject := chatEvents.SendSubject(c.Conf.Environment)
+	if _, err := conn.Subscribe(subject, func(m *nats.Msg) {
+		var ev chatEvents.Send
+		if err := json.Unmarshal(m.Data, &ev); err != nil {
+			slog.ErrorContext(ctx, "chat.send: decode", "err", err, "subject", m.Subject)
+			return
+		}
+		chatsend.Dispatch(ctx, ev,
+			func(text string) { t.app.Chat.Say(text) },
+			mytwitch.SendChatMessageAsBroadcaster,
+		)
+	}); err != nil {
+		slog.ErrorContext(ctx, "chat.send subscribe failed", "err", err, "subject", subject)
+		return
+	}
+	slog.InfoContext(ctx, "nats subscribed", "subject", subject)
+}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -186,6 +186,7 @@ func (t *Tripbot) Run() {
 	t.startEventSub(shutdownCtx)
 	t.startNATS(shutdownCtx)
 	t.srv.StartEventHub(shutdownCtx)       // after startNATS: the hub subscribes to the live NATS conn
+	t.startChatSendSubscriber(shutdownCtx) // after startNATS + setUpTwitchClient: needs the conn and t.app.Chat
 	t.player.EmitCurrentVideo(shutdownCtx) // after the hub subscribes: seed its now-playing cache (no NATS replay)
 	t.startDiscord(shutdownCtx)
 	t.startSilentDisconnectWatchdog(shutdownCtx)

--- a/infra/docker/obs/config/service.json.tmpl
+++ b/infra/docker/obs/config/service.json.tmpl
@@ -2,8 +2,8 @@
   "settings": {
     "bwtest": false,
     "key": "${STREAM_KEY}",
-    "server": "auto",
-    "service": "Twitch"
+    "server": "${OBS_STREAM_SERVER}",
+    "service": "${OBS_STREAM_SERVICE}"
   },
   "type": "rtmp_common"
 }

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -52,6 +52,25 @@ esac
 export OBS_STREAM_ENCODER="${OBS_STREAM_ENCODER:-obs_x264}"
 echo "OBS stream encoder: ${OBS_STREAM_ENCODER}"
 
+# Streaming target platform. Default `twitch` preserves the original
+# hardcoded behavior exactly (service "Twitch", server "auto" — OBS
+# resolves "auto" via Twitch's ingest API at connect time). Set
+# STREAM_PLATFORM=youtube (k8s configmap in the obs-youtube overlay) to
+# point the same canvas/encoder at YouTube's RTMPS ingest. service.json.tmpl
+# consumes OBS_STREAM_SERVICE / OBS_STREAM_SERVER via envsubst below.
+case "${STREAM_PLATFORM:-twitch}" in
+  youtube)
+    export OBS_STREAM_SERVICE="YouTube - RTMPS"
+    export OBS_STREAM_SERVER="rtmps://a.rtmps.youtube.com:443/live2"
+    echo "OBS stream platform: youtube (YouTube - RTMPS)"
+    ;;
+  *)
+    export OBS_STREAM_SERVICE="Twitch"
+    export OBS_STREAM_SERVER="auto"
+    echo "OBS stream platform: twitch (server auto)"
+    ;;
+esac
+
 # OBS 32 split the legacy global.ini in two: app-level settings stayed in
 # global.ini (BrowserHWAccel etc.) and user-preference settings moved to
 # user.ini. Seed both so OBS sees a complete config and never prompts about
@@ -101,7 +120,7 @@ envsubst < /opt/obs/config/obs-websocket.json.tmpl > "$OBS_HOME/plugin_config/ob
 # Render service.json only when STREAM_KEY is set. start-obs.sh keys off
 # this file's existence to decide whether to pass --startstreaming.
 if [[ -n "${STREAM_KEY:-}" ]]; then
-  echo "STREAM_KEY set; configuring Twitch and starting stream."
+  echo "STREAM_KEY set; configuring ${OBS_STREAM_SERVICE} and starting stream."
   envsubst < /opt/obs/config/service.json.tmpl \
     > "$OBS_HOME/basic/profiles/ADanaLife/service.json"
 else

--- a/pkg/chat-events/events.go
+++ b/pkg/chat-events/events.go
@@ -1,0 +1,46 @@
+// Package chatEvents holds the wire format for the chat *command* events
+// published over NATS — operator-initiated "send this message to chat"
+// imperatives on subject tripbot.<env>.chat.send. This is the command
+// counterpart to the observation chat.message events in pkg/eventbus: a Send
+// says "post this", a ChatMessage reports "this was posted".
+//
+// It is imported by the publisher (pkg/server — the admin console's send form)
+// and the subscriber (cmd/tripbot, which owns the Twitch identities and does
+// the actual sending). Like pkg/onscreens-events and pkg/vlc-events it is
+// stdlib-only and side-effect-free: no init(), no pkg/config import, env is
+// always a parameter rather than read from config here — so it links safely
+// into any binary. See vault/decisions/package-boundary-init-discipline.md.
+package chatEvents
+
+import "time"
+
+// Identity selects which Twitch identity a Send is posted as. The values match
+// the /auth/init account selector and pkg/twitch's AccountTokenStatus.Account,
+// so the admin panel's auth card and this command speak the same vocabulary.
+const (
+	IdentityBot         = "bot"
+	IdentityBroadcaster = "broadcaster"
+)
+
+// Envelope is embedded in every chat command event. EmittedAt is an
+// RFC3339Nano UTC timestamp, useful for latency/debugging. Snake_case JSON so a
+// future protobuf schema maps 1-1.
+type Envelope struct {
+	EmittedAt string `json:"emitted_at"`
+}
+
+// NewEnvelope returns an Envelope stamped with the current UTC time.
+func NewEnvelope() Envelope {
+	return Envelope{EmittedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+}
+
+// Send is the payload for the chat.send subject: post Text to the channel as
+// the given Identity (IdentityBot | IdentityBroadcaster). Fire-and-forget —
+// the sent line surfaces back in the live console through the normal
+// chat.message path (the bot's send mirror, or the bot reading a
+// broadcaster-sent line back inbound), so no reply is published here.
+type Send struct {
+	Envelope
+	Identity string `json:"identity"`
+	Text     string `json:"text"`
+}

--- a/pkg/chat-events/events_test.go
+++ b/pkg/chat-events/events_test.go
@@ -1,0 +1,49 @@
+package chatEvents
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSendSubject(t *testing.T) {
+	cases := []struct {
+		env  string
+		want string
+	}{
+		{"staging", "tripbot.staging.chat.send"},
+		{"prod", "tripbot.prod.chat.send"},
+		{"development", "tripbot.development.chat.send"},
+	}
+	for _, tc := range cases {
+		if got := SendSubject(tc.env); got != tc.want {
+			t.Errorf("SendSubject(%q): got %q, want %q", tc.env, got, tc.want)
+		}
+	}
+}
+
+func TestSendRoundTrip(t *testing.T) {
+	in := Send{Envelope: NewEnvelope(), Identity: IdentityBroadcaster, Text: "hello chat"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Send
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Identity != IdentityBroadcaster {
+		t.Errorf("identity: got %q, want %q", out.Identity, IdentityBroadcaster)
+	}
+	if out.Text != in.Text {
+		t.Errorf("text: got %q, want %q", out.Text, in.Text)
+	}
+	if out.EmittedAt == "" {
+		t.Error("emitted_at empty after round-trip")
+	}
+}
+
+func TestNewEnvelopeStampsTime(t *testing.T) {
+	if NewEnvelope().EmittedAt == "" {
+		t.Error("NewEnvelope did not stamp EmittedAt")
+	}
+}

--- a/pkg/chat-events/subjects.go
+++ b/pkg/chat-events/subjects.go
@@ -1,0 +1,16 @@
+package chatEvents
+
+import "fmt"
+
+// domain is the fixed segment between <env> and the verb in the chat command
+// subject: tripbot.<env>.chat.send. It matches the observation domain in
+// pkg/eventbus (chat.message), so all chat subjects share the "chat" namespace
+// and differ only by verb (send vs message).
+const domain = "chat"
+
+// SendSubject builds tripbot.<env>.chat.send — the operator "post this message"
+// command. Subscribers (cmd/tripbot) build the same string to subscribe. The
+// observation counterpart, chat.message, is eventbus.ChatMessageSubject.
+func SendSubject(env string) string {
+	return fmt.Sprintf("tripbot.%s.%s.send", env, domain)
+}

--- a/pkg/chatsend/dispatch.go
+++ b/pkg/chatsend/dispatch.go
@@ -1,0 +1,47 @@
+// Package chatsend holds the pure routing for the admin console's chat.send
+// command: given a decoded chatEvents.Send, call the right sender. It's split
+// out of cmd/tripbot's NATS subscriber so the routing is unit-testable —
+// cmd/tripbot (package main) imports github.com/dimiro1/banner/autoload, whose
+// init() runs flag.Parse() and makes the package untestable under `go test`.
+//
+// The senders are injected as plain funcs so this package stays free of the
+// Twitch/IRC machinery: cmd/tripbot passes the bot's Say and the broadcaster
+// Helix send; tests pass fakes.
+package chatsend
+
+import (
+	"context"
+	"log/slog"
+
+	chatEvents "github.com/adanalife/tripbot/pkg/chat-events"
+)
+
+// Dispatch routes a decoded Send to the right sender. botSay is the bot's IRC
+// Say (which mirrors onto the live console); broadcasterSay is the Helix
+// "send as broadcaster" call (whose result the bot reads back inbound,
+// surfacing on the console via the normal chat.message path). An empty text or
+// unknown identity is dropped with a warning — a publisher bug, not an intent.
+func Dispatch(
+	ctx context.Context,
+	ev chatEvents.Send,
+	botSay func(text string),
+	broadcasterSay func(ctx context.Context, text string) error,
+) {
+	if ev.Text == "" {
+		slog.WarnContext(ctx, "chat.send: empty text dropped", "identity", ev.Identity)
+		return
+	}
+	switch ev.Identity {
+	case chatEvents.IdentityBot:
+		botSay(ev.Text)
+		slog.InfoContext(ctx, "chat.send: sent", "identity", ev.Identity, "text", ev.Text)
+	case chatEvents.IdentityBroadcaster:
+		if err := broadcasterSay(ctx, ev.Text); err != nil {
+			slog.ErrorContext(ctx, "chat.send: broadcaster send failed", "err", err, "text", ev.Text)
+			return
+		}
+		slog.InfoContext(ctx, "chat.send: sent", "identity", ev.Identity, "text", ev.Text)
+	default:
+		slog.WarnContext(ctx, "chat.send: unknown identity dropped", "identity", ev.Identity)
+	}
+}

--- a/pkg/chatsend/dispatch_test.go
+++ b/pkg/chatsend/dispatch_test.go
@@ -1,0 +1,78 @@
+package chatsend
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	chatEvents "github.com/adanalife/tripbot/pkg/chat-events"
+)
+
+func TestDispatch(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("bot routes to botSay", func(t *testing.T) {
+		var botGot string
+		bcastCalled := false
+		Dispatch(ctx,
+			chatEvents.Send{Identity: chatEvents.IdentityBot, Text: "hi"},
+			func(s string) { botGot = s },
+			func(context.Context, string) error { bcastCalled = true; return nil },
+		)
+		if botGot != "hi" {
+			t.Errorf("botSay got %q, want %q", botGot, "hi")
+		}
+		if bcastCalled {
+			t.Error("broadcasterSay should not be called for the bot identity")
+		}
+	})
+
+	t.Run("broadcaster routes to broadcasterSay", func(t *testing.T) {
+		botCalled := false
+		var bcastGot string
+		Dispatch(ctx,
+			chatEvents.Send{Identity: chatEvents.IdentityBroadcaster, Text: "yo"},
+			func(string) { botCalled = true },
+			func(_ context.Context, s string) error { bcastGot = s; return nil },
+		)
+		if bcastGot != "yo" {
+			t.Errorf("broadcasterSay got %q, want %q", bcastGot, "yo")
+		}
+		if botCalled {
+			t.Error("botSay should not be called for the broadcaster identity")
+		}
+	})
+
+	t.Run("empty text is dropped", func(t *testing.T) {
+		called := false
+		Dispatch(ctx,
+			chatEvents.Send{Identity: chatEvents.IdentityBot, Text: ""},
+			func(string) { called = true },
+			func(context.Context, string) error { called = true; return nil },
+		)
+		if called {
+			t.Error("no sender should be called for empty text")
+		}
+	})
+
+	t.Run("unknown identity is dropped", func(t *testing.T) {
+		called := false
+		Dispatch(ctx,
+			chatEvents.Send{Identity: "stranger", Text: "hi"},
+			func(string) { called = true },
+			func(context.Context, string) error { called = true; return nil },
+		)
+		if called {
+			t.Error("no sender should be called for an unknown identity")
+		}
+	})
+
+	t.Run("broadcaster send error does not panic", func(t *testing.T) {
+		// The error path just logs; assert it routes and swallows the error.
+		Dispatch(ctx,
+			chatEvents.Send{Identity: chatEvents.IdentityBroadcaster, Text: "boom"},
+			func(string) { t.Error("botSay should not be called") },
+			func(context.Context, string) error { return errors.New("scope missing") },
+		)
+	})
+}

--- a/pkg/obs/control.go
+++ b/pkg/obs/control.go
@@ -3,11 +3,22 @@ package obs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
+	"github.com/adanalife/tripbot/pkg/contract"
 	goobs "github.com/andreykaipov/goobs"
 )
+
+// defaultOBSWebsocketAddr is the fallback dialed when OBS_WEBSOCKET_ADDR is
+// unset. Derived from the shared contract so it tracks the canonical
+// obs-twitch service name + websocket port instead of drifting when OBS is
+// renamed (it was left as the pre-per-platform "obs:4455" once and broke the
+// watchdog on stage). In-cluster, cdk8s stamps OBS_WEBSOCKET_ADDR per platform
+// so the YouTube stack dials obs-youtube; this default only covers the
+// env-unset case.
+var defaultOBSWebsocketAddr = fmt.Sprintf("%s:%d", contract.ServiceOBSTwitch, contract.PortOBSWebsocket)
 
 // dial opens a fresh OBS WebSocket connection using the same env vars
 // PollStreamingActive reads. Callers are responsible for client.Disconnect().
@@ -16,7 +27,7 @@ import (
 func dial(_ context.Context) (*goobs.Client, error) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
-		addr = "obs:4455"
+		addr = defaultOBSWebsocketAddr
 	}
 	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
 	if passwd == "" {

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -17,7 +17,7 @@ import (
 func PollStreamingActive(ctx context.Context, interval time.Duration) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
-		addr = "obs:4455"
+		addr = defaultOBSWebsocketAddr
 	}
 	passwd := os.Getenv("OBS_WEBSOCKET_PASSWD")
 	if passwd == "" {

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -792,6 +792,9 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
 	// flagRow renders one feature-flag <li>, shared with flagActionHandler so a
 	// live toggle's swapped-in row matches the initial render byte-for-byte.
 	"flagRow": func(f featureFlag) template.HTML { return template.HTML(renderFlagRow(f)) },
+	// sendForm renders the chat send form gated on which identities are logged
+	// in (bot / broadcaster); a muted hint when neither is.
+	"sendForm": func(s []mytwitch.AccountTokenStatus) template.HTML { return template.HTML(renderSendForm(s)) },
 }).Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -963,6 +966,23 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
   .chat-jump { position:absolute; left:50%; bottom:10px; transform:translateX(-50%); z-index:2; font:inherit; font-size:.8em; padding:4px 12px; border-radius:999px; border:1px solid var(--chip-border); background:var(--chip-bg); color:var(--fg); cursor:pointer; box-shadow:0 2px 8px rgba(0,0,0,.35); }
   .chat-jump:hover { border-color:#58a6ff; color:#9cf; }
   .chat-jump[hidden] { display:none; }
+  /* chat send box: identity toggle + text input. Sits below the scrollback. */
+  .chat-send { margin-top:8px; display:flex; flex-direction:column; gap:6px; }
+  .chat-send-as { display:flex; gap:14px; font-size:.82em; color:var(--muted); }
+  .chat-send-as label { cursor:pointer; display:inline-flex; align-items:center; gap:4px; }
+  .chat-send-as-single { font-size:.82em; color:var(--dim); }
+  .chat-send-row { display:flex; gap:6px; }
+  .chat-send-text { flex:1; min-width:0; font:inherit; font-size:.92em; padding:6px 8px; border-radius:6px; border:1px solid var(--chip-border); background:var(--chip-bg); color:var(--fg); }
+  .chat-send-text:focus { outline:none; border-color:#58a6ff; }
+  .chat-send button { font:inherit; font-size:.85em; padding:6px 14px; border-radius:6px; border:1px solid var(--chip-border); background:var(--chip-bg); color:var(--fg); cursor:pointer; }
+  .chat-send button:hover { border-color:#58a6ff; color:#9cf; }
+  .chat-send-empty { margin-top:8px; font-size:.82em; color:var(--dim); font-style:italic; }
+  /* optimistic outgoing line: greyed until the message round-trips back, then
+     the .pending class is removed; .failed reddens it if it never lands. */
+  .chat-line.pending { opacity:.5; }
+  .chat-line.failed { opacity:1; }
+  .chat-line.failed .ct { color:#f78166; }
+  .chat-line.failed::after { content:" · not delivered"; color:#f78166; font-size:.8em; }
   /* clickable chat usernames + the profile popover they open */
   .chat-line .cu { cursor:pointer; }
   .chat-line .cu:hover { text-decoration:underline; }
@@ -1052,6 +1072,10 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
       <!-- shown only while scrolled up (see JS): tapping jumps to the newest line -->
       <button id="chat-jump" class="chat-jump" type="button" hidden>↓ new</button>
     </div>
+    <!-- send box: re-rendered live on the "sendform" SSE event (pushed by the
+         auth poll) so the identity toggle tracks which accounts are logged in.
+         JS hooks submit for the optimistic-grey-then-confirm flow. -->
+    <div id="chat-send-box" sse-swap="sendform" hx-swap="innerHTML">{{sendForm .AuthStatuses}}</div>
   </details>
 
   {{if and .PreviewChannel .PanelHost}}
@@ -1237,17 +1261,109 @@ var adminTmpl = template.Must(template.New("admin").Funcs(template.FuncMap{
     if (!el.dataset.colored) { el.style.color = colorFor(el.textContent); el.dataset.colored = '1'; }
   });
   const decorate = (root) => { localize(root); colorize(root); };
+
+  // --- optimistic send + confirm ------------------------------------------
+  // A message sent from the box below is rendered immediately as a greyed
+  // .pending line. The real message round-trips back on the chat.message SSE
+  // stream (the bot's send mirror, or the bot reading a broadcaster line back
+  // inbound); when a matching line arrives we drop the duplicate and un-grey
+  // the optimistic one. If nothing matches within the timeout, it reddens.
+  const PENDING_TIMEOUT = 8000; // ms — broadcaster sends round-trip in a beat; bot is ~instant
+  const pending = new Map();    // key -> { node, timer }
+  const keyOf = (user, text) => user.trim().toLowerCase() + ' ' + text.trim();
+  const lineKey = (el) => {
+    const cu = el.querySelector('.cu'), ct = el.querySelector('.ct');
+    return (cu && ct) ? keyOf(cu.textContent, ct.textContent) : null;
+  };
+  // reconcile: if the just-arrived line matches a pending one, remove the
+  // duplicate and confirm (un-grey) the optimistic line. Returns true if so.
+  const reconcile = (incoming) => {
+    if (!incoming || !incoming.querySelector) return false;
+    const k = lineKey(incoming);
+    if (!k) return false;
+    const p = pending.get(k);
+    if (!p) return false;
+    clearTimeout(p.timer);
+    pending.delete(k);
+    p.node.classList.remove('pending', 'failed');
+    incoming.remove();
+    return true;
+  };
+  // addPending builds + appends the greyed optimistic line and arms its timeout.
+  const addPending = (username, text) => {
+    const line = document.createElement('div');
+    line.className = 'chat-line pending';
+    const t = document.createElement('time');
+    t.className = 'ct-ts';
+    const now = new Date();
+    t.setAttribute('datetime', now.toISOString());
+    const cu = document.createElement('span');
+    cu.className = 'cu';
+    cu.setAttribute('hx-get', '/admin/user/' + encodeURIComponent(username));
+    cu.setAttribute('hx-target', '#user-popover');
+    cu.setAttribute('hx-swap', 'innerHTML');
+    cu.setAttribute('hx-trigger', 'click');
+    cu.textContent = username;
+    const ct = document.createElement('span');
+    ct.className = 'ct';
+    ct.textContent = text;
+    line.append(t, document.createTextNode(' '), cu, document.createTextNode(' '), ct);
+    log.appendChild(line);
+    if (window.htmx) htmx.process(line);
+    decorate(log);
+    if (pinned) log.scrollTop = log.scrollHeight;
+    const k = keyOf(username, text);
+    const prev = pending.get(k);
+    if (prev) clearTimeout(prev.timer);
+    const timer = setTimeout(() => {
+      if (pending.get(k) && pending.get(k).node === line) { line.classList.add('failed'); pending.delete(k); }
+    }, PENDING_TIMEOUT);
+    pending.set(k, { node: line, timer });
+    return { key: k, node: line };
+  };
+
   log.addEventListener('htmx:afterSwap', () => {
     log.querySelectorAll('.chat-empty').forEach(el => el.remove());
+    const confirmed = reconcile(log.lastElementChild);
     decorate(log);
     if (pinned) {
       while (log.childElementCount > CAP) log.removeChild(log.firstElementChild);
       log.scrollTop = log.scrollHeight;
-    } else {
+    } else if (!confirmed) {
       unread++;
       refreshPill();
     }
   });
+
+  // Send box: hook submit to render the optimistic line, and the response to
+  // clear the input (success) or redden the line (publish failed outright).
+  // Delegated on body because the form is re-rendered live on the sendform SSE.
+  document.body.addEventListener('htmx:beforeRequest', (e) => {
+    const form = e.detail && e.detail.elt;
+    if (!form || !form.classList || !form.classList.contains('chat-send')) return;
+    const fd = new FormData(form);
+    const identity = fd.get('identity');
+    const text = (fd.get('text') || '').trim();
+    if (!identity || !text) return;
+    const user = identity === 'broadcaster' ? form.dataset.broadcasterUser : form.dataset.botUser;
+    if (!user) return;
+    form._pending = addPending(user, text);
+  });
+  document.body.addEventListener('htmx:afterRequest', (e) => {
+    const form = e.detail && e.detail.elt;
+    if (!form || !form.classList || !form.classList.contains('chat-send')) return;
+    const xhr = e.detail.xhr;
+    const ok = e.detail.successful && xhr && xhr.status >= 200 && xhr.status < 300;
+    if (ok) {
+      const input = form.querySelector('.chat-send-text');
+      if (input) input.value = '';
+    } else if (form._pending) {
+      form._pending.node.classList.add('failed');
+      pending.delete(form._pending.key);
+    }
+    form._pending = null;
+  });
+
   decorate(log); // localize times + color usernames in the server-rendered history
   log.scrollTop = log.scrollHeight; // start at the newest message
 })();

--- a/pkg/server/authcard.go
+++ b/pkg/server/authcard.go
@@ -32,6 +32,9 @@ func (h *Hub) pollAuth(ctx context.Context) {
 		statuses := tokenStatusesFn()
 		h.broadcast(sseEvent{Name: "auth", Data: renderAuthCard(statuses)})
 		h.broadcast(sseEvent{Name: "reauth", Data: renderReauthCallout(reauthsFromStatuses(statuses))})
+		// keep the chat send form's identity toggle in sync with login state —
+		// an account going missing/expired removes its "send as" option live.
+		h.broadcast(sseEvent{Name: "sendform", Data: renderSendForm(statuses)})
 	}
 	push()
 	t := time.NewTicker(authPollInterval)

--- a/pkg/server/chatsend.go
+++ b/pkg/server/chatsend.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"encoding/json"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	chatEvents "github.com/adanalife/tripbot/pkg/chat-events"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// maxChatMessageLen is Twitch's per-message character limit; the form's
+// maxlength mirrors it client-side and this is the server-side guard.
+const maxChatMessageLen = 500
+
+// chatSendHandler publishes an operator "send a chat message" command onto
+// NATS (tripbot.<env>.chat.send) for cmd/tripbot's subscriber to send as the
+// chosen identity. Fire-and-forget: the panel renders the line optimistically
+// and reconciles it when the message round-trips back through the chat.message
+// SSE stream, so this just validates + publishes and returns 204.
+//
+// No app-layer auth gate (tailnet-only Ingress, like the other /admin POSTs).
+// Identity is validated against the known values; whether that identity is
+// actually logged in is the send path's concern — a logged-out broadcaster send
+// fails at the subscriber and the optimistic line times out red.
+func (s *Server) chatSendHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	identity := r.FormValue("identity")
+	if identity != chatEvents.IdentityBot && identity != chatEvents.IdentityBroadcaster {
+		http.Error(w, "identity must be 'bot' or 'broadcaster'", http.StatusBadRequest)
+		return
+	}
+	text := strings.TrimSpace(r.FormValue("text"))
+	if text == "" {
+		http.Error(w, "text required", http.StatusBadRequest)
+		return
+	}
+	if len(text) > maxChatMessageLen {
+		http.Error(w, "text too long", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	payload, err := json.Marshal(chatEvents.Send{
+		Envelope: chatEvents.NewEnvelope(),
+		Identity: identity,
+		Text:     text,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "chat.send: marshal", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	s.publisher.Publish(r.Context(), chatEvents.SendSubject(c.Conf.Environment), payload)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// sendIdentity is one selectable "send as" option in the chat form.
+type sendIdentity struct {
+	Account  string // "bot" | "broadcaster" — the chatEvents identity value
+	Username string // the Twitch login, shown on the toggle + used by the JS optimistic line
+}
+
+// availableSendIdentities narrows the per-identity token statuses to the ones
+// that can actually send right now — healthy (Reason == "") means logged in.
+// A logged-out identity is omitted so the form never offers a send that would
+// just fail. Order follows TokenStatuses (bot first, broadcaster second).
+func availableSendIdentities(statuses []mytwitch.AccountTokenStatus) []sendIdentity {
+	var out []sendIdentity
+	for _, st := range statuses {
+		if st.Reason == "" {
+			out = append(out, sendIdentity{Account: st.Account, Username: st.LoginAs})
+		}
+	}
+	return out
+}
+
+type sendFormData struct {
+	Identities []sendIdentity // available (logged-in) identities; drives the toggle
+	Multi      bool           // >1 identity → show the radio toggle; ==1 → a hidden input
+	BotUser    string         // bot login when available, else "" — JS maps identity→username
+	BcastUser  string         // broadcaster login when available, else ""
+}
+
+// sendFormTmpl renders the chat send form, or a muted hint when no identity is
+// logged in. The data-*-user attributes let the page's JS label the optimistic
+// (greyed) line with the right username so it reconciles against the real line
+// when it round-trips back on the chat.message stream.
+var sendFormTmpl = template.Must(template.New("sendform").Parse(
+	`{{if .Identities}}<form class="chat-send" hx-post="/admin/chat/send" hx-swap="none" autocomplete="off" data-bot-user="{{.BotUser}}" data-broadcaster-user="{{.BcastUser}}">` +
+		`{{if .Multi}}<div class="chat-send-as">{{range $i, $id := .Identities}}<label><input type="radio" name="identity" value="{{$id.Account}}"{{if eq $i 0}} checked{{end}}> {{$id.Username}}</label>{{end}}</div>` +
+		`{{else}}<input type="hidden" name="identity" value="{{(index .Identities 0).Account}}"><span class="chat-send-as-single">as {{(index .Identities 0).Username}}</span>{{end}}` +
+		`<div class="chat-send-row"><input class="chat-send-text" type="text" name="text" maxlength="500" placeholder="send a message…" required><button type="submit">send</button></div>` +
+		`</form>` +
+		`{{else}}<p class="chat-send-empty">sign in to send messages</p>{{end}}`))
+
+func renderSendForm(statuses []mytwitch.AccountTokenStatus) string {
+	ids := availableSendIdentities(statuses)
+	data := sendFormData{Identities: ids, Multi: len(ids) > 1}
+	for _, id := range ids {
+		switch id.Account {
+		case chatEvents.IdentityBot:
+			data.BotUser = id.Username
+		case chatEvents.IdentityBroadcaster:
+			data.BcastUser = id.Username
+		}
+	}
+	var sb strings.Builder
+	if err := sendFormTmpl.Execute(&sb, data); err != nil {
+		slog.Error("admin: render send form", "err", err)
+		return ""
+	}
+	return sb.String()
+}

--- a/pkg/server/chatsend_test.go
+++ b/pkg/server/chatsend_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	chatEvents "github.com/adanalife/tripbot/pkg/chat-events"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// recordingPublisher captures the last publish for assertions.
+type recordingPublisher struct {
+	calls int
+	subj  string
+	data  []byte
+}
+
+func (r *recordingPublisher) Publish(_ context.Context, subject string, payload []byte) {
+	r.calls++
+	r.subj = subject
+	r.data = payload
+}
+
+func postForm(s *Server, form string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/admin/chat/send", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.chatSendHandler(rec, req)
+	return rec
+}
+
+func TestChatSendHandler_PublishesValidSend(t *testing.T) {
+	rec := &recordingPublisher{}
+	s := New()
+	s.publisher = rec
+
+	resp := postForm(s, "identity=broadcaster&text=hello+world")
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", resp.Code, resp.Body.String())
+	}
+	if rec.calls != 1 {
+		t.Fatalf("publish calls = %d, want 1", rec.calls)
+	}
+	if !strings.HasSuffix(rec.subj, ".chat.send") {
+		t.Errorf("subject = %q, want suffix .chat.send", rec.subj)
+	}
+	var ev chatEvents.Send
+	if err := json.Unmarshal(rec.data, &ev); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if ev.Identity != chatEvents.IdentityBroadcaster || ev.Text != "hello world" {
+		t.Errorf("payload = %+v, want broadcaster/'hello world'", ev)
+	}
+}
+
+func TestChatSendHandler_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		form string
+		want int
+	}{
+		{"bad identity", "identity=stranger&text=hi", http.StatusBadRequest},
+		{"missing identity", "text=hi", http.StatusBadRequest},
+		{"empty text", "identity=bot&text=", http.StatusBadRequest},
+		{"whitespace text", "identity=bot&text=+++", http.StatusBadRequest},
+		{"too long", "identity=bot&text=" + strings.Repeat("a", maxChatMessageLen+1), http.StatusRequestEntityTooLarge},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingPublisher{}
+			s := New()
+			s.publisher = rec
+			resp := postForm(s, tc.form)
+			if resp.Code != tc.want {
+				t.Errorf("status = %d, want %d", resp.Code, tc.want)
+			}
+			if rec.calls != 0 {
+				t.Errorf("publish calls = %d, want 0 (nothing should publish on a rejected send)", rec.calls)
+			}
+		})
+	}
+}
+
+func TestRenderSendForm_GatesOnLogin(t *testing.T) {
+	healthyBot := mytwitch.AccountTokenStatus{Account: "bot", LoginAs: "tripbot4000"}
+	healthyBcast := mytwitch.AccountTokenStatus{Account: "broadcaster", LoginAs: "adanalife_"}
+	loggedOutBcast := mytwitch.AccountTokenStatus{Account: "broadcaster", LoginAs: "adanalife_", Reason: "missing"}
+
+	t.Run("both logged in shows toggle", func(t *testing.T) {
+		html := renderSendForm([]mytwitch.AccountTokenStatus{healthyBot, healthyBcast})
+		if !strings.Contains(html, `value="bot"`) || !strings.Contains(html, `value="broadcaster"`) {
+			t.Errorf("expected both radio options, got: %s", html)
+		}
+		if !strings.Contains(html, `data-broadcaster-user="adanalife_"`) {
+			t.Errorf("expected broadcaster data attr, got: %s", html)
+		}
+	})
+
+	t.Run("logged-out identity is omitted", func(t *testing.T) {
+		html := renderSendForm([]mytwitch.AccountTokenStatus{healthyBot, loggedOutBcast})
+		if strings.Contains(html, `value="broadcaster"`) {
+			t.Errorf("logged-out broadcaster should not be offered, got: %s", html)
+		}
+		// single available identity → hidden input, no toggle
+		if !strings.Contains(html, `type="hidden"`) || !strings.Contains(html, `value="bot"`) {
+			t.Errorf("expected single hidden bot identity, got: %s", html)
+		}
+	})
+
+	t.Run("none logged in shows hint", func(t *testing.T) {
+		html := renderSendForm([]mytwitch.AccountTokenStatus{
+			{Account: "bot", LoginAs: "tripbot4000", Reason: "expired"},
+		})
+		if !strings.Contains(html, "chat-send-empty") {
+			t.Errorf("expected empty hint, got: %s", html)
+		}
+		if strings.Contains(html, "<form") {
+			t.Errorf("expected no form when nothing is logged in, got: %s", html)
+		}
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/adanalife/tripbot/pkg/natsclient"
 	sentrynegroni "github.com/getsentry/sentry-go/negroni"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -42,16 +43,25 @@ type Server struct {
 
 	flagMu     sync.RWMutex
 	flagClient feature.FlagClient
+
+	// publisher is the fire-and-forget NATS publish seam the admin console's
+	// "send chat message" form uses to emit a chatEvents.Send command. The
+	// subscriber that actually sends lives in cmd/tripbot (the Twitch-identity
+	// owner), so the panel only publishes — which keeps it split-ready. Tests
+	// inject a recording fake.
+	publisher natsclient.Publisher
 }
 
 // New constructs a Server with default runtime state: a fresh hub, the "dev"
-// version tag (overridden by SetVersion), and an empty in-memory flag client
-// (swapped for the Postgres-backed one via SetFlagClient).
+// version tag (overridden by SetVersion), an empty in-memory flag client
+// (swapped for the Postgres-backed one via SetFlagClient), and the singleton
+// NATS publisher (a no-op until natsclient.Connect runs).
 func New() *Server {
 	return &Server{
 		hub:        NewHub(),
 		versionTag: "dev",
 		flagClient: feature.NewInMemoryClient(nil),
+		publisher:  natsclient.DefaultPublisher(),
 	}
 }
 
@@ -114,6 +124,7 @@ func (s *Server) Start(ctx context.Context) {
 	admin.Handle("/flags/{key}/{action}", tagged("/admin/flags/{key}/{action}", s.flagActionHandler))
 	admin.Handle("/shutdown", tagged("/admin/shutdown", httpmw.ShutdownHandler()))
 	admin.Handle("/restart/{service}", tagged("/admin/restart/{service}", restartActionHandler))
+	admin.Handle("/chat/send", tagged("/admin/chat/send", s.chatSendHandler))
 
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -51,11 +51,13 @@ var BotScopes = []string{
 // Helix scopes that authorize against the channel owner's identity:
 // channel:read:subscriptions for GetSubscriptions, moderator:read:followers
 // for GetChannelFollows total, user:edit:broadcast for channel.update
-// (title/category changes).
+// (title/category changes), user:write:chat for the admin console's "send as
+// broadcaster" (Helix Send Chat Message posts as the authenticated user).
 var BroadcasterScopes = []string{
 	"channel:read:subscriptions",
 	"moderator:read:followers",
 	"user:edit:broadcast",
+	"user:write:chat",
 }
 
 // ErrNoToken signals "no oauth_tokens row for the bot account; run the

--- a/pkg/twitch/send.go
+++ b/pkg/twitch/send.go
@@ -1,0 +1,52 @@
+package twitch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/nicklaw5/helix/v2"
+)
+
+// SendChatMessageAsBroadcaster posts text to the channel's chat as the
+// broadcaster identity, via Helix "Send Chat Message" (requires user:write:chat
+// on the broadcaster token — see BroadcasterScopes). The broadcaster is both
+// the channel and the sender, so BroadcasterID and SenderID are the same id.
+//
+// Unlike the bot's IRC Say, a Helix-sent message is read back by the bot's own
+// chat connection like any other viewer line, so it surfaces in the admin live
+// console through the normal chat.message path — no separate console mirror is
+// needed here. Errors (missing token, missing scope, rate limit, a dropped
+// message) are returned so the caller can log them; the admin console's
+// optimistic line will time out and redden when a send never lands.
+func (cl *API) SendChatMessageAsBroadcaster(ctx context.Context, text string) error {
+	if !cl.broadcasterTokenLoaded() {
+		return errors.New("no broadcaster oauth_tokens row")
+	}
+	bclient, err := cl.BroadcasterClient()
+	if err != nil {
+		return fmt.Errorf("broadcaster helix client unavailable: %w", err)
+	}
+	if cl.channelID == "" {
+		cl.channelID = cl.getChannelID(c.Conf.ChannelName)
+	}
+	resp, err := bclient.SendChatMessage(&helix.SendChatMessageParams{
+		BroadcasterID: cl.channelID,
+		SenderID:      cl.channelID,
+		Message:       text,
+	})
+	if err != nil {
+		return fmt.Errorf("send chat message: %w", err)
+	}
+	if cl.checkHelixResp(ctx, "SendChatMessage", "broadcaster", &resp.ResponseCommon) {
+		return fmt.Errorf("send chat message: helix returned %d: %s", resp.StatusCode, resp.ErrorMessage)
+	}
+	// Twitch can accept the request (HTTP 200) but still drop the message
+	// (e.g. a follower-only/slow-mode rejection); IsSent=false carries the why.
+	if len(resp.Data.Messages) > 0 && !resp.Data.Messages[0].IsSent {
+		dr := resp.Data.Messages[0].DropReasons.Data
+		return fmt.Errorf("message dropped: %s %s", dr.Code, dr.Message)
+	}
+	return nil
+}

--- a/pkg/twitch/shims.go
+++ b/pkg/twitch/shims.go
@@ -48,6 +48,10 @@ func Chatters() map[string]struct{} { return defaultClient.Chatters() }
 func UpdateChatters()               { defaultClient.UpdateChatters() }
 func ChannelID() string             { return defaultClient.ChannelID() }
 
+func SendChatMessageAsBroadcaster(ctx context.Context, text string) error {
+	return defaultClient.SendChatMessageAsBroadcaster(ctx, text)
+}
+
 // --- streams ---
 
 func IsChannelLive(ctx context.Context, login string) (bool, error) {


### PR DESCRIPTION
Patch release. The headline is **sending chat messages from the admin console** — a send box that posts to Twitch chat as the bot or the broadcaster. Alongside it: the OBS image can now be pointed at YouTube as well as Twitch via `STREAM_PLATFORM`, a fix for the OBS websocket-address fallback that broke after the per-platform service rename, and CI changes to cut Docker Hub rate-limiting and stop redundant OBS base rebakes.

## What's in this release

### admin
- Send chat messages from the admin console — as the bot or the broadcaster, with optimistic render and round-trip confirm ([#803](https://github.com/adanalife/tripbot/pull/803/changes)). **Broadcaster sends need a re-auth** (`user:write:chat` is new on the broadcaster scopes).

### obs
- OBS streaming target parametrized via `STREAM_PLATFORM` (default `twitch`; `youtube` points at YouTube RTMPS) — the `twitch` path renders byte-identical, so it's a no-op for the existing stream ([#775](https://github.com/adanalife/tripbot/pull/775/changes)).

### fix
- OBS websocket address fallback now derives from `pkg/contract` instead of the stale `obs:4455`, fixing `dial tcp: lookup obs` after the per-platform rename ([#804](https://github.com/adanalife/tripbot/pull/804/changes)).

### CI
- Authenticate Docker Hub pulls, add per-ref concurrency groups, and scope the OBS CEF base bake to develop/master pushes ([#786](https://github.com/adanalife/tripbot/pull/786/changes)).

---

Merge with a **merge commit** (not squash) per the release-flow convention. CHANGELOG reconciled against master (the stale develop `[Unreleased]` drift is cleared).