### PR TITLE
chatbot: alias !ocation to !location

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -199,7 +199,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!location",
-			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation"},
+			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation", "!ocation"},
 			Handler:        a.locationCmd,
 			RequiresFollow: true,
 		},


### PR DESCRIPTION
## Summary
- Register `!ocation` as a typo alias for `!location` (viewer dropping the leading `l`), mirroring the `!leaderborad` alias.

## Test plan
- [x] gofmt + pre-commit hooks pass
- [ ] `task test:macos` (mise/go unavailable in this environment — relying on CI)
- [ ] Dana confirms `ocation` routes to !location in chat