### PR TITLE
admin: default chat-send identity to broadcaster

### DIFF
--- a/pkg/server/chatsend.go
+++ b/pkg/server/chatsend.go
@@ -83,6 +83,7 @@ func availableSendIdentities(statuses []mytwitch.AccountTokenStatus) []sendIdent
 type sendFormData struct {
 	Identities []sendIdentity // available (logged-in) identities; drives the toggle
 	Multi      bool           // >1 identity → show the radio toggle; ==1 → a hidden input
+	Default    string         // pre-checked identity account; broadcaster when available
 	BotUser    string         // bot login when available, else "" — JS maps identity→username
 	BcastUser  string         // broadcaster login when available, else ""
 }
@@ -93,7 +94,7 @@ type sendFormData struct {
 // when it round-trips back on the chat.message stream.
 var sendFormTmpl = template.Must(template.New("sendform").Parse(
 	`{{if .Identities}}<form class="chat-send" hx-post="/admin/chat/send" hx-swap="none" autocomplete="off" data-bot-user="{{.BotUser}}" data-broadcaster-user="{{.BcastUser}}">` +
-		`{{if .Multi}}<div class="chat-send-as">{{range $i, $id := .Identities}}<label><input type="radio" name="identity" value="{{$id.Account}}"{{if eq $i 0}} checked{{end}}> {{$id.Username}}</label>{{end}}</div>` +
+		`{{if .Multi}}<div class="chat-send-as">{{range $id := .Identities}}<label><input type="radio" name="identity" value="{{$id.Account}}"{{if eq $id.Account $.Default}} checked{{end}}> {{$id.Username}}</label>{{end}}</div>` +
 		`{{else}}<input type="hidden" name="identity" value="{{(index .Identities 0).Account}}"><span class="chat-send-as-single">as {{(index .Identities 0).Username}}</span>{{end}}` +
 		`<div class="chat-send-row"><input class="chat-send-text" type="text" name="text" maxlength="500" placeholder="send a message…" required><button type="submit">send</button></div>` +
 		`</form>` +
@@ -109,6 +110,15 @@ func renderSendForm(statuses []mytwitch.AccountTokenStatus) string {
 		case chatEvents.IdentityBroadcaster:
 			data.BcastUser = id.Username
 		}
+	}
+	// Pre-select the broadcaster (talking as the channel owner is the common
+	// case); fall back to the first available identity when the broadcaster
+	// isn't logged in.
+	if len(ids) > 0 {
+		data.Default = ids[0].Account
+	}
+	if data.BcastUser != "" {
+		data.Default = chatEvents.IdentityBroadcaster
 	}
 	var sb strings.Builder
 	if err := sendFormTmpl.Execute(&sb, data); err != nil {

--- a/pkg/server/chatsend.go
+++ b/pkg/server/chatsend.go
@@ -111,7 +111,7 @@ func renderSendForm(statuses []mytwitch.AccountTokenStatus) string {
 			data.BcastUser = id.Username
 		}
 	}
-	// Pre-select the broadcaster (talking as the channel owner is the common
+	// Default to the broadcaster (talking as the channel owner is the common
 	// case); fall back to the first available identity when the broadcaster
 	// isn't logged in.
 	if len(ids) > 0 {

--- a/pkg/server/chatsend_test.go
+++ b/pkg/server/chatsend_test.go
@@ -98,6 +98,23 @@ func TestRenderSendForm_GatesOnLogin(t *testing.T) {
 		if !strings.Contains(html, `data-broadcaster-user="adanalife_"`) {
 			t.Errorf("expected broadcaster data attr, got: %s", html)
 		}
+		// broadcaster is the pre-selected default (talking as the channel
+		// owner is the common case)
+		if !strings.Contains(html, `value="broadcaster" checked`) {
+			t.Errorf("expected broadcaster radio pre-checked, got: %s", html)
+		}
+		if strings.Contains(html, `value="bot" checked`) {
+			t.Errorf("bot radio should not be pre-checked when broadcaster is available, got: %s", html)
+		}
+	})
+
+	t.Run("bot-only falls back to bot pre-checked", func(t *testing.T) {
+		// only the bot logged in → single hidden input, but the default
+		// computation should still resolve to bot rather than nothing
+		html := renderSendForm([]mytwitch.AccountTokenStatus{healthyBot})
+		if !strings.Contains(html, `value="bot"`) {
+			t.Errorf("expected bot identity, got: %s", html)
+		}
 	})
 
 	t.Run("logged-out identity is omitted", func(t *testing.T) {

--- a/pkg/server/chatsend_test.go
+++ b/pkg/server/chatsend_test.go
@@ -98,8 +98,8 @@ func TestRenderSendForm_GatesOnLogin(t *testing.T) {
 		if !strings.Contains(html, `data-broadcaster-user="adanalife_"`) {
 			t.Errorf("expected broadcaster data attr, got: %s", html)
 		}
-		// broadcaster is the pre-selected default (talking as the channel
-		// owner is the common case)
+		// broadcaster is the default (talking as the channel owner is the
+		// common case)
 		if !strings.Contains(html, `value="broadcaster" checked`) {
 			t.Errorf("expected broadcaster radio pre-checked, got: %s", html)
 		}


### PR DESCRIPTION
## Summary
- Default the admin-console "send chat as" toggle to the broadcaster (`adanalife_`) instead of the bot, saving a click for the common case. Both identities remain selectable; falls back to the first available identity when the broadcaster isn't logged in.

## Test plan
- [x] `pkg/server` tests cover broadcaster-pre-checked (multi-identity) and bot-only fallback
- [ ] Dana confirms the broadcaster option is pre-selected on the admin chat-send form

Note: the broadcaster send path requires the `user:write:chat` scope, so a broadcaster re-auth is the deploy prerequisite for the default to work end-to-end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>