### PR TITLE
Release v3.1.0: develop → master #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 - **NATS phase 2 peel — onscreens commands are NATS-only now.** With the command surface burned in on NATS (and phase 3 running on top of it), the redundant HTTP command path is removed: the client publishes its subject and returns, and `onscreens-server` drops the `middle`/`leaderboard`/`timewarp`/`gps`/`flag` handlers and routes (the overlays are driven by the existing NATS subscribers). The browser-source feeds, health, version, metrics, and admin endpoints stay on HTTP, so `ONSCREENS_SERVER_HOST` is unchanged. With `NATS_URL` unset there's no longer an HTTP fallback — every live env runs NATS. ([#788])
 - **VLC command surface — observe-only NATS mirror.** Begins moving the VLC playback commands off direct HTTP onto NATS, following the onscreens template. The four fire-and-forget commands (`PlayRandom`, `PlayFileInPlaylist`, `Skip`, `Back`) now publish to `tripbot.<env>.vlc.<verb>` alongside their HTTP call, and vlc-server connects to NATS and subscribes — but **observe-only**: it logs what it would do without acting, because VLC commands aren't idempotent and acting on both transports would double-execute (skip two videos). HTTP stays the sole actor; this burns in delivery before the peel. `CurrentlyPlaying` is a read and stays HTTP-only. No-op where `NATS_URL` is unset; the peel + cdk8s `NATS_URL` wiring for vlc-server follow. ([#789])
+- **VLC command surface — HTTP peel; NATS is the sole command transport.** Completes the migration started in #789. The client goes publish-only (the `c.get(...)` command calls are gone), vlc-server's subscribers flip from observe-only to acting (driving `PlayRandom` / `PlayVideoFile` / `skip` / `back`), and the `play` / `random` / `skip` / `back` HTTP handlers + routes are removed. The client peel lands first so there's never a window where both transports act. `/vlc/current` stays on HTTP (a read). Requires vlc-server's `NATS_URL` wiring ([infra #645]) to be live in each env. ([#790])
 
 ## [v2.18.3] — 2026-06-02
 
@@ -1373,5 +1374,7 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#744]: https://github.com/adanalife/tripbot/pull/744
 [#788]: https://github.com/adanalife/tripbot/pull/788
 [#789]: https://github.com/adanalife/tripbot/pull/789
+[#790]: https://github.com/adanalife/tripbot/pull/790
 [#803]: https://github.com/adanalife/tripbot/pull/803
 [infra #623]: https://github.com/adanalife/infra/pull/623
+[infra #645]: https://github.com/adanalife/infra/pull/645

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Minor release. The headline is the **VLC command surface completing its move to 
 
 ### admin
 
-- **Chat-send box defaults to the broadcaster identity.** The send-from-console form's identity toggle pre-selected the bot (first in `TokenStatuses`); talking as the channel owner is the common case, so it now pre-selects the broadcaster when it's logged in, falling back to the bot otherwise. Both stay selectable. ([#807])
+- **Chat-send box defaults to the broadcaster identity.** The send-from-console form's identity toggle preselected the bot (first in `TokenStatuses`); talking as the channel owner is the common case, so it now preselects the broadcaster when it's logged in, falling back to the bot otherwise. Both stay selectable. ([#807])
 
 ### chatbot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+## [v3.1.0] — 2026-06-10
+
+Minor release. The headline is the **VLC command surface completing its move to NATS** — the HTTP command path is gone and NATS is now the sole transport for playback commands, the final step of the migration the observe-only mirror began in v3.0.0. Alongside it: the admin console's chat-send box defaults to the broadcaster identity, and `!ocation` joins the `!location` typo aliases.
+
+### pubsub
+
+- **VLC command surface — HTTP peel; NATS is the sole command transport.** Completes the migration the observe-only mirror started in [#789] (v3.0.0). The client goes publish-only (the `c.get(...)` command calls are gone), vlc-server's subscribers flip from observe-only to acting (driving `PlayRandom` / `PlayVideoFile` / `skip` / `back`), and the `play` / `random` / `skip` / `back` HTTP handlers + routes are removed. The client peel lands first so there's never a window where both transports act. `/vlc/current` stays on HTTP (a read). Requires vlc-server's `NATS_URL` wiring ([infra #645]) to be live in each env. ([#790])
+
+### admin
+
+- **Chat-send box defaults to the broadcaster identity.** The send-from-console form's identity toggle pre-selected the bot (first in `TokenStatuses`); talking as the channel owner is the common case, so it now pre-selects the broadcaster when it's logged in, falling back to the bot otherwise. Both stay selectable. ([#807])
+
+### chatbot
+
+- **`!ocation` aliases to `!location`.** A common typo where the viewer drops the leading `l`, added alongside the existing `!location` typo aliases. ([#806])
+
 ## [v3.0.1] — 2026-06-09
 
 Patch release. The headline is **sending chat messages from the admin console** — a send box that posts to Twitch chat as the bot or the broadcaster. Alongside it: the OBS image can now be pointed at YouTube as well as Twitch via `STREAM_PLATFORM`, a fix for the OBS websocket-address fallback that broke after the per-platform service rename, and CI changes to cut Docker Hub rate-limiting and stop redundant OBS base rebakes.
@@ -1441,3 +1457,7 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#802]: https://github.com/adanalife/tripbot/pull/802
 [infra #623]: https://github.com/adanalife/infra/pull/623
 [infra #654]: https://github.com/adanalife/infra/pull/654
+[#790]: https://github.com/adanalife/tripbot/pull/790
+[#807]: https://github.com/adanalife/tripbot/pull/807
+[#806]: https://github.com/adanalife/tripbot/pull/806
+[infra #645]: https://github.com/adanalife/infra/pull/645

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -199,7 +199,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!location",
-			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation"},
+			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation", "!ocation"},
 			Handler:        a.locationCmd,
 			RequiresFollow: true,
 		},

--- a/pkg/server/chatsend.go
+++ b/pkg/server/chatsend.go
@@ -83,6 +83,7 @@ func availableSendIdentities(statuses []mytwitch.AccountTokenStatus) []sendIdent
 type sendFormData struct {
 	Identities []sendIdentity // available (logged-in) identities; drives the toggle
 	Multi      bool           // >1 identity → show the radio toggle; ==1 → a hidden input
+	Default    string         // pre-checked identity account; broadcaster when available
 	BotUser    string         // bot login when available, else "" — JS maps identity→username
 	BcastUser  string         // broadcaster login when available, else ""
 }
@@ -93,7 +94,7 @@ type sendFormData struct {
 // when it round-trips back on the chat.message stream.
 var sendFormTmpl = template.Must(template.New("sendform").Parse(
 	`{{if .Identities}}<form class="chat-send" hx-post="/admin/chat/send" hx-swap="none" autocomplete="off" data-bot-user="{{.BotUser}}" data-broadcaster-user="{{.BcastUser}}">` +
-		`{{if .Multi}}<div class="chat-send-as">{{range $i, $id := .Identities}}<label><input type="radio" name="identity" value="{{$id.Account}}"{{if eq $i 0}} checked{{end}}> {{$id.Username}}</label>{{end}}</div>` +
+		`{{if .Multi}}<div class="chat-send-as">{{range $id := .Identities}}<label><input type="radio" name="identity" value="{{$id.Account}}"{{if eq $id.Account $.Default}} checked{{end}}> {{$id.Username}}</label>{{end}}</div>` +
 		`{{else}}<input type="hidden" name="identity" value="{{(index .Identities 0).Account}}"><span class="chat-send-as-single">as {{(index .Identities 0).Username}}</span>{{end}}` +
 		`<div class="chat-send-row"><input class="chat-send-text" type="text" name="text" maxlength="500" placeholder="send a message…" required><button type="submit">send</button></div>` +
 		`</form>` +
@@ -109,6 +110,15 @@ func renderSendForm(statuses []mytwitch.AccountTokenStatus) string {
 		case chatEvents.IdentityBroadcaster:
 			data.BcastUser = id.Username
 		}
+	}
+	// Default to the broadcaster (talking as the channel owner is the common
+	// case); fall back to the first available identity when the broadcaster
+	// isn't logged in.
+	if len(ids) > 0 {
+		data.Default = ids[0].Account
+	}
+	if data.BcastUser != "" {
+		data.Default = chatEvents.IdentityBroadcaster
 	}
 	var sb strings.Builder
 	if err := sendFormTmpl.Execute(&sb, data); err != nil {

--- a/pkg/server/chatsend_test.go
+++ b/pkg/server/chatsend_test.go
@@ -98,6 +98,23 @@ func TestRenderSendForm_GatesOnLogin(t *testing.T) {
 		if !strings.Contains(html, `data-broadcaster-user="adanalife_"`) {
 			t.Errorf("expected broadcaster data attr, got: %s", html)
 		}
+		// broadcaster is the default (talking as the channel owner is the
+		// common case)
+		if !strings.Contains(html, `value="broadcaster" checked`) {
+			t.Errorf("expected broadcaster radio pre-checked, got: %s", html)
+		}
+		if strings.Contains(html, `value="bot" checked`) {
+			t.Errorf("bot radio should not be pre-checked when broadcaster is available, got: %s", html)
+		}
+	})
+
+	t.Run("bot-only falls back to bot pre-checked", func(t *testing.T) {
+		// only the bot logged in → single hidden input, but the default
+		// computation should still resolve to bot rather than nothing
+		html := renderSendForm([]mytwitch.AccountTokenStatus{healthyBot})
+		if !strings.Contains(html, `value="bot"`) {
+			t.Errorf("expected bot identity, got: %s", html)
+		}
 	})
 
 	t.Run("logged-out identity is omitted", func(t *testing.T) {

--- a/pkg/vlc-client/nats_test.go
+++ b/pkg/vlc-client/nats_test.go
@@ -12,6 +12,11 @@ import (
 	ve "github.com/adanalife/tripbot/pkg/vlc-events"
 )
 
+// commandHost is handed to New for the command tests. The four commands are
+// NATS-only (no HTTP after the peel), so this host is never dialed — it just
+// satisfies New's signature.
+const commandHost = "vlc.invalid:0"
+
 // recordingPublisher captures every publish so tests can assert on the
 // subject + payload. Goroutine-safe. Satisfies natsclient.Publisher.
 type recordingPublisher struct {
@@ -32,9 +37,8 @@ func (r *recordingPublisher) Publish(_ context.Context, subject string, payload 
 	r.Publishes = append(r.Publishes, recordedPublish{Subject: subject, Payload: cp})
 }
 
-// okServer stands up an httptest.Server that 200s everything, so the client's
-// HTTP path succeeds (HTTP still fires during the mirror phase) and tests can
-// focus on the NATS mirror.
+// okServer stands up an httptest.Server that 200s everything, for the one
+// remaining HTTP path — CurrentlyPlaying (a read).
 func okServer(t *testing.T) string {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -46,7 +50,7 @@ func okServer(t *testing.T) string {
 
 func TestPlayRandom_PublishesToNATS(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(okServer(t), rec, "stage")
+	c := New(commandHost, rec, "stage")
 
 	if err := c.PlayRandom(context.Background()); err != nil {
 		t.Fatalf("PlayRandom: %v", err)
@@ -69,7 +73,7 @@ func TestPlayRandom_PublishesToNATS(t *testing.T) {
 
 func TestPlayFileInPlaylist_PublishesFile(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(okServer(t), rec, "prod")
+	c := New(commandHost, rec, "prod")
 
 	if err := c.PlayFileInPlaylist(context.Background(), "clip.mp4"); err != nil {
 		t.Fatalf("PlayFileInPlaylist: %v", err)
@@ -92,7 +96,6 @@ func TestPlayFileInPlaylist_PublishesFile(t *testing.T) {
 }
 
 func TestSkipAndBack_PublishN(t *testing.T) {
-	host := okServer(t)
 	cases := []struct {
 		name    string
 		call    func(c *Client) error
@@ -104,7 +107,7 @@ func TestSkipAndBack_PublishN(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := &recordingPublisher{}
-			c := New(host, rec, "stage")
+			c := New(commandHost, rec, "stage")
 			if err := tc.call(c); err != nil {
 				t.Fatalf("call: %v", err)
 			}
@@ -143,11 +146,10 @@ func TestCurrentlyPlaying_DoesNotPublish(t *testing.T) {
 
 // TestTopicReflectsEnv covers subject scoping per env.
 func TestTopicReflectsEnv(t *testing.T) {
-	host := okServer(t)
 	for _, env := range []string{"prod", "development", "test"} {
 		t.Run(env, func(t *testing.T) {
 			rec := &recordingPublisher{}
-			c := New(host, rec, env)
+			c := New(commandHost, rec, env)
 			if err := c.Skip(context.Background(), 1); err != nil {
 				t.Fatalf("Skip: %v", err)
 			}
@@ -159,10 +161,10 @@ func TestTopicReflectsEnv(t *testing.T) {
 	}
 }
 
-// TestNilPublisher_NoPublishNoPanic asserts a nil publisher disables the
-// mirror without panicking (the HTTP-only path used by test rigs).
+// TestNilPublisher_NoPublishNoPanic asserts a nil publisher disables
+// publishing without panicking.
 func TestNilPublisher_NoPublishNoPanic(t *testing.T) {
-	c := New(okServer(t), nil, "test")
+	c := New(commandHost, nil, "test")
 	if err := c.Skip(context.Background(), 1); err != nil {
 		t.Fatalf("Skip: %v", err)
 	}

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -3,7 +3,6 @@ package vlcClient
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log/slog"
 	"net/http"
@@ -13,15 +12,14 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// Client talks to the vlc-server HTTP API and mirrors each fire-and-forget
-// command onto NATS. Construct via New(host, nats, env).
+// Client issues vlc-server playback commands over NATS and reads the
+// currently-playing file over HTTP. Construct via New(host, nats, env).
 //
-// The NATS publish is the HTTP→NATS migration (observe-only mirror phase):
-// the four playback commands publish to NATS alongside the HTTP call, with
-// HTTP still the source of truth. vlc-server's subscriber currently only logs
-// the published commands (VLC commands aren't idempotent, so it can't act
-// while HTTP also acts). nats may be nil (tests that don't exercise pubsub) —
-// publishes no-op then. CurrentlyPlaying is a read and stays HTTP-only.
+// The four fire-and-forget commands (PlayRandom, PlayFileInPlaylist, Skip,
+// Back) publish to tripbot.<env>.vlc.<verb>; vlc-server's subscriber acts on
+// them. The HTTP command path (the mirror that preceded the peel) is gone.
+// nats may be nil (tests that don't exercise pubsub) — publishes no-op then.
+// CurrentlyPlaying is a read and stays on HTTP, so host is still required.
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
@@ -34,9 +32,9 @@ type Client struct {
 // propagate W3C tracecontext headers. Callers must pass ctx so the
 // propagation has an active span to attach to — passing context.Background()
 // will still send the request, just without a parent span linking it to the
-// caller's trace. nats + env drive the NATS mirror; pass
+// caller's trace. nats + env drive command publishing; pass
 // natsclient.DefaultPublisher() in production, or a nil publisher to disable
-// the mirror (tests).
+// publishing (tests).
 //
 // TODO: eventually support HTTPS
 func New(host string, nats natsclient.Publisher, env string) *Client {
@@ -75,60 +73,31 @@ func (c *Client) CurrentlyPlaying(ctx context.Context) string {
 // PlayRandom plays a random file from the playlist
 func (c *Client) PlayRandom(ctx context.Context) error {
 	c.publish(ctx, ve.PlayRandomSubject(c.env), ve.Command{Envelope: ve.NewEnvelope()})
-	_, err := c.get(ctx, c.serverURL+"/vlc/random")
-	if err != nil {
-		slog.ErrorContext(ctx, "error playing random video", "err", err)
-		return err
-	}
 	return nil
 }
 
 // PlayFileInPlaylist plays a given file
 func (c *Client) PlayFileInPlaylist(ctx context.Context, filename string) error {
 	c.publish(ctx, ve.PlayFileSubject(c.env), ve.PlayFile{Envelope: ve.NewEnvelope(), File: filename})
-	url := c.serverURL + "/vlc/play/" + filename
-	_, err := c.get(ctx, url)
-	if err != nil {
-		slog.ErrorContext(ctx, "error playing file", "err", err)
-		return err
-	}
 	return nil
 }
 
 func (c *Client) Skip(ctx context.Context, n int) error {
 	c.publish(ctx, ve.SkipSubject(c.env), ve.Skip{Envelope: ve.NewEnvelope(), N: n})
-	url := c.serverURL + "/vlc/skip"
-	if n > 0 {
-		url = fmt.Sprintf("%s/%d", url, n)
-	}
-	_, err := c.get(ctx, url)
-	if err != nil {
-		slog.ErrorContext(ctx, "error skipping video", "err", err)
-		return err
-	}
 	return nil
 }
 
 func (c *Client) Back(ctx context.Context, n int) error {
 	c.publish(ctx, ve.BackSubject(c.env), ve.Back{Envelope: ve.NewEnvelope(), N: n})
-	url := c.serverURL + "/vlc/back"
-	if n > 0 {
-		url = fmt.Sprintf("%s/%d", url, n)
-	}
-	_, err := c.get(ctx, url)
-	if err != nil {
-		slog.ErrorContext(ctx, "error going back to a video", "err", err)
-		return err
-	}
 	return nil
 }
 
 // TODO: move this to a common location
 //
-// Transport-layer errors log at Debug, not Error: each wrapper above this
-// (CurrentlyPlaying, PlayRandom, …) logs the operation-specific failure at
-// Error with the same underlying err. Logging here too would triple-count
-// every VLC outage in Loki and Sentry.
+// Transport-layer errors log at Debug, not Error: CurrentlyPlaying (the sole
+// remaining caller) logs its own operation-specific failure at Error with the
+// same underlying err. Logging here too would double-count every VLC outage in
+// Loki and Sentry.
 func (c *Client) get(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -7,11 +7,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
-	"strconv"
 	"time"
-
-	"github.com/davecgh/go-spew/spew"
-	"github.com/gorilla/mux"
 )
 
 // livenessHandler answers /health/ and /health/live. Liveness is a
@@ -86,74 +82,11 @@ func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 // package load; close enough to process start for a human-readable "up Xh".
 var startedAt = time.Now()
 
+// vlcCurrentHandler returns the currently-playing file. This is the only
+// vlc command-surface route still on HTTP — it's a read. The play / random /
+// skip / back commands moved to NATS (see nats.go).
 func (s *Server) vlcCurrentHandler(w http.ResponseWriter, r *http.Request) {
-	// return the currently-playing file
 	fmt.Fprint(w, s.currentlyPlaying())
-}
-
-func (s *Server) vlcPlayHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	spew.Dump(vars)
-
-	videoFile := vars["video"]
-
-	spew.Dump(videoFile)
-	if err := s.PlayVideoFile(videoFile); err != nil {
-		slog.ErrorContext(r.Context(), "couldn't play requested video", "err", err, "video", videoFile)
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
-
-	//TODO: better response
-	fmt.Fprintf(w, "OK")
-}
-
-func (s *Server) vlcBackHandler(w http.ResponseWriter, r *http.Request) {
-	num, ok := r.URL.Query()["n"]
-	if !ok || len(num) > 1 {
-		s.back(1)
-		return
-	}
-	i, err := strconv.Atoi(num[0])
-	if err != nil {
-		slog.ErrorContext(r.Context(), "couldn't convert input to int", "err", err)
-		http.Error(w, "422 unprocessable entity", http.StatusUnprocessableEntity)
-		return
-	}
-
-	s.back(i)
-
-	//TODO: better response
-	fmt.Fprintf(w, "OK")
-
-}
-
-func (s *Server) vlcSkipHandler(w http.ResponseWriter, r *http.Request) {
-	num, ok := r.URL.Query()["n"]
-	if !ok || len(num) > 1 {
-		s.skip(1)
-		return
-	}
-	i, err := strconv.Atoi(num[0])
-	if err != nil {
-		slog.ErrorContext(r.Context(), "couldn't convert input to int", "err", err)
-		http.Error(w, "422 unprocessable entity", http.StatusUnprocessableEntity)
-		return
-	}
-
-	s.skip(i)
-
-	//TODO: better response
-	fmt.Fprintf(w, "OK")
-}
-
-func (s *Server) vlcRandomHandler(w http.ResponseWriter, r *http.Request) {
-	// play a random file
-	err := s.PlayRandom()
-	if err != nil {
-		http.Error(w, "error playing random", http.StatusInternalServerError)
-	}
-	fmt.Fprintf(w, "OK")
 }
 
 // nextFrameJPEGHandler serves the cached first-frame JPEG that the OBS

--- a/pkg/vlc-server/handlers_test.go
+++ b/pkg/vlc-server/handlers_test.go
@@ -35,32 +35,9 @@ func TestVersionHandlerReturnsInjectedTag(t *testing.T) {
 	}
 }
 
-// These tests exercise *parse-error* paths only — the handlers reject bad
-// input before reaching libvlc, so we never touch the real player.
-
-func TestVlcSkipHandlerInvalidIntReturns422(t *testing.T) {
-	s := &Server{}
-	req := httptest.NewRequest(http.MethodGet, "/vlc/skip?n=notanumber", nil)
-	rec := httptest.NewRecorder()
-
-	s.vlcSkipHandler(rec, req)
-
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusUnprocessableEntity)
-	}
-}
-
-func TestVlcBackHandlerInvalidIntReturns422(t *testing.T) {
-	s := &Server{}
-	req := httptest.NewRequest(http.MethodGet, "/vlc/back?n=notanumber", nil)
-	rec := httptest.NewRecorder()
-
-	s.vlcBackHandler(rec, req)
-
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("got status %d, want %d", rec.Code, http.StatusUnprocessableEntity)
-	}
-}
+// The vlc skip / back / play / random commands moved to NATS (nats.go); their
+// HTTP handlers and the parse-error tests that covered them are gone. The
+// equivalent decode-error coverage lives in nats_test.go now.
 
 func TestCatchAllHandlerNonGet(t *testing.T) {
 	s := &Server{}

--- a/pkg/vlc-server/nats.go
+++ b/pkg/vlc-server/nats.go
@@ -13,16 +13,14 @@ import (
 
 // StartNATSSubscribers attaches the server's NATS subscriptions to the
 // package-singleton *nats.Conn (initialized by main via natsclient.Connect).
-// No-op when the conn is nil (NATS_URL unset); HTTP remains the sole
-// transport then.
+// No-op when the conn is nil (NATS_URL unset) — with the HTTP command path
+// peeled off, the server simply receives no commands in that case.
 //
-// OBSERVE-ONLY (mirror phase): vlc commands are not idempotent — acting on
-// both NATS and the mirrored HTTP call would double-execute (skip two videos,
-// two random jumps). So unlike the onscreens subscribers, these handlers
-// decode their payload and LOG what they would do; HTTP stays the sole actor.
-// This burns in NATS delivery + wire format end-to-end without touching
-// playback. The peel PR flips these to act (s.skip(n) etc.) and removes the
-// HTTP command path in the same change — never a window where both act.
+// NATS is the sole transport for the vlc command surface: each handler drives
+// the same playback method the old HTTP handler called. (The observe-only
+// mirror this burned in against, and the HTTP command path, have since been
+// peeled off.) The publish-only client no longer calls HTTP, so there's no
+// double-execution despite vlc commands not being idempotent.
 //
 // Subscribers are registered explicitly (not via a vlc.> wildcard) so each
 // gets its own subscribe log line and the dispatch stays readable.
@@ -52,12 +50,15 @@ func (s *Server) StartNATSSubscribers(ctx context.Context) {
 	}
 }
 
-// The handlers below are observe-only: they decode (validating the wire
-// format and delivery) and log, but do not drive playback — see the
-// StartNATSSubscribers doc. The "would" phrasing in the log is deliberate.
+// Each handler maps 1-1 to the playback method the old HTTP handler called.
+// play.file is strict (an empty filename is a publisher bug, dropped); skip /
+// back normalize a non-positive count to 1, matching the old HTTP handler's
+// default when no n was supplied.
 
 func (s *Server) handlePlayRandom(_ *nats.Msg) {
-	slog.Info("nats: vlc play.random (observe-only, HTTP still acts)")
+	if err := s.PlayRandom(); err != nil {
+		slog.Error("nats: vlc play.random failed", "err", err)
+	}
 }
 
 func (s *Server) handlePlayFile(m *nats.Msg) {
@@ -66,7 +67,13 @@ func (s *Server) handlePlayFile(m *nats.Msg) {
 		slog.Error("nats: decode vlc play.file", "err", err, "subject", m.Subject)
 		return
 	}
-	slog.Info("nats: vlc play.file (observe-only, HTTP still acts)", "file", ev.File)
+	if ev.File == "" {
+		slog.Warn("nats: vlc play.file missing file", "subject", m.Subject)
+		return
+	}
+	if err := s.PlayVideoFile(ev.File); err != nil {
+		slog.Error("nats: vlc play.file failed", "err", err, "file", ev.File)
+	}
 }
 
 func (s *Server) handleSkip(m *nats.Msg) {
@@ -75,7 +82,11 @@ func (s *Server) handleSkip(m *nats.Msg) {
 		slog.Error("nats: decode vlc skip", "err", err, "subject", m.Subject)
 		return
 	}
-	slog.Info("nats: vlc skip (observe-only, HTTP still acts)", "n", ev.N)
+	n := ev.N
+	if n <= 0 {
+		n = 1
+	}
+	s.skip(n)
 }
 
 func (s *Server) handleBack(m *nats.Msg) {
@@ -84,5 +95,9 @@ func (s *Server) handleBack(m *nats.Msg) {
 		slog.Error("nats: decode vlc back", "err", err, "subject", m.Subject)
 		return
 	}
-	slog.Info("nats: vlc back (observe-only, HTTP still acts)", "n", ev.N)
+	n := ev.N
+	if n <= 0 {
+		n = 1
+	}
+	s.back(n)
 }

--- a/pkg/vlc-server/nats_test.go
+++ b/pkg/vlc-server/nats_test.go
@@ -1,39 +1,34 @@
 package vlcServer
 
 import (
-	"encoding/json"
 	"testing"
 
 	ve "github.com/adanalife/tripbot/pkg/vlc-events"
 	"github.com/nats-io/nats.go"
 )
 
-// The observe-only handlers only decode + log, so these tests assert the
-// decode path tolerates both well-formed and malformed payloads without
-// panicking. They don't touch libvlc (a zero Server is enough — the handlers
-// read no server state), which keeps them honest about being side-effect-free.
-
-func TestNATSHandlersDecodeValidPayloads(t *testing.T) {
-	s := &Server{}
-
-	skip, _ := json.Marshal(ve.Skip{Envelope: ve.NewEnvelope(), N: 3})
-	back, _ := json.Marshal(ve.Back{Envelope: ve.NewEnvelope(), N: 2})
-	file, _ := json.Marshal(ve.PlayFile{Envelope: ve.NewEnvelope(), File: "x.mp4"})
-	cmd, _ := json.Marshal(ve.Command{Envelope: ve.NewEnvelope()})
-
-	// None of these should panic or act on playback.
-	s.handleSkip(&nats.Msg{Subject: ve.SkipSubject("test"), Data: skip})
-	s.handleBack(&nats.Msg{Subject: ve.BackSubject("test"), Data: back})
-	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test"), Data: file})
-	s.handlePlayRandom(&nats.Msg{Subject: ve.PlayRandomSubject("test"), Data: cmd})
-}
+// The handlers act on playback now (they drive libvlc), so the valid-payload
+// path can't be unit-tested against a zero Server. What stays testable is the
+// decode-error guard: a malformed body is logged and dropped before any
+// playback call, so it's safe on a zero Server and proves bad input never
+// reaches libvlc. play.random has no decode step, so it's exercised in the
+// live burn-in, not here.
 
 func TestNATSHandlersTolerateMalformedPayloads(t *testing.T) {
 	s := &Server{}
 	bad := []byte("{not json")
 
-	// Malformed bodies are logged and dropped, not panicked on.
+	// Malformed bodies are logged and dropped, not panicked on, and never
+	// reach s.skip / s.back / s.PlayVideoFile.
 	s.handleSkip(&nats.Msg{Subject: ve.SkipSubject("test"), Data: bad})
 	s.handleBack(&nats.Msg{Subject: ve.BackSubject("test"), Data: bad})
 	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test"), Data: bad})
+}
+
+// handlePlayFile with an empty filename is a publisher bug — dropped before
+// the PlayVideoFile call (so safe on a zero Server).
+func TestPlayFileEmptyFilenameDropped(t *testing.T) {
+	s := &Server{}
+	empty := []byte(`{"emitted_at":"2026-01-01T00:00:00Z","file":""}`)
+	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test"), Data: empty})
 }

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -110,15 +110,10 @@ func (s *Server) Start(ctx context.Context) {
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")
 
-	// vlc endpoints
+	// vlc endpoints — the play / random / skip / back commands moved to NATS
+	// (see nats.go); only the currently-playing read remains on HTTP.
 	vlc := r.PathPrefix("/vlc").Methods("GET").Subrouter()
 	vlc.Handle("/current", tagged("/vlc/current", s.vlcCurrentHandler))
-	vlc.Handle("/play/{video}", tagged("/vlc/play/{video}", s.vlcPlayHandler))
-	vlc.Handle("/random", tagged("/vlc/random", s.vlcRandomHandler))
-	vlc.Handle("/back", tagged("/vlc/back", s.vlcBackHandler))
-	vlc.Handle("/back/{n}", tagged("/vlc/back/{n}", s.vlcBackHandler))
-	vlc.Handle("/skip", tagged("/vlc/skip", s.vlcSkipHandler))
-	vlc.Handle("/skip/{n}", tagged("/vlc/skip/{n}", s.vlcSkipHandler))
 
 	// onscreen endpoints now live in cmd/onscreens-server (separate binary,
 	// separate port). vlc-server no longer serves /onscreens/* — clients


### PR DESCRIPTION
Minor release cut from `develop`. Three changes since v3.0.1:

### pubsub
- **#790** — VLC command surface HTTP peel; NATS is now the sole command transport (completes the observe-only mirror from v3.0.0). Requires vlc-server's `NATS_URL` wiring to be live in each env.

### admin
- **#807** — chat-send box defaults to the broadcaster identity.

### chatbot
- **#806** — `!ocation` aliases to `!location`.

`origin/master` was merged into the branch to reconcile the CHANGELOG (develop's `[Unreleased]` had drifted — it still listed #803/#788/#789, all already shipped). The net CHANGELOG diff is exactly the new `[v3.1.0]` section.

`#minor` in the title drives the auto-tag bump (v3.0.1 → v3.1.0) — **keep `#minor` in the merge commit message when merging**, since the tag action reads commit messages, not the PR title.

Merge with a **merge commit** (not squash), per the release-flow convention.