### PR TITLE
feat(chatbot): per-platform command allowlist for YouTube instances

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -25,6 +25,11 @@ var Uptime time.Time
 // App holds injectable dependencies for the chatbot. cmd/tripbot constructs the
 // live one with New(); tests instantiate it directly with fakes.
 type App struct {
+	// Platform names the streaming platform this App serves ("twitch" /
+	// "youtube"). It gates which commands are indexed for dispatch
+	// (indexCommands): Twitch runs the full registry, YouTube runs the v1
+	// allowlist. Empty is treated as Twitch. Set from c.Conf.Platform in New().
+	Platform string
 	// DB is the GORM handle used by commands that need to read or write the
 	// database. nil in tests that don't exercise the DB; otherwise either the
 	// real database.GormDB() or a sqlmock-backed gorm.DB.
@@ -116,6 +121,7 @@ func (a *App) db() *gorm.DB {
 // touches no network or DB — the realX adapters are lazy.
 func New() *App {
 	a := &App{
+		Platform: c.Conf.Platform,
 		// DB stays nil; commands use a.db() which falls back to database.GormDB().
 		Onscreens:  realOnscreens{c: onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment)},
 		VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)},

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -241,16 +241,58 @@ func (a *App) buildRegistry() []Command {
 	}
 }
 
+// Platform names for App.Platform. Empty is treated as Twitch.
+const (
+	platformTwitch  = "twitch"
+	platformYouTube = "youtube"
+)
+
+// youtubeCommands is the v1 allowlist of triggers a YouTube instance runs — the
+// stateless "info + playback control" subset. Identity/miles commands (!miles,
+// !leaderboard, !guess, !state, !location, …), the Twitch-only !followage, and
+// the admin commands (!middle, !secretinfo, !shutdown, !makebot, !unbot) are
+// deliberately excluded: YouTube v1 runs no per-user state. The now-playing /
+// SomaFM commands (!song, !music, !somafm) are also deferred for now — the
+// background-audio source is Twitch-stream-specific. Aliases come along with
+// their trigger, so only triggers are listed. See the YouTube provider plan.
+var youtubeCommands = map[string]bool{
+	"!help": true, "!version": true, "!uptime": true, "!commands": true,
+	"!gas": true, "!report": true, "!flag": true,
+	// info (read current-video state only)
+	"!weather": true, "!time": true, "!date": true, "!sunset": true,
+	// playback control (drives this platform's vlc pipeline)
+	"!timewarp": true, "!goto": true, "!skip": true, "!back": true,
+	// socials / static links
+	"!socialmedia": true, "!discord": true, "!twitter": true, "!instagram": true,
+	"!facebook": true, "!youtube": true, "!tiktok": true, "!bluesky": true,
+}
+
+// commandEnabled reports whether cmd should be indexed for dispatch on this
+// App's platform. Twitch (the primary platform, and the empty default) runs the
+// full registry; YouTube runs only the youtubeCommands allowlist. An unknown
+// platform falls back to the full set.
+func (a *App) commandEnabled(cmd *Command) bool {
+	if a.Platform == platformYouTube {
+		return youtubeCommands[cmd.Trigger]
+	}
+	return true
+}
+
 // indexCommands builds a.commands from a.buildRegistry() and indexes it into
 // a.singleWordLookup / a.multiWordLookup by trigger and alias. Call once after
 // the App is constructed (its deps don't need to be set — buildRegistry only
-// binds handler method values to a).
+// binds handler method values to a). Commands not enabled for a.Platform
+// (commandEnabled) stay in a.commands but are never indexed, so they don't
+// dispatch on that platform.
 func (a *App) indexCommands() {
 	a.commands = a.buildRegistry()
 	a.singleWordLookup = make(map[string]*Command)
 	a.multiWordLookup = make(map[string]*Command)
 	for i := range a.commands {
 		cmd := &a.commands[i]
+		if !a.commandEnabled(cmd) {
+			continue
+		}
 		a.registerTrigger(cmd.Trigger, cmd)
 		for _, alias := range cmd.Aliases {
 			a.registerTrigger(alias, cmd)

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -60,3 +60,39 @@ func TestLookupMapsPointToCorrectCommand(t *testing.T) {
 		}
 	}
 }
+
+// TestYouTubeAllowlistTriggersExist guards against drift: every trigger in the
+// YouTube allowlist must be a real command in the full registry, so a rename or
+// removal can't silently leave a dangling allowlist entry.
+func TestYouTubeAllowlistTriggersExist(t *testing.T) {
+	full := &App{} // empty platform → full registry
+	full.indexCommands()
+	for trigger := range youtubeCommands {
+		if _, ok := full.singleWordLookup[trigger]; !ok {
+			t.Errorf("youtubeCommands trigger %q is not a real command in the registry", trigger)
+		}
+	}
+}
+
+// TestYouTubePlatformIndexesOnlyAllowlist verifies a YouTube App dispatches the
+// v1 allowlist (triggers + their aliases) and nothing else — identity/miles,
+// the Twitch-only !followage, and admin commands must not resolve.
+func TestYouTubePlatformIndexesOnlyAllowlist(t *testing.T) {
+	yt := &App{Platform: platformYouTube}
+	yt.indexCommands()
+
+	// allowed: a trigger and one of its aliases both resolve
+	for _, token := range []string{"!weather", "!meteo", "!skip", "!timewarp", "!warp", "!youtube"} {
+		if cmd, _ := yt.findCommand(token); cmd == nil {
+			t.Errorf("expected %q to be available on YouTube, got nil", token)
+		}
+	}
+
+	// excluded: identity/miles, Twitch-only, admin, and the deferred
+	// now-playing commands do not resolve
+	for _, token := range []string{"!miles", "!km", "!leaderboard", "!guess", "!state", "!location", "!followage", "!middle", "!shutdown", "!makebot", "hello", "!song", "!music", "!somafm"} {
+		if cmd, _ := yt.findCommand(token); cmd != nil {
+			t.Errorf("expected %q to be unavailable on YouTube, got %q", token, cmd.Trigger)
+		}
+	}
+}

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -3,6 +3,14 @@ package config
 type TripbotConfig struct {
 	Environment string `required:"true" envconfig:"ENV"`
 	ServerType  string `default:"tripbot"`
+	// Platform selects which streaming platform this bot instance serves.
+	// "twitch" (the default) runs the full command surface; "youtube" runs the
+	// restricted v1 allowlist (see pkg/chatbot/registry.go). One instance per
+	// platform, selected by config — same binary, blast-radius isolated.
+	// Reads the same STREAM_PLATFORM env key the OBS image uses
+	// (contract.EnvKeyStreamPlatform), so the cdk8s factory stamps one platform
+	// value across every component of a pipeline.
+	Platform string `default:"twitch" envconfig:"STREAM_PLATFORM"`
 
 	// ChannelName is the username of the stream
 	ChannelName string `required:"true" envconfig:"CHANNEL_NAME"`

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -115,8 +115,10 @@ const (
 	EnvKeyOnscreensServerHost = "ONSCREENS_SERVER_HOST"
 	// EnvKeyDatabaseHost is the Postgres host pkg/database requires.
 	EnvKeyDatabaseHost = "DATABASE_HOST"
-	// EnvKeyStreamPlatform selects which platform OBS streams to. Read by the
-	// OBS image entrypoint, not by Go.
+	// EnvKeyStreamPlatform selects which platform a per-platform instance
+	// serves. Read by the OBS image entrypoint (which platform OBS streams to)
+	// and by tripbot via TripbotConfig.Platform (which chat platform the bot
+	// serves + its command surface) — one platform value per pipeline.
 	EnvKeyStreamPlatform = "STREAM_PLATFORM"
 	// EnvKeyStreamKey is the per-platform stream key. Read by the OBS image
 	// entrypoint, not by Go.


### PR DESCRIPTION
First piece of the YouTube provider (Track B groundwork). No YouTube transport yet — this lands the mechanism that lets a `PLATFORM=youtube` bot instance run only the commands appropriate to YouTube.

## What

- Adds a `Platform` selector to `TripbotConfig` / `chatbot.App`. Twitch (the default) runs the full command registry; YouTube runs a restricted **v1 allowlist** — the stateless "info + playback control" subset.
- The allowlist excludes everything that needs per-user identity, miles, scoreboards, Twitch Helix (`!followage`), or admin (`!middle`, `!shutdown`, …). The now-playing / SomaFM commands (`!song`, `!music`, `!somafm`) are deferred for now — the background-audio source is Twitch-stream-specific. YouTube v1 carries no per-user state.
- Enforced at `indexCommands`: disabled triggers stay in the registry but are never indexed into the dispatch lookups, so they don't resolve on that platform. The user login happens at the inbound seam (not in handlers), so the subset never touches identity.

## v1 YouTube allowlist

`!help !commands !version !uptime !gas !report !flag` · `!weather !time !date !sunset` · `!timewarp !goto !skip !back` · socials (`!discord !youtube !twitter !instagram !facebook !tiktok !bluesky !social`)

## Naming

`Platform` reads the same **`STREAM_PLATFORM`** env key the OBS image already uses (`contract.EnvKeyStreamPlatform`), rather than introducing a second near-synonym — so the cdk8s factory stamps one platform value across every component of a pipeline (obs/tripbot/vlc/onscreens). The contract doc is generalized accordingly; the constant value is unchanged, so `contract.json` and its drift gate are untouched.

## Tests

- `TestYouTubePlatformIndexesOnlyAllowlist` — a YouTube App resolves the allowlist (triggers + aliases) and nothing else.
- `TestYouTubeAllowlistTriggersExist` — guards against drift: every allowlist entry is a real registry command.