### PR TITLE
chatbot: validate Discord webhook URL before POSTing a !report

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/scoreboards"
@@ -489,9 +490,28 @@ func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) 
 	// silently when DISCORD_ALERTS_WEBHOOK is unset (e.g. local dev) —
 	// the slog/Sentry path still fires so nothing is lost.
 	if webhook := c.Conf.DiscordAlertsWebhook; webhook != "" {
-		go postReportToDiscord(webhook, user.Username, message)
+		if isDiscordWebhookURL(webhook) {
+			go postReportToDiscord(webhook, user.Username, message)
+		} else {
+			// A misconfigured secret (e.g. the SM placeholder string) would
+			// otherwise log a "unsupported protocol scheme" ERROR on every
+			// !report. Warn once per process and fall through to slog/Sentry.
+			reportWebhookWarnOnce.Do(func() {
+				slog.WarnContext(ctx, "DISCORD_ALERTS_WEBHOOK is not a Discord webhook URL; skipping Discord report")
+			})
+		}
 	}
 	a.Chat.Say("Thank you, I will look into this ASAP!")
+}
+
+// reportWebhookWarnOnce bounds the misconfigured-webhook warning to one line
+// per process instead of one per !report invocation.
+var reportWebhookWarnOnce sync.Once
+
+// isDiscordWebhookURL reports whether s looks like a Discord webhook endpoint,
+// guarding postReportToDiscord against placeholder/garbage secret values.
+func isDiscordWebhookURL(s string) bool {
+	return strings.HasPrefix(s, "https://discord.com/api/webhooks/")
 }
 
 // postReportToDiscord POSTs a viewer report to a Discord webhook.

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -197,6 +197,27 @@ func TestReportCmd_AcksViaIRC(t *testing.T) {
 	}
 }
 
+func TestIsDiscordWebhookURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid", "https://discord.com/api/webhooks/123/abc", true},
+		{"placeholder", "placeholder — set via aws secretsmanager put-secret-value", false},
+		{"empty", "", false},
+		{"http scheme", "http://discord.com/api/webhooks/123/abc", false},
+		{"other host", "https://example.com/api/webhooks/123/abc", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDiscordWebhookURL(tc.in); got != tc.want {
+				t.Errorf("isDiscordWebhookURL(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBonusMilesCmd_SaysViaIRC(t *testing.T) {
 	app := newTestApp(video.Video{})
 	rec := &recordingChat{}


### PR DESCRIPTION
## Summary
- Guard `postReportToDiscord` behind a Discord-webhook-URL prefix check so a placeholder/garbage `DISCORD_ALERTS_WEBHOOK` value no longer logs an "unsupported protocol scheme" ERROR on every `!report`. On a bad value it warns once per process and falls through to the slog/Sentry audit path (nothing lost).

## Test plan
- [x] `go test ./pkg/chatbot/` passes; `TestIsDiscordWebhookURL` covers valid / placeholder / empty / wrong-scheme / wrong-host
- [ ] Dana confirms no per-invocation ERROR when the webhook secret is unset/placeholder

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>