### PR TITLE
feat: pkg/youtube — channel-owner OAuth + token storage (Phase B1)

### DIFF
--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -25,6 +25,20 @@ type TripbotConfig struct {
 	// callers fall back gracefully (no city/state lookups, no generated
 	// maps). The bot continues to run.
 	GoogleMapsAPIKey string `envconfig:"GOOGLE_MAPS_API_KEY"`
+
+	// YouTubeClientID / YouTubeClientSecret are the YouTube OAuth app
+	// credentials (a GCP-console "Web application" OAuth client whose
+	// authorized redirect URIs include <EXTERNAL_URL>/auth/callback).
+	// Only set on PLATFORM=youtube instances; optional everywhere else —
+	// pkg/youtube returns ErrNotConfigured rather than fataling when absent.
+	YouTubeClientID     string `envconfig:"YOUTUBE_CLIENT_ID"`
+	YouTubeClientSecret string `envconfig:"YOUTUBE_CLIENT_SECRET"`
+	// YouTubeChannelID optionally pins the expected channel identity. When
+	// set, the /auth/init?account=youtube consent flow rejects (and does not
+	// persist) tokens from any other channel — keeps a prod pod from storing
+	// the quiet test channel's token, and vice versa.
+	YouTubeChannelID string `envconfig:"YOUTUBE_CHANNEL_ID"`
+
 	// ReadOnly is used to prevent writing some things to the DB
 	ReadOnly bool `default:"false" envconfig:"READ_ONLY"`
 	// Verbose determines output verbosity

--- a/pkg/oauthtokens/oauthtokens.go
+++ b/pkg/oauthtokens/oauthtokens.go
@@ -59,6 +59,29 @@ func getFromDB(db *sqlx.DB, provider, username string) (Token, error) {
 	return t, nil
 }
 
+// GetByProvider returns the provider's single row, or ErrNoToken if none
+// exists. Providers with one identity (YouTube: the channel owner) don't
+// know a username ahead of time the way Twitch does (c.Conf.BotUsername) —
+// the identity is discovered at consent time — so boot-time loading keys on
+// the provider alone. If stray extra rows exist, the most recently updated
+// one wins; clean strays up by hand.
+func GetByProvider(provider string) (Token, error) {
+	return getByProviderFromDB(database.Connection(), provider)
+}
+
+func getByProviderFromDB(db *sqlx.DB, provider string) (Token, error) {
+	var t Token
+	query := `SELECT * FROM oauth_tokens WHERE provider=$1 ORDER BY date_updated DESC LIMIT 1`
+	err := db.Get(&t, query, provider)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Token{}, ErrNoToken
+	}
+	if err != nil {
+		return Token{}, fmt.Errorf("oauthtokens.GetByProvider: %w", err)
+	}
+	return t, nil
+}
+
 // Upsert inserts the row or updates the existing one matching (provider, username).
 // On UPDATE, refresh_fail_count is reset to 0 (Upsert implies a successful refresh
 // or a fresh bootstrap), last_refresh_at + date_updated are stamped to now(),

--- a/pkg/oauthtokens/oauthtokens_test.go
+++ b/pkg/oauthtokens/oauthtokens_test.go
@@ -34,6 +34,47 @@ func sampleToken() Token {
 	}
 }
 
+func TestGetByProvider_Hit(t *testing.T) {
+	db, mock := newMockDB(t)
+	rows := sqlmock.NewRows([]string{
+		"id", "provider", "username", "twitch_user_id", "access_token", "refresh_token",
+		"expires_at", "scopes", "refresh_fail_count", "last_refresh_at",
+		"date_created", "date_updated",
+	}).AddRow(
+		2, "youtube", "UC123", nil, "yt-access", "yt-refresh",
+		time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC),
+		"https://www.googleapis.com/auth/youtube.force-ssl",
+		0, nil,
+		time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+	)
+	mock.ExpectQuery(`SELECT .* FROM oauth_tokens WHERE provider=\$1 ORDER BY date_updated DESC LIMIT 1`).
+		WithArgs("youtube").
+		WillReturnRows(rows)
+
+	got, err := getByProviderFromDB(db, "youtube")
+	if err != nil {
+		t.Fatalf("getByProviderFromDB: %v", err)
+	}
+	if got.Username != "UC123" || got.AccessToken != "yt-access" {
+		t.Errorf("unexpected token: %+v", got)
+	}
+	if got.TwitchUserID.Valid {
+		t.Errorf("twitch_user_id should scan as NULL for youtube rows: %+v", got.TwitchUserID)
+	}
+}
+
+func TestGetByProvider_MissReturnsErrNoToken(t *testing.T) {
+	db, mock := newMockDB(t)
+	mock.ExpectQuery(`SELECT .* FROM oauth_tokens WHERE provider=\$1 ORDER BY date_updated DESC LIMIT 1`).
+		WithArgs("youtube").
+		WillReturnError(sql.ErrNoRows)
+
+	if _, err := getByProviderFromDB(db, "youtube"); !errors.Is(err, ErrNoToken) {
+		t.Fatalf("expected ErrNoToken, got %v", err)
+	}
+}
+
 func TestGet_Hit(t *testing.T) {
 	db, mock := newMockDB(t)
 	rows := sqlmock.NewRows([]string{

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -15,12 +15,21 @@ import (
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
 	"github.com/nicklaw5/helix/v2"
 )
 
 // generateUserAccessToken is overridable in tests so the /auth/callback
 // happy path can be exercised without round-tripping to Twitch.
 var generateUserAccessToken = mytwitch.GenerateUserAccessToken
+
+// youtubeGenerateToken / youtubeAuthCodeURL / youtubeConfigured are the
+// same seams for the YouTube leg of the auth flow.
+var (
+	youtubeGenerateToken = myyoutube.GenerateUserAccessToken
+	youtubeAuthCodeURL   = myyoutube.AuthCodeURL
+	youtubeConfigured    = myyoutube.Configured
+)
 
 // helixClient is overridable in tests so /auth/init's URL-construction can be
 // exercised without triggering mytwitch.Client()'s lazy network init (which
@@ -138,8 +147,32 @@ func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
-		slog.ErrorContext(r.Context(), "no code in response from twitch", "err", errors.New("code missing"))
-		http.Error(w, "no code in response from twitch", http.StatusBadRequest)
+		slog.ErrorContext(r.Context(), "no code in auth callback", "err", errors.New("code missing"))
+		http.Error(w, "no code in auth callback", http.StatusBadRequest)
+		return
+	}
+
+	// YouTube leg: Google redirects to this same path; the account stashed
+	// with the state says which IdP the code belongs to.
+	if account == oauthstate.AccountYouTube {
+		title, err := youtubeGenerateToken(r.Context(), code)
+		if err != nil {
+			var mismatch *myyoutube.ErrChannelMismatch
+			if errors.As(err, &mismatch) {
+				slog.WarnContext(r.Context(), "YouTube consent identity mismatch; no row written",
+					"expected", mismatch.Expected, "got", mismatch.Got, "got_title", mismatch.GotTitle)
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintf(w, authYouTubeMismatchHTML, mismatch.GotTitle, mismatch.Got, mismatch.Expected)
+				return
+			}
+			slog.ErrorContext(r.Context(), "youtube GenerateUserAccessToken failed", "err", err)
+			http.Error(w, "failed to exchange code: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		slog.InfoContext(r.Context(), "received token from youtube via auth callback", "channel", title)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, authSuccessHTML, title, string(account))
 		return
 	}
 
@@ -187,8 +220,18 @@ func authInitHandler(w http.ResponseWriter, r *http.Request) {
 	case "broadcaster":
 		scopes = mytwitch.BroadcasterScopes
 		account = oauthstate.AccountBroadcaster
+	case "youtube":
+		// YouTube goes to Google's authorize URL, not Twitch's — handle the
+		// whole leg here and return (no helix client involved).
+		if !youtubeConfigured() {
+			http.Error(w, "youtube auth not configured (YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET unset)", http.StatusServiceUnavailable)
+			return
+		}
+		state := oauthstate.New(oauthstate.AccountYouTube)
+		http.Redirect(w, r, youtubeAuthCodeURL(state), http.StatusFound)
+		return
 	default:
-		http.Error(w, "account must be 'bot' or 'broadcaster'", http.StatusBadRequest)
+		http.Error(w, "account must be 'bot', 'broadcaster', or 'youtube'", http.StatusBadRequest)
 		return
 	}
 	client, err := helixClient()
@@ -229,6 +272,17 @@ const authMismatchHTML = `<!doctype html>
 <style>body{background:#3a0000;color:#fff;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}div{max-width:540px}code{background:#000;padding:2px 5px;border-radius:3px}a{color:#9cf}</style>
 </head>
 <body><div><h1>Wrong account</h1><p>You signed in as <code>%s</code>, but this leg expected <code>%s</code> (the <strong>%s</strong> account).</p><p>No token was written. Sign out of Twitch in this browser (or open an incognito window), then <a href="/auth/init?account=%s">click here to retry</a>.</p></div></body>
+</html>`
+
+// authYouTubeMismatchHTML is returned when the consenting Google account's
+// channel doesn't match the configured YOUTUBE_CHANNEL_ID. No row is written.
+// %s = got channel title, %s = got channel ID, %s = expected channel ID.
+const authYouTubeMismatchHTML = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>tripbot — wrong channel</title>
+<style>body{background:#3a0000;color:#fff;font:14px/1.5 -apple-system,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}div{max-width:540px}code{background:#000;padding:2px 5px;border-radius:3px}a{color:#9cf}</style>
+</head>
+<body><div><h1>Wrong channel</h1><p>You consented as <code>%s</code> (<code>%s</code>), but this instance expects channel <code>%s</code>.</p><p>No token was written. Switch to the channel-owner Google account (Google's account chooser appears on the consent screen), then <a href="/auth/init?account=youtube">click here to retry</a>.</p></div></body>
 </html>`
 
 // return a favicon if anyone asks for one

--- a/pkg/server/handlers_youtube_test.go
+++ b/pkg/server/handlers_youtube_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/adanalife/tripbot/pkg/server/oauthstate"
+	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
+)
+
+// withStubYouTubeSeams swaps the YouTube auth seams so the handlers can be
+// tested without round-tripping to Google.
+func withStubYouTubeSeams(t *testing.T, configured bool, generate func(context.Context, string) (string, error)) {
+	t.Helper()
+	savedGen, savedURL, savedConf := youtubeGenerateToken, youtubeAuthCodeURL, youtubeConfigured
+	youtubeGenerateToken = generate
+	youtubeAuthCodeURL = func(state string) string {
+		return "https://accounts.google.com/o/oauth2/auth?state=" + state
+	}
+	youtubeConfigured = func() bool { return configured }
+	t.Cleanup(func() {
+		youtubeGenerateToken, youtubeAuthCodeURL, youtubeConfigured = savedGen, savedURL, savedConf
+	})
+}
+
+func TestAuthInitHandler_YouTubeRedirectsToGoogle(t *testing.T) {
+	withStubYouTubeSeams(t, true, func(context.Context, string) (string, error) {
+		t.Fatal("generator should not be called from /auth/init")
+		return "", nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/init?account=youtube", nil)
+	rec := httptest.NewRecorder()
+	authInitHandler(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusFound)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "https://accounts.google.com/") {
+		t.Fatalf("redirect location %q is not Google's authorize URL", loc)
+	}
+	// The state embedded in the redirect must be valid and carry the
+	// youtube account selector for the callback to branch on.
+	state := strings.TrimPrefix(loc, "https://accounts.google.com/o/oauth2/auth?state=")
+	account, ok := oauthstate.Validate(state)
+	if !ok || account != oauthstate.AccountYouTube {
+		t.Errorf("state validates to (%q, %v), want (youtube, true)", account, ok)
+	}
+}
+
+func TestAuthInitHandler_YouTubeUnconfiguredReturns503(t *testing.T) {
+	withStubYouTubeSeams(t, false, func(context.Context, string) (string, error) {
+		t.Fatal("generator should not be called when unconfigured")
+		return "", nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/init?account=youtube", nil)
+	rec := httptest.NewRecorder()
+	authInitHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestAuthCallbackHandler_YouTubeHappyPath(t *testing.T) {
+	state := oauthstate.New(oauthstate.AccountYouTube)
+	var gotCode string
+	withStubYouTubeSeams(t, true, func(_ context.Context, code string) (string, error) {
+		gotCode = code
+		return "Test Channel", nil
+	})
+	// The Twitch generator must not fire for a youtube-account state.
+	withStubGenerateUserAccessToken(t, func(string, string) error {
+		t.Fatal("twitch generator called for youtube state")
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=g-code", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	if gotCode != "g-code" {
+		t.Errorf("generator got code %q, want g-code", gotCode)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Success") || !strings.Contains(body, "Test Channel") {
+		t.Errorf("body should contain Success + channel title; got %q", body)
+	}
+}
+
+func TestAuthCallbackHandler_YouTubeMismatchReturns400(t *testing.T) {
+	state := oauthstate.New(oauthstate.AccountYouTube)
+	withStubYouTubeSeams(t, true, func(context.Context, string) (string, error) {
+		return "", &myyoutube.ErrChannelMismatch{Expected: "UCexpected", Got: "UCwrong", GotTitle: "Personal"}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=g-code", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Wrong channel") || !strings.Contains(body, "UCexpected") {
+		t.Errorf("mismatch body missing expected copy; got %q", body)
+	}
+}
+
+func TestAuthCallbackHandler_YouTubeGeneratorErrorReturns500(t *testing.T) {
+	state := oauthstate.New(oauthstate.AccountYouTube)
+	withStubYouTubeSeams(t, true, func(context.Context, string) (string, error) {
+		return "", errors.New("google broke")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?state="+state+"&code=g-code", nil)
+	rec := httptest.NewRecorder()
+	authCallbackHandler(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}

--- a/pkg/server/oauthstate/oauthstate.go
+++ b/pkg/server/oauthstate/oauthstate.go
@@ -31,6 +31,12 @@ const (
 	AccountUnchecked   Account = ""
 	AccountBot         Account = "bot"
 	AccountBroadcaster Account = "broadcaster"
+	// AccountYouTube is the YouTube channel owner — the one YouTube identity
+	// (no bot/broadcaster split; see pkg/youtube). Doubles as the IdP
+	// selector: both Twitch and Google redirect to the same /auth/callback,
+	// and the account stashed with the state says which flow a callback
+	// belongs to.
+	AccountYouTube Account = "youtube"
 )
 
 type entry struct {

--- a/pkg/youtube/shims.go
+++ b/pkg/youtube/shims.go
@@ -1,0 +1,24 @@
+package youtube
+
+import (
+	"context"
+
+	ytapi "google.golang.org/api/youtube/v3"
+)
+
+// Package-level free-function API delegating to a default Client, matching
+// pkg/twitch's transitional shim pattern: callers (pkg/server's auth
+// handlers, cmd/tripbot's boot sequence) use these until a constructed
+// *Client is threaded through, at which point this file is deleted — see
+// pkg/twitch/shims.go and vault/decisions/chatbot-app-injection-pattern.md.
+
+var defaultClient = New()
+
+func LoadFromDB() error                                   { return defaultClient.LoadFromDB() }
+func ChannelID() string                                   { return defaultClient.ChannelID() }
+func Service(ctx context.Context) (*ytapi.Service, error) { return defaultClient.Service(ctx) }
+func AuthCodeURL(state string) string                     { return defaultClient.AuthCodeURL(state) }
+
+func GenerateUserAccessToken(ctx context.Context, code string) (string, error) {
+	return defaultClient.GenerateUserAccessToken(ctx, code)
+}

--- a/pkg/youtube/youtube.go
+++ b/pkg/youtube/youtube.go
@@ -1,0 +1,347 @@
+// Package youtube owns tripbot's YouTube identity: the channel-owner OAuth
+// token (stored in oauth_tokens, provider="youtube") and the authenticated
+// Data-API service client the chat phases (B2 outbound / B3 inbound) call
+// through. It mirrors pkg/twitch's role for the Twitch identity.
+//
+// Identity model: YouTube has exactly one identity — the channel owner.
+// Live-chat read/write must run as the channel owner via OAuth user consent
+// (service accounts can't operate a channel's live chat), so there is no
+// bot/broadcaster split. The oauth_tokens row is keyed by the channel ID,
+// discovered at consent time via channels.list(mine=true).
+//
+// The OAuth client in the GCP console must be a "Web application" client
+// with <EXTERNAL_URL>/auth/callback in its authorized redirect URIs — unlike
+// cmd/youtube-chat-spike's Desktop client, which only allows localhost.
+//
+// Token refresh: Google access tokens live ~1h and refresh lazily through
+// the oauth2 TokenSource on use; the persisting wrapper writes each rotation
+// back to oauth_tokens so a restart picks up where the process left off.
+// There is no hourly refresh cron analog — the inbound poller exercises the
+// TokenSource constantly, which is what keeps the token warm.
+//
+// Credentials are optional process-wide: a PLATFORM=twitch instance runs the
+// same binary without YOUTUBE_* set, so nothing here log.Fatals at init.
+package youtube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+	ytapi "google.golang.org/api/youtube/v3"
+)
+
+// Provider is the oauth_tokens provider discriminator for YouTube rows.
+const Provider = "youtube"
+
+// Scopes is the OAuth scope set requested at consent. youtube.force-ssl is
+// the one scope covering both liveChatMessages.list and .insert.
+var Scopes = []string{"https://www.googleapis.com/auth/youtube.force-ssl"}
+
+// ErrNoToken signals "no oauth_tokens row for the youtube provider; run the
+// /auth/init?account=youtube flow." Re-exported for caller convenience.
+var ErrNoToken = oauthtokens.ErrNoToken
+
+// ErrNotConfigured is returned when the OAuth app credentials are absent —
+// expected on non-YouTube instances, an env-wiring bug on YouTube ones.
+var ErrNotConfigured = errors.New("youtube: YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET not set")
+
+// ErrChannelMismatch is returned by GenerateUserAccessToken when the
+// discovered channel doesn't match the configured YOUTUBE_CHANNEL_ID — the
+// "consented with the wrong Google account" case (e.g. the personal channel,
+// or the quiet test channel against a prod pod). No row is written.
+type ErrChannelMismatch struct {
+	Expected string // configured YOUTUBE_CHANNEL_ID
+	Got      string // discovered channel ID
+	GotTitle string // discovered channel title, for the operator-facing message
+}
+
+func (e *ErrChannelMismatch) Error() string {
+	return fmt.Sprintf("youtube: consent identity mismatch — expected channel %q but signed in as %q (%s). Sign in with the channel-owner Google account and retry.",
+		e.Expected, e.Got, e.GotTitle)
+}
+
+// Client holds the YouTube identity state: the current oauth_tokens row and
+// the lazily-built Data-API service. The seam fields default to the real
+// implementations in New(); tests swap them for fakes.
+type Client struct {
+	tokenMu sync.RWMutex
+	current oauthtokens.Token
+
+	svcMu sync.Mutex
+	svc   *ytapi.Service
+
+	// exchange swaps an authorization code for a token. Defaults to the
+	// oauth2 Config's Exchange; tests stub it.
+	exchange func(ctx context.Context, code string) (*oauth2.Token, error)
+	// discoverChannel identifies the consenting channel (id, title) from a
+	// fresh token. Defaults to channels.list(mine=true); tests stub it.
+	discoverChannel func(ctx context.Context, tok *oauth2.Token) (id, title string, err error)
+	// persist / loadToken / recordFailure are the oauth_tokens storage seam.
+	persist       func(t oauthtokens.Token) error
+	loadToken     func() (oauthtokens.Token, error)
+	recordFailure func(provider, username string) error
+}
+
+// New constructs a Client wired with the production storage + Google
+// endpoints. Construction touches no network or DB.
+func New() *Client {
+	cl := &Client{}
+	cl.exchange = func(ctx context.Context, code string) (*oauth2.Token, error) {
+		return cl.oauthConfig().Exchange(ctx, code)
+	}
+	cl.discoverChannel = discoverOwnChannel
+	cl.persist = oauthtokens.Upsert
+	cl.loadToken = loadFromOauthTokens
+	cl.recordFailure = oauthtokens.IncrementFailCount
+	return cl
+}
+
+// Configured reports whether the OAuth app credentials are present. Handlers
+// gate the youtube auth flow on this so Twitch-only deployments 503 cleanly
+// instead of redirecting to Google with an empty client_id.
+func Configured() bool {
+	return c.Conf.YouTubeClientID != "" && c.Conf.YouTubeClientSecret != ""
+}
+
+// oauthConfig builds the oauth2 app config. Constructed per-call (not cached)
+// so tests that mutate c.Conf see the change; it's just struct assembly.
+func (cl *Client) oauthConfig() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     c.Conf.YouTubeClientID,
+		ClientSecret: c.Conf.YouTubeClientSecret,
+		Endpoint:     google.Endpoint,
+		// Same callback path as Twitch — the oauthstate account selector
+		// disambiguates which IdP a callback belongs to. Must be registered
+		// on the GCP OAuth client.
+		RedirectURL: c.Conf.ExternalURL + "/auth/callback",
+		Scopes:      Scopes,
+	}
+}
+
+// AuthCodeURL returns Google's authorize URL for the given CSRF state.
+// AccessTypeOffline asks for a refresh token; ApprovalForce makes Google
+// re-issue one even when consent was already granted (otherwise repeat
+// logins return only an access token and the stored refresh token goes
+// un-rotated).
+func (cl *Client) AuthCodeURL(state string) string {
+	return cl.oauthConfig().AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+}
+
+// AuthInitURL returns the operator-facing re-auth URL, mirroring
+// mytwitch.AuthInitURL — surfaced in logs instead of the fully-formed Google
+// URL, which embeds a short-TTL single-use state.
+func AuthInitURL() string {
+	return c.Conf.ExternalURL + "/auth/init?account=youtube"
+}
+
+// loadFromOauthTokens reads the youtube row. When YOUTUBE_CHANNEL_ID pins the
+// identity, read exactly that row; otherwise take the provider's only row
+// (GetByProvider — newest wins if strays exist).
+func loadFromOauthTokens() (oauthtokens.Token, error) {
+	if id := c.Conf.YouTubeChannelID; id != "" {
+		return oauthtokens.Get(Provider, id)
+	}
+	return oauthtokens.GetByProvider(Provider)
+}
+
+// LoadFromDB loads the channel-owner row into memory, ready for Service().
+// Returns ErrNoToken when the row is missing — callers surface AuthInitURL.
+func (cl *Client) LoadFromDB() error {
+	t, err := cl.loadToken()
+	if err != nil {
+		return err
+	}
+	cl.tokenMu.Lock()
+	cl.current = t
+	cl.tokenMu.Unlock()
+	cl.resetService()
+	return nil
+}
+
+// ChannelID returns the loaded identity's channel ID, or "" before LoadFromDB.
+func (cl *Client) ChannelID() string {
+	cl.tokenMu.RLock()
+	defer cl.tokenMu.RUnlock()
+	return cl.current.Username
+}
+
+// GenerateUserAccessToken exchanges an authorization code for tokens,
+// discovers the consenting channel, sanity-checks it against
+// YOUTUBE_CHANNEL_ID (when set), persists the row, and primes the in-memory
+// state so the running pod picks up the new token without a restart. Returns
+// the channel title for the success page.
+//
+// The identity check runs BEFORE persist so a wrong-account consent doesn't
+// pollute oauth_tokens — same contract as the Twitch flow's mismatch check.
+func (cl *Client) GenerateUserAccessToken(ctx context.Context, code string) (string, error) {
+	if !Configured() {
+		return "", ErrNotConfigured
+	}
+	tok, err := cl.exchange(ctx, code)
+	if err != nil {
+		return "", fmt.Errorf("youtube: code exchange: %w", err)
+	}
+	if tok.RefreshToken == "" {
+		// ApprovalForce should always yield one; absence means the flow was
+		// initiated without it (or a Google-side change worth knowing about).
+		return "", errors.New("youtube: no refresh token in code-exchange response")
+	}
+
+	id, title, err := cl.discoverChannel(ctx, tok)
+	if err != nil {
+		return "", fmt.Errorf("youtube: channel discovery: %w", err)
+	}
+	if expected := c.Conf.YouTubeChannelID; expected != "" && id != expected {
+		return "", &ErrChannelMismatch{Expected: expected, Got: id, GotTitle: title}
+	}
+
+	row := oauthtokens.Token{
+		Provider:     Provider,
+		Username:     id,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    tok.Expiry,
+		Scopes:       strings.Join(Scopes, " "),
+	}
+	if err := cl.persist(row); err != nil {
+		return "", err
+	}
+	cl.tokenMu.Lock()
+	cl.current = row
+	cl.tokenMu.Unlock()
+	cl.resetService()
+	slog.InfoContext(ctx, "youtube oauth bootstrap complete", "channel", title, "channel_id", id)
+	return title, nil
+}
+
+// discoverOwnChannel identifies the consenting account's channel via
+// channels.list(mine=true) using a one-shot service, so the cached service's
+// token source is never touched mid-bootstrap.
+func discoverOwnChannel(ctx context.Context, tok *oauth2.Token) (string, string, error) {
+	svc, err := ytapi.NewService(ctx, option.WithTokenSource(oauth2.StaticTokenSource(tok)))
+	if err != nil {
+		return "", "", err
+	}
+	resp, err := svc.Channels.List([]string{"snippet"}).Mine(true).Do()
+	if err != nil {
+		return "", "", err
+	}
+	if len(resp.Items) == 0 {
+		return "", "", errors.New("no channel on the consenting Google account")
+	}
+	ch := resp.Items[0]
+	return ch.Id, ch.Snippet.Title, nil
+}
+
+// Service returns the authenticated Data-API client, lazy-building it on
+// first call. The token source auto-refreshes ~1h access tokens on use and
+// persists each rotation (persistingSource). ErrNoToken before LoadFromDB /
+// the consent flow has produced a row.
+//
+// ctx is captured by the underlying HTTP client for the service's lifetime —
+// callers pass their long-lived runtime context, not a per-request one.
+func (cl *Client) Service(ctx context.Context) (*ytapi.Service, error) {
+	if !Configured() {
+		return nil, ErrNotConfigured
+	}
+	cl.svcMu.Lock()
+	defer cl.svcMu.Unlock()
+	if cl.svc != nil {
+		return cl.svc, nil
+	}
+
+	cl.tokenMu.RLock()
+	t := cl.current
+	cl.tokenMu.RUnlock()
+	if t.RefreshToken == "" {
+		return nil, ErrNoToken
+	}
+
+	base := &oauth2.Token{
+		AccessToken:  t.AccessToken,
+		RefreshToken: t.RefreshToken,
+		Expiry:       t.ExpiresAt,
+	}
+	// ReuseTokenSource serves base until expiry, then falls through to the
+	// persisting wrapper around the real refresher exactly once per rotation.
+	ts := oauth2.ReuseTokenSource(base, &persistingSource{
+		cl:    cl,
+		inner: cl.oauthConfig().TokenSource(ctx, base),
+	})
+	svc, err := ytapi.NewService(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return nil, err
+	}
+	cl.svc = svc
+	return svc, nil
+}
+
+// resetService drops the cached service so the next Service() call rebuilds
+// its token source from the freshly-primed current token.
+func (cl *Client) resetService() {
+	cl.svcMu.Lock()
+	cl.svc = nil
+	cl.svcMu.Unlock()
+}
+
+// persistingSource wraps the refreshing TokenSource so every rotation is
+// written back to oauth_tokens — a restart then resumes from the stored
+// access token instead of burning a refresh on every boot.
+type persistingSource struct {
+	cl    *Client
+	inner oauth2.TokenSource
+}
+
+func (p *persistingSource) Token() (*oauth2.Token, error) {
+	tok, err := p.inner.Token()
+	if err != nil {
+		// Surface persistent refresh failures in monitoring via
+		// refresh_fail_count, same as the Twitch refresh loop.
+		p.cl.tokenMu.RLock()
+		username := p.cl.current.Username
+		p.cl.tokenMu.RUnlock()
+		if username != "" {
+			_ = p.cl.recordFailure(Provider, username)
+		}
+		return nil, err
+	}
+
+	p.cl.tokenMu.Lock()
+	cur := p.cl.current
+	if tok.AccessToken == cur.AccessToken {
+		p.cl.tokenMu.Unlock()
+		return tok, nil
+	}
+	// Google usually omits refresh_token from refresh responses; carry the
+	// stored one forward so the row never loses it.
+	rt := tok.RefreshToken
+	if rt == "" {
+		rt = cur.RefreshToken
+	}
+	rotated := oauthtokens.Token{
+		Provider:     Provider,
+		Username:     cur.Username,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: rt,
+		ExpiresAt:    tok.Expiry,
+		Scopes:       cur.Scopes,
+	}
+	p.cl.current = rotated
+	p.cl.tokenMu.Unlock()
+
+	// Persist outside the lock; failure is non-fatal — the in-memory token
+	// is valid, we just lose the rotation on restart.
+	if err := p.cl.persist(rotated); err != nil {
+		slog.Error("youtube: persisting rotated token failed", "err", err, "channel_id", rotated.Username)
+	}
+	return tok, nil
+}

--- a/pkg/youtube/youtube_test.go
+++ b/pkg/youtube/youtube_test.go
@@ -243,7 +243,7 @@ func TestAuthCodeURL_OfflineWithForcedConsent(t *testing.T) {
 	cl := newTestClient(t)
 	u, err := url.Parse(cl.AuthCodeURL("state-123"))
 	if err != nil {
-		t.Fatalf("AuthCodeURL unparseable: %v", err)
+		t.Fatalf("AuthCodeURL unparsable: %v", err)
 	}
 	q := u.Query()
 	if q.Get("client_id") != "client-id" || q.Get("state") != "state-123" {

--- a/pkg/youtube/youtube_test.go
+++ b/pkg/youtube/youtube_test.go
@@ -1,0 +1,261 @@
+package youtube
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/oauthtokens"
+	"golang.org/x/oauth2"
+)
+
+// newTestClient returns a Client with all storage/network seams stubbed to
+// fail loudly if a test forgets to override one it exercises.
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	return &Client{
+		exchange: func(_ context.Context, _ string) (*oauth2.Token, error) {
+			t.Fatal("exchange seam not stubbed")
+			return nil, nil
+		},
+		discoverChannel: func(_ context.Context, _ *oauth2.Token) (string, string, error) {
+			t.Fatal("discoverChannel seam not stubbed")
+			return "", "", nil
+		},
+		persist: func(_ oauthtokens.Token) error { t.Fatal("persist seam not stubbed"); return nil },
+		loadToken: func() (oauthtokens.Token, error) {
+			t.Fatal("loadToken seam not stubbed")
+			return oauthtokens.Token{}, nil
+		},
+		recordFailure: func(_, _ string) error { t.Fatal("recordFailure seam not stubbed"); return nil },
+	}
+}
+
+// withYouTubeConf sets the YouTube config fields for a test and restores
+// them on cleanup. c.Conf is the package-level config singleton.
+func withYouTubeConf(t *testing.T, clientID, clientSecret, channelID string) {
+	t.Helper()
+	savedID, savedSecret, savedChannel := c.Conf.YouTubeClientID, c.Conf.YouTubeClientSecret, c.Conf.YouTubeChannelID
+	c.Conf.YouTubeClientID = clientID
+	c.Conf.YouTubeClientSecret = clientSecret
+	c.Conf.YouTubeChannelID = channelID
+	t.Cleanup(func() {
+		c.Conf.YouTubeClientID, c.Conf.YouTubeClientSecret, c.Conf.YouTubeChannelID = savedID, savedSecret, savedChannel
+	})
+}
+
+func TestGenerateUserAccessToken_PersistsAndPrimes(t *testing.T) {
+	withYouTubeConf(t, "client-id", "client-secret", "")
+	cl := newTestClient(t)
+	expiry := time.Now().Add(time.Hour)
+	cl.exchange = func(_ context.Context, code string) (*oauth2.Token, error) {
+		if code != "auth-code" {
+			t.Errorf("exchange got code %q", code)
+		}
+		return &oauth2.Token{AccessToken: "access-1", RefreshToken: "refresh-1", Expiry: expiry}, nil
+	}
+	cl.discoverChannel = func(_ context.Context, tok *oauth2.Token) (string, string, error) {
+		if tok.AccessToken != "access-1" {
+			t.Errorf("discoverChannel got token %q", tok.AccessToken)
+		}
+		return "UC123", "Test Channel", nil
+	}
+	var persisted oauthtokens.Token
+	cl.persist = func(row oauthtokens.Token) error { persisted = row; return nil }
+
+	title, err := cl.GenerateUserAccessToken(context.Background(), "auth-code")
+	if err != nil {
+		t.Fatalf("GenerateUserAccessToken: %v", err)
+	}
+	if title != "Test Channel" {
+		t.Errorf("title = %q, want Test Channel", title)
+	}
+	if persisted.Provider != Provider || persisted.Username != "UC123" {
+		t.Errorf("persisted row keyed (%q, %q), want (youtube, UC123)", persisted.Provider, persisted.Username)
+	}
+	if persisted.AccessToken != "access-1" || persisted.RefreshToken != "refresh-1" {
+		t.Errorf("persisted tokens = (%q, %q)", persisted.AccessToken, persisted.RefreshToken)
+	}
+	if got := cl.ChannelID(); got != "UC123" {
+		t.Errorf("ChannelID after bootstrap = %q, want UC123", got)
+	}
+}
+
+func TestGenerateUserAccessToken_NoRefreshTokenRejected(t *testing.T) {
+	withYouTubeConf(t, "client-id", "client-secret", "")
+	cl := newTestClient(t)
+	cl.exchange = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		return &oauth2.Token{AccessToken: "access-only"}, nil
+	}
+
+	_, err := cl.GenerateUserAccessToken(context.Background(), "auth-code")
+	if err == nil || !strings.Contains(err.Error(), "no refresh token") {
+		t.Fatalf("expected no-refresh-token error, got %v", err)
+	}
+}
+
+func TestGenerateUserAccessToken_ChannelMismatchNotPersisted(t *testing.T) {
+	withYouTubeConf(t, "client-id", "client-secret", "UCexpected")
+	cl := newTestClient(t)
+	cl.exchange = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		return &oauth2.Token{AccessToken: "access-1", RefreshToken: "refresh-1"}, nil
+	}
+	cl.discoverChannel = func(_ context.Context, _ *oauth2.Token) (string, string, error) {
+		return "UCwrong", "Personal Channel", nil
+	}
+	// persist stays at the t.Fatal stub: reaching it fails the test, which
+	// is exactly the mismatch contract (no row written).
+
+	_, err := cl.GenerateUserAccessToken(context.Background(), "auth-code")
+	var mismatch *ErrChannelMismatch
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected ErrChannelMismatch, got %v", err)
+	}
+	if mismatch.Expected != "UCexpected" || mismatch.Got != "UCwrong" {
+		t.Errorf("mismatch = %+v", mismatch)
+	}
+	if got := cl.ChannelID(); got != "" {
+		t.Errorf("in-memory token primed despite mismatch: %q", got)
+	}
+}
+
+func TestGenerateUserAccessToken_NotConfigured(t *testing.T) {
+	withYouTubeConf(t, "", "", "")
+	cl := newTestClient(t)
+	if _, err := cl.GenerateUserAccessToken(context.Background(), "code"); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("expected ErrNotConfigured, got %v", err)
+	}
+}
+
+func TestLoadFromDB_PrimesCurrent(t *testing.T) {
+	cl := newTestClient(t)
+	cl.loadToken = func() (oauthtokens.Token, error) {
+		return oauthtokens.Token{Provider: Provider, Username: "UC123", AccessToken: "a", RefreshToken: "r"}, nil
+	}
+	if err := cl.LoadFromDB(); err != nil {
+		t.Fatalf("LoadFromDB: %v", err)
+	}
+	if got := cl.ChannelID(); got != "UC123" {
+		t.Errorf("ChannelID = %q, want UC123", got)
+	}
+}
+
+func TestLoadFromDB_NoRowPassesThroughErrNoToken(t *testing.T) {
+	cl := newTestClient(t)
+	cl.loadToken = func() (oauthtokens.Token, error) { return oauthtokens.Token{}, ErrNoToken }
+	if err := cl.LoadFromDB(); !errors.Is(err, ErrNoToken) {
+		t.Fatalf("expected ErrNoToken, got %v", err)
+	}
+}
+
+func TestService_NoTokenBeforeLoad(t *testing.T) {
+	withYouTubeConf(t, "client-id", "client-secret", "")
+	cl := newTestClient(t)
+	if _, err := cl.Service(context.Background()); !errors.Is(err, ErrNoToken) {
+		t.Fatalf("expected ErrNoToken, got %v", err)
+	}
+}
+
+func TestService_NotConfigured(t *testing.T) {
+	withYouTubeConf(t, "", "", "")
+	cl := newTestClient(t)
+	if _, err := cl.Service(context.Background()); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("expected ErrNotConfigured, got %v", err)
+	}
+}
+
+// staticSource is a fake inner TokenSource for persistingSource tests.
+type staticSource struct {
+	tok *oauth2.Token
+	err error
+}
+
+func (s staticSource) Token() (*oauth2.Token, error) { return s.tok, s.err }
+
+func TestPersistingSource_RotationPersisted(t *testing.T) {
+	cl := newTestClient(t)
+	cl.current = oauthtokens.Token{
+		Provider: Provider, Username: "UC123",
+		AccessToken: "old-access", RefreshToken: "refresh-1", Scopes: "s",
+	}
+	var persisted oauthtokens.Token
+	cl.persist = func(row oauthtokens.Token) error { persisted = row; return nil }
+
+	expiry := time.Now().Add(time.Hour)
+	// Google omits refresh_token on refresh responses — the wrapper must
+	// carry the stored one forward.
+	ps := &persistingSource{cl: cl, inner: staticSource{tok: &oauth2.Token{AccessToken: "new-access", Expiry: expiry}}}
+	tok, err := ps.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok.AccessToken != "new-access" {
+		t.Errorf("returned token = %q", tok.AccessToken)
+	}
+	if persisted.AccessToken != "new-access" || persisted.RefreshToken != "refresh-1" {
+		t.Errorf("persisted = (%q, %q), want (new-access, refresh-1)", persisted.AccessToken, persisted.RefreshToken)
+	}
+	cl.tokenMu.RLock()
+	defer cl.tokenMu.RUnlock()
+	if cl.current.AccessToken != "new-access" {
+		t.Errorf("in-memory token not rotated: %q", cl.current.AccessToken)
+	}
+}
+
+func TestPersistingSource_SameTokenNotRePersisted(t *testing.T) {
+	cl := newTestClient(t)
+	cl.current = oauthtokens.Token{Provider: Provider, Username: "UC123", AccessToken: "access-1", RefreshToken: "r"}
+	// persist stays at the t.Fatal stub: calling it on a non-rotation fails the test.
+
+	ps := &persistingSource{cl: cl, inner: staticSource{tok: &oauth2.Token{AccessToken: "access-1"}}}
+	if _, err := ps.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+}
+
+func TestPersistingSource_RefreshFailureRecorded(t *testing.T) {
+	cl := newTestClient(t)
+	cl.current = oauthtokens.Token{Provider: Provider, Username: "UC123", AccessToken: "a", RefreshToken: "r"}
+	var failedUser string
+	cl.recordFailure = func(provider, username string) error {
+		if provider != Provider {
+			t.Errorf("recordFailure provider = %q", provider)
+		}
+		failedUser = username
+		return nil
+	}
+
+	ps := &persistingSource{cl: cl, inner: staticSource{err: errors.New("invalid_grant")}}
+	if _, err := ps.Token(); err == nil {
+		t.Fatal("expected refresh error to propagate")
+	}
+	if failedUser != "UC123" {
+		t.Errorf("refresh_fail_count not bumped for UC123 (got %q)", failedUser)
+	}
+}
+
+func TestAuthCodeURL_OfflineWithForcedConsent(t *testing.T) {
+	withYouTubeConf(t, "client-id", "client-secret", "")
+	cl := newTestClient(t)
+	u, err := url.Parse(cl.AuthCodeURL("state-123"))
+	if err != nil {
+		t.Fatalf("AuthCodeURL unparseable: %v", err)
+	}
+	q := u.Query()
+	if q.Get("client_id") != "client-id" || q.Get("state") != "state-123" {
+		t.Errorf("client_id/state = %q/%q", q.Get("client_id"), q.Get("state"))
+	}
+	if q.Get("access_type") != "offline" {
+		t.Errorf("access_type = %q, want offline (refresh token required)", q.Get("access_type"))
+	}
+	if q.Get("approval_prompt") != "force" && q.Get("prompt") == "" {
+		t.Errorf("no forced re-consent param in %q", u.String())
+	}
+	if !strings.Contains(q.Get("scope"), "youtube.force-ssl") {
+		t.Errorf("scope = %q", q.Get("scope"))
+	}
+}


### PR DESCRIPTION
## Summary

Phase B1 of the YouTube provider track (follows the B0 spike in #811): a new `pkg/youtube` owning tripbot's YouTube identity — the channel-owner OAuth token and the authenticated Data-API service the chat phases (B2 outbound, B3 inbound) will call through. Mirrors `pkg/twitch`'s role, including the transitional package-level shims.

## Design

- **One identity, no bot/broadcaster split.** YouTube live-chat read/write must run as the channel owner via user consent (service accounts can't operate live chat). The `oauth_tokens` row is `provider=youtube`, keyed by **channel ID** discovered at consent time via `channels.list(mine=true)` — which is why `oauthtokens` grows a `GetByProvider` (boot doesn't know a username ahead of time the way Twitch does).
- **Refresh is lazy + persisted, no cron.** Google access tokens live ~1h and refresh through the oauth2 `TokenSource` on use; a persisting wrapper writes each rotation back to `oauth_tokens` (carrying the refresh token forward — Google omits it from refresh responses) and bumps `refresh_fail_count` on failures. The eventual inbound poller exercises the source constantly, which is what keeps the token warm — no hourly-cron analog needed.
- **`YOUTUBE_CHANNEL_ID` identity pin (optional).** When set, consent from any other channel is rejected *before* persist — a prod pod can't store the quiet test channel's token, and vice versa. Same contract as the Twitch flow's `ErrIdentityMismatch`.
- **Admin re-auth is a click:** `/auth/init?account=youtube` 302s to Google's consent screen; the callback rides the existing `/auth/callback` path, with the `oauthstate` account selector saying which IdP the code belongs to. 503 when credentials are unset.
- **Optional process-wide.** A `PLATFORM=twitch` instance runs the same binary with no `YOUTUBE_*` env: nothing here fatals at init, and `Configured()` gates the flow.

## Ops notes

- The GCP OAuth client for this flow must be a **Web application** client with `<EXTERNAL_URL>/auth/callback` in its authorized redirect URIs (the B0 spike's Desktop client only allows localhost).
- While the consent screen is in *Testing* status, Google expires refresh tokens after 7 days — publish before any long-running deploy.

## Test plan

- [x] `task test:macos` fully green (29 packages)
- [x] pkg/youtube unit tests: bootstrap persist+prime, mismatch-not-persisted, no-refresh-token rejection, rotation persisted, refresh-failure recorded, AuthCodeURL params
- [x] handler tests: youtube init redirect + state validity, unconfigured 503, callback happy/mismatch/error paths, Twitch generator not fired for youtube states
- [ ] (needs GCP OAuth client) end-to-end consent against the quiet test channel