### PR TITLE
feat(chatbot): outbound YouTube live-chat client (Phase B2)

### DIFF
--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -1,0 +1,115 @@
+package chatbot
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/geo"
+	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
+)
+
+// liveChatBinding holds the currently-bound live chat ID, shared between the
+// outbound youtubeChat (Say targets it) and the inbound poller (which
+// discovers and re-binds it across broadcast lifecycles — Phase B3). Empty
+// means "not live right now": sends drop, the poller keeps re-discovering.
+type liveChatBinding struct {
+	mu sync.RWMutex
+	id string
+}
+
+func (b *liveChatBinding) ID() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.id
+}
+
+func (b *liveChatBinding) Bind(id string) {
+	b.mu.Lock()
+	b.id = id
+	b.mu.Unlock()
+}
+
+// youtubeChat sends to YouTube live chat through pkg/youtube, implementing
+// the provider-neutral ChatClient seam — the second provider the seam was
+// built for. The insert func defaults to myyoutube.InsertChatMessage;
+// tests inject a recorder.
+type youtubeChat struct {
+	binding *liveChatBinding
+	insert  func(ctx context.Context, chatID, text string) error
+}
+
+func (yc youtubeChat) Say(msg string) {
+	// Twitch-only IRC emote command (the Chatter cron prefixes help messages
+	// with it); on YouTube it would render as literal text.
+	msg = strings.TrimPrefix(msg, "/me ")
+
+	chatID := yc.binding.ID()
+	if chatID == "" {
+		// Not live (or the poller hasn't bound the broadcast yet). Same
+		// drop-quietly contract as disconnectedChat, but logged: a dropped
+		// command response is worth seeing in Loki.
+		slog.Warn("youtube chat send dropped; no live chat bound", "text", msg)
+		return
+	}
+	if err := yc.insert(context.Background(), chatID, msg); err != nil {
+		slog.Error("youtube chat send failed", "err", err, "text", msg)
+	}
+}
+
+// Whisper is a no-op: YouTube live chat has no direct-message equivalent.
+// The only production caller is HandleWhisper's admin remote-say, which is
+// Twitch-inbound anyway.
+func (yc youtubeChat) Whisper(username, msg string) {
+	slog.Debug("youtube has no whispers; dropped", "to", username, "text", msg)
+}
+
+// ConnectYouTube wires this App's outbound chat to YouTube — the
+// ConnectIRC analog for a PLATFORM=youtube instance. It loads the
+// channel-owner token from the DB, binds the active broadcast's live chat
+// (non-fatal when nothing is live: sends drop until the inbound poller —
+// Phase B3 — binds it), and points a.Chat at the youtubeChat client wrapped
+// in the provider-neutral console mirror.
+//
+// Returns the binding for the inbound poller to share. Errors only when the
+// OAuth token is missing/unusable — the operator-facing signal to visit
+// /auth/init?account=youtube.
+func (a *App) ConnectYouTube(ctx context.Context) (*liveChatBinding, error) {
+	Uptime = time.Now()
+
+	// process-wide geocoder warmup, same as ConnectIRC (pkg/video routes
+	// through the default for coords -> places).
+	geo.SetDefault(geo.New(c.Conf.GoogleMapsAPIKey))
+
+	if err := myyoutube.LoadFromDB(); err != nil {
+		return nil, err
+	}
+
+	binding := &liveChatBinding{}
+	chatID, err := myyoutube.ActiveLiveChatID(ctx)
+	switch {
+	case err == nil:
+		binding.Bind(chatID)
+		slog.InfoContext(ctx, "bound youtube live chat", "live_chat_id", chatID)
+	case errors.Is(err, myyoutube.ErrNoActiveBroadcast):
+		slog.WarnContext(ctx, "no active youtube broadcast at startup; chat sends drop until one is bound")
+	default:
+		// Discovery failed for a non-"not live" reason (network, auth).
+		// Still come up — the poller retries — but say why loudly.
+		slog.ErrorContext(ctx, "youtube live-chat discovery failed at startup", "err", err)
+	}
+
+	a.Chat = consoleMirror{
+		inner: youtubeChat{
+			binding: binding,
+			insert:  myyoutube.InsertChatMessage,
+		},
+		env:         c.Conf.Environment,
+		botUsername: c.Conf.BotUsername,
+	}
+	return binding, nil
+}

--- a/pkg/chatbot/youtube_test.go
+++ b/pkg/chatbot/youtube_test.go
@@ -1,0 +1,104 @@
+package chatbot
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// recordingInsert captures InsertChatMessage calls for assertions.
+type recordingInsert struct {
+	calls []struct{ chatID, text string }
+	err   error
+}
+
+func (r *recordingInsert) insert(_ context.Context, chatID, text string) error {
+	r.calls = append(r.calls, struct{ chatID, text string }{chatID, text})
+	return r.err
+}
+
+func TestYouTubeChat_SaySendsToBoundChat(t *testing.T) {
+	rec := &recordingInsert{}
+	binding := &liveChatBinding{}
+	binding.Bind("chat-123")
+	yc := youtubeChat{binding: binding, insert: rec.insert}
+
+	yc.Say("hello youtube")
+
+	if len(rec.calls) != 1 {
+		t.Fatalf("insert called %d times, want 1", len(rec.calls))
+	}
+	if rec.calls[0].chatID != "chat-123" || rec.calls[0].text != "hello youtube" {
+		t.Errorf("insert got (%q, %q)", rec.calls[0].chatID, rec.calls[0].text)
+	}
+}
+
+func TestYouTubeChat_SayDropsWhenUnbound(t *testing.T) {
+	rec := &recordingInsert{}
+	yc := youtubeChat{binding: &liveChatBinding{}, insert: rec.insert}
+
+	yc.Say("into the void")
+
+	if len(rec.calls) != 0 {
+		t.Fatalf("insert called %d times for an unbound chat, want 0", len(rec.calls))
+	}
+}
+
+func TestYouTubeChat_SayStripsMeCommand(t *testing.T) {
+	rec := &recordingInsert{}
+	binding := &liveChatBinding{}
+	binding.Bind("chat-123")
+	yc := youtubeChat{binding: binding, insert: rec.insert}
+
+	// the Chatter cron prefixes help messages with the Twitch IRC emote
+	// command; YouTube would render it literally.
+	yc.Say("/me try !help")
+
+	if len(rec.calls) != 1 || rec.calls[0].text != "try !help" {
+		t.Fatalf("want stripped text %q, got %+v", "try !help", rec.calls)
+	}
+}
+
+func TestYouTubeChat_SaySurvivesInsertError(t *testing.T) {
+	rec := &recordingInsert{err: errors.New("quota exceeded")}
+	binding := &liveChatBinding{}
+	binding.Bind("chat-123")
+	yc := youtubeChat{binding: binding, insert: rec.insert}
+
+	// must not panic; the error is logged and swallowed (ChatClient.Say
+	// has no error return — same contract as twitchChat).
+	yc.Say("doomed message")
+
+	if len(rec.calls) != 1 {
+		t.Fatalf("insert called %d times, want 1", len(rec.calls))
+	}
+}
+
+func TestYouTubeChat_WhisperIsNoOp(t *testing.T) {
+	rec := &recordingInsert{}
+	binding := &liveChatBinding{}
+	binding.Bind("chat-123")
+	yc := youtubeChat{binding: binding, insert: rec.insert}
+
+	yc.Whisper("someone", "psst")
+
+	if len(rec.calls) != 0 {
+		t.Fatalf("Whisper should not insert; called %d times", len(rec.calls))
+	}
+}
+
+func TestLiveChatBinding_RebindSwitchesTarget(t *testing.T) {
+	rec := &recordingInsert{}
+	binding := &liveChatBinding{}
+	binding.Bind("chat-old")
+	yc := youtubeChat{binding: binding, insert: rec.insert}
+
+	yc.Say("first")
+	// broadcast ended; the poller re-discovers and re-binds (Phase B3 flow)
+	binding.Bind("chat-new")
+	yc.Say("second")
+
+	if len(rec.calls) != 2 || rec.calls[0].chatID != "chat-old" || rec.calls[1].chatID != "chat-new" {
+		t.Fatalf("rebind not honored: %+v", rec.calls)
+	}
+}

--- a/pkg/youtube/livechat.go
+++ b/pkg/youtube/livechat.go
@@ -1,0 +1,68 @@
+package youtube
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	ytapi "google.golang.org/api/youtube/v3"
+)
+
+// ErrNoActiveBroadcast is returned by ActiveLiveChatID when the channel has
+// no active broadcast (or it has chat disabled). Callers treat it as "not
+// live right now" and retry on their own cadence rather than failing hard.
+var ErrNoActiveBroadcast = errors.New("youtube: no active broadcast with live chat")
+
+// maxChatMessageLen is YouTube's per-message limit for
+// liveChatMessages.insert (200 characters; the API 400s above it). Twitch
+// allows 500, so command output written for Twitch can exceed this —
+// InsertChatMessage truncates rather than letting the send fail.
+const maxChatMessageLen = 200
+
+// ActiveLiveChatID finds the channel's active broadcast and returns its live
+// chat ID. liveBroadcasts.list's filters (mine, broadcastStatus, id) are
+// mutually exclusive — broadcastStatus=active is already scoped to the
+// authorized channel, so it's the only filter set. Works for unlisted
+// broadcasts (the quiet-testing surface) the same as public ones.
+func (cl *Client) ActiveLiveChatID(ctx context.Context) (string, error) {
+	svc, err := cl.Service(ctx)
+	if err != nil {
+		return "", err
+	}
+	resp, err := svc.LiveBroadcasts.List([]string{"snippet"}).
+		BroadcastStatus("active").
+		BroadcastType("all").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Items) == 0 || resp.Items[0].Snippet.LiveChatId == "" {
+		return "", ErrNoActiveBroadcast
+	}
+	return resp.Items[0].Snippet.LiveChatId, nil
+}
+
+// InsertChatMessage posts one message to the given live chat as the channel
+// owner. Messages over YouTube's 200-character limit are truncated (with a
+// log) instead of failing the send.
+func (cl *Client) InsertChatMessage(ctx context.Context, chatID, text string) error {
+	svc, err := cl.Service(ctx)
+	if err != nil {
+		return err
+	}
+	if r := []rune(text); len(r) > maxChatMessageLen {
+		slog.WarnContext(ctx, "youtube chat message truncated to 200 chars", "text", text)
+		text = string(r[:maxChatMessageLen-1]) + "…"
+	}
+	_, err = svc.LiveChatMessages.Insert([]string{"snippet"}, &ytapi.LiveChatMessage{
+		Snippet: &ytapi.LiveChatMessageSnippet{
+			LiveChatId: chatID,
+			Type:       "textMessageEvent",
+			TextMessageDetails: &ytapi.LiveChatTextMessageDetails{
+				MessageText: text,
+			},
+		},
+	}).Context(ctx).Do()
+	return err
+}

--- a/pkg/youtube/shims.go
+++ b/pkg/youtube/shims.go
@@ -22,3 +22,11 @@ func AuthCodeURL(state string) string                     { return defaultClient
 func GenerateUserAccessToken(ctx context.Context, code string) (string, error) {
 	return defaultClient.GenerateUserAccessToken(ctx, code)
 }
+
+func ActiveLiveChatID(ctx context.Context) (string, error) {
+	return defaultClient.ActiveLiveChatID(ctx)
+}
+
+func InsertChatMessage(ctx context.Context, chatID, text string) error {
+	return defaultClient.InsertChatMessage(ctx, chatID, text)
+}


### PR DESCRIPTION
## Summary

Phase B2: `youtubeChat` — the second provider the `ChatClient` seam was built for. **Stacked on #812** (base = `feat/youtube-oauth`); will retarget to develop after that merges.

## What it does

- `youtubeChat.Say` posts via `liveChatMessages.insert` as the channel owner; `Whisper` is a no-op (YouTube has no DM equivalent, and the only production caller is the Twitch-inbound admin remote-say).
- `ConnectYouTube` — the `ConnectIRC` analog: loads the channel-owner token (errors only when the token is missing → the operator visits `/auth/init?account=youtube`), binds the active broadcast's live chat, and wires `a.Chat` through the provider-neutral console mirror so the admin live console sees YouTube output exactly like Twitch output.
- **`liveChatBinding`** is a rebindable chat-ID holder shared with the Phase-B3 inbound poller: empty = not live (sends drop with a log, same contract as `disconnectedChat`); the poller re-binds across broadcast end/restart.
- Defensive edges: messages over YouTube's **200-char insert limit** truncate with a log instead of 400ing (Twitch-sized output is 500); a leading IRC `/me` (the Chatter cron's emote prefix) is stripped since YouTube renders it literally.

## Test plan

- [x] `task test:macos` fully green
- [x] unit: Say targets the bound chat, drops when unbound, strips `/me`, survives insert errors, rebind switches target, Whisper never inserts
- [ ] (needs OAuth client + unlisted broadcast) send-first validation: `ConnectYouTube` + one `Say` against the quiet test channel before any inbound wiring — same observe-first discipline as the NATS migration