### PR TITLE
feat(chatbot): inbound YouTube live-chat poller (Phase B3)

### DIFF
--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -8,9 +8,15 @@ import (
 	"sync"
 	"time"
 
+	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/geo"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/adanalife/tripbot/pkg/users"
 	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // liveChatBinding holds the currently-bound live chat ID, shared between the
@@ -112,4 +118,156 @@ func (a *App) ConnectYouTube(ctx context.Context) (*liveChatBinding, error) {
 		botUsername: c.Conf.BotUsername,
 	}
 	return binding, nil
+}
+
+// HandleYouTubeMessage processes one inbound YouTube chat message. Identical
+// to HandleMessage except the login step: YouTube viewers are NOT logged in
+// or persisted — v1 punts identity, presence, and miles entirely (see the
+// platform allowlist), so the command path gets a transient User carrying
+// just the display name. The Loki chat line, the admin-console event-bus
+// mirror, and the metrics all stay.
+func (a *App) HandleYouTubeMessage(ctx context.Context, msg IncomingMessage) {
+	// span attribute key shared with the Twitch path for observability
+	// continuity; renaming both to a platform-tagged key is the B4 pass.
+	ctx, span := tracer.Start(ctx, "chatbot.handle_message",
+		trace.WithAttributes(attribute.String("twitch.user", msg.User)))
+	defer span.End()
+
+	instrumentation.ChatMessages.Inc()
+	mylog.ChatMsg(msg.User, msg.Text)
+	eventbus.EmitChatMessage(ctx, c.Conf.Environment, msg.User, msg.Text)
+
+	// transient, never written to the users table — the allowlisted command
+	// subset reads nothing user-specific beyond the name.
+	user := &users.User{Username: strings.ToLower(msg.User)}
+	a.runCommand(ctx, user, strings.ToLower(msg.Text))
+}
+
+// youtubeChatPoller is the inbound transport for a PLATFORM=youtube
+// instance: it discovers the active broadcast, binds its live chat (the same
+// binding youtubeChat sends to), and pages through liveChatMessages.list at
+// the server-suggested cadence, feeding each viewer message into the shared
+// command path. The seam fields default to pkg/youtube in
+// NewYouTubeChatPoller; tests inject fakes.
+type youtubeChatPoller struct {
+	app     *App
+	binding *liveChatBinding
+
+	discover     func(ctx context.Context) (string, error)
+	list         func(ctx context.Context, chatID, pageToken string) (*myyoutube.LiveChatPage, error)
+	ownChannelID func() string
+
+	pollFloor      time.Duration // minimum wait between list calls
+	rediscoverWait time.Duration // wait between discovery attempts while not live
+	quotaWait      time.Duration // backoff after a quota rejection
+}
+
+// NewYouTubeChatPoller builds the production poller sharing this App and the
+// binding returned by ConnectYouTube. Run it in a goroutine (cmd/tripbot's
+// platform branch — Phase B4).
+func (a *App) NewYouTubeChatPoller(binding *liveChatBinding) *youtubeChatPoller {
+	return &youtubeChatPoller{
+		app:          a,
+		binding:      binding,
+		discover:     myyoutube.ActiveLiveChatID,
+		list:         myyoutube.ListChatMessages,
+		ownChannelID: myyoutube.ChannelID,
+		// floor under the server-suggested interval; YouTube usually asks
+		// for ~3-10s, this only guards against pathological responses.
+		pollFloor:      2 * time.Second,
+		rediscoverWait: time.Minute,
+		quotaWait:      5 * time.Minute,
+	}
+}
+
+// Run polls until ctx is done. Lifecycle: unbound → discover (quietly idle
+// while the channel isn't live) → bind → page through chat → on ErrChatGone
+// (broadcast ended) unbind and rediscover. The first page after every bind
+// is discarded: liveChatMessages.list opens with recent history, and
+// replaying an hour-old !skip against the live pipeline would be wrong.
+func (p *youtubeChatPoller) Run(ctx context.Context) {
+	pageToken := ""
+	fresh := true // next page is the post-bind backlog page
+
+	for ctx.Err() == nil {
+		chatID := p.binding.ID()
+		if chatID == "" {
+			id, err := p.discover(ctx)
+			switch {
+			case err == nil:
+				p.binding.Bind(id)
+				pageToken = ""
+				fresh = true
+				slog.InfoContext(ctx, "youtube poller bound live chat", "live_chat_id", id)
+				continue
+			case errors.Is(err, myyoutube.ErrNoActiveBroadcast):
+				// not live is the normal idle state; stay quiet
+			default:
+				slog.ErrorContext(ctx, "youtube broadcast discovery failed", "err", err)
+			}
+			if !sleepCtx(ctx, p.rediscoverWait) {
+				return
+			}
+			continue
+		}
+
+		page, err := p.list(ctx, chatID, pageToken)
+		if err != nil {
+			switch {
+			case errors.Is(err, myyoutube.ErrChatGone):
+				slog.InfoContext(ctx, "youtube live chat ended; rediscovering")
+				p.binding.Bind("")
+				pageToken = ""
+			case myyoutube.IsQuotaError(err):
+				slog.ErrorContext(ctx, "youtube quota rejection; backing off", "err", err)
+				if !sleepCtx(ctx, p.quotaWait) {
+					return
+				}
+			case errors.Is(err, context.Canceled):
+				return
+			default:
+				slog.ErrorContext(ctx, "youtube chat poll failed", "err", err)
+				if !sleepCtx(ctx, p.rediscoverWait) {
+					return
+				}
+			}
+			continue
+		}
+		pageToken = page.NextPageToken
+
+		if fresh {
+			slog.InfoContext(ctx, "youtube poller skipped backlog page", "count", len(page.Messages))
+			fresh = false
+		} else {
+			own := p.ownChannelID()
+			for _, m := range page.Messages {
+				// the bot posts as the channel owner, so its own sends echo
+				// back in the list — already mirrored by consoleMirror.
+				if own != "" && m.AuthorChannelID == own {
+					continue
+				}
+				p.app.HandleYouTubeMessage(ctx, IncomingMessage{User: m.Author, Text: m.Text})
+			}
+		}
+
+		wait := page.PollAfter
+		if wait < p.pollFloor {
+			wait = p.pollFloor
+		}
+		if !sleepCtx(ctx, wait) {
+			return
+		}
+	}
+}
+
+// sleepCtx waits d or until ctx is done; false means ctx ended first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }

--- a/pkg/chatbot/youtube_test.go
+++ b/pkg/chatbot/youtube_test.go
@@ -3,7 +3,12 @@ package chatbot
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/video"
+	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
 )
 
 // recordingInsert captures InsertChatMessage calls for assertions.
@@ -84,6 +89,161 @@ func TestYouTubeChat_WhisperIsNoOp(t *testing.T) {
 
 	if len(rec.calls) != 0 {
 		t.Fatalf("Whisper should not insert; called %d times", len(rec.calls))
+	}
+}
+
+func TestHandleYouTubeMessage_RunsCommandWithoutLogin(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingChat{}
+	app.Chat = rec
+	// UserSessions stays nil: if HandleYouTubeMessage attempted the
+	// LoginIfNecessary step the Twitch path does, this test would panic —
+	// passing proves the skip-login contract.
+
+	app.HandleYouTubeMessage(context.Background(), IncomingMessage{User: "YouTubeViewer", Text: "!help"})
+
+	if len(rec.Says) == 0 {
+		t.Fatal("expected !help to dispatch and reply via App.Chat")
+	}
+}
+
+func TestHandleYouTubeMessage_NonCommandIsQuiet(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingChat{}
+	app.Chat = rec
+
+	app.HandleYouTubeMessage(context.Background(), IncomingMessage{User: "YouTubeViewer", Text: "nice stream"})
+
+	if len(rec.Says) != 0 {
+		t.Fatalf("plain chatter should not reply; got %v", rec.Says)
+	}
+}
+
+// pollerScript drives youtubeChatPoller.Run through a scripted sequence of
+// list responses, canceling the context when the script is exhausted.
+type pollerScript struct {
+	mu      sync.Mutex
+	pages   []func() (*myyoutube.LiveChatPage, error)
+	calls   []string // pageTokens seen, for cursor assertions
+	cancel  context.CancelFunc
+	discRet func() (string, error)
+	discN   int
+}
+
+func (s *pollerScript) discover(_ context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discN++
+	return s.discRet()
+}
+
+func (s *pollerScript) list(_ context.Context, _, pageToken string) (*myyoutube.LiveChatPage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, pageToken)
+	if len(s.pages) == 0 {
+		s.cancel()
+		return nil, context.Canceled
+	}
+	next := s.pages[0]
+	s.pages = s.pages[1:]
+	return next()
+}
+
+func newScriptedPoller(t *testing.T, app *App, binding *liveChatBinding, s *pollerScript) (*youtubeChatPoller, context.Context) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	s.cancel = cancel
+	return &youtubeChatPoller{
+		app:            app,
+		binding:        binding,
+		discover:       s.discover,
+		list:           s.list,
+		ownChannelID:   func() string { return "UCbot" },
+		pollFloor:      time.Millisecond,
+		rediscoverWait: time.Millisecond,
+		quotaWait:      time.Millisecond,
+	}, ctx
+}
+
+func page(token string, msgs ...myyoutube.LiveChatMessage) func() (*myyoutube.LiveChatPage, error) {
+	return func() (*myyoutube.LiveChatPage, error) {
+		return &myyoutube.LiveChatPage{Messages: msgs, NextPageToken: token, PollAfter: time.Millisecond}, nil
+	}
+}
+
+func TestPoller_SkipsBacklogThenProcesses(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingChat{}
+	app.Chat = rec
+
+	binding := &liveChatBinding{}
+	binding.Bind("chat-1") // pre-bound, as after ConnectYouTube
+	script := &pollerScript{pages: []func() (*myyoutube.LiveChatPage, error){
+		// page 1 is backlog: this !help must NOT dispatch
+		page("t1", myyoutube.LiveChatMessage{AuthorChannelID: "UCviewer", Author: "Old", Text: "!help"}),
+		// page 2 is live traffic: this one must dispatch
+		page("t2", myyoutube.LiveChatMessage{AuthorChannelID: "UCviewer", Author: "Now", Text: "!help"}),
+	}}
+	p, ctx := newScriptedPoller(t, app, binding, script)
+
+	p.Run(ctx)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("want exactly 1 dispatched reply (backlog skipped), got %d: %v", len(rec.Says), rec.Says)
+	}
+	// the cursor must advance even across the discarded backlog page
+	if len(script.calls) < 2 || script.calls[0] != "" || script.calls[1] != "t1" {
+		t.Errorf("pageToken sequence wrong: %v", script.calls)
+	}
+}
+
+func TestPoller_SkipsOwnEchoedMessages(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingChat{}
+	app.Chat = rec
+
+	binding := &liveChatBinding{}
+	binding.Bind("chat-1")
+	script := &pollerScript{pages: []func() (*myyoutube.LiveChatPage, error){
+		page("t1"), // backlog page (empty)
+		page("t2",
+			myyoutube.LiveChatMessage{AuthorChannelID: "UCbot", Author: "TheChannel", Text: "!help"},
+			myyoutube.LiveChatMessage{AuthorChannelID: "UCviewer", Author: "Viewer", Text: "!help"},
+		),
+	}}
+	p, ctx := newScriptedPoller(t, app, binding, script)
+
+	p.Run(ctx)
+
+	if len(rec.Says) != 1 {
+		t.Fatalf("own echoed message should be filtered; got %d replies: %v", len(rec.Says), rec.Says)
+	}
+}
+
+func TestPoller_RebindsAfterChatGone(t *testing.T) {
+	app := newTestApp(video.Video{})
+	app.Chat = &recordingChat{}
+
+	binding := &liveChatBinding{}
+	binding.Bind("chat-old")
+	script := &pollerScript{pages: []func() (*myyoutube.LiveChatPage, error){
+		func() (*myyoutube.LiveChatPage, error) { return nil, myyoutube.ErrChatGone },
+	}}
+	script.discRet = func() (string, error) { return "chat-new", nil }
+	p, ctx := newScriptedPoller(t, app, binding, script)
+	// after ErrChatGone the poller rediscovers, binds chat-new, and calls
+	// list again; the script is exhausted by then, so that call cancels the
+	// ctx and Run exits.
+
+	p.Run(ctx)
+
+	if got := binding.ID(); got != "chat-new" {
+		t.Errorf("binding after ErrChatGone = %q, want chat-new (rediscovered)", got)
+	}
+	if script.discN == 0 {
+		t.Error("discover never called after ErrChatGone")
 	}
 }
 

--- a/pkg/chatbot/youtube_test.go
+++ b/pkg/chatbot/youtube_test.go
@@ -122,19 +122,19 @@ func TestHandleYouTubeMessage_NonCommandIsQuiet(t *testing.T) {
 // pollerScript drives youtubeChatPoller.Run through a scripted sequence of
 // list responses, canceling the context when the script is exhausted.
 type pollerScript struct {
-	mu      sync.Mutex
-	pages   []func() (*myyoutube.LiveChatPage, error)
-	calls   []string // pageTokens seen, for cursor assertions
-	cancel  context.CancelFunc
-	discRet func() (string, error)
-	discN   int
+	mu            sync.Mutex
+	pages         []func() (*myyoutube.LiveChatPage, error)
+	calls         []string // pageTokens seen, for cursor assertions
+	cancel        context.CancelFunc
+	discoverRet   func() (string, error)
+	discoverCalls int
 }
 
 func (s *pollerScript) discover(_ context.Context) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.discN++
-	return s.discRet()
+	s.discoverCalls++
+	return s.discoverRet()
 }
 
 func (s *pollerScript) list(_ context.Context, _, pageToken string) (*myyoutube.LiveChatPage, error) {
@@ -231,7 +231,7 @@ func TestPoller_RebindsAfterChatGone(t *testing.T) {
 	script := &pollerScript{pages: []func() (*myyoutube.LiveChatPage, error){
 		func() (*myyoutube.LiveChatPage, error) { return nil, myyoutube.ErrChatGone },
 	}}
-	script.discRet = func() (string, error) { return "chat-new", nil }
+	script.discoverRet = func() (string, error) { return "chat-new", nil }
 	p, ctx := newScriptedPoller(t, app, binding, script)
 	// after ErrChatGone the poller rediscovers, binds chat-new, and calls
 	// list again; the script is exhausted by then, so that call cancels the
@@ -242,7 +242,7 @@ func TestPoller_RebindsAfterChatGone(t *testing.T) {
 	if got := binding.ID(); got != "chat-new" {
 		t.Errorf("binding after ErrChatGone = %q, want chat-new (rediscovered)", got)
 	}
-	if script.discN == 0 {
+	if script.discoverCalls == 0 {
 		t.Error("discover never called after ErrChatGone")
 	}
 }

--- a/pkg/youtube/livechat.go
+++ b/pkg/youtube/livechat.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
+	"google.golang.org/api/googleapi"
 	ytapi "google.golang.org/api/youtube/v3"
 )
 
@@ -12,6 +14,11 @@ import (
 // no active broadcast (or it has chat disabled). Callers treat it as "not
 // live right now" and retry on their own cadence rather than failing hard.
 var ErrNoActiveBroadcast = errors.New("youtube: no active broadcast with live chat")
+
+// ErrChatGone is returned by ListChatMessages when the bound live chat no
+// longer exists — the broadcast ended or chat was disabled. Callers unbind
+// and go back to broadcast discovery.
+var ErrChatGone = errors.New("youtube: live chat ended or not found")
 
 // maxChatMessageLen is YouTube's per-message limit for
 // liveChatMessages.insert (200 characters; the API 400s above it). Twitch
@@ -65,4 +72,98 @@ func (cl *Client) InsertChatMessage(ctx context.Context, chatID, text string) er
 		},
 	}).Context(ctx).Do()
 	return err
+}
+
+// LiveChatMessage is one inbound chat message in provider-neutral shape, so
+// pkg/chatbot's poller never sees Google API types.
+type LiveChatMessage struct {
+	AuthorChannelID string // for filtering the bot's own echoed sends
+	Author          string // display name
+	Text            string // raw message text
+}
+
+// LiveChatPage is one liveChatMessages.list response: the text messages, the
+// cursor for the next page, and how long YouTube asks us to wait before
+// fetching it.
+type LiveChatPage struct {
+	Messages      []LiveChatMessage
+	NextPageToken string
+	PollAfter     time.Duration
+}
+
+// ListChatMessages fetches one page of the live chat. Only textMessageEvent
+// items are returned — Super Chats, membership milestones etc. are not
+// command input. A 403/404 meaning "this chat is over" maps to ErrChatGone;
+// quota errors pass through unmapped (check with IsQuotaError) so callers
+// back off instead of spinning rediscovery.
+func (cl *Client) ListChatMessages(ctx context.Context, chatID, pageToken string) (*LiveChatPage, error) {
+	svc, err := cl.Service(ctx)
+	if err != nil {
+		return nil, err
+	}
+	call := svc.LiveChatMessages.List(chatID, []string{"snippet", "authorDetails"})
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		if isChatGone(err) {
+			return nil, ErrChatGone
+		}
+		return nil, err
+	}
+
+	page := &LiveChatPage{
+		NextPageToken: resp.NextPageToken,
+		PollAfter:     time.Duration(resp.PollingIntervalMillis) * time.Millisecond,
+	}
+	for _, item := range resp.Items {
+		if item.Snippet == nil || item.Snippet.Type != "textMessageEvent" || item.Snippet.TextMessageDetails == nil {
+			continue
+		}
+		var author, authorID string
+		if item.AuthorDetails != nil {
+			author = item.AuthorDetails.DisplayName
+			authorID = item.AuthorDetails.ChannelId
+		}
+		page.Messages = append(page.Messages, LiveChatMessage{
+			AuthorChannelID: authorID,
+			Author:          author,
+			Text:            item.Snippet.TextMessageDetails.MessageText,
+		})
+	}
+	return page, nil
+}
+
+// isChatGone reports whether err means the live chat is over (broadcast
+// ended, chat disabled, or chat ID no longer resolves) — distinct from a 403
+// that means quota exhaustion.
+func isChatGone(err error) bool {
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	for _, e := range gerr.Errors {
+		switch e.Reason {
+		case "liveChatEnded", "liveChatDisabled", "liveChatNotFound", "notFound":
+			return true
+		}
+	}
+	return gerr.Code == 404
+}
+
+// IsQuotaError reports whether err is a YouTube Data API quota / rate-limit
+// rejection. Callers back off rather than retrying at the normal cadence.
+func IsQuotaError(err error) bool {
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	for _, e := range gerr.Errors {
+		switch e.Reason {
+		case "quotaExceeded", "rateLimitExceeded", "userRateLimitExceeded":
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/youtube/shims.go
+++ b/pkg/youtube/shims.go
@@ -30,3 +30,7 @@ func ActiveLiveChatID(ctx context.Context) (string, error) {
 func InsertChatMessage(ctx context.Context, chatID, text string) error {
 	return defaultClient.InsertChatMessage(ctx, chatID, text)
 }
+
+func ListChatMessages(ctx context.Context, chatID, pageToken string) (*LiveChatPage, error) {
+	return defaultClient.ListChatMessages(ctx, chatID, pageToken)
+}


### PR DESCRIPTION
## Summary

Phase B3: the inbound transport for a `PLATFORM=youtube` instance. **Stacked on #814** (base = `feat/youtube-outbound-chat`); will retarget after the stack merges.

With this, the YouTube bot loop is code-complete end to end: poller → `IncomingMessage` → shared command path (filtered by the #809 allowlist) → `youtubeChat.Say`. What remains is cmd wiring (B4) and deploy (B5).

## Design

- **`HandleYouTubeMessage` — the skip-login seam from the plan.** Identical to `HandleMessage` except viewers get a transient `users.User` that is never logged in or persisted (v1 punts identity/presence/miles). The Loki chat line, admin-console event-bus mirror, and metrics counter all stay, so the live console shows YouTube chat exactly like Twitch chat. Test proves the contract by running with `UserSessions` nil — a login attempt would panic.
- **Lifecycle:** unbound → discover (`liveBroadcasts.list`, quietly idle while not live) → bind → page through chat → on `ErrChatGone` unbind and rediscover. Shares the `liveChatBinding` with outbound `Say`, so both flip to a new broadcast together.
- **Backlog skip:** the first page after every bind is discarded — `liveChatMessages.list` opens with recent history, and replaying an hour-old `!skip` against the live pipeline would be wrong. The cursor still advances across the discarded page.
- **Own-echo filter:** the bot posts as the channel owner, so its sends come back in the list; they're dropped by author channel ID (`consoleMirror` already mirrors outbound to the console).
- **Quota-vs-ended disambiguation:** both arrive as 403s. `googleapi` reasons `liveChatEnded`/`liveChatNotFound`/etc. map to `ErrChatGone` (rediscover); `quotaExceeded`/`rateLimitExceeded` back off 5 minutes instead of spinning discovery on a dead quota.
- `ListChatMessages` returns provider-neutral shapes so pkg/chatbot never sees Google API types; only `textMessageEvent` items become command input.

## Test plan

- [x] `task test:macos` fully green
- [x] poller: backlog page skipped but cursor advances; own echoes filtered; `ErrChatGone` → rediscover → rebind; scripted fakes, no network
- [x] `HandleYouTubeMessage`: dispatches `!help` with nil `UserSessions` (skip-login proof); plain chatter stays quiet
- [ ] (needs OAuth client + unlisted broadcast) type `!help` / `!weather` / `!skip` in the quiet test stream's chat; confirm replies and that `!miles` produces nothing