### PR TITLE
feat: per-platform boot — Run() branches on STREAM_PLATFORM (Phase B4)

### DIFF
--- a/cmd/tripbot/chatsend.go
+++ b/cmd/tripbot/chatsend.go
@@ -29,7 +29,7 @@ func (t *Tripbot) startChatSendSubscriber(ctx context.Context) {
 		slog.InfoContext(ctx, "chat.send subscriber skipped (NATS_URL unset)")
 		return
 	}
-	subject := chatEvents.SendSubject(c.Conf.Environment)
+	subject := chatEvents.SendSubject(c.Conf.Environment, chatEvents.PlatformTwitch)
 	if _, err := conn.Subscribe(subject, func(m *nats.Msg) {
 		var ev chatEvents.Send
 		if err := json.Unmarshal(m.Data, &ev); err != nil {

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -31,6 +31,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
+	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
 	_ "github.com/dimiro1/banner/autoload"
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/getsentry/sentry-go"
@@ -156,9 +157,21 @@ func main() {
 	NewTripbot(version).Run()
 }
 
-// Run performs the various steps to get the bot running.
+// platformIsTwitch reports whether this instance serves Twitch. Empty
+// Platform is treated as Twitch, matching the chatbot registry's contract.
+func platformIsTwitch() bool {
+	return c.Conf.Platform == "" || c.Conf.Platform == "twitch"
+}
+
+// Run performs the various steps to get the bot running. The spine —
+// telemetry, HTTP server, player, sessions, cron, feature flags, NATS, the
+// admin hub — is platform-neutral and runs on every instance; only the
+// chat-transport bring-up swaps on STREAM_PLATFORM. Twitch-only steps (IRC
+// token plumbing, EventSub, subscriber polling, the admin chat-send
+// subscriber, Discord, the OBS↔Twitch watchdog) are gated off non-Twitch
+// instances.
 func (t *Tripbot) Run() {
-	slog.Info("tripbot starting", "version", t.version)
+	slog.Info("tripbot starting", "version", t.version, "platform", c.Conf.Platform)
 	createRandomSeed()
 	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
 	// to trigger a graceful shutdown so in-flight requests aren't cut.
@@ -178,19 +191,57 @@ func (t *Tripbot) Run() {
 	t.sessions.InitLeaderboard(context.Background())
 	t.startCron()
 	t.startFeatureFlags(shutdownCtx)
-	t.loadTwitchToken(shutdownCtx)           // must precede setUpTwitchClient — provides the IRC token
-	t.refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
-	t.setUpTwitchClient()                    // required for the below
-	t.updateSubscribers()
-	t.getCurrentUsers()
-	t.startEventSub(shutdownCtx)
+	if platformIsTwitch() {
+		t.loadTwitchToken(shutdownCtx)           // must precede setUpTwitchClient — provides the IRC token
+		t.refreshTokensIfNearExpiry(shutdownCtx) // closes the restart-desync gap with the hourly cron
+		t.setUpTwitchClient()                    // required for the below
+		t.updateSubscribers()
+		t.getCurrentUsers()
+		t.startEventSub(shutdownCtx)
+	}
 	t.startNATS(shutdownCtx)
 	t.srv.StartEventHub(shutdownCtx)       // after startNATS: the hub subscribes to the live NATS conn
-	t.startChatSendSubscriber(shutdownCtx) // after startNATS + setUpTwitchClient: needs the conn and t.app.Chat
 	t.player.EmitCurrentVideo(shutdownCtx) // after the hub subscribes: seed its now-playing cache (no NATS replay)
-	t.startDiscord(shutdownCtx)
-	t.startSilentDisconnectWatchdog(shutdownCtx)
+	if !platformIsTwitch() {
+		t.connectToYouTube(shutdownCtx)
+		return
+	}
+	// chat.send subjects are per-env, not per-platform — both platform
+	// instances would receive every admin send, so only the Twitch instance
+	// (which owns the bot/broadcaster identities the command names)
+	// subscribes.
+	t.startChatSendSubscriber(shutdownCtx)       // after startNATS + setUpTwitchClient: needs the conn and t.app.Chat
+	t.startDiscord(shutdownCtx)                  // Discord stays Twitch-side for v1
+	t.startSilentDisconnectWatchdog(shutdownCtx) // watches the OBS→Twitch stream specifically
 	t.connectToTwitch()
+}
+
+// connectToYouTube wires outbound chat + starts the inbound poller for a
+// PLATFORM=youtube instance, then blocks until shutdown — the YouTube analog
+// of connectToTwitch's blocking connect loop. Mirrors loadTwitchToken's
+// stay-up pattern: when the channel-owner oauth_tokens row is missing at
+// boot, the pod stays Ready (the admin panel + /auth/init?account=youtube
+// remain reachable for re-auth) and retries until the token lands.
+func (t *Tripbot) connectToYouTube(ctx context.Context) {
+	const retry = 15 * time.Second
+	binding, err := t.app.ConnectYouTube(ctx)
+	for err != nil {
+		slog.WarnContext(ctx, "no usable YouTube token; starting without chat and polling",
+			"reauth_url", myyoutube.AuthInitURL(), "err", err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(retry):
+		}
+		binding, err = t.app.ConnectYouTube(ctx)
+	}
+
+	go t.app.NewYouTubeChatPoller(binding).Run(ctx)
+	slog.InfoContext(ctx, "youtube chat poller started", "channel_id", myyoutube.ChannelID())
+
+	// nothing else to do on the main goroutine — the poller and HTTP server
+	// run until the signal handler shuts the process down.
+	<-ctx.Done()
 }
 
 // featureFlagRefreshInterval is how often the Postgres-backed flag client
@@ -556,8 +607,20 @@ func (t *Tripbot) gracefulShutdown() {
 // Lives in this package (not pkg/background) to avoid circular deps with
 // the job-target packages.
 func (t *Tripbot) scheduleBackgroundJobs() {
-	onscreensCli := onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment)
+	// platform-neutral jobs: every instance plays video and posts the
+	// periodic help message.
 	t.addJob(60*time.Second, "video.GetCurrentlyPlaying", t.player.GetCurrentlyPlaying)
+	t.addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", t.app.Chatter)
+
+	if !platformIsTwitch() {
+		// Twitch-sourced jobs stay off non-Twitch instances: session/presence
+		// tracking reads Twitch chatters (YouTube presence is punted in v1),
+		// the guess leaderboard backs an excluded command, the subscriber /
+		// follower polls hit Helix, and the token-refresh job dereferences the
+		// IRC client this instance never constructs.
+		return
+	}
+	onscreensCli := onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment)
 	t.addJob(61*time.Second, "users.UpdateSession", t.sessions.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
 	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
@@ -573,7 +636,6 @@ func (t *Tripbot) scheduleBackgroundJobs() {
 			t.irc.SetIRCToken(tok)
 		}
 	})
-	t.addJob(2*time.Hour+57*time.Minute+30*time.Second, "chatbot.Chatter", t.app.Chatter)
 }
 
 // addJob registers a gocron job at the given interval, wrapping fn with

--- a/pkg/chat-events/events_test.go
+++ b/pkg/chat-events/events_test.go
@@ -7,16 +7,18 @@ import (
 
 func TestSendSubject(t *testing.T) {
 	cases := []struct {
-		env  string
-		want string
+		env      string
+		platform string
+		want     string
 	}{
-		{"staging", "tripbot.staging.chat.send"},
-		{"prod", "tripbot.prod.chat.send"},
-		{"development", "tripbot.development.chat.send"},
+		{"staging", PlatformTwitch, "tripbot.staging.chat.send.twitch"},
+		{"prod", PlatformTwitch, "tripbot.prod.chat.send.twitch"},
+		{"prod", PlatformYouTube, "tripbot.prod.chat.send.youtube"},
+		{"development", PlatformTwitch, "tripbot.development.chat.send.twitch"},
 	}
 	for _, tc := range cases {
-		if got := SendSubject(tc.env); got != tc.want {
-			t.Errorf("SendSubject(%q): got %q, want %q", tc.env, got, tc.want)
+		if got := SendSubject(tc.env, tc.platform); got != tc.want {
+			t.Errorf("SendSubject(%q, %q): got %q, want %q", tc.env, tc.platform, got, tc.want)
 		}
 	}
 }

--- a/pkg/chat-events/subjects.go
+++ b/pkg/chat-events/subjects.go
@@ -8,9 +8,20 @@ import "fmt"
 // and differ only by verb (send vs message).
 const domain = "chat"
 
-// SendSubject builds tripbot.<env>.chat.send — the operator "post this message"
-// command. Subscribers (cmd/tripbot) build the same string to subscribe. The
-// observation counterpart, chat.message, is eventbus.ChatMessageSubject.
-func SendSubject(env string) string {
-	return fmt.Sprintf("tripbot.%s.%s.send", env, domain)
+// Platform values for the SendSubject platform segment. Per-platform
+// tripbot instances subscribe only to their own platform's sends, so an
+// admin send can never be double-handled (or handled by the wrong
+// instance) in envs running more than one platform.
+const (
+	PlatformTwitch  = "twitch"
+	PlatformYouTube = "youtube"
+)
+
+// SendSubject builds tripbot.<env>.chat.send.<platform> — the operator "post
+// this message to <platform>'s chat" command. Subscribers (cmd/tripbot) build
+// the same string to subscribe. The observation counterpart, chat.message, is
+// eventbus.ChatMessageSubject (which carries platform in the payload instead:
+// every console reads all platforms' lines, but a send targets exactly one).
+func SendSubject(env, platform string) string {
+	return fmt.Sprintf("tripbot.%s.%s.send.%s", env, domain, platform)
 }

--- a/pkg/chatbot/chat.go
+++ b/pkg/chatbot/chat.go
@@ -28,6 +28,7 @@ type ChatClient interface {
 type consoleMirror struct {
 	inner       ChatClient
 	env         string
+	platform    string
 	botUsername string
 }
 
@@ -38,7 +39,7 @@ func (m consoleMirror) Say(msg string) {
 	// live console — the platform doesn't echo our sent messages back, so
 	// without this the console would miss everything the bot says.
 	// Fire-and-forget; no-op when NATS is unconfigured.
-	eventbus.EmitChatMessage(context.Background(), m.env, m.botUsername, msg)
+	eventbus.EmitChatMessage(context.Background(), m.env, m.platform, m.botUsername, msg)
 	m.inner.Say(msg)
 }
 

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -193,6 +193,7 @@ func (a *App) ConnectIRC() *twitch.Client {
 			botUsername:   c.Conf.BotUsername,
 		},
 		env:         c.Conf.Environment,
+		platform:    c.Conf.Platform,
 		botUsername: c.Conf.BotUsername,
 	}
 

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -184,7 +184,7 @@ func (a *App) HandleMessage(ctx context.Context, msg IncomingMessage) {
 	// mirror the chat line onto the event bus so live consumers (the admin
 	// panel's chat pane) see it. Original-case username + text, matching the
 	// Loki line above; fire-and-forget, no-op when NATS is unconfigured.
-	eventbus.EmitChatMessage(ctx, c.Conf.Environment, msg.User, msg.Text)
+	eventbus.EmitChatMessage(ctx, c.Conf.Environment, a.Platform, msg.User, msg.Text)
 
 	// log in the user, then run any command (lowercased for matching)
 	//TODO: we lose capitalization here, is that okay?

--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -115,6 +115,7 @@ func (a *App) ConnectYouTube(ctx context.Context) (*liveChatBinding, error) {
 			insert:  myyoutube.InsertChatMessage,
 		},
 		env:         c.Conf.Environment,
+		platform:    c.Conf.Platform,
 		botUsername: c.Conf.BotUsername,
 	}
 	return binding, nil
@@ -135,7 +136,7 @@ func (a *App) HandleYouTubeMessage(ctx context.Context, msg IncomingMessage) {
 
 	instrumentation.ChatMessages.Inc()
 	mylog.ChatMsg(msg.User, msg.Text)
-	eventbus.EmitChatMessage(ctx, c.Conf.Environment, msg.User, msg.Text)
+	eventbus.EmitChatMessage(ctx, c.Conf.Environment, a.Platform, msg.User, msg.Text)
 
 	// transient, never written to the users table — the allowlisted command
 	// subset reads nothing user-specific beyond the name.

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -79,8 +79,13 @@ func emit(ctx context.Context, subj string, ev any) {
 // --- chat.message ---------------------------------------------------------
 
 // ChatMessage is the wire format for tripbot.<env>.chat.message — one incoming
-// Twitch chat line.
+// chat line from whichever platform this instance serves.
 type ChatMessage struct {
+	// Platform is the streaming platform the line came from ("twitch" /
+	// "youtube"). Both per-platform instances publish into the same env's
+	// subject, so this is what lets the admin console disambiguate. Empty on
+	// events emitted before the tag existed.
+	Platform  string `json:"platform,omitempty"`
 	Username  string `json:"username"`
 	Text      string `json:"text"`
 	EmittedAt string `json:"emitted_at"`
@@ -92,8 +97,9 @@ func ChatMessageSubject(env string) string { return subject(env, "chat", "messag
 
 // EmitChatMessage publishes an incoming chat line. Pass the original-case
 // username + text (not the lowercased command-parse copy).
-func EmitChatMessage(ctx context.Context, env, username, text string) {
+func EmitChatMessage(ctx context.Context, env, platform, username, text string) {
 	emit(ctx, ChatMessageSubject(env), ChatMessage{
+		Platform:  platform,
 		Username:  username,
 		Text:      text,
 		EmittedAt: emittedAt(),

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -55,7 +55,7 @@ func TestEmitChatMessage(t *testing.T) {
 	nowFn = func() time.Time { return fixed }
 	t.Cleanup(func() { nowFn = func() time.Time { return time.Now().UTC() } })
 
-	EmitChatMessage(context.Background(), "development", "DanaLol", "Hello, World!")
+	EmitChatMessage(context.Background(), "development", "twitch", "DanaLol", "Hello, World!")
 
 	if len(rec.Publishes) != 1 {
 		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
@@ -164,5 +164,5 @@ func TestEmit_NoNATS_NoPanic(t *testing.T) {
 	SetPublisher(realPublisher{})
 	t.Cleanup(func() { SetPublisher(realPublisher{}) })
 	// natsclient.Conn() is nil here (Connect never called) — must not panic.
-	EmitChatMessage(context.Background(), "test", "u", "x")
+	EmitChatMessage(context.Background(), "test", "twitch", "u", "x")
 }

--- a/pkg/server/chatsend.go
+++ b/pkg/server/chatsend.go
@@ -56,7 +56,11 @@ func (s *Server) chatSendHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	s.publisher.Publish(r.Context(), chatEvents.SendSubject(c.Conf.Environment), payload)
+	// The send form only offers the Twitch identities (bot/broadcaster)
+	// today, so every send routes to the Twitch instance regardless of which
+	// instance's console it was typed into. A YouTube send option would
+	// publish to SendSubject(env, PlatformYouTube).
+	s.publisher.Publish(r.Context(), chatEvents.SendSubject(c.Conf.Environment, chatEvents.PlatformTwitch), payload)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/pkg/server/chatsend_test.go
+++ b/pkg/server/chatsend_test.go
@@ -45,8 +45,8 @@ func TestChatSendHandler_PublishesValidSend(t *testing.T) {
 	if rec.calls != 1 {
 		t.Fatalf("publish calls = %d, want 1", rec.calls)
 	}
-	if !strings.HasSuffix(rec.subj, ".chat.send") {
-		t.Errorf("subject = %q, want suffix .chat.send", rec.subj)
+	if !strings.HasSuffix(rec.subj, ".chat.send.twitch") {
+		t.Errorf("subject = %q, want suffix .chat.send.twitch", rec.subj)
 	}
 	var ev chatEvents.Send
 	if err := json.Unmarshal(rec.data, &ev); err != nil {

--- a/pkg/server/hub_jetstream_test.go
+++ b/pkg/server/hub_jetstream_test.go
@@ -44,8 +44,8 @@ func TestHub_Start_replaysHistoryFromJetStream(t *testing.T) {
 	}
 
 	// Publish history BEFORE the hub starts — the whole point is replay.
-	eventbus.EmitChatMessage(ctx, env, "alice", "first")
-	eventbus.EmitChatMessage(ctx, env, "bob", "second")
+	eventbus.EmitChatMessage(ctx, env, "twitch", "alice", "first")
+	eventbus.EmitChatMessage(ctx, env, "twitch", "bob", "second")
 	eventbus.EmitVideoChanged(ctx, env, "wy_0001.MP4", "Wyoming", false, 41.5, -110.2)
 	eventbus.EmitVideoChanged(ctx, env, "ut_0002.MP4", "Utah", false, 40.0, -111.0)
 	if err := nc.Flush(); err != nil {


### PR DESCRIPTION
## Summary

Phase B4, the last code phase before deploy: `cmd/tripbot`'s boot sequence branches on `STREAM_PLATFORM`. **Stacked on #815**; will retarget as the stack merges. With this, `PLATFORM=youtube` is a runnable instance end to end.

## Design

- **The spine stays common.** Telemetry, HTTP/admin server, player, sessions, cron scheduler, feature flags, NATS, and the admin event hub run identically on both platforms; only chat-transport bring-up swaps — `setUpTwitchClient`/`connectToTwitch` vs `connectToYouTube` (ConnectYouTube + the B3 poller, then block until shutdown).
- **Missing-token boot mirrors `loadTwitchToken`'s stay-up pattern:** a `PLATFORM=youtube` pod with no channel-owner `oauth_tokens` row stays Ready — the admin panel and `/auth/init?account=youtube` remain reachable for one-click re-auth — and retries every 15s until the token lands. No crashloop.
- **Twitch-only steps gated off non-Twitch instances:** IRC token load/refresh, EventSub, subscriber/follower polls, chatter-session tracking (YouTube presence is punted in v1), the guess-leaderboard overlay job (backs an excluded command), Discord (Twitch-side for v1), and the OBS↔Twitch silent-disconnect watchdog. Notably the hourly token-refresh cron **would nil-deref `t.irc`** on a youtube instance — it's now scheduled only on Twitch.
- **The admin chat-send subscriber is Twitch-only.** `chat.send` subjects are per-env, not per-platform — both instances would otherwise receive and act on every admin send. The Twitch instance owns the bot/broadcaster identities the command names, so it's the one that subscribes.
- **`eventbus.ChatMessage` gains a `platform` tag** (the plan's B4 item): both platform instances publish into the same env's `chat.message` subject, and the tag is what lets the admin console disambiguate. `consoleMirror` and both inbound handlers thread it through; old events without the tag stay decodable (`omitempty`).

## Test plan

- [x] `task test:macos` fully green; `go vet` clean
- [x] `go list -deps` audit: `vlc-server` / `onscreens-server` still pull zero google-api / pkg/youtube packages
- [ ] (B5) boot `PLATFORM=youtube` from the laptop against the quiet test broadcast: `!help`/`!skip` round-trip, `!miles` silent, admin console shows platform-tagged lines