### PR TITLE
ci: create a GitHub Release for each release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,6 +382,22 @@ jobs:
             docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
           done <<< "${{ steps.meta.outputs.tags }}"
 
+  # The auto-tag flow (bump-version.yml) creates only a git tag; this is what
+  # makes the tag show up as a real GitHub Release with auto-generated notes
+  # (the infra bump PRs link to it).
+  github-release:
+    needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
+
   notify:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `github-release` job to `release.yml` (after all four image manifests publish): `gh release create` with `--generate-notes`, titled with the tag.

## Why

The auto-tag flow creates only a git tag — the Releases page has been frozen at v1.9.1 (2022). Real Releases give the upcoming infra version-bump PRs a human-readable "what's in this version" link, and `--generate-notes` writes the PR-by-PR summary for free.

`--verify-tag` makes the job fail loudly if the tag somehow vanished rather than minting a release off a phantom ref. Uses plain `GITHUB_TOKEN` — nothing downstream triggers off the release event.

Part of the prod version-pinning work: [infra#692](https://github.com/adanalife/infra/pull/692/changes), [infra#693](https://github.com/adanalife/infra/pull/693/changes), [infra#694](https://github.com/adanalife/infra/pull/694/changes).