### PR TITLE
ci: dispatch infra bump PRs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,6 +382,22 @@ jobs:
             docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
           done <<< "${{ steps.meta.outputs.tags }}"
 
+  # The auto-tag flow (bump-version.yml) creates only a git tag; this is what
+  # makes the tag show up as a real GitHub Release with auto-generated notes
+  # (the infra bump PRs link to it).
+  github-release:
+    needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
+
   notify:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,15 +400,24 @@ jobs:
 
   # Tell infra a new version exists: its bump-prs workflow fans out one
   # Dependabot-style "bump prod <component>" PR per image (merge = deploy).
-  # Needs AUTOMATION_PAT (fine-grained PAT with Contents r/w on
-  # adanalife/infra) — GITHUB_TOKEN can't dispatch cross-repo.
+  # Auths as the adanalife-automation GitHub App (credentials fanned out by
+  # infra's terraform/platform) — GITHUB_TOKEN can't dispatch cross-repo.
   dispatch-infra-bumps:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
     runs-on: ubuntu-latest
     steps:
+      - name: Mint automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          owner: adanalife
+          repositories: infra
+
       - name: Fire repository_dispatch to infra
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api repos/adanalife/infra/dispatches \
             -f event_type=tripbot-release \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,22 @@ jobs:
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
 
+  # Tell infra a new version exists: its bump-prs workflow fans out one
+  # Dependabot-style "bump prod <component>" PR per image (merge = deploy).
+  # Needs AUTOMATION_PAT (fine-grained PAT with Contents r/w on
+  # adanalife/infra) — GITHUB_TOKEN can't dispatch cross-repo.
+  dispatch-infra-bumps:
+    needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository_dispatch to infra
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+        run: |
+          gh api repos/adanalife/infra/dispatches \
+            -f event_type=tripbot-release \
+            -f "client_payload[version]=${GITHUB_REF_NAME#v}"
+
   notify:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `dispatch-infra-bumps` job to `release.yml`: once all four image manifests publish, fire `repository_dispatch` (`tripbot-release`, payload `{version}` without the `v`) at `adanalife/infra`. Infra's bump-prs workflow ([infra#694](https://github.com/adanalife/infra/pull/694/changes)) fans that out into one Dependabot-style "bump prod <component>" PR per image — merge = deploy, OBS/VLC PRs wait for a stream-safe moment.

## Auth

Mints a short-lived **adanalife-automation GitHub App** token scoped to `adanalife/infra` (`actions/create-github-app-token@v3`). The app credentials land in this repo's Actions via infra's terraform ([infra#695](https://github.com/adanalife/infra/pull/695/changes)) — no PAT, nothing expires. `GITHUB_TOKEN` can't dispatch cross-repo.

## Stack

Stacked on [#817](https://github.com/adanalife/tripbot/pull/817/changes) (both append jobs to `release.yml`); retarget to develop after that merges. Siblings: [infra#692](https://github.com/adanalife/infra/pull/692/changes), [infra#693](https://github.com/adanalife/infra/pull/693/changes), [infra#694](https://github.com/adanalife/infra/pull/694/changes), [infra#695](https://github.com/adanalife/infra/pull/695/changes).