### PR TITLE
ci: pull base images from GHCR mirrors, not Docker Hub

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -50,3 +50,7 @@ jobs:
           docker.io/migrate/migrate:4 ghcr.io/adanalife/mirror/migrate:4
           docker.io/pgvector/pgvector:pg16 ghcr.io/adanalife/mirror/pgvector:pg16
           EOF
+      # mirror/obs-cef-base:<ver> is also on GHCR but deliberately NOT in the
+      # refresh list: its tags are immutable version pins (a CEF bump changes
+      # the tag in Dockerfile.arm64), so each new tag is a one-time crane copy
+      # when obs-base.yml publishes it.

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -48,4 +48,5 @@ jobs:
           docker.io/golang:1.26-bookworm ghcr.io/adanalife/mirror/golang:1.26-bookworm
           docker.io/ubuntu:24.04 ghcr.io/adanalife/mirror/ubuntu:24.04
           docker.io/migrate/migrate:4 ghcr.io/adanalife/mirror/migrate:4
+          docker.io/pgvector/pgvector:pg16 ghcr.io/adanalife/mirror/pgvector:pg16
           EOF

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,51 @@
+# Refreshes the GHCR mirrors of the third-party Docker Hub base images our
+# Dockerfiles build FROM. The mirrors exist so CI never pulls from Docker Hub
+# at build time — Hub's pull rate limit repeatedly broke builds (manifest
+# resolution counts against the quota even on full layer-cache hits, so GHA
+# caching can't prevent it). The Dockerfiles reference
+# ghcr.io/adanalife/mirror/<image>:<tag>; this weekly copy keeps those mutable
+# tags tracking upstream (security patches, point releases).
+#
+# Adding a new base image: push the first copy (the crane command below, from
+# any authed machine), make the package public in the org packages UI, grant
+# this repo write access under the package's "Manage Actions access", and add
+# the pair to the list here + use the mirror ref in the Dockerfile.
+name: Mirror base images
+
+on:
+  schedule:
+    - cron: "17 9 * * 1" # weekly, Monday morning UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # crane copies the full multi-arch manifest list registry-to-registry
+      # (the release workflow's arm64 legs pull these mirrors too). crane
+      # rather than `docker buildx imagetools create`: the latter 400s on
+      # ghcr blob uploads for large layers (hit on golang:1.26-bookworm).
+      # The weekly Hub pulls here are a handful of requests — far under any
+      # limit. crane reads the docker-config auth the login step wrote.
+      - name: Copy images Hub -> GHCR
+        run: |
+          set -euo pipefail
+          while read -r src dst; do
+            echo "::group::${src} -> ${dst}"
+            go run github.com/google/go-containerregistry/cmd/crane@latest copy "${src}" "${dst}"
+            echo "::endgroup::"
+          done <<'EOF'
+          docker.io/golang:1.26-bookworm ghcr.io/adanalife/mirror/golang:1.26-bookworm
+          docker.io/ubuntu:24.04 ghcr.io/adanalife/mirror/ubuntu:24.04
+          docker.io/migrate/migrate:4 ghcr.io/adanalife/mirror/migrate:4
+          EOF

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -86,7 +86,7 @@ services:
   db:
     # pgvector/pgvector:pg16 is a drop-in for postgres:16-alpine that adds the
     # `vector` extension (used by frame_embeddings / dashcam-cv visual search).
-    image: pgvector/pgvector:pg16
+    image: ghcr.io/adanalife/mirror/pgvector:pg16
     restart: always
     ports:
       - "5432"
@@ -97,7 +97,7 @@ services:
     # data persistence is opt-in per environment (see docker-compose.development.yml)
 
   migrate:
-    image: migrate/migrate
+    image: ghcr.io/adanalife/mirror/migrate:4
     depends_on:
       - db
     volumes:

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ghcr.io/adanalife/mirror/ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -17,7 +17,7 @@ FROM adanalife/obs-cef-base:arm64-32.1.2-6533 AS builder
 # =============================================================================
 # Runtime: minimal Ubuntu 24.04 with the artifacts copied over from builder.
 # =============================================================================
-FROM ubuntu:24.04
+FROM ghcr.io/adanalife/mirror/ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -11,7 +11,7 @@
 # but publishes amd64 only — no arm64 across any Ubuntu release. amd64 stays
 # on the PPA build (see Dockerfile).
 # =============================================================================
-FROM adanalife/obs-cef-base:arm64-32.1.2-6533 AS builder
+FROM ghcr.io/adanalife/mirror/obs-cef-base:arm64-32.1.2-6533 AS builder
 
 
 # =============================================================================

--- a/infra/docker/obs/Dockerfile.arm64-base
+++ b/infra/docker/obs/Dockerfile.arm64-base
@@ -11,7 +11,7 @@
 #   - Build wiki: https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux
 #   - aarch64 CEF: https://cdn-fastly.obsproject.com/downloads/cef_binary_6533_linux_aarch64_v6.tar.xz
 # =============================================================================
-FROM ubuntu:24.04 AS builder
+FROM ghcr.io/adanalife/mirror/ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/infra/docker/onscreens-server/Dockerfile
+++ b/infra/docker/onscreens-server/Dockerfile
@@ -5,7 +5,7 @@
 # embedded in the binary (pkg/onscreens-server), so the runtime needs no assets.
 
 # Builder: produce a static binary with Go 1.26
-FROM golang:1.26-bookworm AS builder
+FROM ghcr.io/adanalife/mirror/golang:1.26-bookworm AS builder
 
 WORKDIR /src
 
@@ -18,7 +18,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/onscreens-server ./cmd/onscreens-server
 
 # Runtime: minimal Ubuntu 24.04 matching the tripbot/vlc/obs containers
-FROM ubuntu:24.04
+FROM ghcr.io/adanalife/mirror/ubuntu:24.04
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/infra/docker/test/Dockerfile
+++ b/infra/docker/test/Dockerfile
@@ -5,7 +5,7 @@
 # this), and vlc/Dockerfile does have it but is heavyweight (X server,
 # supervisor, the VLC daemon itself). Easier to keep tests on a small
 # purpose-built image.
-FROM golang:1.26-bookworm
+FROM ghcr.io/adanalife/mirror/golang:1.26-bookworm
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/infra/docker/tripbot/Dockerfile
+++ b/infra/docker/tripbot/Dockerfile
@@ -1,5 +1,5 @@
 # Builder: produce a static-ish tripbot binary with Go 1.26
-FROM golang:1.26-bookworm AS builder
+FROM ghcr.io/adanalife/mirror/golang:1.26-bookworm AS builder
 
 WORKDIR /src
 
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/t
  && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/auth-bootstrap ./cmd/auth-bootstrap
 
 # Runtime: minimal Ubuntu 24.04 matching the VLC/OBS containers
-FROM ubuntu:24.04
+FROM ghcr.io/adanalife/mirror/ubuntu:24.04
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -27,7 +27,7 @@ COPY --from=builder /out/tripbot /usr/local/bin/tripbot
 COPY --from=builder /out/auth-bootstrap /usr/local/bin/auth-bootstrap
 
 # Bundle the migrate CLI + db/migrate so this image can run schema migrations.
-COPY --from=migrate/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
+COPY --from=ghcr.io/adanalife/mirror/migrate:4 /usr/local/bin/migrate /usr/local/bin/migrate
 COPY db/migrate /migrations
 
 # Bundle seed script + data so the k8s seed Job is self-contained.

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ghcr.io/adanalife/mirror/ubuntu:24.04
 
 # libva2 / libva-drm2 / mesa-va-drivers / vainfo are the userspace
 # VA-API plumbing libvlc needs to discover and use /dev/dri/renderD128


### PR DESCRIPTION
## Summary

Docker Hub's pull rate limit broke CI twice today (#816's build, and previously the v3.0.1 manifest jobs). Layer caching can't fix it: the 429 happens at **manifest resolution**, which BuildKit performs for every `FROM`/`COPY --from` image at solve start — before the GHA cache (#786) is ever consulted.

This mirrors the three third-party base images to `ghcr.io/adanalife/mirror/*` (unlimited anonymous pulls, co-located with the runners) and points every Dockerfile at the mirrors:

| Hub image | Mirror |
|---|---|
| `golang:1.26-bookworm` | `ghcr.io/adanalife/mirror/golang:1.26-bookworm` |
| `ubuntu:24.04` | `ghcr.io/adanalife/mirror/ubuntu:24.04` |
| `migrate/migrate:4` | `ghcr.io/adanalife/mirror/migrate:4` |

A weekly `mirror-images` workflow re-copies the tags with crane so the mutable tags keep tracking upstream security patches (crane, not `imagetools` — the latter 400s on ghcr blob uploads for large layers).

`adanalife/obs-cef-base` stays on Docker Hub: it's our own published image with its own release flow, not a third-party mirror candidate.

## Before merging (one-time UI steps)

The mirrors are pushed, but each package needs two clicks in the org packages UI (https://github.com/orgs/adanalife/packages):
1. **Change visibility → Public** (so CI pulls anonymously — they're verbatim mirrors of public OSS images)
2. **Manage Actions access → add `adanalife/tripbot` with write** (so the weekly workflow's `GITHUB_TOKEN` can push refreshes)

Do that for `mirror/golang`, `mirror/ubuntu`, `mirror/migrate`. CI on this PR will fail until step 1 is done — re-run it after.

## Test plan

- [x] mirrors pushed and verified on GHCR (multi-arch manifest lists intact)
- [ ] PR CI builds green pulling only from GHCR (after the visibility flip)
- [ ] `gh workflow run mirror-images.yml` once merged, to prove the refresh path