### PR TITLE
ci: load release images locally so verify doesn't pull from Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
           file: infra/docker/tripbot/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          # load the image into the local daemon too, so the verify step
+          # runs it without pulling back from Docker Hub (quota)
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
@@ -145,6 +148,7 @@ jobs:
           file: infra/docker/vlc/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
@@ -244,6 +248,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
@@ -338,6 +343,7 @@ jobs:
           file: infra/docker/onscreens-server/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}


### PR DESCRIPTION
## Problem

The v3.2.0 release ([run 27376399697](https://github.com/adanalife/tripbot/actions/runs/27376399697)) failed in all eight build legs at the **Verify version stamping** step with `toomanyrequests` from Docker Hub. The builds and pushes themselves succeeded — the GHCR base-image mirrors from #820 did their job — but `verify-stamped-image.sh` does a `docker run` of the just-pushed tag, and buildx's docker-container driver pushes without loading into the local daemon. That `docker run` pulled our own image back from Docker Hub, and authenticated pulls of your own images count against the same account quota the day's PR burst had already drained.

This is exactly the carve-out the GHCR-mirrors ADR listed as "not covered."

## Fix

Add `load: true` alongside `push: true` on all four `docker/build-push-action` blocks. push+load multi-exporter has been supported since buildx 0.13, so each leg now keeps its single-arch image in the local daemon and the verify step runs it with **zero Hub pulls**.

## Not covered here

The `<image>-manifest` jobs still read per-arch manifests from Docker Hub via `imagetools create` and can 429 under a drained quota (they did on v3.0.1). That's the separate per-arch-pin item already tracked in the infra TODO — small GET volume, much less exposed than the verify pulls.
