### PR TITLE
Release v3.2.1: develop → master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
           file: infra/docker/tripbot/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          # load the image into the local daemon too, so the verify step
+          # runs it without pulling back from Docker Hub (quota)
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
@@ -145,6 +148,7 @@ jobs:
           file: infra/docker/vlc/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
@@ -244,6 +248,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}
@@ -338,6 +343,7 @@ jobs:
           file: infra/docker/onscreens-server/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          load: true
           build-args: |
             VERSION=${{ steps.ver.outputs.value }}
             SHA=${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+## [v3.2.1] — 2026-06-11
+
+Patch release. The v3.2.0 release run pushed its per-arch images but died at the version-stamping verify step — Docker Hub rate-limited the pull-back of our own just-pushed images — so the multi-arch manifests, GitHub Release, and infra bump dispatch never happened. This release fixes the verify step and ships everything v3.2.0 built.
+
+### CI
+
+- **Release builds load images locally for verification.** Each per-arch build leg now passes `load: true` alongside `push: true` (multi-exporter, buildx ≥ 0.13), so the verify step runs the locally-built image instead of pulling it back from Docker Hub — closing the "our own images still count against the pull quota" gap the GHCR mirrors ([#820]) deliberately left open. ([#821])
+
 ## [v3.2.0] — 2026-06-11
 
 Minor release. The headline is the **YouTube provider going code-complete**: a `PLATFORM=youtube` tripbot instance now runs end to end — channel-owner OAuth, outbound live-chat sends, an inbound chat poller, and a boot sequence that branches per platform — built on the provider-neutral chat seams the Phase C refactor left behind. Alongside it: release CI now publishes a GitHub Release per tag, dispatches the infra version-bump PRs automatically, and pulls base images from GHCR mirrors to dodge Docker Hub rate limits; and `!report` validates its Discord webhook URL before POSTing.
@@ -1494,5 +1502,6 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#817]: https://github.com/adanalife/tripbot/pull/817
 [#818]: https://github.com/adanalife/tripbot/pull/818
 [#820]: https://github.com/adanalife/tripbot/pull/820
+[#821]: https://github.com/adanalife/tripbot/pull/821
 [infra #694]: https://github.com/adanalife/infra/pull/694
 [infra #695]: https://github.com/adanalife/infra/pull/695


### PR DESCRIPTION
Patch release. Recovery for the v3.2.0 release run, whose eight build legs all pushed their per-arch images but failed at the version-stamping verify step — Docker Hub rate-limited the pull-back of our own just-pushed images — so the `:3.2.0` multi-arch manifests, GitHub Release, Discord notify, and infra bump dispatch never happened ([failed run](https://github.com/adanalife/tripbot/actions/runs/27376399697)).

## What's in it

### CI
- [#821](https://github.com/adanalife/tripbot/pull/821/changes) — release build legs add `load: true` alongside `push: true`, so the verify step runs the locally-built image with zero Docker Hub pulls. Closes the "own images count against the pull quota" gap that #820's GHCR mirrors deliberately left open.

Everything else shipping here is the v3.2.0 content (YouTube provider code-complete, release CI automation, `!report` webhook fix) finally getting its manifests, GitHub Release, and infra bump PRs.

## Release mechanics

- Version bump: **patch** (default, no override tag) → v3.2.1
- v3.2.0's tag exists, so auto-tag computes v3.2.1 correctly; nothing downstream ever consumed bare `3.2.0` (manifests/release/dispatch were all skipped), so jumping straight to 3.2.1 leaves no half-deployed state
- `origin/master` was merged into this branch for a clean three-way base (picks up the v3.2.0 changelog commit)
- Merge with a **merge commit** (not squash), per the merge-strategy-by-target-branch convention
- Residual risk: the `<image>-manifest` jobs still do a few Hub manifest GETs and could 429 if the quota is still drained — if that happens, "re-run failed jobs" is cheap (no rebuild)