### PR TITLE
docs: make in-repo comments self-contained

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -21,8 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Go toolchain from .tool-versions, per
-      # vault/decisions/golang-development-with-mise.md.
+      # Go toolchain from .tool-versions.
       - uses: jdx/mise-action@v4
 
       # `go generate` must reproduce the committed contract.json byte-for-byte.

--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -1,7 +1,7 @@
 # Publishes :develop multi-arch images on push to develop, gated by
 # per-image path filters. Stage pulls :develop; prod stays on :latest
 # (release.yml). Mirrors release.yml's matrix-on-native-runners +
-# manifest-list shape (see vault/decisions/multi-arch-release-pattern.md).
+# manifest-list shape.
 name: Release Development
 on:
   push:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,7 +33,7 @@ tasks:
 
   # Native macOS test runner — host mise + VLC.app's bundled libvlc, no
   # docker. Mirrors vlc-server:build:macos's CGO incantation (rpath is
-  # required for `go test` too, per vault/tripbot/vlc-server/gotchas.md).
+  # required for `go test` too).
   # `dotenv` injects .env.testing's keys as real env vars so the config
   # loader resolves them from the environment — `go test` runs each package
   # from its own dir, so the .env.testing file itself isn't on the path.
@@ -94,7 +94,7 @@ tasks:
         printf '\a'
         mise exec -- go run ./cmd/auth-bootstrap --account=broadcaster
 
-  # Release smoke flow — see vault/tripbot/release-checklist.md.
+  # Release smoke flow.
   # Targets the local k3d cluster running the stage-1 overlay
   # (cloudflared tunnel + apps).
 
@@ -147,7 +147,7 @@ tasks:
 
   # vlc-server native macOS build — links against the libvlc bundled
   # inside VLC.app. Saves recreating the CGO incantation from memory.
-  # See vault/tripbot/vlc-server/gotchas.md for the full story; key bits:
+  # Key bits:
   #   * rpath is required for `go test` / `go run`, not just `go build` —
   #     otherwise `dyld: Library not loaded: @rpath/libvlc.dylib`.
   #   * Do NOT add `-lvlc` to LDFLAGS — libvlc-go's own #cgo LDFLAGS

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -270,11 +270,8 @@ func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 }
 
 // startNATS connects to the in-cluster NATS broker and declares the JetStream
-// streams that back the admin live console's durable history (phase 1 + 3 of
-// the pubsub migration). Optional — when NATS_URL is empty the connection is
-// skipped and publishes no-op silently; chatbot.realOnscreens.ShowMiddleText
-// still mirrors to NATS but the publish becomes a nil check, leaving HTTP as
-// the sole transport.
+// streams that back the admin live console's durable history. Optional — when
+// NATS_URL is empty the connection is skipped and publishes no-op silently.
 //
 // EnsureStreams must run before StartEventHub so the streams exist when the hub
 // binds its ordered consumers. It no-ops when JetStream is unavailable (NATS off

--- a/cmd/youtube-chat-spike/youtube-chat-spike.go
+++ b/cmd/youtube-chat-spike/youtube-chat-spike.go
@@ -1,12 +1,11 @@
-// cmd/youtube-chat-spike is the Phase-B0 de-risk spike for the YouTube
-// provider: it proves the OAuth → active-broadcast → liveChatId →
+// cmd/youtube-chat-spike is the de-risk spike that preceded tripbot's
+// YouTube support: it proves the OAuth → active-broadcast → liveChatId →
 // poll/insert loop end-to-end and measures how fast the polling cadence
-// burns API quota, before any of it is wired into tripbot proper.
+// burns API quota, independent of tripbot proper.
 //
 // It is deliberately standalone — no tripbot/pkg imports, config via env
 // vars and flags only — so running it needs nothing but an OAuth client
-// and a live (unlisted is fine) broadcast. Delete or keep as a diagnostic
-// once Track B lands.
+// and a live (unlisted is fine) broadcast. Kept as a diagnostic.
 //
 // Setup (one-time, manual — terraform can't create OAuth clients):
 //  1. GCP console → APIs & Services → Credentials → Create OAuth client ID,
@@ -123,7 +122,7 @@ func oauthConfig() *oauth2.Config {
 
 // runLogin walks the authorization-code flow on a localhost listener and
 // prints the refresh token for the caller to export. Mirrors the shape of
-// cmd/auth-bootstrap's Twitch flow, minus the DB write — Phase B1 owns
+// cmd/auth-bootstrap's Twitch flow, minus the DB write — pkg/youtube owns
 // persistence.
 func runLogin(ctx context.Context, conf *oauth2.Config) {
 	stateBytes := make([]byte, 16)
@@ -250,9 +249,9 @@ func sendMessage(svc *youtube.Service, counts *callCounts, chatID, text string) 
 	fmt.Printf("sent: %q\n", text)
 }
 
-// pollChat runs the read loop the eventual inbound adapter (Phase B3) will
-// use: page through liveChatMessages.list at the server-suggested cadence,
-// printing each message, until the duration elapses.
+// pollChat runs the same read loop tripbot's inbound poller uses: page
+// through liveChatMessages.list at the server-suggested cadence, printing
+// each message, until the duration elapses.
 func pollChat(ctx context.Context, svc *youtube.Service, counts *callCounts, chatID string, duration time.Duration) {
 	fmt.Printf("polling live chat for %s (Ctrl-C to stop early loses the report)...\n", duration)
 	deadline := time.Now().Add(duration)

--- a/pkg/chat-events/events.go
+++ b/pkg/chat-events/events.go
@@ -9,7 +9,7 @@
 // the actual sending). Like pkg/onscreens-events and pkg/vlc-events it is
 // stdlib-only and side-effect-free: no init(), no pkg/config import, env is
 // always a parameter rather than read from config here — so it links safely
-// into any binary. See vault/decisions/package-boundary-init-discipline.md.
+// into any binary.
 package chatEvents
 
 import "time"

--- a/pkg/chatbot/nats.go
+++ b/pkg/chatbot/nats.go
@@ -10,10 +10,6 @@ import (
 // NATS is the publish surface chatbot uses for fire-and-forget pubsub
 // events. Tests inject a fake (recordingNATS / noopNATS); production
 // uses realNATS which delegates to the pkg/natsclient singleton.
-//
-// Phase 1: a single call site (realOnscreens.ShowMiddleText) publishes
-// alongside the HTTP path. Phase 2 peels more onscreens-client surface
-// onto NATS; phase 3 adds JetStream for events that need replay.
 type NATS interface {
 	// Publish sends payload on subject. Errors are logged but never
 	// returned — every chatbot publish is fire-and-forget by design.

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -8,13 +8,11 @@ import (
 
 // Twitch is the command-time Twitch Helix surface the chatbot needs. Today
 // that's only follow lookups (followageCmd); it grows as admin-panel Helix
-// features land (ban/timeout, send-as-broadcaster — see
-// vault/tripbot/tripbot/TODO.md).
+// features land (ban/timeout, send-as-broadcaster).
 //
-// It is deliberately the seam where, once the Twitch Helix API moves into its
-// own service (vault/tripbot/TODO.md "Extract Twitch Helix API into a separate
-// service"), the in-process adapter below is swapped for an HTTP client —
-// without touching any command code.
+// It is deliberately the seam where, if the Twitch Helix API ever moves into
+// its own service, the in-process adapter below is swapped for an HTTP
+// client — without touching any command code.
 type Twitch interface {
 	FollowedAt(username string) (time.Time, bool)
 }

--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -21,7 +21,7 @@ import (
 
 // liveChatBinding holds the currently-bound live chat ID, shared between the
 // outbound youtubeChat (Say targets it) and the inbound poller (which
-// discovers and re-binds it across broadcast lifecycles — Phase B3). Empty
+// discovers and re-binds it across broadcast lifecycles). Empty
 // means "not live right now": sends drop, the poller keeps re-discovering.
 type liveChatBinding struct {
 	mu sync.RWMutex
@@ -77,8 +77,8 @@ func (yc youtubeChat) Whisper(username, msg string) {
 // ConnectYouTube wires this App's outbound chat to YouTube — the
 // ConnectIRC analog for a PLATFORM=youtube instance. It loads the
 // channel-owner token from the DB, binds the active broadcast's live chat
-// (non-fatal when nothing is live: sends drop until the inbound poller —
-// Phase B3 — binds it), and points a.Chat at the youtubeChat client wrapped
+// (non-fatal when nothing is live: sends drop until the inbound poller
+// binds it), and points a.Chat at the youtubeChat client wrapped
 // in the provider-neutral console mirror.
 //
 // Returns the binding for the inbound poller to share. Errors only when the
@@ -165,7 +165,7 @@ type youtubeChatPoller struct {
 
 // NewYouTubeChatPoller builds the production poller sharing this App and the
 // binding returned by ConnectYouTube. Run it in a goroutine (cmd/tripbot's
-// platform branch — Phase B4).
+// platform branch does).
 func (a *App) NewYouTubeChatPoller(binding *liveChatBinding) *youtubeChatPoller {
 	return &youtubeChatPoller{
 		app:          a,

--- a/pkg/chatbot/youtube_test.go
+++ b/pkg/chatbot/youtube_test.go
@@ -254,7 +254,7 @@ func TestLiveChatBinding_RebindSwitchesTarget(t *testing.T) {
 	yc := youtubeChat{binding: binding, insert: rec.insert}
 
 	yc.Say("first")
-	// broadcast ended; the poller re-discovers and re-binds (Phase B3 flow)
+	// broadcast ended; the poller re-discovers and re-binds
 	binding.Bind("chat-new")
 	yc.Say("second")
 

--- a/pkg/config/onscreens-server/type.go
+++ b/pkg/config/onscreens-server/type.go
@@ -24,9 +24,8 @@ type OnscreensServerConfig struct {
 	// on its own pod/IP there's nothing to collide with.
 	OnscreensServerBindAddress string `default:":8081" envconfig:"ONSCREENS_SERVER_BIND_ADDRESS"`
 
-	// NatsURL is the in-cluster NATS endpoint the subscriber connects to
-	// (phase 1: tripbot.<env>.onscreens.middle.show). Format:
-	// nats://nats.<env-platform-ns>.svc.cluster.local:4222. Optional —
-	// when unset, the subscriber is skipped and HTTP is the sole transport.
+	// NatsURL is the in-cluster NATS endpoint the subscriber connects to.
+	// Format: nats://nats.<env-platform-ns>.svc.cluster.local:4222.
+	// Optional — when unset, the subscriber is skipped.
 	NatsURL string `envconfig:"NATS_URL"`
 }

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -70,10 +70,10 @@ type TripbotConfig struct {
 	ObsServerHost string `envconfig:"OBS_SERVER_HOST"`
 
 	// NatsURL is the in-cluster NATS endpoint used for fire-and-forget
-	// inter-component events (phase 1: ShowMiddleText alongside HTTP).
-	// Format: nats://nats.<env-platform-ns>.svc.cluster.local:4222.
-	// Optional — when unset, NATS publishes no-op and the HTTP path is
-	// the sole transport. Lets local dev / tests skip NATS entirely.
+	// inter-component events. Format:
+	// nats://nats.<env-platform-ns>.svc.cluster.local:4222.
+	// Optional — when unset, NATS publishes no-op silently. Lets local
+	// dev / tests skip NATS entirely.
 	NatsURL string `envconfig:"NATS_URL"`
 
 	// DiscordAlertsWebhook is the Discord webhook URL that !report posts

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -13,7 +13,7 @@
 //
 // Subjects follow the project convention tripbot.<env>.<domain>.<event>;
 // envelopes are snake_case JSON carrying emitted_at (RFC3339Nano UTC) so a
-// future protobuf schema maps 1-1. See the NATS phase-0/1 session notes.
+// future protobuf schema maps 1-1.
 package eventbus
 
 import (

--- a/pkg/httpmw/shutdown.go
+++ b/pkg/httpmw/shutdown.go
@@ -28,10 +28,10 @@ var ShutdownDelay = 500 * time.Millisecond
 // tripbot's Go servers (tripbot, vlc-server, onscreens-server). Responds
 // 202 + a short body, then schedules SIGTERM after ShutdownDelay.
 //
-// The handler is intentionally minimal: no body parsing, no auth check
-// (tailnet-only by Ingress per the admin-panel discussion in CLAUDE.md +
-// vault/decisions). If/when the panel reaches beyond the tailnet, the
-// auth gate goes on the route registration, not here.
+// The handler is intentionally minimal: no body parsing, and no auth check
+// because the admin surface is only reachable over the tailnet by Ingress.
+// If/when the panel reaches beyond the tailnet, the auth gate goes on the
+// route registration, not here.
 func ShutdownHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slog.WarnContext(r.Context(), "admin shutdown requested — SIGTERMing self", "delay", ShutdownDelay)

--- a/pkg/natsclient/natsclient.go
+++ b/pkg/natsclient/natsclient.go
@@ -2,10 +2,9 @@
 // onscreens-server. Mirrors the pkg/database singleton pattern: lazy on
 // first Connect, no-op when the URL is empty, swappable for tests.
 //
-// Phase 1 (vault/tripbot/TODO.md "Adopt NATS as the inter-component
-// message bus"): fire-and-forget pubsub over core NATS. Phase 3 adds the
-// JetStream accessor below for durable, replayable streams — the admin
-// live console backfills its chat/map buffers from them on startup.
+// Core NATS carries fire-and-forget pubsub; the JetStream accessor below
+// serves durable, replayable streams — the admin live console backfills
+// its chat/map buffers from them on startup.
 package natsclient
 
 import (

--- a/pkg/onscreens-events/events.go
+++ b/pkg/onscreens-events/events.go
@@ -6,7 +6,7 @@
 // pkg/onscreens-client) and the subscriber (cmd/onscreens-server). To stay
 // safe as a shared package it is stdlib-only and side-effect-free: no
 // init(), no pkg/config import, env is always a parameter rather than read
-// from config here. See vault/decisions/package-boundary-init-discipline.md.
+// from config here.
 package onscreensEvents
 
 import "time"

--- a/pkg/server/hub_jetstream_test.go
+++ b/pkg/server/hub_jetstream_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-// TestHub_Start_replaysHistoryFromJetStream is the load-bearing test for phase 3:
-// it proves the live console survives a reboot. We publish chat + video history,
+// TestHub_Start_replaysHistoryFromJetStream proves the live console survives
+// a reboot. We publish chat + video history,
 // then start a *fresh* hub with no SSE clients connected and assert the durable
 // JetStream consumers replayed that history into the chat ring and map trail.
 // This is delivery-on-startup (replay), not live delivery — the messages were

--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -40,9 +40,9 @@ type userProfile struct {
 }
 
 // userProfileHandler serves GET /admin/user/{username}: the HTML fragment the
-// live console pops over when an operator clicks a username. Phase 2 will add
-// timeout/ban actions here (needs the broadcaster token's
-// moderator:manage:banned_users scope — see the vault TODO).
+// live console pops over when an operator clicks a username. Timeout/ban
+// actions are planned here (they need the broadcaster token's
+// moderator:manage:banned_users scope).
 func userProfileHandler(w http.ResponseWriter, r *http.Request) {
 	username := strings.ToLower(strings.TrimSpace(mux.Vars(r)["username"]))
 	prof := userProfile{Username: username}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -118,7 +118,7 @@ func (s *Server) Start(ctx context.Context) {
 	r.PathPrefix("/static/").Handler(staticHandler())
 
 	// admin actions — tailnet-only by virtue of where the Ingress is
-	// exposed; no app-layer auth gate (see CLAUDE.md / vault decisions).
+	// exposed; no app-layer auth gate.
 	admin := r.PathPrefix("/admin").Methods("POST").Subrouter()
 	admin.Handle("/obs/stream/{action}", tagged("/admin/obs/stream/{action}", obsStreamActionHandler))
 	admin.Handle("/flags/{key}/{action}", tagged("/admin/flags/{key}/{action}", s.flagActionHandler))

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,7 +1,6 @@
 // Package telemetry initializes OpenTelemetry providers (traces, metrics,
 // logs) for tripbot's binaries. Backend is OTLP/HTTP — typically Grafana
-// Cloud. Configuration comes from standard OTEL_* env vars; see
-// vault/decisions for the surrounding design.
+// Cloud. Configuration comes from standard OTEL_* env vars.
 //
 // Setting OTEL_SDK_DISABLED=true (or leaving OTEL_EXPORTER_OTLP_ENDPOINT
 // unset) makes Init skip the OTLP exporters and only wire up a Prometheus

--- a/pkg/twitch/authentication.go
+++ b/pkg/twitch/authentication.go
@@ -38,8 +38,7 @@ var helixHTTPClient = &http.Client{Transport: rateLimitRecorder{next: otelhttp.N
 //
 // Broadcaster-gated endpoints (GetSubscriptions, GetChannelFollows total)
 // authorize against the broadcaster identity, not the bot — those live in
-// BroadcasterScopes. See [[../decisions/...]] / vault/tripbot/tripbot/TODO.md
-// "Subscriber/follower data" item for the identity-vs-scope distinction.
+// BroadcasterScopes.
 var BotScopes = []string{
 	"chat:read",
 	"chat:edit",

--- a/pkg/twitch/client.go
+++ b/pkg/twitch/client.go
@@ -17,9 +17,8 @@ import (
 // the shims in shims.go are deleted.)
 //
 // Fields are grouped into two clusters on purpose. The **auth core** (helix
-// clients + tokens) is the cohesive unit that is slated to move into its own
-// auth service (see vault/tripbot/TODO.md "Extract Twitch Helix API into a
-// separate service") — keeping it visually distinct here marks that future
+// clients + tokens) is the cohesive unit that may eventually move into its
+// own auth service — keeping it visually distinct here marks that future
 // seam. The **query/viewer** cluster is cached read-state derived from Helix.
 //
 // Methods are still fronted by package-level free-function shims (see

--- a/pkg/twitch/shims.go
+++ b/pkg/twitch/shims.go
@@ -14,8 +14,7 @@ import (
 // the package-level mutable globals are gone.
 //
 // These shims are transitional. Once a constructed *Client is threaded through
-// those callers, this whole file (and defaultClient) is deleted — see the
-// Phase B/C plan and vault/decisions/chatbot-app-injection-pattern.md.
+// those callers, this whole file (and defaultClient) is deleted.
 
 // --- auth / token ---
 

--- a/pkg/users/source.go
+++ b/pkg/users/source.go
@@ -7,10 +7,9 @@ import "github.com/adanalife/tripbot/pkg/twitch"
 // session tracking (platform-agnostic) and the chat transport (per-platform).
 //
 // Today the only implementation is twitchSource, backed by Twitch Helix via
-// pkg/twitch. When the multi-platform chat-transport work lands, a YouTube or
-// TikTok adapter drops in here so a per-platform bot instance
-// (PLATFORM=youtube, etc.) tracks its own audience without Sessions changing.
-// See vault/sessions/2026-05-31-multi-platform-streaming-arch.md.
+// pkg/twitch. A YouTube or TikTok adapter drops in here so a per-platform bot
+// instance (PLATFORM=youtube, etc.) tracks its own audience without Sessions
+// changing.
 type ChatterSource interface {
 	// UpdateChatters refreshes the source's notion of who is in chat.
 	UpdateChatters()

--- a/pkg/vlc-events/events.go
+++ b/pkg/vlc-events/events.go
@@ -4,8 +4,7 @@
 // It is imported by both the publisher (cmd/tripbot, via pkg/vlc-client) and
 // the subscriber (cmd/vlc-server). To stay safe as a shared package it is
 // stdlib-only and side-effect-free: no init(), no pkg/config import, env is
-// always a parameter rather than read from config here. See
-// vault/decisions/package-boundary-init-discipline.md.
+// always a parameter rather than read from config here.
 //
 // Scope: the fire-and-forget playback commands only (random / file / skip /
 // back). The currently-playing read stays on HTTP — a request/response read

--- a/pkg/vlc-server/watchdog.go
+++ b/pkg/vlc-server/watchdog.go
@@ -43,7 +43,7 @@ func ResumeMarkerPath() string {
 // The libvlc RTSP server can answer OPTIONS (process alive, port bound)
 // while DESCRIBE returns 500 — the silent-failure mode that motivates this
 // probe: the sout chain went away without the player crashing or releasing
-// :8554. See vault/tripbot/vlc-server/gotchas.md.
+// :8554.
 func probeRTSPDescribe() error {
 	return probeRTSPDescribeAt(rtspProbeAddr)
 }

--- a/pkg/youtube/shims.go
+++ b/pkg/youtube/shims.go
@@ -10,7 +10,7 @@ import (
 // pkg/twitch's transitional shim pattern: callers (pkg/server's auth
 // handlers, cmd/tripbot's boot sequence) use these until a constructed
 // *Client is threaded through, at which point this file is deleted — see
-// pkg/twitch/shims.go and vault/decisions/chatbot-app-injection-pattern.md.
+// pkg/twitch/shims.go.
 
 var defaultClient = New()
 


### PR DESCRIPTION
Sweep of code comments, the Taskfile, and workflow comments for references a reader of this repo can't follow — pointers to private planning docs and internal milestone labels (phase/track/tier names) left over from how the work was sequenced.

Where the referenced doc was carrying load-bearing context, that context is now stated inline (briefly); where the comment was only narrating project history, it's trimmed. A few comments that had gone stale relative to the code (e.g. the NATS command path no longer having an HTTP fallback) were corrected in passing.

No code changes — comments only. Full test suite passes.

Companion to #824, which does the same sweep over the CHANGELOG.