### PR TITLE
feat: publish auth.status snapshots to NATS

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -202,6 +202,7 @@ func (t *Tripbot) Run() {
 	t.startNATS(shutdownCtx)
 	t.srv.StartEventHub(shutdownCtx)       // after startNATS: the hub subscribes to the live NATS conn
 	t.player.EmitCurrentVideo(shutdownCtx) // after the hub subscribes: seed its now-playing cache (no NATS replay)
+	t.startAuthStatusEmitter(shutdownCtx)  // after startNATS: publishes auth.status snapshots for the standalone console
 	if !platformIsTwitch() {
 		t.connectToYouTube(shutdownCtx)
 		return
@@ -283,6 +284,78 @@ func (t *Tripbot) startNATS(ctx context.Context) {
 		slog.WarnContext(ctx, "jetstream stream setup failed; live console will run without durable history",
 			"err", err)
 	}
+}
+
+// authStatusInterval is how often the instance publishes its auth.status
+// snapshot. Matches the in-process panel's 30s pollAuth cadence — token expiry
+// moves on the order of minutes/hours, and the TRIPBOT_AUTH last-value stream
+// means a freshly-connected console is at most one interval stale.
+const authStatusInterval = 30 * time.Second
+
+// startAuthStatusEmitter publishes this instance's token state to
+// tripbot.<env>.auth.status.<platform> on start and every authStatusInterval.
+// The in-process admin hub ignores the subject (it polls token state directly);
+// the standalone console is the consumer. Snapshots are assembled here — not in
+// pkg/eventbus — so the eventbus stays free of pkg/twitch / pkg/youtube imports.
+func (t *Tripbot) startAuthStatusEmitter(ctx context.Context) {
+	platform := c.Conf.Platform
+	if platform == "" {
+		platform = "twitch"
+	}
+	snapshot := twitchAuthAccounts
+	if !platformIsTwitch() {
+		snapshot = youtubeAuthAccounts
+	}
+	go func() {
+		eventbus.EmitAuthStatus(ctx, c.Conf.Environment, platform, snapshot())
+		tick := time.NewTicker(authStatusInterval)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				eventbus.EmitAuthStatus(ctx, c.Conf.Environment, platform, snapshot())
+			}
+		}
+	}()
+}
+
+// twitchAuthAccounts converts the live Twitch token state (bot + broadcaster)
+// into the eventbus wire shape.
+func twitchAuthAccounts() []eventbus.AuthAccount {
+	statuses := mytwitch.TokenStatuses()
+	accounts := make([]eventbus.AuthAccount, 0, len(statuses))
+	for _, s := range statuses {
+		expiresAt := ""
+		if !s.ExpiresAt.IsZero() {
+			expiresAt = s.ExpiresAt.UTC().Format(time.RFC3339Nano)
+		}
+		accounts = append(accounts, eventbus.AuthAccount{
+			Account:   s.Account,
+			LoginAs:   s.LoginAs,
+			ExpiresAt: expiresAt,
+			Reason:    s.Reason,
+			InitURL:   s.InitURL,
+		})
+	}
+	return accounts
+}
+
+// youtubeAuthAccounts reports the channel-owner token's loaded/missing state.
+// No expiry: the oauth2 client auto-refreshes the access token via the refresh
+// token, so loaded-vs-missing is the operational signal (a dead refresh token
+// surfaces as the row being blanked → "missing").
+func youtubeAuthAccounts() []eventbus.AuthAccount {
+	account := eventbus.AuthAccount{
+		Account: "youtube",
+		LoginAs: myyoutube.ChannelID(),
+		InitURL: myyoutube.AuthInitURL(),
+	}
+	if myyoutube.ChannelID() == "" {
+		account.Reason = "missing"
+	}
+	return []eventbus.AuthAccount{account}
 }
 
 // startSilentDisconnectWatchdog launches the goroutine that detects the

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -161,6 +161,52 @@ func EmitVideoChanged(ctx context.Context, env, file, state string, flagged bool
 	})
 }
 
+// --- auth.status ------------------------------------------------------------
+
+// AuthAccount is one identity's token state inside an AuthStatus snapshot.
+// Field semantics mirror mytwitch.AccountTokenStatus, but the type is defined
+// here so the eventbus stays free of pkg/twitch (and its DB-reaching imports)
+// per the package-boundary ADR — cmd/tripbot converts at the call site.
+type AuthAccount struct {
+	Account   string `json:"account"`              // "bot" | "broadcaster" | "youtube" — the /auth/init account selector
+	LoginAs   string `json:"login_as,omitempty"`   // the exact platform username/channel to sign in as
+	ExpiresAt string `json:"expires_at,omitempty"` // RFC3339Nano UTC; empty when unknown (missing token, or auto-refreshed)
+	Reason    string `json:"reason,omitempty"`     // "" healthy, else "missing" | "expired"
+	InitURL   string `json:"init_url,omitempty"`   // absolute re-auth URL (tripbot's /auth/init)
+}
+
+// AuthStatus is the wire format for tripbot.<env>.auth.status.<platform> — a
+// full token-state snapshot for one platform instance's identities, emitted on
+// a ~30s ticker. Consumers (the standalone console) render countdowns and
+// re-auth links from it; re-auth itself stays in tripbot (InitURL points there).
+type AuthStatus struct {
+	Platform  string        `json:"platform"`
+	Accounts  []AuthAccount `json:"accounts"`
+	EmittedAt string        `json:"emitted_at"`
+}
+
+// AuthStatusSubject returns the publish subject for one platform instance's
+// auth snapshots. Unlike the other domains this subject is per-platform — the
+// twitch and youtube instances own disjoint identities, and the per-platform
+// leaf lets the TRIPBOT_AUTH stream keep a last-value cache of each
+// (MaxMsgsPerSubject=1) instead of the instances clobbering one another.
+func AuthStatusSubject(env, platform string) string {
+	return subject(env, "auth", "status") + "." + platform
+}
+
+// AuthStatusWildcard returns the subscribe pattern covering every platform's
+// auth snapshots in env.
+func AuthStatusWildcard(env string) string { return subject(env, "auth", "status") + ".*" }
+
+// EmitAuthStatus publishes a token-state snapshot for this instance's platform.
+func EmitAuthStatus(ctx context.Context, env, platform string, accounts []AuthAccount) {
+	emit(ctx, AuthStatusSubject(env, platform), AuthStatus{
+		Platform:  platform,
+		Accounts:  accounts,
+		EmittedAt: emittedAt(),
+	})
+}
+
 // --- JetStream streams (durable history) ----------------------------------
 //
 // Two subjects need to survive a tripbot reboot so the admin live console can
@@ -174,6 +220,7 @@ func EmitVideoChanged(ctx context.Context, env, file, state string, flagged bool
 const (
 	chatStreamName  = "TRIPBOT_CHAT"
 	videoStreamName = "TRIPBOT_VIDEO"
+	authStreamName  = "TRIPBOT_AUTH"
 )
 
 // Retention caps match the admin hub's in-memory buffer sizes (pkg/server:
@@ -218,18 +265,31 @@ func EnsureStreams(ctx context.Context, js jetstream.JetStream, env string) erro
 			Discard:     jetstream.DiscardOld,
 			MaxMsgs:     videoStreamMaxMsgs,
 		},
+		{
+			Name:        authStreamName,
+			Description: "Last-known auth.status snapshot per platform instance (last-value cache).",
+			Subjects:    []string{AuthStatusWildcard(env)},
+			Storage:     jetstream.FileStorage,
+			Retention:   jetstream.LimitsPolicy,
+			Discard:     jetstream.DiscardOld,
+			// One retained message per subject leaf (= per platform): a fresh
+			// console replays exactly the latest snapshot from each instance,
+			// then live updates arrive on the same subscription.
+			MaxMsgsPerSubject: 1,
+		},
 	}
 	for _, cfg := range configs {
 		if _, err := js.CreateOrUpdateStream(ctx, cfg); err != nil {
 			return fmt.Errorf("ensure stream %s: %w", cfg.Name, err)
 		}
 	}
-	slog.InfoContext(ctx, "jetstream streams ensured", "streams", chatStreamName+","+videoStreamName, "env", env)
+	slog.InfoContext(ctx, "jetstream streams ensured", "streams", chatStreamName+","+videoStreamName+","+authStreamName, "env", env)
 	return nil
 }
 
-// ChatStreamName and VideoStreamName expose the stream names so consumers (the
-// admin hub) can bind ordered consumers to them without re-deriving the
-// constants.
+// ChatStreamName, VideoStreamName, and AuthStreamName expose the stream names
+// so consumers (the admin hub, the standalone console) can bind ordered
+// consumers to them without re-deriving the constants.
 func ChatStreamName() string  { return chatStreamName }
 func VideoStreamName() string { return videoStreamName }
+func AuthStreamName() string  { return authStreamName }

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -166,3 +166,63 @@ func TestEmit_NoNATS_NoPanic(t *testing.T) {
 	// natsclient.Conn() is nil here (Connect never called) — must not panic.
 	EmitChatMessage(context.Background(), "test", "twitch", "u", "x")
 }
+
+func TestAuthStatusSubject(t *testing.T) {
+	for _, env := range []string{"prod", "stage", "development"} {
+		for _, platform := range []string{"twitch", "youtube"} {
+			got := AuthStatusSubject(env, platform)
+			want := "tripbot." + env + ".auth.status." + platform
+			if got != want {
+				t.Errorf("AuthStatusSubject(%q, %q) = %q, want %q", env, platform, got, want)
+			}
+		}
+	}
+}
+
+func TestAuthStatusWildcard(t *testing.T) {
+	if got, want := AuthStatusWildcard("development"), "tripbot.development.auth.status.*"; got != want {
+		t.Errorf("AuthStatusWildcard(development) = %q, want %q", got, want)
+	}
+}
+
+func TestEmitAuthStatus(t *testing.T) {
+	rec := withRecorder(t)
+
+	fixed := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = func() time.Time { return time.Now().UTC() } })
+
+	accounts := []AuthAccount{
+		{Account: "bot", LoginAs: "tripbot4001", ExpiresAt: fixed.Add(2 * time.Hour).Format(time.RFC3339Nano), InitURL: "https://tripbot.example/auth/init?account=bot"},
+		{Account: "broadcaster", LoginAs: "adanalife_staging", Reason: "expired", InitURL: "https://tripbot.example/auth/init?account=broadcaster"},
+	}
+	EmitAuthStatus(context.Background(), "development", "twitch", accounts)
+
+	if len(rec.Publishes) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
+	}
+	pub := rec.Publishes[0]
+	if pub.Subject != "tripbot.development.auth.status.twitch" {
+		t.Errorf("subject = %q, want tripbot.development.auth.status.twitch", pub.Subject)
+	}
+
+	var ev AuthStatus
+	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Platform != "twitch" {
+		t.Errorf("platform = %q, want twitch", ev.Platform)
+	}
+	if len(ev.Accounts) != 2 {
+		t.Fatalf("accounts = %d, want 2", len(ev.Accounts))
+	}
+	if ev.Accounts[0].Account != "bot" || ev.Accounts[0].Reason != "" {
+		t.Errorf("accounts[0] = %+v, want healthy bot row", ev.Accounts[0])
+	}
+	if ev.Accounts[1].Reason != "expired" || ev.Accounts[1].InitURL == "" {
+		t.Errorf("accounts[1] = %+v, want expired broadcaster row with InitURL", ev.Accounts[1])
+	}
+	if ev.EmittedAt != fixed.Format(time.RFC3339Nano) {
+		t.Errorf("emitted_at = %q, want %q", ev.EmittedAt, fixed.Format(time.RFC3339Nano))
+	}
+}


### PR DESCRIPTION
Adds the missing NATS producer the standalone admin console needs: each platform instance now publishes its token state to `tripbot.<env>.auth.status.<platform>` every 30s.

- New `TRIPBOT_AUTH` JetStream stream with `MaxMsgsPerSubject: 1` — a last-value cache per platform, so a freshly-connected console replays exactly the latest snapshot from each instance (twitch + youtube) and then receives live updates on the same subscription.
- Envelope (`AuthStatus` / `AuthAccount`) carries account, login-as, expiry, missing/expired reason, and the absolute `/auth/init` URL — re-auth itself stays in tripbot.
- Snapshot assembly lives in `cmd/tripbot` (twitch: `TokenStatuses()`; youtube: channel-owner loaded/missing — no expiry since oauth2 auto-refreshes), keeping `pkg/eventbus` free of `pkg/twitch`/`pkg/youtube` imports.
- The in-process admin hub is unchanged: it keeps its direct `pollAuth` path and ignores the new subject.

No console-side consumer exists yet; this lands first so the producer is burning in on stage while the console repo is built out.