### PR TITLE
feat: fuzzy-match misspelled chat commands to their nearest trigger

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,2 +1,2 @@
 [codespell]
-ignore-words-list = caf,nd,abitrate,copys,commads,quess,loacation,lcoation,wether,weahter
+ignore-words-list = caf,nd,abitrate,copys,commads,quess,loacation,lcoation,wether,weahter,locaiton,stae,comands

--- a/pkg/chatbot/fuzzy.go
+++ b/pkg/chatbot/fuzzy.go
@@ -1,0 +1,79 @@
+package chatbot
+
+import (
+	"strings"
+)
+
+// fuzzyMaxDistance returns the maximum edit distance allowed when fuzzy-
+// matching an input of the given rune length (including the "!"). Inputs
+// shorter than 4 runes never fuzzy-match: at that length a single edit
+// reaches too many unrelated triggers.
+func fuzzyMaxDistance(length int) int {
+	switch {
+	case length < 4:
+		return 0
+	case length <= 6:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// fuzzyLookup returns the registered command whose trigger or alias is
+// closest to command by edit distance, or nil when there is no unambiguous
+// match within fuzzyMaxDistance. Only !-prefixed triggers are considered, so
+// bare-word triggers ("hello") can't be reached by typo. A tie between two
+// *different* commands at the best distance returns nil rather than guessing
+// (e.g. "!tate" is one edit from both !date and !state).
+func (a *App) fuzzyLookup(command string) *Command {
+	maxDist := fuzzyMaxDistance(len([]rune(command)))
+	if maxDist == 0 {
+		return nil
+	}
+
+	var best *Command
+	bestDist := maxDist + 1
+	ambiguous := false
+	for trigger, cmd := range a.singleWordLookup {
+		if !strings.HasPrefix(trigger, "!") {
+			continue
+		}
+		dist := levenshtein(command, trigger)
+		if dist > maxDist {
+			continue
+		}
+		switch {
+		case dist < bestDist:
+			best, bestDist, ambiguous = cmd, dist, false
+		case dist == bestDist && cmd != best:
+			ambiguous = true
+		}
+	}
+	if ambiguous {
+		return nil
+	}
+	return best
+}
+
+// levenshtein returns the edit distance (insertions, deletions,
+// substitutions) between two strings, comparing rune-by-rune.
+func levenshtein(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}

--- a/pkg/chatbot/fuzzy_test.go
+++ b/pkg/chatbot/fuzzy_test.go
@@ -1,0 +1,86 @@
+package chatbot
+
+import "testing"
+
+func TestLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "", 3},
+		{"!location", "!locaiton", 2}, // transposition = 2 plain-Levenshtein edits
+		{"!state", "!stae", 1},
+		{"!date", "!tate", 1},
+		{"kitten", "sitting", 3},
+	}
+	for _, c := range cases {
+		if got := levenshtein(c.a, c.b); got != c.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestFuzzyLookup_RoutesCloseTypo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"!locaiton", "!location"},
+		{"!stae", "!state"},
+		{"!comands", "!commands"},
+		{"!mils", "!miles"},
+		{"!shutdwon", "!shutdown"}, // routes, but the handler's own admin gate still applies
+	}
+	for _, c := range cases {
+		cmd := builtTestApp.fuzzyLookup(c.input)
+		if cmd == nil {
+			t.Errorf("fuzzyLookup(%q) = nil, want %s", c.input, c.want)
+			continue
+		}
+		if cmd.Trigger != c.want {
+			t.Errorf("fuzzyLookup(%q) = %s, want %s", c.input, cmd.Trigger, c.want)
+		}
+	}
+}
+
+func TestFuzzyLookup_AmbiguousTieReturnsNil(t *testing.T) {
+	// "!tate" is one edit from both !date and !state — refuse to guess
+	if cmd := builtTestApp.fuzzyLookup("!tate"); cmd != nil {
+		t.Errorf("fuzzyLookup(!tate) = %s, want nil (ambiguous)", cmd.Trigger)
+	}
+}
+
+func TestFuzzyLookup_TooFarReturnsNil(t *testing.T) {
+	if cmd := builtTestApp.fuzzyLookup("!zzzzzzz"); cmd != nil {
+		t.Errorf("fuzzyLookup(!zzzzzzz) = %s, want nil", cmd.Trigger)
+	}
+}
+
+func TestFuzzyLookup_ShortInputNeverFuzzes(t *testing.T) {
+	// "!bt" is one edit from !bot, but 3-rune inputs are excluded entirely
+	if cmd := builtTestApp.fuzzyLookup("!bt"); cmd != nil {
+		t.Errorf("fuzzyLookup(!bt) = %s, want nil (too short)", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_FuzzyRoutesWithParams(t *testing.T) {
+	cmd, params := builtTestApp.findCommand("!gotoo 42")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!goto" {
+		t.Errorf("got trigger %q, want !goto", cmd.Trigger)
+	}
+	if len(params) != 1 || params[0] != "42" {
+		t.Errorf("unexpected params: %v", params)
+	}
+}
+
+func TestFindCommand_BareWordNotFuzzyRouted(t *testing.T) {
+	// bare-word triggers ("hello") are only reachable by exact match
+	if cmd, _ := builtTestApp.findCommand("helo"); cmd != nil {
+		t.Errorf("findCommand(helo) = %s, want nil", cmd.Trigger)
+	}
+}

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -127,6 +127,15 @@ func (a *App) findCommand(message string) (*Command, []string) {
 	if cmd, ok := a.singleWordLookup[command]; ok {
 		return cmd, params
 	}
+
+	// fuzzy fallback: route close misspellings of !-prefixed commands to
+	// their nearest registered trigger (e.g. "!locaiton" -> !location)
+	if strings.HasPrefix(command, "!") {
+		if cmd := a.fuzzyLookup(command); cmd != nil {
+			slog.Info("fuzzy-routed misspelled command", "text", command, "command", cmd.Trigger)
+			return cmd, params
+		}
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## What

When an unrecognized `!`-prefixed command arrives, `findCommand` now falls back to fuzzy-matching it against the registered triggers and aliases by Levenshtein distance, so `!locaiton` runs `!location` and `!comands` runs `!commands` — no per-typo alias maintenance needed.

## Rules

- **Distance threshold scales with length**: 1 edit for inputs of 4–6 runes, 2 edits for 7+. Inputs under 4 runes never fuzzy-match (one edit reaches too many unrelated triggers at that length).
- **Ties refuse to guess**: `!tate` is one edit from both `!date` and `!state`, so it routes to neither.
- **Bare-word triggers are unreachable by typo** — only `!`-prefixed triggers participate, so `helo` doesn't greet anyone.
- **Auto-routes silently** (matching how the existing typo aliases like `!timewqrp` behave), but every fuzzy route emits a `fuzzy-routed misspelled command` log line with the typed text + resolved trigger, so mis-routes are auditable in Loki.
- Access gates are preserved: routing goes through the normal `dispatch` path, so `RequiresFollow`/`RequiresSubscriber` checks and in-handler admin gates (`!shutdown`'s "Nice try bucko") still apply.
- Per-platform command allowlists are respected by construction — the matcher only searches the indexed lookup, which excludes commands not enabled for the platform.

The existing hand-maintained typo aliases stay in place as exact matches; they can be pruned in a future pass once this has burned in.

## Testing

- Unit tests for the distance function, routing, tie-refusal, short-input exclusion, params passthrough, and bare-word exclusion.
- Existing `FuzzFindCommand` fuzz target now exercises the fuzzy path: 223k execs, no panics.
- `go vet` + gofmt clean.