### PR TITLE
ci: mirror python:3.13-slim-bookworm base image

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -49,6 +49,7 @@ jobs:
           docker.io/ubuntu:24.04 ghcr.io/adanalife/mirror/ubuntu:24.04
           docker.io/migrate/migrate:4 ghcr.io/adanalife/mirror/migrate:4
           docker.io/pgvector/pgvector:pg16 ghcr.io/adanalife/mirror/pgvector:pg16
+          docker.io/python:3.13-slim-bookworm ghcr.io/adanalife/mirror/python:3.13-slim-bookworm
           EOF
       # mirror/obs-cef-base:<ver> is also on GHCR but deliberately NOT in the
       # refresh list: its tags are immutable version pins (a CEF bump changes


### PR DESCRIPTION
Adds `python:3.13-slim-bookworm` to the weekly GHCR mirror refresh list. The one-time first copy is already pushed to `ghcr.io/adanalife/mirror/python:3.13-slim-bookworm`.

This is the base image for the upcoming `tripbot-console` service (the admin-panel split — see [#826](https://github.com/adanalife/tripbot/pull/826/changes) for the producer side).

**Two one-time UI clicks needed** (GitHub has no API for these, org packages UI → `mirror/python`):
1. Change visibility → **Public**
2. Manage Actions access → add **adanalife/tripbot** with **write** (so the weekly refresh can push)