### PR TITLE
vlc-server resumes its last-played video across restarts

### DIFF
--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -57,6 +57,13 @@ func main() {
 	// registration is skipped; HTTP remains the sole transport.
 	natsclient.Connect(c.Conf.NatsURL, "vlc-server")
 
+	// Declare the lastplayed last-value-cache stream before the first play —
+	// a core publish to a subject no stream covers is silently uncaptured.
+	// Best-effort: resume-on-restart degrades to PlayRandom without it.
+	if err := vlcServer.EnsureLastPlayedStream(shutdownCtx, natsclient.JetStream(), c.Conf.Environment); err != nil {
+		slog.Warn("lastplayed stream setup failed; resume-on-restart disabled", "err", err)
+	}
+
 	// await graceful shutdown signal
 	listenForShutdown()
 
@@ -84,7 +91,7 @@ func main() {
 		srv.Shutdown(drainCtx)
 	}()
 
-	resumeFromMarker(srv)
+	pickStartupVideo(shutdownCtx, srv)
 
 	// poll libvlc for playback stats (FPS, bitrate, dropped frames) and
 	// surface them as OTel gauges. No-op when telemetry is disabled.
@@ -109,32 +116,50 @@ func main() {
 	srv.Start(shutdownCtx)
 }
 
-// resumeFromMarker picks the startup video. If the self-heal watchdog
-// wrote a resume marker on its previous exit, play that file; otherwise
-// start fresh with a random pick. The marker is consumed on read so a
-// crash-loop doesn't pin playback to the same broken clip forever.
-func resumeFromMarker(srv *vlcServer.Server) {
+// pickStartupVideo picks the startup video, trying the most specific resume
+// signal first:
+//
+//  1. the watchdog's file marker (written just before a self-heal SIGTERM —
+//     same pod, freshest signal, consumed on read),
+//  2. the JetStream lastplayed last-value cache (survives pod restarts and
+//     reschedules; per-platform leaf so the twitch and youtube instances
+//     each resume their own clip),
+//  3. a fresh random pick.
+func pickStartupVideo(ctx context.Context, srv *vlcServer.Server) {
+	if resumeFromMarker(srv) {
+		return
+	}
+	if srv.ResumeFromLastPlayed(ctx) {
+		return
+	}
+	srv.PlayRandom()
+}
+
+// resumeFromMarker resumes from the self-heal watchdog's file marker, if one
+// exists. The marker is consumed on read so a crash-loop doesn't pin playback
+// to the same broken clip forever. Returns false when there's no marker (the
+// common case) or the marked file can't be played.
+func resumeFromMarker(srv *vlcServer.Server) bool {
 	marker := vlcServer.ResumeMarkerPath()
 	data, err := os.ReadFile(marker)
 	if err != nil {
-		srv.PlayRandom()
-		return
+		return false
 	}
 	// Remove the marker immediately so any subsequent crash falls back to
-	// PlayRandom rather than retrying the same file.
+	// the next startup pick rather than retrying the same file.
 	if rmErr := os.Remove(marker); rmErr != nil {
 		slog.Warn("failed to remove resume marker", "err", rmErr, "marker", marker)
 	}
 	basename := strings.TrimSpace(string(data))
 	if basename == "" {
-		srv.PlayRandom()
-		return
+		return false
 	}
 	slog.Info("resuming playback from watchdog marker", "video", basename, "marker", marker)
 	if err := srv.PlayVideoFile(basename); err != nil {
-		slog.Error("resume failed; falling back to PlayRandom", "err", err, "video", basename)
-		srv.PlayRandom()
+		slog.Error("marker resume failed; falling back", "err", err, "video", basename)
+		return false
 	}
+	return true
 }
 
 // initializeTelemetry brings up OpenTelemetry providers (traces, metrics,

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -99,6 +98,11 @@ func main() {
 	// SIGINT/SIGTERM.
 	srv.StartStatsPoller(shutdownCtx, 5*time.Second)
 
+	// keep the JetStream lastplayed last-value cache tracking the playback
+	// position, so a restart resumes mid-clip (at worst one interval behind).
+	// No-op publishes when NATS is off.
+	srv.StartLastPlayedTicker(shutdownCtx, 5*time.Second)
+
 	// poll the OBS WebSocket for streaming state + render/output stats.
 	go obs.PollStreamingActive(context.Background(), 30*time.Second)
 
@@ -126,7 +130,7 @@ func main() {
 //     each resume their own clip),
 //  3. a fresh random pick.
 func pickStartupVideo(ctx context.Context, srv *vlcServer.Server) {
-	if resumeFromMarker(srv) {
+	if resumeFromMarker(ctx, srv) {
 		return
 	}
 	if srv.ResumeFromLastPlayed(ctx) {
@@ -139,7 +143,7 @@ func pickStartupVideo(ctx context.Context, srv *vlcServer.Server) {
 // exists. The marker is consumed on read so a crash-loop doesn't pin playback
 // to the same broken clip forever. Returns false when there's no marker (the
 // common case) or the marked file can't be played.
-func resumeFromMarker(srv *vlcServer.Server) bool {
+func resumeFromMarker(ctx context.Context, srv *vlcServer.Server) bool {
 	marker := vlcServer.ResumeMarkerPath()
 	data, err := os.ReadFile(marker)
 	if err != nil {
@@ -150,15 +154,16 @@ func resumeFromMarker(srv *vlcServer.Server) bool {
 	if rmErr := os.Remove(marker); rmErr != nil {
 		slog.Warn("failed to remove resume marker", "err", rmErr, "marker", marker)
 	}
-	basename := strings.TrimSpace(string(data))
+	basename, posMs := vlcServer.ParseResumeMarker(data)
 	if basename == "" {
 		return false
 	}
-	slog.Info("resuming playback from watchdog marker", "video", basename, "marker", marker)
+	slog.Info("resuming playback from watchdog marker", "video", basename, "position_ms", posMs, "marker", marker)
 	if err := srv.PlayVideoFile(basename); err != nil {
 		slog.Error("marker resume failed; falling back", "err", err, "video", basename)
 		return false
 	}
+	srv.SeekToPosition(ctx, posMs)
 	return true
 }
 

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -4,6 +4,15 @@ type VlcServerConfig struct {
 	Environment string `required:"true" envconfig:"ENV"`
 	ServerType  string `default:"vlc_server"`
 
+	// Platform names which streaming platform's stack this instance feeds
+	// ("twitch" / "youtube"). Reads the same STREAM_PLATFORM env key the other
+	// per-platform images use (contract.EnvKeyStreamPlatform), so the cdk8s
+	// factory stamps one platform per instance. It scopes the lastplayed
+	// subject leaf (tripbot.<env>.vlc.lastplayed.<platform>) — every platform
+	// instance shares the env's NATS, so without it the instances would
+	// clobber each other's resume state.
+	Platform string `default:"twitch" envconfig:"STREAM_PLATFORM"`
+
 	// Verbose determines output verbosity
 	Verbose bool `default:"false" envconfig:"VERBOSE"`
 	// VlcVerbose adds extra VLC output

--- a/pkg/vlc-events/events.go
+++ b/pkg/vlc-events/events.go
@@ -55,3 +55,14 @@ type PlayFile struct {
 type Command struct {
 	Envelope
 }
+
+// LastPlayed is the payload for the lastplayed subject — the playlist
+// basename vlc-server most recently started playing. Published by vlc-server
+// itself on every successful play and read back on startup so a restarted
+// instance resumes the clip it was on. Just the basename: the playlist is
+// re-derived from disk on boot, so anything richer (state, GPS) would go
+// stale; tripbot's video.changed remains the enriched observation event.
+type LastPlayed struct {
+	Envelope
+	File string `json:"file"`
+}

--- a/pkg/vlc-events/events.go
+++ b/pkg/vlc-events/events.go
@@ -57,12 +57,17 @@ type Command struct {
 }
 
 // LastPlayed is the payload for the lastplayed subject — the playlist
-// basename vlc-server most recently started playing. Published by vlc-server
-// itself on every successful play and read back on startup so a restarted
-// instance resumes the clip it was on. Just the basename: the playlist is
-// re-derived from disk on boot, so anything richer (state, GPS) would go
-// stale; tripbot's video.changed remains the enriched observation event.
+// basename vlc-server most recently started playing, plus how far in it was.
+// Published by vlc-server itself (at clip start and on a periodic position
+// ticker) and read back on startup so a restarted instance resumes the clip —
+// and the spot — it was on. Just the basename: the playlist is re-derived
+// from disk on boot, so anything richer (state, GPS) would go stale;
+// tripbot's video.changed remains the enriched observation event.
 type LastPlayed struct {
 	Envelope
 	File string `json:"file"`
+	// PositionMs is the playback position within File in milliseconds.
+	// 0 / omitted means start-of-clip — which is also what messages published
+	// before this field existed decode to.
+	PositionMs int64 `json:"position_ms,omitempty"`
 }

--- a/pkg/vlc-events/events_test.go
+++ b/pkg/vlc-events/events_test.go
@@ -59,7 +59,7 @@ func TestPlayFileRoundTrip(t *testing.T) {
 }
 
 func TestLastPlayedRoundTrip(t *testing.T) {
-	in := LastPlayed{Envelope: NewEnvelope(), File: "2020-01-02-1234.mp4"}
+	in := LastPlayed{Envelope: NewEnvelope(), File: "2020-01-02-1234.mp4", PositionMs: 42_500}
 	b, err := json.Marshal(in)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -70,6 +70,21 @@ func TestLastPlayedRoundTrip(t *testing.T) {
 	}
 	if out.File != in.File {
 		t.Errorf("file: got %q, want %q", out.File, in.File)
+	}
+	if out.PositionMs != in.PositionMs {
+		t.Errorf("position_ms: got %d, want %d", out.PositionMs, in.PositionMs)
+	}
+}
+
+func TestLastPlayedPositionlessDecodesToClipStart(t *testing.T) {
+	// Messages published before position_ms existed must decode as 0 —
+	// start-of-clip — not error.
+	var out LastPlayed
+	if err := json.Unmarshal([]byte(`{"emitted_at":"2026-01-01T00:00:00Z","file":"a.MP4"}`), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.PositionMs != 0 {
+		t.Errorf("position_ms: got %d, want 0", out.PositionMs)
 	}
 }
 

--- a/pkg/vlc-events/events_test.go
+++ b/pkg/vlc-events/events_test.go
@@ -15,6 +15,8 @@ func TestSubjects(t *testing.T) {
 		{"play.file", PlayFileSubject("prod"), "tripbot.prod.vlc.play.file"},
 		{"skip", SkipSubject("development"), "tripbot.development.vlc.skip"},
 		{"back", BackSubject("staging"), "tripbot.staging.vlc.back"},
+		{"lastplayed", LastPlayedSubject("prod", "twitch"), "tripbot.prod.vlc.lastplayed.twitch"},
+		{"lastplayed wildcard", LastPlayedWildcard("prod"), "tripbot.prod.vlc.lastplayed.*"},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {
@@ -48,6 +50,21 @@ func TestPlayFileRoundTrip(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	var out PlayFile
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.File != in.File {
+		t.Errorf("file: got %q, want %q", out.File, in.File)
+	}
+}
+
+func TestLastPlayedRoundTrip(t *testing.T) {
+	in := LastPlayed{Envelope: NewEnvelope(), File: "2020-01-02-1234.mp4"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out LastPlayed
 	if err := json.Unmarshal(b, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/pkg/vlc-events/subjects.go
+++ b/pkg/vlc-events/subjects.go
@@ -22,3 +22,18 @@ func PlayRandomSubject(env string) string { return subject(env, "play", "random"
 func PlayFileSubject(env string) string   { return subject(env, "play", "file") }
 func SkipSubject(env string) string       { return subject(env, "skip") }
 func BackSubject(env string) string       { return subject(env, "back") }
+
+// LastPlayedSubject is the per-platform leaf vlc-server publishes its
+// now-playing state to (tripbot.<env>.vlc.lastplayed.<platform>). Unlike the
+// command subjects above this one is *state*, not a command: every platform
+// instance (vlc-twitch, vlc-youtube) shares the env's NATS, so the platform
+// leaf keeps the TRIPBOT_VLC_LASTPLAYED stream's last-value cache
+// (MaxMsgsPerSubject=1) per instance instead of the instances clobbering one
+// another — same shape as tripbot.<env>.auth.status.<platform>.
+func LastPlayedSubject(env, platform string) string {
+	return subject(env, "lastplayed") + "." + platform
+}
+
+// LastPlayedWildcard covers every platform's lastplayed leaf in env — the
+// subject filter the TRIPBOT_VLC_LASTPLAYED stream is declared with.
+func LastPlayedWildcard(env string) string { return subject(env, "lastplayed") + ".*" }

--- a/pkg/vlc-server/lastplayed.go
+++ b/pkg/vlc-server/lastplayed.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	"github.com/adanalife/tripbot/pkg/natsclient"
@@ -48,15 +49,16 @@ func EnsureLastPlayedStream(ctx context.Context, js jetstream.JetStream, env str
 	return nil
 }
 
-// publishLastPlayed publishes file as this instance's lastplayed state.
-// Fire-and-forget core publish — the stream captures it; when NATS is
-// unconfigured it's a silent no-op (matching the eventbus convention).
-func publishLastPlayed(ctx context.Context, env, platform, file string) {
+// publishLastPlayed publishes file (+ playback position) as this instance's
+// lastplayed state. Fire-and-forget core publish — the stream captures it;
+// when NATS is unconfigured it's a silent no-op (matching the eventbus
+// convention).
+func publishLastPlayed(ctx context.Context, env, platform, file string, positionMs int64) {
 	conn := natsclient.Conn()
 	if conn == nil {
 		return
 	}
-	payload, err := json.Marshal(ve.LastPlayed{Envelope: ve.NewEnvelope(), File: file})
+	payload, err := json.Marshal(ve.LastPlayed{Envelope: ve.NewEnvelope(), File: file, PositionMs: positionMs})
 	if err != nil {
 		slog.ErrorContext(ctx, "lastplayed marshal failed", "err", err, "file", file)
 		return
@@ -68,24 +70,63 @@ func publishLastPlayed(ctx context.Context, env, platform, file string) {
 }
 
 // announceLastPlayed is the config-bound wrapper playAtIndex calls on every
-// successful play. Background ctx: the playback paths (NATS handlers, startup
-// resume) don't carry a request context.
+// successful play. Position 0 — a fresh clip starts at the top; the position
+// ticker refines it from there. Background ctx: the playback paths (NATS
+// handlers, startup resume) don't carry a request context.
 func (s *Server) announceLastPlayed(file string) {
-	publishLastPlayed(context.Background(), c.Conf.Environment, c.Conf.Platform, file)
+	publishLastPlayed(context.Background(), c.Conf.Environment, c.Conf.Platform, file, 0)
 }
 
-// lastPlayedFile reads the last-value cache back: the playlist basename this
-// (env, platform) instance most recently published, or ok=false when there's
-// nothing to resume (empty stream, NATS off, or any read error — resume is
-// best-effort, so errors are logged and swallowed).
-func lastPlayedFile(ctx context.Context, js jetstream.JetStream, env, platform string) (string, bool) {
+// StartLastPlayedTicker launches a goroutine that republishes the current
+// clip + playback position every interval, so the last-value cache tracks
+// where playback is (not just which clip started). Worst case a restart
+// resumes one interval behind. Same launcher shape as StartStatsPoller.
+func (s *Server) StartLastPlayedTicker(ctx context.Context, interval time.Duration) {
+	slog.InfoContext(ctx, "starting lastplayed position ticker", "interval", interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.publishCurrentPosition(ctx)
+			}
+		}
+	}()
+}
+
+// publishCurrentPosition publishes the currently-playing file + position, or
+// quietly does nothing when playback isn't up (between clips, during boot).
+func (s *Server) publishCurrentPosition(ctx context.Context) {
+	if s.Player == nil || !s.Player.IsPlaying() {
+		return
+	}
+	file := s.currentlyPlaying()
+	if file == "" || file == "." {
+		return
+	}
+	pos, err := s.Player.MediaTime()
+	if err != nil {
+		slog.WarnContext(ctx, "lastplayed ticker: media time read failed", "err", err)
+		return
+	}
+	publishLastPlayed(ctx, c.Conf.Environment, c.Conf.Platform, file, int64(pos))
+}
+
+// lastPlayed reads the last-value cache back: the playlist basename + position
+// this (env, platform) instance most recently published, or ok=false when
+// there's nothing to resume (empty stream, NATS off, or any read error —
+// resume is best-effort, so errors are logged and swallowed).
+func lastPlayed(ctx context.Context, js jetstream.JetStream, env, platform string) (file string, positionMs int64, ok bool) {
 	if js == nil {
-		return "", false
+		return "", 0, false
 	}
 	stream, err := js.Stream(ctx, lastPlayedStreamName)
 	if err != nil {
 		slog.WarnContext(ctx, "lastplayed stream lookup failed", "err", err, "stream", lastPlayedStreamName)
-		return "", false
+		return "", 0, false
 	}
 	subj := ve.LastPlayedSubject(env, platform)
 	raw, err := stream.GetLastMsgForSubject(ctx, subj)
@@ -93,26 +134,26 @@ func lastPlayedFile(ctx context.Context, js jetstream.JetStream, env, platform s
 		if !errors.Is(err, jetstream.ErrMsgNotFound) {
 			slog.WarnContext(ctx, "lastplayed read failed", "err", err, "subject", subj)
 		}
-		return "", false
+		return "", 0, false
 	}
 	var ev ve.LastPlayed
 	if err := json.Unmarshal(raw.Data, &ev); err != nil {
 		slog.WarnContext(ctx, "lastplayed decode failed", "err", err, "subject", subj)
-		return "", false
+		return "", 0, false
 	}
 	if ev.File == "" {
-		return "", false
+		return "", 0, false
 	}
-	return ev.File, true
+	return ev.File, ev.PositionMs, true
 }
 
-// ResumeFromLastPlayed tries to resume the clip this instance was playing
-// before its last restart, read from the JetStream last-value cache. Returns
-// true when playback started; false means the caller should fall through to
-// the next startup pick (PlayRandom). A file that has since left the playlist
-// (corpus changed under the PVC) falls through too.
+// ResumeFromLastPlayed tries to resume the clip (and position) this instance
+// was playing before its last restart, read from the JetStream last-value
+// cache. Returns true when playback started; false means the caller should
+// fall through to the next startup pick (PlayRandom). A file that has since
+// left the playlist (corpus changed under the PVC) falls through too.
 func (s *Server) ResumeFromLastPlayed(ctx context.Context) bool {
-	file, ok := lastPlayedFile(ctx, natsclient.JetStream(), c.Conf.Environment, c.Conf.Platform)
+	file, posMs, ok := lastPlayed(ctx, natsclient.JetStream(), c.Conf.Environment, c.Conf.Platform)
 	if !ok {
 		return false
 	}
@@ -120,6 +161,8 @@ func (s *Server) ResumeFromLastPlayed(ctx context.Context) bool {
 		slog.WarnContext(ctx, "lastplayed resume failed; falling back", "err", err, "video", file)
 		return false
 	}
-	slog.InfoContext(ctx, "resumed playback from jetstream lastplayed", "video", file, "platform", c.Conf.Platform)
+	slog.InfoContext(ctx, "resumed playback from jetstream lastplayed",
+		"video", file, "position_ms", posMs, "platform", c.Conf.Platform)
+	s.SeekToPosition(ctx, posMs)
 	return true
 }

--- a/pkg/vlc-server/lastplayed.go
+++ b/pkg/vlc-server/lastplayed.go
@@ -1,0 +1,125 @@
+package vlcServer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	ve "github.com/adanalife/tripbot/pkg/vlc-events"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// lastPlayedStreamName is the JetStream stream holding each platform
+// instance's most recent lastplayed publish — a last-value cache keyed by
+// subject leaf (tripbot.<env>.vlc.lastplayed.<platform>), same shape as
+// TRIPBOT_AUTH. A restarted vlc-server reads its own leaf back to resume the
+// clip it was playing; instances never read each other's.
+const lastPlayedStreamName = "TRIPBOT_VLC_LASTPLAYED"
+
+// EnsureLastPlayedStream idempotently declares the lastplayed stream. Call it
+// once at startup, before the first play — a core publish to a subject no
+// stream covers is silently uncaptured, so the stream has to exist before
+// playback starts for resume-on-restart to have anything to read. No-op when
+// js is nil (NATS off / JetStream unavailable); resume then degrades to the
+// watchdog marker + PlayRandom chain.
+func EnsureLastPlayedStream(ctx context.Context, js jetstream.JetStream, env string) error {
+	if js == nil {
+		return nil
+	}
+	cfg := jetstream.StreamConfig{
+		Name:        lastPlayedStreamName,
+		Description: "Last-played video per platform vlc instance (last-value cache).",
+		Subjects:    []string{ve.LastPlayedWildcard(env)},
+		Storage:     jetstream.FileStorage,
+		Retention:   jetstream.LimitsPolicy,
+		Discard:     jetstream.DiscardOld,
+		// One retained message per subject leaf (= per platform instance):
+		// exactly the latest clip each instance started, nothing to prune.
+		MaxMsgsPerSubject: 1,
+	}
+	if _, err := js.CreateOrUpdateStream(ctx, cfg); err != nil {
+		return fmt.Errorf("ensure stream %s: %w", lastPlayedStreamName, err)
+	}
+	slog.InfoContext(ctx, "jetstream stream ensured", "stream", lastPlayedStreamName, "env", env)
+	return nil
+}
+
+// publishLastPlayed publishes file as this instance's lastplayed state.
+// Fire-and-forget core publish — the stream captures it; when NATS is
+// unconfigured it's a silent no-op (matching the eventbus convention).
+func publishLastPlayed(ctx context.Context, env, platform, file string) {
+	conn := natsclient.Conn()
+	if conn == nil {
+		return
+	}
+	payload, err := json.Marshal(ve.LastPlayed{Envelope: ve.NewEnvelope(), File: file})
+	if err != nil {
+		slog.ErrorContext(ctx, "lastplayed marshal failed", "err", err, "file", file)
+		return
+	}
+	subj := ve.LastPlayedSubject(env, platform)
+	if err := conn.Publish(subj, payload); err != nil {
+		slog.ErrorContext(ctx, "lastplayed publish failed", "err", err, "subject", subj)
+	}
+}
+
+// announceLastPlayed is the config-bound wrapper playAtIndex calls on every
+// successful play. Background ctx: the playback paths (NATS handlers, startup
+// resume) don't carry a request context.
+func (s *Server) announceLastPlayed(file string) {
+	publishLastPlayed(context.Background(), c.Conf.Environment, c.Conf.Platform, file)
+}
+
+// lastPlayedFile reads the last-value cache back: the playlist basename this
+// (env, platform) instance most recently published, or ok=false when there's
+// nothing to resume (empty stream, NATS off, or any read error — resume is
+// best-effort, so errors are logged and swallowed).
+func lastPlayedFile(ctx context.Context, js jetstream.JetStream, env, platform string) (string, bool) {
+	if js == nil {
+		return "", false
+	}
+	stream, err := js.Stream(ctx, lastPlayedStreamName)
+	if err != nil {
+		slog.WarnContext(ctx, "lastplayed stream lookup failed", "err", err, "stream", lastPlayedStreamName)
+		return "", false
+	}
+	subj := ve.LastPlayedSubject(env, platform)
+	raw, err := stream.GetLastMsgForSubject(ctx, subj)
+	if err != nil {
+		if !errors.Is(err, jetstream.ErrMsgNotFound) {
+			slog.WarnContext(ctx, "lastplayed read failed", "err", err, "subject", subj)
+		}
+		return "", false
+	}
+	var ev ve.LastPlayed
+	if err := json.Unmarshal(raw.Data, &ev); err != nil {
+		slog.WarnContext(ctx, "lastplayed decode failed", "err", err, "subject", subj)
+		return "", false
+	}
+	if ev.File == "" {
+		return "", false
+	}
+	return ev.File, true
+}
+
+// ResumeFromLastPlayed tries to resume the clip this instance was playing
+// before its last restart, read from the JetStream last-value cache. Returns
+// true when playback started; false means the caller should fall through to
+// the next startup pick (PlayRandom). A file that has since left the playlist
+// (corpus changed under the PVC) falls through too.
+func (s *Server) ResumeFromLastPlayed(ctx context.Context) bool {
+	file, ok := lastPlayedFile(ctx, natsclient.JetStream(), c.Conf.Environment, c.Conf.Platform)
+	if !ok {
+		return false
+	}
+	if err := s.PlayVideoFile(file); err != nil {
+		slog.WarnContext(ctx, "lastplayed resume failed; falling back", "err", err, "video", file)
+		return false
+	}
+	slog.InfoContext(ctx, "resumed playback from jetstream lastplayed", "video", file, "platform", c.Conf.Platform)
+	return true
+}

--- a/pkg/vlc-server/lastplayed_test.go
+++ b/pkg/vlc-server/lastplayed_test.go
@@ -31,29 +31,29 @@ func TestLastPlayedRoundTrip(t *testing.T) {
 		t.Fatalf("ensure stream: %v", err)
 	}
 
-	publishLastPlayed(ctx, env, "twitch", "wy_0001.MP4")
-	publishLastPlayed(ctx, env, "youtube", "ut_0002.MP4")
-	publishLastPlayed(ctx, env, "twitch", "wy_0003.MP4") // supersedes wy_0001
+	publishLastPlayed(ctx, env, "twitch", "wy_0001.MP4", 0)
+	publishLastPlayed(ctx, env, "youtube", "ut_0002.MP4", 90_000)
+	publishLastPlayed(ctx, env, "twitch", "wy_0003.MP4", 42_500) // supersedes wy_0001
 	if err := nc.Flush(); err != nil {
 		t.Fatalf("flush: %v", err)
 	}
 
 	// JetStream captures core publishes asynchronously; poll until the twitch
-	// leaf shows the superseding value.
-	waitLastPlayed(t, ctx, js, env, "twitch", "wy_0003.MP4")
-	waitLastPlayed(t, ctx, js, env, "youtube", "ut_0002.MP4")
+	// leaf shows the superseding value (file AND position).
+	waitLastPlayed(t, ctx, js, env, "twitch", "wy_0003.MP4", 42_500)
+	waitLastPlayed(t, ctx, js, env, "youtube", "ut_0002.MP4", 90_000)
 
 	// A platform that never published has nothing to resume.
-	if file, ok := lastPlayedFile(ctx, js, env, "kick"); ok {
-		t.Errorf("lastPlayedFile for unpublished platform = %q, want ok=false", file)
+	if file, _, ok := lastPlayed(ctx, js, env, "kick"); ok {
+		t.Errorf("lastPlayed for unpublished platform = %q, want ok=false", file)
 	}
 }
 
 // TestLastPlayedNilJetStream proves the read path degrades to "nothing to
 // resume" when NATS is unconfigured.
 func TestLastPlayedNilJetStream(t *testing.T) {
-	if file, ok := lastPlayedFile(context.Background(), nil, "testing", "twitch"); ok {
-		t.Errorf("lastPlayedFile with nil js = %q, want ok=false", file)
+	if file, _, ok := lastPlayed(context.Background(), nil, "testing", "twitch"); ok {
+		t.Errorf("lastPlayed with nil js = %q, want ok=false", file)
 	}
 	if err := EnsureLastPlayedStream(context.Background(), nil, "testing"); err != nil {
 		t.Errorf("EnsureLastPlayedStream with nil js = %v, want nil", err)
@@ -89,17 +89,18 @@ func connectEmbeddedJetStream(t *testing.T) *nats.Conn {
 }
 
 // waitLastPlayed polls the last-value cache until the platform leaf reads
-// want, or fails after a short deadline.
-func waitLastPlayed(t *testing.T, ctx context.Context, js jetstream.JetStream, env, platform, want string) {
+// wantFile at wantPos, or fails after a short deadline.
+func waitLastPlayed(t *testing.T, ctx context.Context, js jetstream.JetStream, env, platform, wantFile string, wantPos int64) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
-	var got string
+	var gotFile string
+	var gotPos int64
 	var ok bool
 	for time.Now().Before(deadline) {
-		if got, ok = lastPlayedFile(ctx, js, env, platform); ok && got == want {
+		if gotFile, gotPos, ok = lastPlayed(ctx, js, env, platform); ok && gotFile == wantFile && gotPos == wantPos {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("lastplayed %s/%s = %q (ok=%v), want %q", env, platform, got, ok, want)
+	t.Fatalf("lastplayed %s/%s = %q@%d (ok=%v), want %q@%d", env, platform, gotFile, gotPos, ok, wantFile, wantPos)
 }

--- a/pkg/vlc-server/lastplayed_test.go
+++ b/pkg/vlc-server/lastplayed_test.go
@@ -1,0 +1,105 @@
+package vlcServer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// TestLastPlayedRoundTrip proves the resume-on-restart store end to end
+// against an embedded JetStream server: each platform leaf keeps exactly the
+// latest publish (last-value cache), and the leaves don't clobber each other.
+func TestLastPlayedRoundTrip(t *testing.T) {
+	nc := connectEmbeddedJetStream(t)
+	natsclient.SetConn(nc)
+	t.Cleanup(func() { natsclient.SetConn(nil) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	const env = "testing"
+	js := natsclient.JetStream()
+	if js == nil {
+		t.Fatal("JetStream() returned nil against a JetStream-enabled server")
+	}
+	if err := EnsureLastPlayedStream(ctx, js, env); err != nil {
+		t.Fatalf("ensure stream: %v", err)
+	}
+
+	publishLastPlayed(ctx, env, "twitch", "wy_0001.MP4")
+	publishLastPlayed(ctx, env, "youtube", "ut_0002.MP4")
+	publishLastPlayed(ctx, env, "twitch", "wy_0003.MP4") // supersedes wy_0001
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// JetStream captures core publishes asynchronously; poll until the twitch
+	// leaf shows the superseding value.
+	waitLastPlayed(t, ctx, js, env, "twitch", "wy_0003.MP4")
+	waitLastPlayed(t, ctx, js, env, "youtube", "ut_0002.MP4")
+
+	// A platform that never published has nothing to resume.
+	if file, ok := lastPlayedFile(ctx, js, env, "kick"); ok {
+		t.Errorf("lastPlayedFile for unpublished platform = %q, want ok=false", file)
+	}
+}
+
+// TestLastPlayedNilJetStream proves the read path degrades to "nothing to
+// resume" when NATS is unconfigured.
+func TestLastPlayedNilJetStream(t *testing.T) {
+	if file, ok := lastPlayedFile(context.Background(), nil, "testing", "twitch"); ok {
+		t.Errorf("lastPlayedFile with nil js = %q, want ok=false", file)
+	}
+	if err := EnsureLastPlayedStream(context.Background(), nil, "testing"); err != nil {
+		t.Errorf("EnsureLastPlayedStream with nil js = %v, want nil", err)
+	}
+}
+
+// connectEmbeddedJetStream starts an in-process JetStream-enabled nats-server
+// on a random port with a temp store dir and returns a client connection.
+// (Same fixture shape as pkg/server's hub_jetstream_test.)
+func connectEmbeddedJetStream(t *testing.T) *nats.Conn {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{
+		Host:      "127.0.0.1",
+		Port:      -1,
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("new nats server: %v", err)
+	}
+	go ns.Start()
+	if !ns.ReadyForConnections(10 * time.Second) {
+		t.Fatal("embedded nats server not ready")
+	}
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := nats.Connect(ns.ClientURL())
+	if err != nil {
+		t.Fatalf("connect to embedded server: %v", err)
+	}
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+// waitLastPlayed polls the last-value cache until the platform leaf reads
+// want, or fails after a short deadline.
+func waitLastPlayed(t *testing.T, ctx context.Context, js jetstream.JetStream, env, platform, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var got string
+	var ok bool
+	for time.Now().Before(deadline) {
+		if got, ok = lastPlayedFile(ctx, js, env, platform); ok && got == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("lastplayed %s/%s = %q (ok=%v), want %q", env, platform, got, ok, want)
+}

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/rand"
 	"path/filepath"
 	"time"
@@ -114,9 +115,12 @@ func shouldSeekTo(positionMs, lengthMs int64) bool {
 // while we seek; the one-time discontinuity lands at boot, when the OBS
 // ffmpeg_source is reconnecting anyway.
 func (s *Server) SeekToPosition(ctx context.Context, positionMs int64) {
-	if positionMs <= 0 || s.Player == nil {
+	// The upper bound rejects garbage input (no clip runs ~24.8 days) and
+	// makes the int64→int conversion safe where int is 32 bits.
+	if positionMs <= 0 || positionMs > math.MaxInt32 || s.Player == nil {
 		return
 	}
+	seekToMs := int(positionMs)
 	go func() {
 		deadline := time.Now().Add(seekSettleTimeout)
 		for !s.Player.IsPlaying() {
@@ -138,7 +142,7 @@ func (s *Server) SeekToPosition(ctx context.Context, positionMs int64) {
 				"position_ms", positionMs, "length_ms", lengthMs)
 			return
 		}
-		if err := s.Player.SetMediaTime(int(positionMs)); err != nil {
+		if err := s.Player.SetMediaTime(seekToMs); err != nil {
 			slog.WarnContext(ctx, "resume seek failed; continuing from clip start", "err", err, "position_ms", positionMs)
 			return
 		}

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -1,11 +1,13 @@
 package vlcServer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
 	"path/filepath"
+	"time"
 )
 
 // TODO: should we handle the case where index is outside range?
@@ -76,6 +78,72 @@ func (s *Server) PlayRandom() error {
 
 	// start playing the media
 	return s.playAtIndex(random)
+}
+
+// seekTailGuardMs keeps a resume-seek from landing in the last moments of a
+// clip — seeking to (or past) the end would make the list player roll
+// straight over to the next clip, which reads as a glitch, not a resume.
+const seekTailGuardMs = 2000
+
+// seekSettleTimeout bounds how long SeekToPosition waits for libvlc to reach
+// Playing state before giving up. Clips load in well under a second locally;
+// the headroom covers cold NFS reads.
+const seekSettleTimeout = 5 * time.Second
+
+// shouldSeekTo reports whether resuming at positionMs is worthwhile given the
+// clip's length. Pure so the guard is unit-testable without libvlc. Unknown
+// length (lengthMs <= 0, e.g. media not parsed yet) errs toward seeking —
+// libvlc clamps overshoots.
+func shouldSeekTo(positionMs, lengthMs int64) bool {
+	if positionMs <= 0 {
+		return false
+	}
+	if lengthMs > 0 && positionMs >= lengthMs-seekTailGuardMs {
+		return false
+	}
+	return true
+}
+
+// SeekToPosition seeks the currently-loading clip to positionMs once libvlc
+// actually reaches Playing state — a seek issued during Opening is silently
+// ignored, so the wait is load-bearing. Runs async (resume happens during
+// boot; blocking here would delay the HTTP listener) and is best-effort: on
+// timeout or error playback simply continues from the top of the clip.
+//
+// Burn-in note: the clip is being re-streamed through the RTSP sout chain
+// while we seek; the one-time discontinuity lands at boot, when the OBS
+// ffmpeg_source is reconnecting anyway.
+func (s *Server) SeekToPosition(ctx context.Context, positionMs int64) {
+	if positionMs <= 0 || s.Player == nil {
+		return
+	}
+	go func() {
+		deadline := time.Now().Add(seekSettleTimeout)
+		for !s.Player.IsPlaying() {
+			if time.Now().After(deadline) {
+				slog.WarnContext(ctx, "resume seek skipped: player never reached Playing", "position_ms", positionMs)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+		// MediaLength can read 0 until the demuxer settles; it's only a
+		// guard, so take whatever it says at this point.
+		lengthMs, _ := s.Player.MediaLength()
+		if !shouldSeekTo(positionMs, int64(lengthMs)) {
+			slog.InfoContext(ctx, "resume seek skipped: position at clip tail",
+				"position_ms", positionMs, "length_ms", lengthMs)
+			return
+		}
+		if err := s.Player.SetMediaTime(int(positionMs)); err != nil {
+			slog.WarnContext(ctx, "resume seek failed; continuing from clip start", "err", err, "position_ms", positionMs)
+			return
+		}
+		slog.InfoContext(ctx, "resumed playback position", "position_ms", positionMs, "length_ms", lengthMs)
+	}()
 }
 
 func (s *Server) getIndex(vidStr string) int {

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -12,7 +12,16 @@ import (
 // or just explicitly pass in what we get here?
 func (s *Server) playAtIndex(index int) error {
 	// start playing the media
-	return s.Playlist.PlayAtIndex(uint(index))
+	if err := s.Playlist.PlayAtIndex(uint(index)); err != nil {
+		return err
+	}
+	// Every playback path (random / file / skip / back) funnels through here,
+	// so this is the one spot that keeps the JetStream last-value cache
+	// current for resume-on-restart. No-op when NATS is off.
+	if index >= 0 && index < len(s.VideoFiles) {
+		s.announceLastPlayed(s.VideoFiles[index])
+	}
+	return nil
 }
 
 // PlayVideoFile plays a video file in the playlist by basename. Returns

--- a/pkg/vlc-server/playback_test.go
+++ b/pkg/vlc-server/playback_test.go
@@ -43,3 +43,27 @@ func TestNextIndexAlwaysInRange(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldSeekTo(t *testing.T) {
+	tests := []struct {
+		name               string
+		positionMs, length int64
+		want               bool
+	}{
+		{"zero position never seeks", 0, 600_000, false},
+		{"negative position never seeks", -5, 600_000, false},
+		{"mid-clip seeks", 300_000, 600_000, true},
+		{"unknown length errs toward seeking", 300_000, 0, true},
+		{"position inside tail guard skipped", 599_000, 600_000, false},
+		{"position exactly at guard boundary skipped", 598_000, 600_000, false},
+		{"position just before guard seeks", 597_999, 600_000, true},
+		{"position past end skipped", 700_000, 600_000, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSeekTo(tt.positionMs, tt.length); got != tt.want {
+				t.Fatalf("shouldSeekTo(%d, %d) = %v, want %v", tt.positionMs, tt.length, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/vlc-server/watchdog.go
+++ b/pkg/vlc-server/watchdog.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -34,6 +35,28 @@ const resumeMarkerName = "vlc-server-resume-from.txt"
 // pidfile.
 func ResumeMarkerPath() string {
 	return filepath.Join(c.Conf.RunDir, resumeMarkerName)
+}
+
+// formatResumeMarker renders the marker file content: the basename on the
+// first line, the playback position (ms) on the second. Two lines rather
+// than one delimited line so the original basename-only format stays a valid
+// prefix of the new one.
+func formatResumeMarker(file string, positionMs int64) []byte {
+	return []byte(file + "\n" + strconv.FormatInt(positionMs, 10) + "\n")
+}
+
+// ParseResumeMarker decodes marker file content. The position line is
+// optional (markers written before positions existed have only the
+// basename); a missing or malformed position decodes as 0 = start of clip.
+func ParseResumeMarker(data []byte) (file string, positionMs int64) {
+	lines := strings.SplitN(strings.TrimSpace(string(data)), "\n", 2)
+	file = strings.TrimSpace(lines[0])
+	if len(lines) > 1 {
+		if ms, err := strconv.ParseInt(strings.TrimSpace(lines[1]), 10, 64); err == nil && ms > 0 {
+			positionMs = ms
+		}
+	}
+	return file, positionMs
 }
 
 // probeRTSPDescribe sends a single RTSP DESCRIBE to the local listener and
@@ -133,11 +156,18 @@ func (s *Server) triggerSelfHeal(ctx context.Context) {
 	if current == "" {
 		slog.WarnContext(ctx, "RTSP self-heal: no current video; skipping marker write", "marker", marker)
 	} else {
+		// Best-effort position capture — the player is mid-failure, so a
+		// read error just means the respawn resumes from the clip's start.
+		var posMs int64
+		if ms, err := s.Player.MediaTime(); err == nil {
+			posMs = int64(ms)
+		}
 		slog.ErrorContext(ctx, "RTSP self-heal: persisting resume marker and signaling SIGTERM",
 			"resume_from", current,
+			"position_ms", posMs,
 			"marker", marker,
 		)
-		if err := os.WriteFile(marker, []byte(current), 0o644); err != nil {
+		if err := os.WriteFile(marker, formatResumeMarker(current, posMs), 0o644); err != nil {
 			slog.ErrorContext(ctx, "failed to write resume marker", "err", err, "marker", marker)
 		}
 	}

--- a/pkg/vlc-server/watchdog_test.go
+++ b/pkg/vlc-server/watchdog_test.go
@@ -65,3 +65,28 @@ func TestProbeRTSPDescribe_NoListener(t *testing.T) {
 		t.Fatalf("expected dial error, got: %v", err)
 	}
 }
+
+func TestResumeMarkerRoundTrip(t *testing.T) {
+	file, pos := ParseResumeMarker(formatResumeMarker("wy_0042.MP4", 123_456))
+	if file != "wy_0042.MP4" || pos != 123_456 {
+		t.Fatalf("round-trip = %q@%d, want wy_0042.MP4@123456", file, pos)
+	}
+}
+
+func TestParseResumeMarkerLegacyBasenameOnly(t *testing.T) {
+	// Markers written before positions existed carry only the basename.
+	file, pos := ParseResumeMarker([]byte("wy_0042.MP4\n"))
+	if file != "wy_0042.MP4" || pos != 0 {
+		t.Fatalf("legacy parse = %q@%d, want wy_0042.MP4@0", file, pos)
+	}
+}
+
+func TestParseResumeMarkerMalformedPosition(t *testing.T) {
+	file, pos := ParseResumeMarker([]byte("wy_0042.MP4\nnot-a-number\n"))
+	if file != "wy_0042.MP4" || pos != 0 {
+		t.Fatalf("malformed-position parse = %q@%d, want wy_0042.MP4@0", file, pos)
+	}
+	if f, p := ParseResumeMarker(nil); f != "" || p != 0 {
+		t.Fatalf("empty parse = %q@%d, want \"\"@0", f, p)
+	}
+}


### PR DESCRIPTION
## What

When a vlc-server instance restarts, it now resumes the video it was playing instead of starting on a random clip.

- New per-platform subject `tripbot.<env>.vlc.lastplayed.<platform>` + `LastPlayed` payload in `pkg/vlc-events`.
- New `TRIPBOT_VLC_LASTPLAYED` JetStream stream — a last-value cache (`MaxMsgsPerSubject: 1`), same shape as `TRIPBOT_AUTH`. The per-platform leaf matters because the twitch and youtube vlc instances share the one per-env NATS; each resumes its own clip.
- vlc-server publishes on every successful play: random/file/skip/back all funnel through `playAtIndex`, so that's the single hook point.
- Startup pick order: watchdog file marker (same-pod self-heal, consumed on read) → JetStream lastplayed (survives pod restarts/reschedules) → `PlayRandom`. Every step degrades gracefully (NATS off, empty stream, file no longer in the playlist).
- **Position resume**: `LastPlayed` carries `position_ms`; a 5s ticker republishes file + `MediaTime()` into the last-value cache, so a restart resumes mid-clip (at worst one interval behind). On resume, `SeekToPosition` waits for libvlc to reach Playing (seeks during Opening are silently ignored), skips the seek if the position lands in the clip's final 2s (instant rollover would read as a glitch), then `SetMediaTime`. The watchdog marker carries a position line too (old basename-only markers still parse).
- `VlcServerConfig` gains `STREAM_PLATFORM` (same contract key tripbot/OBS use, default `twitch`); the sibling [infra#717](https://github.com/adanalife/infra/pull/717/changes) stamps it from the cdk8s vlc factory.

## Burn-in note

Seeking happens inside the RTSP sout chain — a one-time output discontinuity at boot, when OBS's ffmpeg_source is reconnecting anyway. Worth watching on stage before this rides a release.

## Testing

- End-to-end round-trip test against an embedded JetStream nats-server: per-platform last-value semantics (superseding publish wins, leaves don't clobber each other, unpublished platform → nothing to resume).
- Nil-JetStream degradation tests.
- Full suite green via `task test:macos`.


- Seek tail-guard table test, marker format round-trip (incl. legacy basename-only markers), positionless-payload decode test.