### PR TITLE
refactor: drop hand-registered typo aliases now covered by the fuzzy router

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,3 +1,5 @@
 [codespell]
-# commads/quess/loacation/lcoation stay: CHANGELOG.md's historical #466 entry quotes them
+# abitrate/commads/quess/loacation/lcoation: quoted in CHANGELOG.md's historical #466 entry.
+# copys: obs-base.yml says "COPYs" (editing that file would trigger the 90-min CEF rebake).
+# locaiton/stae/comands: used by the fuzzy-router tests.
 ignore-words-list = caf,nd,abitrate,copys,commads,quess,loacation,lcoation,locaiton,stae,comands

--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,2 +1,3 @@
 [codespell]
-ignore-words-list = caf,nd,abitrate,copys,locaiton,stae,comands
+# commads/quess/loacation/lcoation stay: CHANGELOG.md's historical #466 entry quotes them
+ignore-words-list = caf,nd,abitrate,copys,commads,quess,loacation,lcoation,locaiton,stae,comands

--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,2 +1,2 @@
 [codespell]
-ignore-words-list = caf,nd,abitrate,copys,commads,quess,loacation,lcoation,wether,weahter,locaiton,stae,comands
+ignore-words-list = caf,nd,abitrate,copys,locaiton,stae,comands

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode"
 
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -28,9 +29,19 @@ func incChatCommandCounter(command string) {
 // `¡` (U+00A1, two bytes in UTF-8: 0xC2 0xA1) to a regular `!` so that
 // Spanish-keyboard users (who type `¡` where US keyboards type `!`) can run
 // commands without switching layouts. e.g. `¡miles` -> `!miles`.
+//
+// A leading `1` (the unshifted `!` on US keyboards) is rewritten the same
+// way, but only when a letter follows — messages that genuinely start with a
+// number ("100 miles", "10/10") must not turn into command lookups.
+// e.g. `1location` -> `!location`.
 func normalizeCommandPrefix(msg string) string {
 	if strings.HasPrefix(msg, "¡") {
 		return "!" + strings.TrimPrefix(msg, "¡")
+	}
+	if rest := strings.TrimPrefix(msg, "1"); rest != msg && rest != "" {
+		if r := []rune(rest)[0]; unicode.IsLetter(r) {
+			return "!" + rest
+		}
 	}
 	return msg
 }

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -37,6 +37,31 @@ func TestNormalizeCommandPrefix(t *testing.T) {
 			want: "say ¡hola",
 		},
 		{
+			name: "leading 1 before a letter is rewritten to !",
+			in:   "1location",
+			want: "!location",
+		},
+		{
+			name: "leading 1 with params is rewritten to !",
+			in:   "1goto 42",
+			want: "!goto 42",
+		},
+		{
+			name: "number-leading message is untouched",
+			in:   "100 miles",
+			want: "100 miles",
+		},
+		{
+			name: "1 followed by punctuation is untouched",
+			in:   "10/10",
+			want: "10/10",
+		},
+		{
+			name: "bare 1 is untouched",
+			in:   "1",
+			want: "1",
+		},
+		{
 			name: "empty string is untouched",
 			in:   "",
 			want: "",
@@ -134,6 +159,24 @@ func TestFindCommand_InvertedBangRoutes(t *testing.T) {
 	}
 	if cmd.Trigger != "!miles" {
 		t.Errorf("got trigger %q, want !miles", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_DigitOnePrefixRoutes(t *testing.T) {
+	// 1location should route to the same command as !location
+	cmd, _ := builtTestApp.findCommand("1location")
+	if cmd == nil {
+		t.Fatal("expected a command, got nil")
+	}
+	if cmd.Trigger != "!location" {
+		t.Errorf("got trigger %q, want !location", cmd.Trigger)
+	}
+}
+
+func TestFindCommand_NumberLeadingMessageDoesNotRoute(t *testing.T) {
+	// a message that genuinely starts with a number must not become a command
+	if cmd, _ := builtTestApp.findCommand("100 miles"); cmd != nil {
+		t.Errorf("findCommand(\"100 miles\") = %s, want nil", cmd.Trigger)
 	}
 }
 

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -199,10 +199,9 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger: "!location",
-			// "1location" stays: fuzzyLookup only fires on "!"-prefixed
-			// tokens, so the digit-prefix typo can't reach it. "!loclistion"
-			// stays too: 3 edits from !location, beyond fuzzyLookup's max of 2
-			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loc", "!loclistion", "1location"},
+			// "!loclistion" stays: 3 edits from !location, beyond
+			// fuzzyLookup's max of 2
+			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loc", "!loclistion"},
 			Handler:        a.locationCmd,
 			RequiresFollow: true,
 		},

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -38,7 +38,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!timewarp",
-			Aliases:        []string{"!timewrap", "!timeskip", "!tw", "!timewqrp", "!warp"},
+			Aliases:        []string{"!timeskip", "!tw", "!warp"},
 			Handler:        a.timewarpCmd,
 			RequiresFollow: true,
 		},
@@ -117,7 +117,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger: "!commands",
-			Aliases: []string{"!command", "¡command", "¡commands", "!commads", "!controls", "!commande"},
+			Aliases: []string{"!command", "!controls"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {
 				a.Chat.Say("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, !song, and many other hidden commands!")
 			},
@@ -129,31 +129,31 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!sunset",
-			Aliases:        []string{"!sunet"},
 			Handler:        a.sunsetCmd,
 			RequiresFollow: true,
 		},
 		{
 			Trigger:        "!weather",
-			Aliases:        []string{"!wether", "!weahter", "!meteo"},
+			Aliases:        []string{"!meteo"},
 			Handler:        a.weatherCmd,
 			RequiresFollow: true,
 		},
 		{
 			Trigger:        "!time",
-			Aliases:        []string{"!timr"},
 			Handler:        a.timeCmd,
 			RequiresFollow: true,
 		},
 		{
 			Trigger:        "!date",
-			Aliases:        []string{"!datw", "is this live", "is this live?"},
+			Aliases:        []string{"is this live", "is this live?"},
 			Handler:        a.dateCmd,
 			RequiresFollow: true,
 		},
 		{
-			Trigger:        "!guess",
-			Aliases:        []string{"!guss", "guess", "!gusss", "!guees", "!gues", "!quess", "!guis"},
+			Trigger: "!guess",
+			// "!guis" stays: it's 2 edits from !guess, beyond fuzzyLookup's
+			// reach at that length (max 1 edit for inputs of 4-6 runes)
+			Aliases:        []string{"guess", "!guis"},
 			Handler:        a.guessCmd,
 			RequiresFollow: true,
 		},
@@ -198,14 +198,17 @@ func (a *App) buildRegistry() []Command {
 			RequiresFollow: true,
 		},
 		{
-			Trigger:        "!location",
-			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loacation", "!loation", "!loc", "!locatioin", "!locatoion", "!locaton", "!loclistion", "!locton", "1location", "¡location", "!locatiom", "!location!", "!locatio", "!lcoation", "!ocation"},
+			Trigger: "!location",
+			// "1location" stays: fuzzyLookup only fires on "!"-prefixed
+			// tokens, so the digit-prefix typo can't reach it. "!loclistion"
+			// stays too: 3 edits from !location, beyond fuzzyLookup's max of 2
+			Aliases:        []string{"!tripbot", "!city", "!town", "!where", "!loc", "!loclistion", "1location"},
 			Handler:        a.locationCmd,
 			RequiresFollow: true,
 		},
 		{
 			Trigger:        "!leaderboard",
-			Aliases:        []string{"!monthlyleaderboard", "!lb", "!mlb", "!leaderbord", "!leaderborad", "!ldb", "!ldbd"},
+			Aliases:        []string{"!monthlyleaderboard", "!lb", "!mlb", "!ldb", "!ldbd"},
 			Handler:        a.monthlyMilesLeaderboardCmd,
 			RequiresFollow: true,
 		},


### PR DESCRIPTION
## What

Removes the typo aliases that accumulated in the command registry over the years — they're redundant now that the fuzzy router ([#827](https://github.com/adanalife/tripbot/pull/827/changes)) routes close misspellings automatically. Also extends `normalizeCommandPrefix` to cover the digit-1 prefix, and prunes the codespell custom dictionary.

**Removed (31):** `!timewrap`, `!timewqrp`, `¡command`, `¡commands`, `!commads`, `!commande`, `!sunet`, `!wether`, `!weahter`, `!timr`, `!datw`, `!guss`, `!gusss`, `!guees`, `!gues`, `!quess`, `!loacation`, `!loation`, `!locatioin`, `!locatoion`, `!locaton`, `!locton`, `¡location`, `!locatiom`, `!location!`, `!locatio`, `!lcoation`, `!ocation`, `!leaderbord`, `!leaderborad`, `1location`

Every removed typo was verified (via a throwaway test against `findCommand`) to still resolve to the same command. The `¡`-prefixed forms are covered by `normalizeCommandPrefix`; the rest ride the fuzzy fallback.

## Digit-1 prefix normalization

`1` is the unshifted `!` on US keyboards, so `normalizeCommandPrefix` now rewrites a leading `1` the same way as `¡` — but only when a letter follows, so number-leading chat (`100 miles`, `10/10`) is untouched. This retires the hand-registered `1location` alias and gives every command its `1`-prefix form for free, including combined typos via fuzzy (`1locaton` → `!location`). Unit tests cover the rewrite, the guard cases, and end-to-end routing.

**Kept (2), with comments explaining why:**
- `!guis` — 2 edits from `!guess`, over the fuzzy router's 1-edit cap for short inputs
- `!loclistion` — 3 edits from `!location`, over the 2-edit cap

Deliberate alternate names (`!warp`, `!meteo`, `!controls`, `!loc`, bare `guess`, etc.) are untouched.

## Codespell dictionary

Only `wether`/`weahter` actually come out. The rest of the stale-looking entries are load-bearing, now documented in `.codespellrc`:
- `abitrate`/`commads`/`quess`/`loacation`/`lcoation` — quoted verbatim in the [#466](https://github.com/adanalife/tripbot/pull/466/changes) CHANGELOG entry (frozen history)
- `copys` — `obs-base.yml`'s header says "COPYs"; rewording that file would trigger the 90-min CEF rebake on merge (its push `paths` filter includes the workflow itself)
- `locaiton`/`stae`/`comands` — used by the fuzzy-router tests

## Testing

`pkg/chatbot` green incl. new prefix tests; `codespell --config .github/linters/.codespellrc` clean locally over `.github/`, `pkg/chatbot/`, CHANGELOG, README; gofmt + vet clean.