### PR TITLE
Rotate the periodic leaderboard onscreen across miles + guess boards

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -685,15 +685,14 @@ func (t *Tripbot) scheduleBackgroundJobs() {
 	if !platformIsTwitch() {
 		// Twitch-sourced jobs stay off non-Twitch instances: session/presence
 		// tracking reads Twitch chatters (YouTube presence is punted in v1),
-		// the guess leaderboard backs an excluded command, the subscriber /
+		// the leaderboards back excluded commands, the subscriber /
 		// follower polls hit Helix, and the token-refresh job dereferences the
 		// IRC client this instance never constructs.
 		return
 	}
-	onscreensCli := onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment)
 	t.addJob(61*time.Second, "users.UpdateSession", t.sessions.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
-	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
+	t.addJob(5*time.Minute, "chatbot.ShowRotatingLeaderboard", t.app.ShowRotatingLeaderboard)
 	t.addJob(5*time.Minute, "users.PrintCurrentSession", t.sessions.PrintCurrentSession)
 	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
 	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -27,6 +27,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// leaderboardSize is how many rows the leaderboard commands show.
+const leaderboardSize = 10
+
 // lastHelloTime is used to rate-limit the hello command
 var lastHelloTime time.Time = time.Now()
 
@@ -284,18 +287,13 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 	slog.InfoContext(ctx, "ran !leaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
-	size := 10
-	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentMilesScoreboard(), size)
-	if size > len(leaderboard) {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
+	leaderboard := scoreboards.TopMilesRows(ctx, leaderboardSize)
 
 	// display leaderboard on screen
 	a.Onscreens.ShowLeaderboard(ctx, "Monthly Miles", leaderboard)
 
 	// build a message to send to chat
-	msg := fmt.Sprintf("Top %d miles this month: ", size)
+	msg := fmt.Sprintf("Top %d miles this month: ", len(leaderboard))
 	for i, leaderPair := range leaderboard {
 		msg += fmt.Sprintf("%d. %s (%smi)", i+1, leaderPair[0], leaderPair[1])
 		if i+1 != len(leaderboard) {
@@ -309,7 +307,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 	slog.InfoContext(ctx, "ran !totalleaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
-	size := 10
+	size := leaderboardSize
 	lifetime := a.Sessions.LifetimeLeaderboard()
 	if size > len(lifetime) {
 		size = len(lifetime)
@@ -333,27 +331,8 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !guessleaderboard", "username", user.Username)
 
-	// select users to show in leaderboard
-	size := 10
-	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
-
-	// truncate the leaderboard if necessary
-	if size > len(leaderboard) {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
-
-	// Filter zero-scorers (AddToScoreByName uses FirstOrCreate, so every
-	// user who's ever guessed has a row — many at 0 early in the month).
-	var intLeaderboard [][]string
-	for _, leaderPair := range leaderboard {
-		// guesses are ints not floats, so remove the decimal place
-		intVersion := strings.Split(leaderPair[1], ".")[0]
-		if intVersion == "0" || intVersion == "" {
-			continue
-		}
-		intLeaderboard = append(intLeaderboard, []string{leaderPair[0], intVersion})
-	}
+	// select users to show in leaderboard (zero-scorers already filtered)
+	intLeaderboard := scoreboards.TopGuessRows(ctx, leaderboardSize)
 
 	// special message if no one has any correct guesses yet
 	if len(intLeaderboard) == 0 {

--- a/pkg/chatbot/leaderboard_rotation.go
+++ b/pkg/chatbot/leaderboard_rotation.go
@@ -1,0 +1,70 @@
+package chatbot
+
+import (
+	"context"
+	"math/rand/v2"
+
+	"github.com/adanalife/tripbot/pkg/scoreboards"
+)
+
+// totalMilesOdds is the chance a given rotation tick shows the lifetime
+// "Total Miles" board; the remaining probability mass splits evenly
+// between the two monthly boards.
+const totalMilesOdds = 0.1
+
+type leaderboardKind int
+
+const (
+	guessLeaderboard leaderboardKind = iota
+	monthlyMilesLeaderboard
+	totalMilesLeaderboard
+)
+
+// pickLeaderboard maps a [0,1) roll onto a leaderboard choice.
+func pickLeaderboard(roll float64) leaderboardKind {
+	switch {
+	case roll < totalMilesOdds:
+		return totalMilesLeaderboard
+	case roll < totalMilesOdds+(1-totalMilesOdds)/2:
+		return guessLeaderboard
+	default:
+		return monthlyMilesLeaderboard
+	}
+}
+
+// ShowRotatingLeaderboard is the periodic onscreen-leaderboard job: each
+// tick it puts one of the three leaderboards on screen, chosen at random.
+func (a *App) ShowRotatingLeaderboard(ctx context.Context) {
+	a.showRotatingLeaderboard(ctx, rand.Float64())
+}
+
+// showRotatingLeaderboard takes the roll as a parameter so tests can pin
+// the choice. An empty pick (the guess board has no correct guesses early
+// in the month) falls back to monthly miles so the slot isn't wasted.
+func (a *App) showRotatingLeaderboard(ctx context.Context, roll float64) {
+	title, rows := a.fetchLeaderboard(ctx, pickLeaderboard(roll))
+	if len(rows) == 0 {
+		title, rows = a.fetchLeaderboard(ctx, monthlyMilesLeaderboard)
+	}
+	if len(rows) == 0 {
+		return
+	}
+	a.Onscreens.ShowLeaderboard(ctx, title, rows)
+}
+
+// fetchLeaderboard returns the overlay title and rows for the given kind.
+// Titles match the ones the corresponding chat commands use.
+func (a *App) fetchLeaderboard(ctx context.Context, kind leaderboardKind) (string, [][]string) {
+	switch kind {
+	case totalMilesLeaderboard:
+		rows := a.Sessions.LifetimeLeaderboard()
+		if len(rows) > leaderboardSize {
+			rows = rows[:leaderboardSize]
+		}
+		return "Total Miles", rows
+	case guessLeaderboard:
+		return "Correct Guesses This Month", scoreboards.TopGuessRows(ctx, leaderboardSize)
+	default:
+		return "Monthly Miles", scoreboards.TopMilesRows(ctx, leaderboardSize)
+	}
+}

--- a/pkg/chatbot/leaderboard_rotation.go
+++ b/pkg/chatbot/leaderboard_rotation.go
@@ -10,7 +10,7 @@ import (
 // totalMilesOdds is the chance a given rotation tick shows the lifetime
 // "Total Miles" board; the remaining probability mass splits evenly
 // between the two monthly boards.
-const totalMilesOdds = 0.1
+const totalMilesOdds = 0.05
 
 type leaderboardKind int
 

--- a/pkg/chatbot/leaderboard_rotation_test.go
+++ b/pkg/chatbot/leaderboard_rotation_test.go
@@ -16,10 +16,10 @@ func TestPickLeaderboard(t *testing.T) {
 		want leaderboardKind
 	}{
 		{0.0, totalMilesLeaderboard},
-		{0.0999, totalMilesLeaderboard},
-		{0.1, guessLeaderboard},
-		{0.5499, guessLeaderboard},
-		{0.55, monthlyMilesLeaderboard},
+		{0.0499, totalMilesLeaderboard},
+		{0.05, guessLeaderboard},
+		{0.5249, guessLeaderboard},
+		{0.525, monthlyMilesLeaderboard},
 		{0.9999, monthlyMilesLeaderboard},
 	}
 	for _, tt := range tests {
@@ -110,7 +110,7 @@ func TestShowRotatingLeaderboard_TotalMiles_TruncatesToSize(t *testing.T) {
 	}
 	app.Sessions = &recordingSessions{Leaderboard: lifetime}
 
-	app.showRotatingLeaderboard(context.Background(), 0.05) // total miles
+	app.showRotatingLeaderboard(context.Background(), 0.01) // total miles
 
 	want := fmt.Sprintf(`ShowLeaderboard("Total Miles", %d rows)`, leaderboardSize)
 	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], want) {
@@ -130,7 +130,7 @@ func TestShowRotatingLeaderboard_AllEmpty_SkipsOverlay(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"username", "value"}))
 
 	// total miles via noopSessions returns nil; the miles fallback is empty too
-	app.showRotatingLeaderboard(context.Background(), 0.05)
+	app.showRotatingLeaderboard(context.Background(), 0.01)
 
 	if len(rec.Calls) != 0 {
 		t.Errorf("expected no overlay call when every board is empty, got %v", rec.Calls)

--- a/pkg/chatbot/leaderboard_rotation_test.go
+++ b/pkg/chatbot/leaderboard_rotation_test.go
@@ -1,0 +1,141 @@
+package chatbot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+func TestPickLeaderboard(t *testing.T) {
+	tests := []struct {
+		roll float64
+		want leaderboardKind
+	}{
+		{0.0, totalMilesLeaderboard},
+		{0.0999, totalMilesLeaderboard},
+		{0.1, guessLeaderboard},
+		{0.5499, guessLeaderboard},
+		{0.55, monthlyMilesLeaderboard},
+		{0.9999, monthlyMilesLeaderboard},
+	}
+	for _, tt := range tests {
+		if got := pickLeaderboard(tt.roll); got != tt.want {
+			t.Errorf("pickLeaderboard(%v) = %v, want %v", tt.roll, got, tt.want)
+		}
+	}
+}
+
+func TestShowRotatingLeaderboard_MonthlyMiles(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	rows := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 12.5).
+		AddRow("viewer2", 3.2)
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(rows)
+
+	app.showRotatingLeaderboard(context.Background(), 0.99) // monthly miles
+
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 2 rows)`) {
+		t.Errorf("expected one Monthly Miles overlay call, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestShowRotatingLeaderboard_Guess(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	rows := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 7.0).
+		AddRow("viewer2", 0.0) // zero-scorer, filtered
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(rows)
+
+	app.showRotatingLeaderboard(context.Background(), 0.3) // guess
+
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Correct Guesses This Month", 1 rows)`) {
+		t.Errorf("expected one guess overlay call with the zero-scorer filtered, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// An empty guess board (early in the month) falls back to monthly miles
+// rather than skipping the rotation slot.
+func TestShowRotatingLeaderboard_EmptyGuess_FallsBackToMonthlyMiles(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	empty := sqlmock.NewRows([]string{"username", "value"})
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(empty)
+	miles := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 12.5)
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(miles)
+
+	app.showRotatingLeaderboard(context.Background(), 0.3) // guess → empty → miles
+
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 1 rows)`) {
+		t.Errorf("expected fallback to Monthly Miles overlay, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestShowRotatingLeaderboard_TotalMiles_TruncatesToSize(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	var lifetime [][]string
+	for i := 0; i < leaderboardSize+5; i++ {
+		lifetime = append(lifetime, []string{fmt.Sprintf("viewer%d", i), "100.0"})
+	}
+	app.Sessions = &recordingSessions{Leaderboard: lifetime}
+
+	app.showRotatingLeaderboard(context.Background(), 0.05) // total miles
+
+	want := fmt.Sprintf(`ShowLeaderboard("Total Miles", %d rows)`, leaderboardSize)
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], want) {
+		t.Errorf("expected truncated Total Miles overlay (%s), got %v", want, rec.Calls)
+	}
+}
+
+// If both the pick and the monthly-miles fallback are empty, no overlay is
+// published at all.
+func TestShowRotatingLeaderboard_AllEmpty_SkipsOverlay(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "value"}))
+
+	// total miles via noopSessions returns nil; the miles fallback is empty too
+	app.showRotatingLeaderboard(context.Background(), 0.05)
+
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected no overlay call when every board is empty, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/natsclient"
 	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
-	"github.com/adanalife/tripbot/pkg/scoreboards"
 )
 
 // Client publishes onscreens overlay commands onto NATS. Construct via
@@ -67,36 +65,6 @@ func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard 
 		Rows:     leaderboard,
 	})
 	return nil
-}
-
-// TODO: this is taken right from the !guessleaderboard command, DRY it?
-func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
-	// select users to show in leaderboard
-	size := 10
-	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
-	if size > len(leaderboard) {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
-
-	// Filter zero-scorers (AddToScoreByName uses FirstOrCreate, so every
-	// user who's ever guessed has a row — many at 0 early in the month).
-	// If the filtered list is empty, skip the overlay entirely.
-	var intLeaderboard [][]string
-	for _, leaderPair := range leaderboard {
-		// guesses are ints not floats, so remove the decimal place
-		intVersion := strings.Split(leaderPair[1], ".")[0]
-		if intVersion == "0" || intVersion == "" {
-			continue
-		}
-		intLeaderboard = append(intLeaderboard, []string{leaderPair[0], intVersion})
-	}
-	if len(intLeaderboard) == 0 {
-		return
-	}
-
-	// display leaderboard on screen
-	c.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 }
 
 func (c *Client) ShowTimewarp(ctx context.Context) error {

--- a/pkg/scoreboards/rows.go
+++ b/pkg/scoreboards/rows.go
@@ -1,0 +1,30 @@
+package scoreboards
+
+import (
+	"context"
+	"strings"
+)
+
+// TopMilesRows returns the top-N rows of the current monthly miles
+// scoreboard as [username, miles] pairs, ready for leaderboard rendering.
+func TopMilesRows(ctx context.Context, size int) [][]string {
+	return TopUsers(ctx, CurrentMilesScoreboard(), size)
+}
+
+// TopGuessRows returns the top-N rows of the current monthly guess
+// scoreboard as [username, guesses] pairs. Zero-scorers are filtered out
+// (AddToScoreByName uses FirstOrCreate, so every user who's ever guessed
+// has a row — many at 0 early in the month), and the float values are
+// rendered as ints. May return an empty slice.
+func TopGuessRows(ctx context.Context, size int) [][]string {
+	var rows [][]string
+	for _, pair := range TopUsers(ctx, CurrentGuessScoreboard(), size) {
+		// guesses are ints not floats, so remove the decimal place
+		guesses := strings.Split(pair[1], ".")[0]
+		if guesses == "0" || guesses == "" {
+			continue
+		}
+		rows = append(rows, []string{pair[0], guesses})
+	}
+	return rows
+}


### PR DESCRIPTION
## What

The 5-minute leaderboard cron only ever showed the **guess** leaderboard — the miles boards appeared on screen solely when someone ran `!leaderboard` / `!totalleaderboard` in chat. Each tick now picks at random:

- **Monthly Miles** — 47.5%
- **Correct Guesses This Month** — 47.5%
- **Total Miles** (lifetime) — 5%, the rare treat

An empty pick (the guess board has no correct guesses early in the month) falls back to monthly miles so the slot isn't wasted; if everything is empty, no overlay is published (same as today).

## How

- New `scoreboards.TopMilesRows` / `TopGuessRows` helpers centralize the fetch + zero-scorer filtering the chat commands each reimplemented.
- The job moves onto the chatbot `App` (`ShowRotatingLeaderboard`) so it reaches the overlay and the lifetime board through the injected `Onscreens`/`Sessions` interfaces — testable with the existing fakes, unlike `cmd/tripbot` (banner autoload parses flags at init).
- `onscreens-client.ShowGuessLeaderboard` — carrying a `DRY it?` TODO since it duplicated the chat command — retires with its only caller. That also drops onscreens-client's `pkg/scoreboards` (and transitively DB) dependency, which `script/collect-gps` was inheriting.

## Testing

Picker boundary tests + rotation tests (each board, guess→miles fallback, total-miles truncation, all-empty skip) via the existing sqlmock / recordingOnscreens / recordingSessions scaffolding. Full `task test:macos` suite green.