### PR TITLE
Make tripbot's chat command surface YouTube-aware

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -3,7 +3,6 @@ package chatbot
 import (
 	"context"
 	"log/slog"
-	"math/rand"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -103,6 +102,14 @@ type App struct {
 	commands         []Command
 	singleWordLookup map[string]*Command
 	multiWordLookup  map[string]*Command
+
+	// helpMessages is the platform-filtered subset of c.HelpMessages — the
+	// rotating !help / Chatter lines, minus any whose command isn't enabled on
+	// this App's platform (so a YouTube instance doesn't advertise !miles etc.).
+	// helpIndex walks it; randomized at indexCommands() so each restart starts
+	// on a different line.
+	helpMessages []string
+	helpIndex    int
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -139,10 +146,6 @@ func New() *App {
 	a.indexCommands()
 	return a
 }
-
-// used to determine which help message to display
-// randomized so it starts with a new one every restart
-var helpIndex = rand.Intn(len(c.HelpMessages))
 
 const followerMsg = "Right now only followers of the channel can run unlimited commands :)"
 const subscriberMsg = "You must be a subscriber to run that command :)"
@@ -205,13 +208,19 @@ func (a *App) ConnectIRC() *twitch.Client {
 // ctx is forward-compat plumbing — a.Chat.Say doesn't take ctx yet, so it's
 // not propagated into the chat write.
 func (a *App) Chatter(_ context.Context) {
-	// use twitch emote feature to add some color
-	a.Chat.Say("/me " + help())
+	// the "/me " twitch emote prefix adds some color on Twitch; youtubeChat.Say
+	// strips it (it would render as literal text on YouTube).
+	a.Chat.Say("/me " + a.help())
 }
 
-func help() string {
-	text := c.HelpMessages[helpIndex]
-	// bump the index
-	helpIndex = (helpIndex + 1) % len(c.HelpMessages)
+// help returns the next rotating help message for this App's platform and
+// advances the index. Empty when no help messages are enabled (guards against
+// a divide-by-zero on the modulo).
+func (a *App) help() string {
+	if len(a.helpMessages) == 0 {
+		return ""
+	}
+	text := a.helpMessages[a.helpIndex]
+	a.helpIndex = (a.helpIndex + 1) % len(a.helpMessages)
 	return text
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -45,8 +45,28 @@ const guessScoreboard = "guess_state_total"
 
 func (a *App) helpCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !help", "username", user.Username)
-	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
+	n := len(a.helpMessages)
+	// a.help() advances the index, so capture the displayed line's number first.
+	pos := a.helpIndex + 1
+	msg := fmt.Sprintf("%s (%d of %d)", a.help(), pos, n)
 	a.Chat.Say(msg)
+}
+
+// commandsCmd lists a curated set of featured commands — filtered to the ones
+// actually dispatchable on this App's platform, so a YouTube instance doesn't
+// suggest commands that would silently no-op.
+func (a *App) commandsCmd(_ context.Context, _ *users.User, _ []string) {
+	featured := []string{
+		"!location", "!guess", "!date", "!state",
+		"!sunset", "!timewarp", "!miles", "!leaderboard", "!song",
+	}
+	avail := make([]string, 0, len(featured))
+	for _, t := range featured {
+		if _, ok := a.singleWordLookup[t]; ok {
+			avail = append(avail, t)
+		}
+	}
+	a.Chat.Say("You can try: " + strings.Join(avail, ", ") + ", and many other hidden commands!")
 }
 
 func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -250,10 +250,10 @@ const (
 )
 
 // youtubeCommands is the v1 allowlist of triggers a YouTube instance runs — the
-// stateless "info + playback control" subset. Identity/miles commands (!miles,
-// !leaderboard, !guess, !state, !location, …), the Twitch-only !followage, and
-// the admin commands (!middle, !secretinfo, !shutdown, !makebot, !unbot) are
-// deliberately excluded: YouTube v1 runs no per-user state. The now-playing /
+// "info + playback control" subset, plus the !state/!location info commands.
+// Identity/miles commands (!miles, !leaderboard, !guess, …), the Twitch-only
+// !followage, and the admin commands (!middle, !secretinfo, !shutdown, !makebot,
+// !unbot) are excluded: those are per-user identity/score state. The now-playing /
 // SomaFM commands (!song, !music, !somafm) are also deferred for now — the
 // background-audio source is Twitch-stream-specific. Aliases come along with
 // their trigger, so only triggers are listed. See the YouTube provider plan.
@@ -262,6 +262,7 @@ var youtubeCommands = map[string]bool{
 	"!gas": true, "!report": true, "!flag": true,
 	// info (read current-video state only)
 	"!weather": true, "!time": true, "!date": true, "!sunset": true,
+	"!state": true, "!location": true,
 	// playback control (drives this platform's vlc pipeline)
 	"!timewarp": true, "!goto": true, "!skip": true, "!back": true,
 	// socials / static links

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -2,8 +2,10 @@ package chatbot
 
 import (
 	"context"
+	"math/rand"
 	"strings"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
@@ -118,9 +120,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "!controls"},
-			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				a.Chat.Say("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, !song, and many other hidden commands!")
-			},
+			Handler: a.commandsCmd,
 		},
 		{
 			Trigger:            "!bonusmiles",
@@ -301,6 +301,34 @@ func (a *App) indexCommands() {
 			a.registerTrigger(alias, cmd)
 		}
 	}
+	// Filter the rotating help lines to this platform, then start on a random
+	// one (so each restart opens differently). Must run after the lookups are
+	// built — enabledHelpMessages reads singleWordLookup.
+	a.helpMessages = a.enabledHelpMessages()
+	if len(a.helpMessages) > 0 {
+		a.helpIndex = rand.Intn(len(a.helpMessages))
+	}
+}
+
+// enabledHelpMessages returns c.HelpMessages minus any line whose leading
+// "!command" token isn't dispatchable on this platform — so a YouTube instance
+// never advertises a command that would silently no-op. A line that doesn't
+// start with a "!command" token is always kept.
+func (a *App) enabledHelpMessages() []string {
+	out := make([]string, 0, len(c.HelpMessages))
+	for _, msg := range c.HelpMessages {
+		fields := strings.Fields(msg)
+		if len(fields) > 0 {
+			token := strings.TrimRight(fields[0], ":")
+			if strings.HasPrefix(token, "!") {
+				if _, ok := a.singleWordLookup[token]; !ok {
+					continue // command disabled on this platform
+				}
+			}
+		}
+		out = append(out, msg)
+	}
+	return out
 }
 
 func (a *App) registerTrigger(trigger string, cmd *Command) {

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -82,7 +82,7 @@ func TestYouTubePlatformIndexesOnlyAllowlist(t *testing.T) {
 	yt.indexCommands()
 
 	// allowed: a trigger and one of its aliases both resolve
-	for _, token := range []string{"!weather", "!meteo", "!skip", "!timewarp", "!warp", "!youtube"} {
+	for _, token := range []string{"!weather", "!meteo", "!skip", "!timewarp", "!warp", "!youtube", "!state", "!location", "!where"} {
 		if cmd, _ := yt.findCommand(token); cmd == nil {
 			t.Errorf("expected %q to be available on YouTube, got nil", token)
 		}
@@ -90,7 +90,7 @@ func TestYouTubePlatformIndexesOnlyAllowlist(t *testing.T) {
 
 	// excluded: identity/miles, Twitch-only, admin, and the deferred
 	// now-playing commands do not resolve
-	for _, token := range []string{"!miles", "!km", "!leaderboard", "!guess", "!state", "!location", "!followage", "!middle", "!shutdown", "!makebot", "hello", "!song", "!music", "!somafm"} {
+	for _, token := range []string{"!miles", "!km", "!leaderboard", "!guess", "!followage", "!middle", "!shutdown", "!makebot", "hello", "!song", "!music", "!somafm"} {
 		if cmd, _ := yt.findCommand(token); cmd != nil {
 			t.Errorf("expected %q to be unavailable on YouTube, got %q", token, cmd.Trigger)
 		}

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -1,8 +1,11 @@
 package chatbot
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 )
 
 func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
@@ -94,5 +97,64 @@ func TestYouTubePlatformIndexesOnlyAllowlist(t *testing.T) {
 		if cmd, _ := yt.findCommand(token); cmd != nil {
 			t.Errorf("expected %q to be unavailable on YouTube, got %q", token, cmd.Trigger)
 		}
+	}
+}
+
+// TestCommandsCmdFiltersByPlatform verifies the !commands reply advertises only
+// commands dispatchable on the App's platform — Twitch lists the disabled-on-
+// YouTube ones (!guess, !miles, !leaderboard); YouTube does not, but still
+// includes the YouTube-enabled !state / !location.
+func TestCommandsCmdFiltersByPlatform(t *testing.T) {
+	twitch := &App{}
+	twitch.indexCommands()
+	twChat := &recordingChat{}
+	twitch.Chat = twChat
+	twitch.commandsCmd(context.Background(), nil, nil)
+	twOut := twChat.Output()
+	for _, want := range []string{"!guess", "!miles", "!leaderboard", "!state", "!location"} {
+		if !strings.Contains(twOut, want) {
+			t.Errorf("Twitch !commands missing %q: %q", want, twOut)
+		}
+	}
+
+	yt := &App{Platform: platformYouTube}
+	yt.indexCommands()
+	ytChat := &recordingChat{}
+	yt.Chat = ytChat
+	yt.commandsCmd(context.Background(), nil, nil)
+	ytOut := ytChat.Output()
+	for _, absent := range []string{"!guess", "!miles", "!leaderboard", "!song"} {
+		if strings.Contains(ytOut, absent) {
+			t.Errorf("YouTube !commands should not advertise %q: %q", absent, ytOut)
+		}
+	}
+	for _, want := range []string{"!state", "!location"} {
+		if !strings.Contains(ytOut, want) {
+			t.Errorf("YouTube !commands missing %q: %q", want, ytOut)
+		}
+	}
+}
+
+// TestEnabledHelpMessagesFiltersByPlatform verifies the rotating help lines drop
+// any whose command isn't dispatchable on the platform — so a YouTube instance
+// never advertises !miles / !guess / !leaderboard via !help or the Chatter cron.
+func TestEnabledHelpMessagesFiltersByPlatform(t *testing.T) {
+	twitch := &App{}
+	twitch.indexCommands()
+	if len(twitch.helpMessages) != len(c.HelpMessages) {
+		t.Errorf("Twitch should keep all %d help messages, got %d", len(c.HelpMessages), len(twitch.helpMessages))
+	}
+
+	yt := &App{Platform: platformYouTube}
+	yt.indexCommands()
+	for _, msg := range yt.helpMessages {
+		for _, banned := range []string{"!miles", "!guess", "!leaderboard"} {
+			if strings.HasPrefix(msg, banned) {
+				t.Errorf("YouTube help message advertises disabled %q: %q", banned, msg)
+			}
+		}
+	}
+	if len(yt.helpMessages) == 0 {
+		t.Error("YouTube help messages unexpectedly empty")
 	}
 }


### PR DESCRIPTION
Running `!state` on the YouTube stream did nothing. Root cause: YouTube runs a per-platform command allowlist (`youtubeCommands`), and non-allowlisted commands are never indexed for dispatch — so they silently no-op. On top of that, the bot *advertised* several of those disabled commands, inviting viewers to run them.

## Changes

**1. Enable `!state` + `!location` on YouTube**
They read the current video's location (`vid.State` / `vid.Location`) and show the flag overlay — the same read-current-video-state info category as the already-allowlisted `!weather` / `!time` / `!date` / `!sunset`, not the per-user identity/miles commands they were grouped with. The "no per-user state" rationale no longer holds since users/events/flags were platform-scoped (#832).

**2. Stop advertising disabled commands in chat**
- `!commands` now builds its list from a featured set filtered by the platform's indexed lookups — only dispatchable commands are shown.
- The rotating `!help` / `Chatter` lines move onto the App (`a.helpMessages` / `a.helpIndex`, populated in `indexCommands`), filtered to lines whose leading `!command` is enabled on this platform. Drops the package-level `help()`/`helpIndex`.

## Not in this PR

The **onscreens overlay** rotators (`pkg/onscreens-server/{left,right}-rotator.go`) also advertise disabled commands (`!miles`, `!guess`) and have no platform awareness. That needs platform plumbing into onscreens-server (+ infra) and is a separate PR.

## Test

`go test ./pkg/chatbot/` + `go vet` pass. New tests: `TestCommandsCmdFiltersByPlatform`, `TestEnabledHelpMessagesFiltersByPlatform`, updated `TestYouTubePlatformIndexesOnlyAllowlist`.