### PR TITLE
Platform-aware onscreens rotators with weighted selection

### DIFF
--- a/pkg/config/onscreens-server/type.go
+++ b/pkg/config/onscreens-server/type.go
@@ -28,4 +28,10 @@ type OnscreensServerConfig struct {
 	// Format: nats://nats.<env-platform-ns>.svc.cluster.local:4222.
 	// Optional — when unset, the subscriber is skipped.
 	NatsURL string `envconfig:"NATS_URL"`
+
+	// Platform names the streaming platform this onscreens instance serves
+	// ("twitch" / "youtube"). Drives per-platform rotator-message filtering so a
+	// YouTube overlay doesn't advertise Twitch-only commands. Defaults to twitch
+	// (the primary platform). Set by infra per onscreens-<platform> pod.
+	Platform string `default:"twitch" envconfig:"PLATFORM"`
 }

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -8,20 +8,22 @@ import (
 
 var leftRotatorUpdateFrequency = time.Duration(45 * time.Second)
 
-var possibleLeftMessages = []string{
-	"Crave something new? Try !timewarp",
-	"Earn miles for every minute you watch (!miles)",
-	"Follow the project elsewhere on !socialmedia",
-	"Join us on !discord",
-	"Join us on !discord",
-	"Try and !guess what state we're in",
-	"Use !commands to interact with the bot",
-	"Use !commands to interact with the bot",
-	"Where are we? (!location)",
-	// "LEADER",
-	// "Looking for artist for emotes and more",
-	// "Twitch Prime subs keep us on air :D",
-	// "Use !report to report stream issues",
+// !miles and !guess are Twitch-only (not in the YouTube command allowlist), so
+// those lines are scoped to Twitch — a YouTube overlay would otherwise advertise
+// commands that silently no-op there. Weight 2 reproduces the old duplicated
+// entries (!discord, !commands each appeared twice).
+var possibleLeftMessages = []rotatorMessage{
+	{Text: "Crave something new? Try !timewarp"},
+	{Text: "Earn miles for every minute you watch (!miles)", Platforms: []string{platformTwitch}},
+	{Text: "Follow the project elsewhere on !socialmedia"},
+	{Text: "Join us on !discord", Weight: 2},
+	{Text: "Try and !guess what state we're in", Platforms: []string{platformTwitch}},
+	{Text: "Use !commands to interact with the bot", Weight: 2},
+	{Text: "Where are we? (!location)"},
+	// {Text: "LEADER"},
+	// {Text: "Looking for artist for emotes and more"},
+	// {Text: "Twitch Prime subs keep us on air :D"},
+	// {Text: "Use !report to report stream issues"},
 }
 
 // newLeftRotator constructs the left-rotator *Onscreen, primes it with a
@@ -46,32 +48,11 @@ func leftRotatorLoop(osc *Onscreen) {
 
 // leftRotatorContent creates the content for the leftRotator
 func leftRotatorContent() string {
-	var output string
-
 	// show a special, very rare message
 	if rand.Intn(10000) == 0 {
 		return "You found the rare message! Make a clip for a prize!"
 	}
 
-	// pick a random message
-	message := possibleLeftMessages[rand.Intn(len(possibleLeftMessages))]
-
-	// some messages require custom logic
-	switch message {
-	//case "LEADER":
-	//	//TODO: maybe turn this into a call to tripbot?
-	//	if len(users.Leaderboard) == 0 {
-	//		terrors.Log(errors.New("leaderboard empty"), "")
-	//		// just use the default value
-	//		output = message
-	//		break
-	//	}
-	//	// get the first leader in the leaderboard
-	//	leader := users.Leaderboard[:1][0]
-	//	output = fmt.Sprintf("%s is leader with %s miles (!leaderboard)", leader[0], leader[1])
-	default:
-		output = message
-	}
-
-	return output
+	// pick a weighted-random message for this platform
+	return pickRotatorMessage(possibleLeftMessages)
 }

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -2,19 +2,18 @@ package onscreensServer
 
 import (
 	"log/slog"
-	"math/rand"
 	"time"
 )
 
 var rightRotatorUpdateFrequency = time.Duration(90 * time.Second)
 
-var possibleRightMessages = []string{
-	"Don't forget to follow :)",
-	"Don't forget to follow :)",
-	"Try running !location",
-	"Try running !location",
-	"Try running !timewarp",
-	"Streaming 24 hours a day",
+// All right-rotator lines are platform-neutral (!location and !timewarp are both
+// in the YouTube allowlist). Weight 2 reproduces the old duplicated entries.
+var possibleRightMessages = []rotatorMessage{
+	{Text: "Don't forget to follow :)", Weight: 2},
+	{Text: "Try running !location", Weight: 2},
+	{Text: "Try running !timewarp"},
+	{Text: "Streaming 24 hours a day"},
 }
 
 // newRightRotator constructs the right-rotator *Onscreen, primes it with
@@ -39,10 +38,6 @@ func rightRotatorLoop(osc *Onscreen) {
 
 // rightRotatorContent creates the content for the rightRotator
 func rightRotatorContent() string {
-	var output string
-
-	// pick a random message
-	output = possibleRightMessages[rand.Intn(len(possibleRightMessages))]
-
-	return output
+	// pick a weighted-random message for this platform
+	return pickRotatorMessage(possibleRightMessages)
 }

--- a/pkg/onscreens-server/rotator.go
+++ b/pkg/onscreens-server/rotator.go
@@ -1,0 +1,82 @@
+package onscreensServer
+
+import (
+	"math/rand"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+)
+
+// Streaming platforms a rotator message can be scoped to. Mirrors the values
+// pkg/chatbot uses, but kept local — onscreens-server must not import chatbot
+// (that would drag tripbot-only config/DB init into this binary; see the
+// package-boundary-init-discipline ADR).
+const (
+	platformTwitch  = "twitch"
+	platformYouTube = "youtube"
+)
+
+// rotatorMessage is one line a rotator can display.
+//
+//   - Platforms scopes the line to specific streaming platforms; empty means
+//     "all platforms". This is what keeps a YouTube overlay from advertising
+//     Twitch-only commands (!miles, !guess).
+//   - Weight biases weighted-random selection (<1 is treated as 1). It replaces
+//     the old "list the same line twice" trick for making a message more
+//     frequent.
+//
+// The hardcoded slices are the current source of truth; this struct is also the
+// seam for a future admin-console-editable source (swap the slice for a loaded
+// one) — tracked as a TODO, not built yet.
+type rotatorMessage struct {
+	Text      string
+	Platforms []string
+	Weight    int
+}
+
+// appliesTo reports whether m should show on the given platform.
+func (m rotatorMessage) appliesTo(platform string) bool {
+	if len(m.Platforms) == 0 {
+		return true
+	}
+	for _, p := range m.Platforms {
+		if p == platform {
+			return true
+		}
+	}
+	return false
+}
+
+func (m rotatorMessage) weight() int {
+	if m.Weight < 1 {
+		return 1
+	}
+	return m.Weight
+}
+
+// pickRotatorMessage returns a weighted-random message among those applicable
+// to this instance's platform. Returns "" when none apply (the rotator shows
+// nothing rather than panicking).
+func pickRotatorMessage(msgs []rotatorMessage) string {
+	platform := c.Conf.Platform
+
+	total := 0
+	for _, m := range msgs {
+		if m.appliesTo(platform) {
+			total += m.weight()
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+
+	n := rand.Intn(total)
+	for _, m := range msgs {
+		if !m.appliesTo(platform) {
+			continue
+		}
+		if n -= m.weight(); n < 0 {
+			return m.Text
+		}
+	}
+	return "" // unreachable: n < total guarantees a hit above
+}

--- a/pkg/onscreens-server/rotator_test.go
+++ b/pkg/onscreens-server/rotator_test.go
@@ -1,0 +1,93 @@
+package onscreensServer
+
+import (
+	"strings"
+	"testing"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+)
+
+// withPlatform sets c.Conf.Platform for the duration of a test and restores it.
+func withPlatform(t *testing.T, platform string) {
+	t.Helper()
+	prev := c.Conf.Platform
+	c.Conf.Platform = platform
+	t.Cleanup(func() { c.Conf.Platform = prev })
+}
+
+func TestRotatorMessageAppliesTo(t *testing.T) {
+	all := rotatorMessage{Text: "x"}
+	if !all.appliesTo(platformYouTube) || !all.appliesTo(platformTwitch) {
+		t.Error("empty Platforms should apply to all platforms")
+	}
+	tw := rotatorMessage{Text: "x", Platforms: []string{platformTwitch}}
+	if tw.appliesTo(platformYouTube) {
+		t.Error("twitch-only message should not apply to YouTube")
+	}
+	if !tw.appliesTo(platformTwitch) {
+		t.Error("twitch-only message should apply to Twitch")
+	}
+}
+
+// TestLeftRotatorOmitsTwitchOnlyOnYouTube guards the headline behavior: a
+// YouTube overlay must never surface the !miles / !guess lines, which would
+// advertise commands disabled on that platform.
+func TestLeftRotatorOmitsTwitchOnlyOnYouTube(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	for i := 0; i < 2000; i++ {
+		msg := pickRotatorMessage(possibleLeftMessages)
+		if strings.Contains(msg, "!miles") || strings.Contains(msg, "!guess") {
+			t.Fatalf("YouTube left rotator surfaced a Twitch-only line: %q", msg)
+		}
+	}
+}
+
+// TestLeftRotatorSurfacesTwitchOnlyOnTwitch confirms the Twitch-only lines are
+// still reachable on Twitch (the filter doesn't drop them everywhere).
+func TestLeftRotatorSurfacesTwitchOnlyOnTwitch(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	var sawMiles, sawGuess bool
+	for i := 0; i < 5000 && !(sawMiles && sawGuess); i++ {
+		switch pickRotatorMessage(possibleLeftMessages) {
+		case "Earn miles for every minute you watch (!miles)":
+			sawMiles = true
+		case "Try and !guess what state we're in":
+			sawGuess = true
+		}
+	}
+	if !sawMiles || !sawGuess {
+		t.Errorf("expected Twitch-only lines reachable on Twitch: miles=%v guess=%v", sawMiles, sawGuess)
+	}
+}
+
+func TestPickRotatorMessageEmptyWhenNoneApply(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	twitchOnly := []rotatorMessage{
+		{Text: "a", Platforms: []string{platformTwitch}},
+		{Text: "b", Platforms: []string{platformTwitch}},
+	}
+	if got := pickRotatorMessage(twitchOnly); got != "" {
+		t.Errorf("expected empty string when no message applies, got %q", got)
+	}
+}
+
+// TestPickRotatorMessageRespectsWeight checks the weighted draw is biased: a
+// Weight:9 entry should dominate a Weight:1 entry over many samples.
+func TestPickRotatorMessageRespectsWeight(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	msgs := []rotatorMessage{
+		{Text: "rare"},              // weight 1
+		{Text: "common", Weight: 9}, // weight 9
+	}
+	var common int
+	const n = 10000
+	for i := 0; i < n; i++ {
+		if pickRotatorMessage(msgs) == "common" {
+			common++
+		}
+	}
+	// Expect ~90%; allow generous slack to stay non-flaky.
+	if common < n*3/4 {
+		t.Errorf("weighted draw not biased: common=%d/%d", common, n)
+	}
+}


### PR DESCRIPTION
The OBS overlay rotators (`pkg/onscreens-server/{left,right}-rotator.go`) advertised commands regardless of platform, so the YouTube overlay promoted `!miles` and `!guess` — commands disabled on YouTube that silently no-op. They also faked per-message likelihood by listing a line twice.

Follow-up to the chat-side fix in #835 (which made `!commands` / `!help` platform-aware); this covers the overlay surface.

## Changes

- New `rotatorMessage{Text, Platforms, Weight}` model: `Platforms` scopes a line to streaming platforms (empty = all); `Weight` biases weighted-random selection (replacing the duplicate-line trick).
- `pickRotatorMessage` filters by `c.Conf.Platform` and draws by weight.
- `!miles` / `!guess` lines scoped to Twitch; everything else neutral.
- New `ONSCREENS_SERVER_PLATFORM` config (defaults to `twitch`).

onscreens-server keeps its **own** platform constants rather than importing `pkg/chatbot`'s allowlist — importing chatbot would drag tripbot-only config/DB init into this binary (package-boundary-init-discipline ADR).

## Companion PR

Requires infra adanalife/infra#725 to set `ONSCREENS_SERVER_PLATFORM` per pod. Without it, behavior is unchanged (defaults to twitch).

## Future

The `rotatorMessage` struct is the seam for admin-console-editable rotator text (swap the hardcoded slices for a loaded source) — deferred, tracked in the vault TODO.

## Test

`go test ./pkg/onscreens-server/` + `go vet` pass. New `rotator_test.go` covers platform filtering, the empty-when-none-apply case, and weighted bias.
