### PR TITLE
Read-only JSON user-profile endpoint for tripbot-console

### DIFF
--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -27,40 +28,63 @@ var (
 )
 
 // userProfile is the chat-console popover payload — a small at-a-glance view of
-// a chatter, events-derived per the tripbot-events-table-design ADR.
+// a chatter, events-derived per the tripbot-events-table-design ADR. The JSON
+// tags are the wire format the standalone tripbot-console reads via
+// GET /api/user/{username} (it has no DB access of its own and proxies here).
 type userProfile struct {
-	Username     string
-	Found        bool
-	IsBot        bool
-	Miles        float32 // lifetime
-	MonthlyMiles float32 // current month
-	Sessions     int64
-	FirstSeen    time.Time
-	LastSeen     time.Time
+	Username     string    `json:"username"`
+	Found        bool      `json:"found"`
+	IsBot        bool      `json:"is_bot"`
+	Miles        float32   `json:"miles"`         // lifetime
+	MonthlyMiles float32   `json:"monthly_miles"` // current month
+	Sessions     int64     `json:"sessions"`
+	FirstSeen    time.Time `json:"first_seen"`
+	LastSeen     time.Time `json:"last_seen"`
+}
+
+// gatherUserProfile reads a chatter's at-a-glance stats through the DB seams.
+// Operator-triggered (one click), not a hot path, so the extra monthly-score
+// query is fine. An empty username or no matching row returns Found=false.
+func gatherUserProfile(ctx context.Context, username string) userProfile {
+	username = strings.ToLower(strings.TrimSpace(username))
+	prof := userProfile{Username: username}
+	if username == "" {
+		return prof
+	}
+	if u := findUser(ctx, username); u.ID != 0 {
+		prof.Found = true
+		prof.IsBot = u.IsBot
+		prof.Miles = u.Miles
+		prof.MonthlyMiles = monthlyMiles(ctx, u)
+		prof.FirstSeen = u.DateCreated
+		prof.LastSeen = u.LastSeen
+		prof.Sessions = sessionCount(ctx, username)
+	}
+	return prof
 }
 
 // userProfileHandler serves GET /admin/user/{username}: the HTML fragment the
-// live console pops over when an operator clicks a username. Timeout/ban
-// actions are planned here (they need the broadcaster token's
+// in-tripbot live console pops over when an operator clicks a username.
+// Timeout/ban actions are planned here (they need the broadcaster token's
 // moderator:manage:banned_users scope).
 func userProfileHandler(w http.ResponseWriter, r *http.Request) {
-	username := strings.ToLower(strings.TrimSpace(mux.Vars(r)["username"]))
-	prof := userProfile{Username: username}
-	if username != "" {
-		if u := findUser(r.Context(), username); u.ID != 0 {
-			prof.Found = true
-			prof.IsBot = u.IsBot
-			prof.Miles = u.Miles
-			prof.MonthlyMiles = monthlyMiles(r.Context(), u)
-			prof.FirstSeen = u.DateCreated
-			prof.LastSeen = u.LastSeen
-			prof.Sessions = sessionCount(r.Context(), username)
-		}
-	}
+	prof := gatherUserProfile(r.Context(), mux.Vars(r)["username"])
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	if err := userProfileTmpl.Execute(w, prof); err != nil {
 		slog.ErrorContext(r.Context(), "couldn't render user profile", "err", err)
+	}
+}
+
+// userProfileAPIHandler serves GET /api/user/{username}: the same data as
+// userProfileHandler but as JSON, for the standalone tripbot-console to render
+// its own popover (the console holds no DB access — it links over to here).
+func userProfileAPIHandler(w http.ResponseWriter, r *http.Request) {
+	prof := gatherUserProfile(r.Context(), mux.Vars(r)["username"])
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(prof); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't encode user profile", "err", err)
 	}
 }
 

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -69,6 +70,53 @@ func TestUserProfileHandler_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(body, "ghost") {
 		t.Errorf("empty card should still name the user")
+	}
+}
+
+func TestUserProfileAPIHandler_JSON(t *testing.T) {
+	withProfileSeams(t, users.User{
+		ID:          42,
+		Username:    "danalol",
+		Miles:       123.0,
+		DateCreated: time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),
+		LastSeen:    time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC),
+	}, 87, 42.0)
+
+	r := mux.NewRouter()
+	r.Handle("/api/user/{username}", http.HandlerFunc(userProfileAPIHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/user/danalol", nil))
+
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	var got userProfile
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, rec.Body.String())
+	}
+	if !got.Found || got.Username != "danalol" || got.Miles != 123.0 ||
+		got.MonthlyMiles != 42.0 || got.Sessions != 87 {
+		t.Errorf("unexpected profile: %+v", got)
+	}
+	// snake_case wire format the console reads.
+	if !strings.Contains(rec.Body.String(), `"monthly_miles"`) {
+		t.Errorf("expected snake_case keys: %s", rec.Body.String())
+	}
+}
+
+func TestUserProfileAPIHandler_NotFound(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 0}, 0, 0)
+	r := mux.NewRouter()
+	r.Handle("/api/user/{username}", http.HandlerFunc(userProfileAPIHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/user/ghost", nil))
+
+	var got userProfile
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Found || got.Username != "ghost" {
+		t.Errorf("expected not-found ghost, got %+v", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,6 +114,9 @@ func (s *Server) Start(ctx context.Context) {
 	// + stream toggle so they stay current without a full reload.
 	r.Handle("/admin/refresh", tagged("/admin/refresh", s.refreshHandler)).Methods("GET")
 	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
+	// read-only JSON profile for the standalone tripbot-console's popover (it
+	// has no DB access and proxies here over the in-namespace Service).
+	r.Handle("/api/user/{username}", tagged("/api/user/{username}", userProfileAPIHandler)).Methods("GET")
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())
 


### PR DESCRIPTION
Adds `GET /api/user/{username}` to tripbot's HTTP surface: the same chatter stats as the in-tripbot panel's `/admin/user` popover (miles, monthly miles, sessions, first/last seen) but as JSON.

## Why
The standalone [tripbot-console](https://github.com/adanalife/tripbot-console) is rebuilding the unified NATS/JetStream chat console (Twitch + YouTube), including the click-a-username popover Dana liked. The console holds **no database access by design** (the RBAC isolation that was the headline of the console split). So it links over to tripbot for the DB-derived profile data, exactly as the [tripbot-console-split ADR](https://github.com/adanalife/tripbot-console) anticipated ("the DB-backed user-profile popover stays in tripbot — the console links over").

## What
- Factor the DB-backed gather out of `userProfileHandler` into `gatherUserProfile(ctx, username)`.
- New `userProfileAPIHandler` serves the same data as JSON (snake_case wire format) on `/api/user/{username}`.
- The existing `/admin/user/{username}` HTML handler is unchanged in behavior (now just calls the shared gather).

The console reaches this over the in-namespace Service (`http://tripbot-twitch:8080/api/user/<name>`); either per-platform instance can serve it since they share Postgres.

Tests cover the JSON found/not-found paths; `pkg/server` builds + vets clean.

Console side (chat reader + popover proxy + render) lands in a follow-up tripbot-console PR that consumes this endpoint.