### PR TITLE
Strip SomaFM from the YouTube OBS scene

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -42,6 +42,7 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
          feh \
          tini \
          gettext-base \
+         jq \
          procps \
          libgl1-mesa-dri \
          intel-media-va-driver-non-free \

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -33,7 +33,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
       | debconf-set-selections \
     && apt-get update && apt-get install -y --no-install-recommends \
-      sway wayvnc xwayland supervisor feh tini gettext-base procps \
+      sway wayvnc xwayland supervisor feh tini gettext-base jq procps \
       ca-certificates curl libgl1-mesa-dri \
       fonts-dejavu-core ttf-mscorefonts-installer \
       # OBS runtime deps (mirrors the build deps with -dev stripped) \

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -80,6 +80,25 @@ cp /opt/obs/config/user.ini   "$OBS_HOME/user.ini"
 envsubst < /opt/obs/config/basic.ini.tmpl > "$OBS_HOME/basic/profiles/ADanaLife/basic.ini"
 envsubst < /opt/obs/config/Tripbot.json.tmpl > "$OBS_HOME/basic/scenes/Tripbot.json"
 
+# SomaFM (the "Groove Salad Classic" ffmpeg_source) plays licensed music that
+# trips YouTube's Content ID and earns copyright strikes. Twitch tolerates it,
+# so the source stays in the shared scene collection and is stripped out only
+# for the YouTube canvas: drop the source definition plus every scene item that
+# references it, before OBS loads the collection. Top-level "sources" holds both
+# real sources and the scene objects (scenes reference members by name under
+# settings.items), so both passes are needed.
+if [ "${STREAM_PLATFORM:-twitch}" = "youtube" ]; then
+  scene_file="$OBS_HOME/basic/scenes/Tripbot.json"
+  jq --arg t "Groove Salad Classic" '
+    .sources |= map(select(.name != $t))
+    | .sources |= map(
+        if (.settings.items? | type) == "array"
+        then .settings.items |= map(select(.name != $t))
+        else . end)
+  ' "$scene_file" > "$scene_file.tmp" && mv "$scene_file.tmp" "$scene_file"
+  echo "stripped 'Groove Salad Classic' (SomaFM) from YouTube scene collection"
+fi
+
 # Advanced Output mode reads encoder-specific settings from streamEncoder.json
 # in the profile dir. VAAPI's keys (vaapi_device, integer profile) don't
 # overlap with x264's, so we case on OBS_STREAM_ENCODER to ship the right


### PR DESCRIPTION
## What

The YouTube stream was playing SomaFM ("Groove Salad Classic" ffmpeg_source), which trips YouTube's Content ID and earns copyright strikes.

This strips the source — and its scene-item references — from the rendered scene collection **only when `STREAM_PLATFORM=youtube`**. Twitch keeps the background music; the shared `Tripbot.json.tmpl` stays single-source.

## How

`entrypoint.sh` runs a `jq` pass over the envsubst'd `Tripbot.json` for the YouTube canvas: it drops the source from top-level `sources[]` and prunes any dangling scene-item references by name.

Adds `jq` to both the amd64 and arm64 OBS images.

## Verification

Ran the filter against a fully-substituted scene: 2 `Groove Salad Classic` occurrences → 0, JSON stays valid, source count 17 → 16. Twitch path is untouched (gate defaults to `twitch`).

## Notes

`STREAM_PLATFORM=youtube` is set in the `obs-youtube` configmap (currently stage-1 only — YouTube is still on stage), so the strip fires there. Requires an OBS image rebuild + redeploy to take effect.