### PR TITLE
Release v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+## [v3.3.1] — 2026-06-13
+
+Patch release. Mostly YouTube platform-awareness polish on the chat and overlay surfaces, plus a read-only user-profile endpoint for the standalone console and a copyright-safety fix for the YouTube OBS scene.
+
+### chatbot
+
+- **Chat command surface is YouTube-aware.** `!state` and `!location` are enabled on YouTube — they read the current video's location/flag overlay, the same read-current-video-state category as the already-allowlisted `!weather`/`!time`/`!date`/`!sunset` (they previously no-op'd silently as unindexed commands on YouTube). `!commands` and the rotating `!help`/Chatter lines now build from a featured set filtered by the platform's indexed lookups, so a YouTube instance no longer advertises commands that aren't in its allowlist (`!guess`, `!miles`, `!leaderboard`, `!song`). ([#835])
+
+### onscreens
+
+- **Periodic leaderboard overlay rotates across all three boards.** The 5-minute cron job only ever showed the guess leaderboard; it now picks at random each tick — monthly miles and guesses weighted evenly, lifetime total miles rarely (5%), with an empty pick falling back to monthly miles. Shared leaderboard row helpers move into `pkg/scoreboards`, and the job moves onto the chatbot `App` so it reaches the overlay and lifetime leaderboard through injected interfaces. ([#834])
+- **Rotator overlays are platform-aware with weighted selection.** The left/right overlay rotators advertised commands regardless of platform, so a YouTube overlay promoted `!miles`/`!guess` (disabled there). A new `rotatorMessage{Text, Platforms, Weight}` scopes lines to streaming platforms and biases weighted-random selection, replacing the old duplicate-line likelihood trick; `!miles`/`!guess` lines are scoped to Twitch. Adds `ONSCREENS_SERVER_PLATFORM` config. ([#836])
+
+### server
+
+- **Read-only JSON user-profile endpoint for tripbot-console.** `GET /api/user/{username}` returns the same chatter stats as the in-tripbot `/admin/user` popover (miles, monthly miles, sessions, first/last seen) as JSON, so the standalone console — which has no DB access by design — can proxy here over the in-namespace Service. ([#837])
+
+### obs
+
+- **YouTube OBS scene strips the SomaFM audio source.** The "Groove Salad Classic" ffmpeg_source plays licensed SomaFM audio that trips YouTube's Content ID and earns copyright strikes. Twitch tolerates it, so the OBS entrypoint now strips the source (and its scene-item references) via a jq pass over the rendered `Tripbot.json` only when `STREAM_PLATFORM=youtube`. Adds jq to both the amd64 and arm64 OBS images. ([#838])
+
 ## [v3.3.0] — 2026-06-12
 
 Minor release. The headline is **typo-tolerant chat commands** — misspelled `!`-commands now fuzzy-route to their nearest trigger, bare state names work as guess shortcuts (`!florida`), and the 31 hand-registered typo aliases that accumulated over the years retire. Alongside it: vlc-server resumes its last-played video (and position) across restarts, the shared database gains a platform dimension so YouTube viewers and feature flags don't collide with Twitch's, and each bot instance publishes auth-token snapshots to NATS for the standalone admin console.
@@ -1545,4 +1566,9 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#830]: https://github.com/adanalife/tripbot/pull/830
 [#831]: https://github.com/adanalife/tripbot/pull/831
 [#832]: https://github.com/adanalife/tripbot/pull/832
+[#834]: https://github.com/adanalife/tripbot/pull/834
+[#835]: https://github.com/adanalife/tripbot/pull/835
+[#836]: https://github.com/adanalife/tripbot/pull/836
+[#837]: https://github.com/adanalife/tripbot/pull/837
+[#838]: https://github.com/adanalife/tripbot/pull/838
 [infra #717]: https://github.com/adanalife/infra/pull/717

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -685,15 +685,14 @@ func (t *Tripbot) scheduleBackgroundJobs() {
 	if !platformIsTwitch() {
 		// Twitch-sourced jobs stay off non-Twitch instances: session/presence
 		// tracking reads Twitch chatters (YouTube presence is punted in v1),
-		// the guess leaderboard backs an excluded command, the subscriber /
+		// the leaderboards back excluded commands, the subscriber /
 		// follower polls hit Helix, and the token-refresh job dereferences the
 		// IRC client this instance never constructs.
 		return
 	}
-	onscreensCli := onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment)
 	t.addJob(61*time.Second, "users.UpdateSession", t.sessions.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
-	t.addJob(5*time.Minute, "onscreens.ShowGuessLeaderboard", onscreensCli.ShowGuessLeaderboard)
+	t.addJob(5*time.Minute, "chatbot.ShowRotatingLeaderboard", t.app.ShowRotatingLeaderboard)
 	t.addJob(5*time.Minute, "users.PrintCurrentSession", t.sessions.PrintCurrentSession)
 	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
 	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -42,6 +42,7 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
          feh \
          tini \
          gettext-base \
+         jq \
          procps \
          libgl1-mesa-dri \
          intel-media-va-driver-non-free \

--- a/infra/docker/obs/Dockerfile.arm64
+++ b/infra/docker/obs/Dockerfile.arm64
@@ -33,7 +33,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
       | debconf-set-selections \
     && apt-get update && apt-get install -y --no-install-recommends \
-      sway wayvnc xwayland supervisor feh tini gettext-base procps \
+      sway wayvnc xwayland supervisor feh tini gettext-base jq procps \
       ca-certificates curl libgl1-mesa-dri \
       fonts-dejavu-core ttf-mscorefonts-installer \
       # OBS runtime deps (mirrors the build deps with -dev stripped) \

--- a/infra/docker/obs/entrypoint.sh
+++ b/infra/docker/obs/entrypoint.sh
@@ -80,6 +80,25 @@ cp /opt/obs/config/user.ini   "$OBS_HOME/user.ini"
 envsubst < /opt/obs/config/basic.ini.tmpl > "$OBS_HOME/basic/profiles/ADanaLife/basic.ini"
 envsubst < /opt/obs/config/Tripbot.json.tmpl > "$OBS_HOME/basic/scenes/Tripbot.json"
 
+# SomaFM (the "Groove Salad Classic" ffmpeg_source) plays licensed music that
+# trips YouTube's Content ID and earns copyright strikes. Twitch tolerates it,
+# so the source stays in the shared scene collection and is stripped out only
+# for the YouTube canvas: drop the source definition plus every scene item that
+# references it, before OBS loads the collection. Top-level "sources" holds both
+# real sources and the scene objects (scenes reference members by name under
+# settings.items), so both passes are needed.
+if [ "${STREAM_PLATFORM:-twitch}" = "youtube" ]; then
+  scene_file="$OBS_HOME/basic/scenes/Tripbot.json"
+  jq --arg t "Groove Salad Classic" '
+    .sources |= map(select(.name != $t))
+    | .sources |= map(
+        if (.settings.items? | type) == "array"
+        then .settings.items |= map(select(.name != $t))
+        else . end)
+  ' "$scene_file" > "$scene_file.tmp" && mv "$scene_file.tmp" "$scene_file"
+  echo "stripped 'Groove Salad Classic' (SomaFM) from YouTube scene collection"
+fi
+
 # Advanced Output mode reads encoder-specific settings from streamEncoder.json
 # in the profile dir. VAAPI's keys (vaapi_device, integer profile) don't
 # overlap with x264's, so we case on OBS_STREAM_ENCODER to ship the right

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -3,7 +3,6 @@ package chatbot
 import (
 	"context"
 	"log/slog"
-	"math/rand"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -103,6 +102,14 @@ type App struct {
 	commands         []Command
 	singleWordLookup map[string]*Command
 	multiWordLookup  map[string]*Command
+
+	// helpMessages is the platform-filtered subset of c.HelpMessages — the
+	// rotating !help / Chatter lines, minus any whose command isn't enabled on
+	// this App's platform (so a YouTube instance doesn't advertise !miles etc.).
+	// helpIndex walks it; randomized at indexCommands() so each restart starts
+	// on a different line.
+	helpMessages []string
+	helpIndex    int
 }
 
 // db returns the DB handle the App should use. Prefers an explicit a.DB
@@ -139,10 +146,6 @@ func New() *App {
 	a.indexCommands()
 	return a
 }
-
-// used to determine which help message to display
-// randomized so it starts with a new one every restart
-var helpIndex = rand.Intn(len(c.HelpMessages))
 
 const followerMsg = "Right now only followers of the channel can run unlimited commands :)"
 const subscriberMsg = "You must be a subscriber to run that command :)"
@@ -205,13 +208,19 @@ func (a *App) ConnectIRC() *twitch.Client {
 // ctx is forward-compat plumbing — a.Chat.Say doesn't take ctx yet, so it's
 // not propagated into the chat write.
 func (a *App) Chatter(_ context.Context) {
-	// use twitch emote feature to add some color
-	a.Chat.Say("/me " + help())
+	// the "/me " twitch emote prefix adds some color on Twitch; youtubeChat.Say
+	// strips it (it would render as literal text on YouTube).
+	a.Chat.Say("/me " + a.help())
 }
 
-func help() string {
-	text := c.HelpMessages[helpIndex]
-	// bump the index
-	helpIndex = (helpIndex + 1) % len(c.HelpMessages)
+// help returns the next rotating help message for this App's platform and
+// advances the index. Empty when no help messages are enabled (guards against
+// a divide-by-zero on the modulo).
+func (a *App) help() string {
+	if len(a.helpMessages) == 0 {
+		return ""
+	}
+	text := a.helpMessages[a.helpIndex]
+	a.helpIndex = (a.helpIndex + 1) % len(a.helpMessages)
 	return text
 }

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -27,6 +27,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// leaderboardSize is how many rows the leaderboard commands show.
+const leaderboardSize = 10
+
 // lastHelloTime is used to rate-limit the hello command
 var lastHelloTime time.Time = time.Now()
 
@@ -304,18 +307,13 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 	slog.InfoContext(ctx, "ran !leaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
-	size := 10
-	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentMilesScoreboard(), size)
-	if size > len(leaderboard) {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
+	leaderboard := scoreboards.TopMilesRows(ctx, leaderboardSize)
 
 	// display leaderboard on screen
 	a.Onscreens.ShowLeaderboard(ctx, "Monthly Miles", leaderboard)
 
 	// build a message to send to chat
-	msg := fmt.Sprintf("Top %d miles this month: ", size)
+	msg := fmt.Sprintf("Top %d miles this month: ", len(leaderboard))
 	for i, leaderPair := range leaderboard {
 		msg += fmt.Sprintf("%d. %s (%smi)", i+1, leaderPair[0], leaderPair[1])
 		if i+1 != len(leaderboard) {
@@ -329,7 +327,7 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 	slog.InfoContext(ctx, "ran !totalleaderboard", "username", user.Username)
 
 	// select users to show in leaderboard
-	size := 10
+	size := leaderboardSize
 	lifetime := a.Sessions.LifetimeLeaderboard()
 	if size > len(lifetime) {
 		size = len(lifetime)
@@ -353,27 +351,8 @@ func (a *App) lifetimeMilesLeaderboardCmd(ctx context.Context, user *users.User,
 func (a *App) monthlyGuessLeaderboardCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !guessleaderboard", "username", user.Username)
 
-	// select users to show in leaderboard
-	size := 10
-	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
-
-	// truncate the leaderboard if necessary
-	if size > len(leaderboard) {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
-
-	// Filter zero-scorers (AddToScoreByName uses FirstOrCreate, so every
-	// user who's ever guessed has a row — many at 0 early in the month).
-	var intLeaderboard [][]string
-	for _, leaderPair := range leaderboard {
-		// guesses are ints not floats, so remove the decimal place
-		intVersion := strings.Split(leaderPair[1], ".")[0]
-		if intVersion == "0" || intVersion == "" {
-			continue
-		}
-		intLeaderboard = append(intLeaderboard, []string{leaderPair[0], intVersion})
-	}
+	// select users to show in leaderboard (zero-scorers already filtered)
+	intLeaderboard := scoreboards.TopGuessRows(ctx, leaderboardSize)
 
 	// special message if no one has any correct guesses yet
 	if len(intLeaderboard) == 0 {

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -45,8 +45,28 @@ const guessScoreboard = "guess_state_total"
 
 func (a *App) helpCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !help", "username", user.Username)
-	msg := fmt.Sprintf("%s (%d of %d)", help(), helpIndex+1, len(c.HelpMessages))
+	n := len(a.helpMessages)
+	// a.help() advances the index, so capture the displayed line's number first.
+	pos := a.helpIndex + 1
+	msg := fmt.Sprintf("%s (%d of %d)", a.help(), pos, n)
 	a.Chat.Say(msg)
+}
+
+// commandsCmd lists a curated set of featured commands — filtered to the ones
+// actually dispatchable on this App's platform, so a YouTube instance doesn't
+// suggest commands that would silently no-op.
+func (a *App) commandsCmd(_ context.Context, _ *users.User, _ []string) {
+	featured := []string{
+		"!location", "!guess", "!date", "!state",
+		"!sunset", "!timewarp", "!miles", "!leaderboard", "!song",
+	}
+	avail := make([]string, 0, len(featured))
+	for _, t := range featured {
+		if _, ok := a.singleWordLookup[t]; ok {
+			avail = append(avail, t)
+		}
+	}
+	a.Chat.Say("You can try: " + strings.Join(avail, ", ") + ", and many other hidden commands!")
 }
 
 func (a *App) helloCmd(ctx context.Context, user *users.User, params []string) {

--- a/pkg/chatbot/leaderboard_rotation.go
+++ b/pkg/chatbot/leaderboard_rotation.go
@@ -1,0 +1,70 @@
+package chatbot
+
+import (
+	"context"
+	"math/rand/v2"
+
+	"github.com/adanalife/tripbot/pkg/scoreboards"
+)
+
+// totalMilesOdds is the chance a given rotation tick shows the lifetime
+// "Total Miles" board; the remaining probability mass splits evenly
+// between the two monthly boards.
+const totalMilesOdds = 0.05
+
+type leaderboardKind int
+
+const (
+	guessLeaderboard leaderboardKind = iota
+	monthlyMilesLeaderboard
+	totalMilesLeaderboard
+)
+
+// pickLeaderboard maps a [0,1) roll onto a leaderboard choice.
+func pickLeaderboard(roll float64) leaderboardKind {
+	switch {
+	case roll < totalMilesOdds:
+		return totalMilesLeaderboard
+	case roll < totalMilesOdds+(1-totalMilesOdds)/2:
+		return guessLeaderboard
+	default:
+		return monthlyMilesLeaderboard
+	}
+}
+
+// ShowRotatingLeaderboard is the periodic onscreen-leaderboard job: each
+// tick it puts one of the three leaderboards on screen, chosen at random.
+func (a *App) ShowRotatingLeaderboard(ctx context.Context) {
+	a.showRotatingLeaderboard(ctx, rand.Float64())
+}
+
+// showRotatingLeaderboard takes the roll as a parameter so tests can pin
+// the choice. An empty pick (the guess board has no correct guesses early
+// in the month) falls back to monthly miles so the slot isn't wasted.
+func (a *App) showRotatingLeaderboard(ctx context.Context, roll float64) {
+	title, rows := a.fetchLeaderboard(ctx, pickLeaderboard(roll))
+	if len(rows) == 0 {
+		title, rows = a.fetchLeaderboard(ctx, monthlyMilesLeaderboard)
+	}
+	if len(rows) == 0 {
+		return
+	}
+	a.Onscreens.ShowLeaderboard(ctx, title, rows)
+}
+
+// fetchLeaderboard returns the overlay title and rows for the given kind.
+// Titles match the ones the corresponding chat commands use.
+func (a *App) fetchLeaderboard(ctx context.Context, kind leaderboardKind) (string, [][]string) {
+	switch kind {
+	case totalMilesLeaderboard:
+		rows := a.Sessions.LifetimeLeaderboard()
+		if len(rows) > leaderboardSize {
+			rows = rows[:leaderboardSize]
+		}
+		return "Total Miles", rows
+	case guessLeaderboard:
+		return "Correct Guesses This Month", scoreboards.TopGuessRows(ctx, leaderboardSize)
+	default:
+		return "Monthly Miles", scoreboards.TopMilesRows(ctx, leaderboardSize)
+	}
+}

--- a/pkg/chatbot/leaderboard_rotation_test.go
+++ b/pkg/chatbot/leaderboard_rotation_test.go
@@ -1,0 +1,141 @@
+package chatbot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/video"
+)
+
+func TestPickLeaderboard(t *testing.T) {
+	tests := []struct {
+		roll float64
+		want leaderboardKind
+	}{
+		{0.0, totalMilesLeaderboard},
+		{0.0499, totalMilesLeaderboard},
+		{0.05, guessLeaderboard},
+		{0.5249, guessLeaderboard},
+		{0.525, monthlyMilesLeaderboard},
+		{0.9999, monthlyMilesLeaderboard},
+	}
+	for _, tt := range tests {
+		if got := pickLeaderboard(tt.roll); got != tt.want {
+			t.Errorf("pickLeaderboard(%v) = %v, want %v", tt.roll, got, tt.want)
+		}
+	}
+}
+
+func TestShowRotatingLeaderboard_MonthlyMiles(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	rows := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 12.5).
+		AddRow("viewer2", 3.2)
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(rows)
+
+	app.showRotatingLeaderboard(context.Background(), 0.99) // monthly miles
+
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 2 rows)`) {
+		t.Errorf("expected one Monthly Miles overlay call, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestShowRotatingLeaderboard_Guess(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	rows := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 7.0).
+		AddRow("viewer2", 0.0) // zero-scorer, filtered
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(rows)
+
+	app.showRotatingLeaderboard(context.Background(), 0.3) // guess
+
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Correct Guesses This Month", 1 rows)`) {
+		t.Errorf("expected one guess overlay call with the zero-scorer filtered, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// An empty guess board (early in the month) falls back to monthly miles
+// rather than skipping the rotation slot.
+func TestShowRotatingLeaderboard_EmptyGuess_FallsBackToMonthlyMiles(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	empty := sqlmock.NewRows([]string{"username", "value"})
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(empty)
+	miles := sqlmock.NewRows([]string{"username", "value"}).
+		AddRow("viewer1", 12.5)
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(miles)
+
+	app.showRotatingLeaderboard(context.Background(), 0.3) // guess → empty → miles
+
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 1 rows)`) {
+		t.Errorf("expected fallback to Monthly Miles overlay, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestShowRotatingLeaderboard_TotalMiles_TruncatesToSize(t *testing.T) {
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	var lifetime [][]string
+	for i := 0; i < leaderboardSize+5; i++ {
+		lifetime = append(lifetime, []string{fmt.Sprintf("viewer%d", i), "100.0"})
+	}
+	app.Sessions = &recordingSessions{Leaderboard: lifetime}
+
+	app.showRotatingLeaderboard(context.Background(), 0.01) // total miles
+
+	want := fmt.Sprintf(`ShowLeaderboard("Total Miles", %d rows)`, leaderboardSize)
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], want) {
+		t.Errorf("expected truncated Total Miles overlay (%s), got %v", want, rec.Calls)
+	}
+}
+
+// If both the pick and the monthly-miles fallback are empty, no overlay is
+// published at all.
+func TestShowRotatingLeaderboard_AllEmpty_SkipsOverlay(t *testing.T) {
+	mock := installMockDB(t)
+	app := newTestApp(video.Video{})
+	rec := &recordingOnscreens{}
+	app.Onscreens = rec
+
+	mock.ExpectQuery(`SELECT users\.username, scores\.value FROM "scores"`).
+		WillReturnRows(sqlmock.NewRows([]string{"username", "value"}))
+
+	// total miles via noopSessions returns nil; the miles fallback is empty too
+	app.showRotatingLeaderboard(context.Background(), 0.01)
+
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected no overlay call when every board is empty, got %v", rec.Calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -2,8 +2,10 @@ package chatbot
 
 import (
 	"context"
+	"math/rand"
 	"strings"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/users"
 )
 
@@ -118,9 +120,7 @@ func (a *App) buildRegistry() []Command {
 		{
 			Trigger: "!commands",
 			Aliases: []string{"!command", "!controls"},
-			Handler: func(_ context.Context, _ *users.User, _ []string) {
-				a.Chat.Say("You can try: !location, !guess, !date, !state, !sunset, !timewarp, !miles, !leaderboard, !song, and many other hidden commands!")
-			},
+			Handler: a.commandsCmd,
 		},
 		{
 			Trigger:            "!bonusmiles",
@@ -250,10 +250,10 @@ const (
 )
 
 // youtubeCommands is the v1 allowlist of triggers a YouTube instance runs — the
-// stateless "info + playback control" subset. Identity/miles commands (!miles,
-// !leaderboard, !guess, !state, !location, …), the Twitch-only !followage, and
-// the admin commands (!middle, !secretinfo, !shutdown, !makebot, !unbot) are
-// deliberately excluded: YouTube v1 runs no per-user state. The now-playing /
+// "info + playback control" subset, plus the !state/!location info commands.
+// Identity/miles commands (!miles, !leaderboard, !guess, …), the Twitch-only
+// !followage, and the admin commands (!middle, !secretinfo, !shutdown, !makebot,
+// !unbot) are excluded: those are per-user identity/score state. The now-playing /
 // SomaFM commands (!song, !music, !somafm) are also deferred for now — the
 // background-audio source is Twitch-stream-specific. Aliases come along with
 // their trigger, so only triggers are listed. See the YouTube provider plan.
@@ -262,6 +262,7 @@ var youtubeCommands = map[string]bool{
 	"!gas": true, "!report": true, "!flag": true,
 	// info (read current-video state only)
 	"!weather": true, "!time": true, "!date": true, "!sunset": true,
+	"!state": true, "!location": true,
 	// playback control (drives this platform's vlc pipeline)
 	"!timewarp": true, "!goto": true, "!skip": true, "!back": true,
 	// socials / static links
@@ -300,6 +301,34 @@ func (a *App) indexCommands() {
 			a.registerTrigger(alias, cmd)
 		}
 	}
+	// Filter the rotating help lines to this platform, then start on a random
+	// one (so each restart opens differently). Must run after the lookups are
+	// built — enabledHelpMessages reads singleWordLookup.
+	a.helpMessages = a.enabledHelpMessages()
+	if len(a.helpMessages) > 0 {
+		a.helpIndex = rand.Intn(len(a.helpMessages))
+	}
+}
+
+// enabledHelpMessages returns c.HelpMessages minus any line whose leading
+// "!command" token isn't dispatchable on this platform — so a YouTube instance
+// never advertises a command that would silently no-op. A line that doesn't
+// start with a "!command" token is always kept.
+func (a *App) enabledHelpMessages() []string {
+	out := make([]string, 0, len(c.HelpMessages))
+	for _, msg := range c.HelpMessages {
+		fields := strings.Fields(msg)
+		if len(fields) > 0 {
+			token := strings.TrimRight(fields[0], ":")
+			if strings.HasPrefix(token, "!") {
+				if _, ok := a.singleWordLookup[token]; !ok {
+					continue // command disabled on this platform
+				}
+			}
+		}
+		out = append(out, msg)
+	}
+	return out
 }
 
 func (a *App) registerTrigger(trigger string, cmd *Command) {

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -1,8 +1,11 @@
 package chatbot
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 )
 
 func TestCommandsHaveNonEmptyTrigger(t *testing.T) {
@@ -82,7 +85,7 @@ func TestYouTubePlatformIndexesOnlyAllowlist(t *testing.T) {
 	yt.indexCommands()
 
 	// allowed: a trigger and one of its aliases both resolve
-	for _, token := range []string{"!weather", "!meteo", "!skip", "!timewarp", "!warp", "!youtube"} {
+	for _, token := range []string{"!weather", "!meteo", "!skip", "!timewarp", "!warp", "!youtube", "!state", "!location", "!where"} {
 		if cmd, _ := yt.findCommand(token); cmd == nil {
 			t.Errorf("expected %q to be available on YouTube, got nil", token)
 		}
@@ -90,9 +93,68 @@ func TestYouTubePlatformIndexesOnlyAllowlist(t *testing.T) {
 
 	// excluded: identity/miles, Twitch-only, admin, and the deferred
 	// now-playing commands do not resolve
-	for _, token := range []string{"!miles", "!km", "!leaderboard", "!guess", "!state", "!location", "!followage", "!middle", "!shutdown", "!makebot", "hello", "!song", "!music", "!somafm"} {
+	for _, token := range []string{"!miles", "!km", "!leaderboard", "!guess", "!followage", "!middle", "!shutdown", "!makebot", "hello", "!song", "!music", "!somafm"} {
 		if cmd, _ := yt.findCommand(token); cmd != nil {
 			t.Errorf("expected %q to be unavailable on YouTube, got %q", token, cmd.Trigger)
 		}
+	}
+}
+
+// TestCommandsCmdFiltersByPlatform verifies the !commands reply advertises only
+// commands dispatchable on the App's platform — Twitch lists the disabled-on-
+// YouTube ones (!guess, !miles, !leaderboard); YouTube does not, but still
+// includes the YouTube-enabled !state / !location.
+func TestCommandsCmdFiltersByPlatform(t *testing.T) {
+	twitch := &App{}
+	twitch.indexCommands()
+	twChat := &recordingChat{}
+	twitch.Chat = twChat
+	twitch.commandsCmd(context.Background(), nil, nil)
+	twOut := twChat.Output()
+	for _, want := range []string{"!guess", "!miles", "!leaderboard", "!state", "!location"} {
+		if !strings.Contains(twOut, want) {
+			t.Errorf("Twitch !commands missing %q: %q", want, twOut)
+		}
+	}
+
+	yt := &App{Platform: platformYouTube}
+	yt.indexCommands()
+	ytChat := &recordingChat{}
+	yt.Chat = ytChat
+	yt.commandsCmd(context.Background(), nil, nil)
+	ytOut := ytChat.Output()
+	for _, absent := range []string{"!guess", "!miles", "!leaderboard", "!song"} {
+		if strings.Contains(ytOut, absent) {
+			t.Errorf("YouTube !commands should not advertise %q: %q", absent, ytOut)
+		}
+	}
+	for _, want := range []string{"!state", "!location"} {
+		if !strings.Contains(ytOut, want) {
+			t.Errorf("YouTube !commands missing %q: %q", want, ytOut)
+		}
+	}
+}
+
+// TestEnabledHelpMessagesFiltersByPlatform verifies the rotating help lines drop
+// any whose command isn't dispatchable on the platform — so a YouTube instance
+// never advertises !miles / !guess / !leaderboard via !help or the Chatter cron.
+func TestEnabledHelpMessagesFiltersByPlatform(t *testing.T) {
+	twitch := &App{}
+	twitch.indexCommands()
+	if len(twitch.helpMessages) != len(c.HelpMessages) {
+		t.Errorf("Twitch should keep all %d help messages, got %d", len(c.HelpMessages), len(twitch.helpMessages))
+	}
+
+	yt := &App{Platform: platformYouTube}
+	yt.indexCommands()
+	for _, msg := range yt.helpMessages {
+		for _, banned := range []string{"!miles", "!guess", "!leaderboard"} {
+			if strings.HasPrefix(msg, banned) {
+				t.Errorf("YouTube help message advertises disabled %q: %q", banned, msg)
+			}
+		}
+	}
+	if len(yt.helpMessages) == 0 {
+		t.Error("YouTube help messages unexpectedly empty")
 	}
 }

--- a/pkg/config/onscreens-server/type.go
+++ b/pkg/config/onscreens-server/type.go
@@ -28,4 +28,10 @@ type OnscreensServerConfig struct {
 	// Format: nats://nats.<env-platform-ns>.svc.cluster.local:4222.
 	// Optional — when unset, the subscriber is skipped.
 	NatsURL string `envconfig:"NATS_URL"`
+
+	// Platform names the streaming platform this onscreens instance serves
+	// ("twitch" / "youtube"). Drives per-platform rotator-message filtering so a
+	// YouTube overlay doesn't advertise Twitch-only commands. Defaults to twitch
+	// (the primary platform). Set by infra per onscreens-<platform> pod.
+	Platform string `default:"twitch" envconfig:"PLATFORM"`
 }

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/adanalife/tripbot/pkg/natsclient"
 	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
-	"github.com/adanalife/tripbot/pkg/scoreboards"
 )
 
 // Client publishes onscreens overlay commands onto NATS. Construct via
@@ -67,36 +65,6 @@ func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard 
 		Rows:     leaderboard,
 	})
 	return nil
-}
-
-// TODO: this is taken right from the !guessleaderboard command, DRY it?
-func (c *Client) ShowGuessLeaderboard(ctx context.Context) {
-	// select users to show in leaderboard
-	size := 10
-	leaderboard := scoreboards.TopUsers(ctx, scoreboards.CurrentGuessScoreboard(), size)
-	if size > len(leaderboard) {
-		size = len(leaderboard)
-	}
-	leaderboard = leaderboard[:size]
-
-	// Filter zero-scorers (AddToScoreByName uses FirstOrCreate, so every
-	// user who's ever guessed has a row — many at 0 early in the month).
-	// If the filtered list is empty, skip the overlay entirely.
-	var intLeaderboard [][]string
-	for _, leaderPair := range leaderboard {
-		// guesses are ints not floats, so remove the decimal place
-		intVersion := strings.Split(leaderPair[1], ".")[0]
-		if intVersion == "0" || intVersion == "" {
-			continue
-		}
-		intLeaderboard = append(intLeaderboard, []string{leaderPair[0], intVersion})
-	}
-	if len(intLeaderboard) == 0 {
-		return
-	}
-
-	// display leaderboard on screen
-	c.ShowLeaderboard(ctx, "Correct Guesses This Month", intLeaderboard)
 }
 
 func (c *Client) ShowTimewarp(ctx context.Context) error {

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -8,20 +8,22 @@ import (
 
 var leftRotatorUpdateFrequency = time.Duration(45 * time.Second)
 
-var possibleLeftMessages = []string{
-	"Crave something new? Try !timewarp",
-	"Earn miles for every minute you watch (!miles)",
-	"Follow the project elsewhere on !socialmedia",
-	"Join us on !discord",
-	"Join us on !discord",
-	"Try and !guess what state we're in",
-	"Use !commands to interact with the bot",
-	"Use !commands to interact with the bot",
-	"Where are we? (!location)",
-	// "LEADER",
-	// "Looking for artist for emotes and more",
-	// "Twitch Prime subs keep us on air :D",
-	// "Use !report to report stream issues",
+// !miles and !guess are Twitch-only (not in the YouTube command allowlist), so
+// those lines are scoped to Twitch — a YouTube overlay would otherwise advertise
+// commands that silently no-op there. Weight 2 reproduces the old duplicated
+// entries (!discord, !commands each appeared twice).
+var possibleLeftMessages = []rotatorMessage{
+	{Text: "Crave something new? Try !timewarp"},
+	{Text: "Earn miles for every minute you watch (!miles)", Platforms: []string{platformTwitch}},
+	{Text: "Follow the project elsewhere on !socialmedia"},
+	{Text: "Join us on !discord", Weight: 2},
+	{Text: "Try and !guess what state we're in", Platforms: []string{platformTwitch}},
+	{Text: "Use !commands to interact with the bot", Weight: 2},
+	{Text: "Where are we? (!location)"},
+	// {Text: "LEADER"},
+	// {Text: "Looking for artist for emotes and more"},
+	// {Text: "Twitch Prime subs keep us on air :D"},
+	// {Text: "Use !report to report stream issues"},
 }
 
 // newLeftRotator constructs the left-rotator *Onscreen, primes it with a
@@ -46,32 +48,11 @@ func leftRotatorLoop(osc *Onscreen) {
 
 // leftRotatorContent creates the content for the leftRotator
 func leftRotatorContent() string {
-	var output string
-
 	// show a special, very rare message
 	if rand.Intn(10000) == 0 {
 		return "You found the rare message! Make a clip for a prize!"
 	}
 
-	// pick a random message
-	message := possibleLeftMessages[rand.Intn(len(possibleLeftMessages))]
-
-	// some messages require custom logic
-	switch message {
-	//case "LEADER":
-	//	//TODO: maybe turn this into a call to tripbot?
-	//	if len(users.Leaderboard) == 0 {
-	//		terrors.Log(errors.New("leaderboard empty"), "")
-	//		// just use the default value
-	//		output = message
-	//		break
-	//	}
-	//	// get the first leader in the leaderboard
-	//	leader := users.Leaderboard[:1][0]
-	//	output = fmt.Sprintf("%s is leader with %s miles (!leaderboard)", leader[0], leader[1])
-	default:
-		output = message
-	}
-
-	return output
+	// pick a weighted-random message for this platform
+	return pickRotatorMessage(possibleLeftMessages)
 }

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -2,19 +2,18 @@ package onscreensServer
 
 import (
 	"log/slog"
-	"math/rand"
 	"time"
 )
 
 var rightRotatorUpdateFrequency = time.Duration(90 * time.Second)
 
-var possibleRightMessages = []string{
-	"Don't forget to follow :)",
-	"Don't forget to follow :)",
-	"Try running !location",
-	"Try running !location",
-	"Try running !timewarp",
-	"Streaming 24 hours a day",
+// All right-rotator lines are platform-neutral (!location and !timewarp are both
+// in the YouTube allowlist). Weight 2 reproduces the old duplicated entries.
+var possibleRightMessages = []rotatorMessage{
+	{Text: "Don't forget to follow :)", Weight: 2},
+	{Text: "Try running !location", Weight: 2},
+	{Text: "Try running !timewarp"},
+	{Text: "Streaming 24 hours a day"},
 }
 
 // newRightRotator constructs the right-rotator *Onscreen, primes it with
@@ -39,10 +38,6 @@ func rightRotatorLoop(osc *Onscreen) {
 
 // rightRotatorContent creates the content for the rightRotator
 func rightRotatorContent() string {
-	var output string
-
-	// pick a random message
-	output = possibleRightMessages[rand.Intn(len(possibleRightMessages))]
-
-	return output
+	// pick a weighted-random message for this platform
+	return pickRotatorMessage(possibleRightMessages)
 }

--- a/pkg/onscreens-server/rotator.go
+++ b/pkg/onscreens-server/rotator.go
@@ -1,0 +1,82 @@
+package onscreensServer
+
+import (
+	"math/rand"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+)
+
+// Streaming platforms a rotator message can be scoped to. Mirrors the values
+// pkg/chatbot uses, but kept local — onscreens-server must not import chatbot
+// (that would drag tripbot-only config/DB init into this binary; see the
+// package-boundary-init-discipline ADR).
+const (
+	platformTwitch  = "twitch"
+	platformYouTube = "youtube"
+)
+
+// rotatorMessage is one line a rotator can display.
+//
+//   - Platforms scopes the line to specific streaming platforms; empty means
+//     "all platforms". This is what keeps a YouTube overlay from advertising
+//     Twitch-only commands (!miles, !guess).
+//   - Weight biases weighted-random selection (<1 is treated as 1). It replaces
+//     the old "list the same line twice" trick for making a message more
+//     frequent.
+//
+// The hardcoded slices are the current source of truth; this struct is also the
+// seam for a future admin-console-editable source (swap the slice for a loaded
+// one) — tracked as a TODO, not built yet.
+type rotatorMessage struct {
+	Text      string
+	Platforms []string
+	Weight    int
+}
+
+// appliesTo reports whether m should show on the given platform.
+func (m rotatorMessage) appliesTo(platform string) bool {
+	if len(m.Platforms) == 0 {
+		return true
+	}
+	for _, p := range m.Platforms {
+		if p == platform {
+			return true
+		}
+	}
+	return false
+}
+
+func (m rotatorMessage) weight() int {
+	if m.Weight < 1 {
+		return 1
+	}
+	return m.Weight
+}
+
+// pickRotatorMessage returns a weighted-random message among those applicable
+// to this instance's platform. Returns "" when none apply (the rotator shows
+// nothing rather than panicking).
+func pickRotatorMessage(msgs []rotatorMessage) string {
+	platform := c.Conf.Platform
+
+	total := 0
+	for _, m := range msgs {
+		if m.appliesTo(platform) {
+			total += m.weight()
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+
+	n := rand.Intn(total)
+	for _, m := range msgs {
+		if !m.appliesTo(platform) {
+			continue
+		}
+		if n -= m.weight(); n < 0 {
+			return m.Text
+		}
+	}
+	return "" // unreachable: n < total guarantees a hit above
+}

--- a/pkg/onscreens-server/rotator_test.go
+++ b/pkg/onscreens-server/rotator_test.go
@@ -1,0 +1,93 @@
+package onscreensServer
+
+import (
+	"strings"
+	"testing"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+)
+
+// withPlatform sets c.Conf.Platform for the duration of a test and restores it.
+func withPlatform(t *testing.T, platform string) {
+	t.Helper()
+	prev := c.Conf.Platform
+	c.Conf.Platform = platform
+	t.Cleanup(func() { c.Conf.Platform = prev })
+}
+
+func TestRotatorMessageAppliesTo(t *testing.T) {
+	all := rotatorMessage{Text: "x"}
+	if !all.appliesTo(platformYouTube) || !all.appliesTo(platformTwitch) {
+		t.Error("empty Platforms should apply to all platforms")
+	}
+	tw := rotatorMessage{Text: "x", Platforms: []string{platformTwitch}}
+	if tw.appliesTo(platformYouTube) {
+		t.Error("twitch-only message should not apply to YouTube")
+	}
+	if !tw.appliesTo(platformTwitch) {
+		t.Error("twitch-only message should apply to Twitch")
+	}
+}
+
+// TestLeftRotatorOmitsTwitchOnlyOnYouTube guards the headline behavior: a
+// YouTube overlay must never surface the !miles / !guess lines, which would
+// advertise commands disabled on that platform.
+func TestLeftRotatorOmitsTwitchOnlyOnYouTube(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	for i := 0; i < 2000; i++ {
+		msg := pickRotatorMessage(possibleLeftMessages)
+		if strings.Contains(msg, "!miles") || strings.Contains(msg, "!guess") {
+			t.Fatalf("YouTube left rotator surfaced a Twitch-only line: %q", msg)
+		}
+	}
+}
+
+// TestLeftRotatorSurfacesTwitchOnlyOnTwitch confirms the Twitch-only lines are
+// still reachable on Twitch (the filter doesn't drop them everywhere).
+func TestLeftRotatorSurfacesTwitchOnlyOnTwitch(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	var sawMiles, sawGuess bool
+	for i := 0; i < 5000 && !(sawMiles && sawGuess); i++ {
+		switch pickRotatorMessage(possibleLeftMessages) {
+		case "Earn miles for every minute you watch (!miles)":
+			sawMiles = true
+		case "Try and !guess what state we're in":
+			sawGuess = true
+		}
+	}
+	if !sawMiles || !sawGuess {
+		t.Errorf("expected Twitch-only lines reachable on Twitch: miles=%v guess=%v", sawMiles, sawGuess)
+	}
+}
+
+func TestPickRotatorMessageEmptyWhenNoneApply(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	twitchOnly := []rotatorMessage{
+		{Text: "a", Platforms: []string{platformTwitch}},
+		{Text: "b", Platforms: []string{platformTwitch}},
+	}
+	if got := pickRotatorMessage(twitchOnly); got != "" {
+		t.Errorf("expected empty string when no message applies, got %q", got)
+	}
+}
+
+// TestPickRotatorMessageRespectsWeight checks the weighted draw is biased: a
+// Weight:9 entry should dominate a Weight:1 entry over many samples.
+func TestPickRotatorMessageRespectsWeight(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	msgs := []rotatorMessage{
+		{Text: "rare"},              // weight 1
+		{Text: "common", Weight: 9}, // weight 9
+	}
+	var common int
+	const n = 10000
+	for i := 0; i < n; i++ {
+		if pickRotatorMessage(msgs) == "common" {
+			common++
+		}
+	}
+	// Expect ~90%; allow generous slack to stay non-flaky.
+	if common < n*3/4 {
+		t.Errorf("weighted draw not biased: common=%d/%d", common, n)
+	}
+}

--- a/pkg/scoreboards/rows.go
+++ b/pkg/scoreboards/rows.go
@@ -1,0 +1,30 @@
+package scoreboards
+
+import (
+	"context"
+	"strings"
+)
+
+// TopMilesRows returns the top-N rows of the current monthly miles
+// scoreboard as [username, miles] pairs, ready for leaderboard rendering.
+func TopMilesRows(ctx context.Context, size int) [][]string {
+	return TopUsers(ctx, CurrentMilesScoreboard(), size)
+}
+
+// TopGuessRows returns the top-N rows of the current monthly guess
+// scoreboard as [username, guesses] pairs. Zero-scorers are filtered out
+// (AddToScoreByName uses FirstOrCreate, so every user who's ever guessed
+// has a row — many at 0 early in the month), and the float values are
+// rendered as ints. May return an empty slice.
+func TopGuessRows(ctx context.Context, size int) [][]string {
+	var rows [][]string
+	for _, pair := range TopUsers(ctx, CurrentGuessScoreboard(), size) {
+		// guesses are ints not floats, so remove the decimal place
+		guesses := strings.Split(pair[1], ".")[0]
+		if guesses == "0" || guesses == "" {
+			continue
+		}
+		rows = append(rows, []string{pair[0], guesses})
+	}
+	return rows
+}

--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -27,40 +28,63 @@ var (
 )
 
 // userProfile is the chat-console popover payload — a small at-a-glance view of
-// a chatter, events-derived per the tripbot-events-table-design ADR.
+// a chatter, events-derived per the tripbot-events-table-design ADR. The JSON
+// tags are the wire format the standalone tripbot-console reads via
+// GET /api/user/{username} (it has no DB access of its own and proxies here).
 type userProfile struct {
-	Username     string
-	Found        bool
-	IsBot        bool
-	Miles        float32 // lifetime
-	MonthlyMiles float32 // current month
-	Sessions     int64
-	FirstSeen    time.Time
-	LastSeen     time.Time
+	Username     string    `json:"username"`
+	Found        bool      `json:"found"`
+	IsBot        bool      `json:"is_bot"`
+	Miles        float32   `json:"miles"`         // lifetime
+	MonthlyMiles float32   `json:"monthly_miles"` // current month
+	Sessions     int64     `json:"sessions"`
+	FirstSeen    time.Time `json:"first_seen"`
+	LastSeen     time.Time `json:"last_seen"`
+}
+
+// gatherUserProfile reads a chatter's at-a-glance stats through the DB seams.
+// Operator-triggered (one click), not a hot path, so the extra monthly-score
+// query is fine. An empty username or no matching row returns Found=false.
+func gatherUserProfile(ctx context.Context, username string) userProfile {
+	username = strings.ToLower(strings.TrimSpace(username))
+	prof := userProfile{Username: username}
+	if username == "" {
+		return prof
+	}
+	if u := findUser(ctx, username); u.ID != 0 {
+		prof.Found = true
+		prof.IsBot = u.IsBot
+		prof.Miles = u.Miles
+		prof.MonthlyMiles = monthlyMiles(ctx, u)
+		prof.FirstSeen = u.DateCreated
+		prof.LastSeen = u.LastSeen
+		prof.Sessions = sessionCount(ctx, username)
+	}
+	return prof
 }
 
 // userProfileHandler serves GET /admin/user/{username}: the HTML fragment the
-// live console pops over when an operator clicks a username. Timeout/ban
-// actions are planned here (they need the broadcaster token's
+// in-tripbot live console pops over when an operator clicks a username.
+// Timeout/ban actions are planned here (they need the broadcaster token's
 // moderator:manage:banned_users scope).
 func userProfileHandler(w http.ResponseWriter, r *http.Request) {
-	username := strings.ToLower(strings.TrimSpace(mux.Vars(r)["username"]))
-	prof := userProfile{Username: username}
-	if username != "" {
-		if u := findUser(r.Context(), username); u.ID != 0 {
-			prof.Found = true
-			prof.IsBot = u.IsBot
-			prof.Miles = u.Miles
-			prof.MonthlyMiles = monthlyMiles(r.Context(), u)
-			prof.FirstSeen = u.DateCreated
-			prof.LastSeen = u.LastSeen
-			prof.Sessions = sessionCount(r.Context(), username)
-		}
-	}
+	prof := gatherUserProfile(r.Context(), mux.Vars(r)["username"])
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	if err := userProfileTmpl.Execute(w, prof); err != nil {
 		slog.ErrorContext(r.Context(), "couldn't render user profile", "err", err)
+	}
+}
+
+// userProfileAPIHandler serves GET /api/user/{username}: the same data as
+// userProfileHandler but as JSON, for the standalone tripbot-console to render
+// its own popover (the console holds no DB access — it links over to here).
+func userProfileAPIHandler(w http.ResponseWriter, r *http.Request) {
+	prof := gatherUserProfile(r.Context(), mux.Vars(r)["username"])
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(prof); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't encode user profile", "err", err)
 	}
 }
 

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -69,6 +70,53 @@ func TestUserProfileHandler_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(body, "ghost") {
 		t.Errorf("empty card should still name the user")
+	}
+}
+
+func TestUserProfileAPIHandler_JSON(t *testing.T) {
+	withProfileSeams(t, users.User{
+		ID:          42,
+		Username:    "danalol",
+		Miles:       123.0,
+		DateCreated: time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),
+		LastSeen:    time.Date(2026, 5, 29, 13, 5, 0, 0, time.UTC),
+	}, 87, 42.0)
+
+	r := mux.NewRouter()
+	r.Handle("/api/user/{username}", http.HandlerFunc(userProfileAPIHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/user/danalol", nil))
+
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	var got userProfile
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, rec.Body.String())
+	}
+	if !got.Found || got.Username != "danalol" || got.Miles != 123.0 ||
+		got.MonthlyMiles != 42.0 || got.Sessions != 87 {
+		t.Errorf("unexpected profile: %+v", got)
+	}
+	// snake_case wire format the console reads.
+	if !strings.Contains(rec.Body.String(), `"monthly_miles"`) {
+		t.Errorf("expected snake_case keys: %s", rec.Body.String())
+	}
+}
+
+func TestUserProfileAPIHandler_NotFound(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 0}, 0, 0)
+	r := mux.NewRouter()
+	r.Handle("/api/user/{username}", http.HandlerFunc(userProfileAPIHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/user/ghost", nil))
+
+	var got userProfile
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Found || got.Username != "ghost" {
+		t.Errorf("expected not-found ghost, got %+v", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,6 +114,9 @@ func (s *Server) Start(ctx context.Context) {
 	// + stream toggle so they stay current without a full reload.
 	r.Handle("/admin/refresh", tagged("/admin/refresh", s.refreshHandler)).Methods("GET")
 	r.Handle("/admin/user/{username}", tagged("/admin/user/{username}", userProfileHandler)).Methods("GET")
+	// read-only JSON profile for the standalone tripbot-console's popover (it
+	// has no DB access and proxies here over the in-namespace Service).
+	r.Handle("/api/user/{username}", tagged("/api/user/{username}", userProfileAPIHandler)).Methods("GET")
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())
 


### PR DESCRIPTION
Patch release: v3.3.0 → v3.3.1. YouTube platform-awareness polish on the chat and overlay surfaces, a read-only user-profile endpoint for the standalone console, and a copyright-safety fix for the YouTube OBS scene.

## Included PRs

- [#834](https://github.com/adanalife/tripbot/pull/834) — Rotate the periodic leaderboard overlay across miles + guess boards
- [#835](https://github.com/adanalife/tripbot/pull/835) — Make tripbot's chat command surface YouTube-aware
- [#836](https://github.com/adanalife/tripbot/pull/836) — Make onscreens rotators platform-aware with weighted selection
- [#837](https://github.com/adanalife/tripbot/pull/837) — Read-only JSON user-profile endpoint for tripbot-console
- [#838](https://github.com/adanalife/tripbot/pull/838) — Strip SomaFM source from the YouTube OBS scene collection

See `CHANGELOG.md` for the full notes.

**Merge with "Create a merge commit"** (not squash) per the release flow. No `#minor`/`#major` keyword — patch bump.