### PR TITLE
Reconcile prod-1 vlc pin to 3.3.0

### DIFF
--- a/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
@@ -54,7 +54,7 @@ spec:
             - secretRef:
                 name: grafana-cloud-otlp
                 optional: false
-          image: adanalife/vlc:3.2.1
+          image: adanalife/vlc:3.3.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/cdk8s/versions.yaml
+++ b/cdk8s/versions.yaml
@@ -15,7 +15,7 @@ prod-1:
   # restarts the chat bot only; no stream impact
   tripbot: "3.3.0"
   # restarting drops the playing video briefly on stream
-  vlc: "3.2.1"
+  vlc: "3.3.0"
   # restarting takes the stream down until OBS reconnects — pick a quiet moment
   obs: "3.2.1"
   # overlays blip; the stream itself stays up


### PR DESCRIPTION
Prod runs `vlc:3.3.0` (bumped in infra before tripbot's cdk8s tree moved in-repo), but the ported `cdk8s/versions.yaml` still pinned `3.2.1`. This brings the pin in line with live prod and re-synths `prod-1-vlc-twitch.k8s.yaml` so it is byte-identical to infra's current output.

Prereq for the prod Argo cutover (pointing prod-1's app workloads at this repo): without this, the source flip would roll prod vlc **back** to 3.2.1 and restart the stream. With it, the flip is a no-op.

Targets `master` directly (the prod-tracking branch, same as the bump-prs deploy gesture). A back-merge to `develop` follows so the two stay in sync.

**Sibling:** [infra#733](https://github.com/adanalife/infra/pull/733) (the prod Argo cutover that depends on this).