### PR TITLE
release: fan out prod bump PRs in-repo (retire the infra dispatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,11 +404,14 @@ jobs:
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
 
-  # Tell infra a new version exists: its bump-prs workflow fans out one
-  # Dependabot-style "bump prod <component>" PR per image (merge = deploy).
+  # Fan out the prod version-bump PRs: the in-repo bump-prs workflow opens one
+  # Dependabot-style "bump prod <component>" PR per image against master (merge =
+  # deploy). Relocated here from infra once the manifests moved into this repo —
+  # it now edits this repo's cdk8s/versions.yaml.
   # Auths as the adanalife-automation GitHub App (credentials fanned out by
-  # infra's terraform/platform) — GITHUB_TOKEN can't dispatch cross-repo.
-  dispatch-infra-bumps:
+  # infra's terraform/platform): the App token mints workflow runs whose later
+  # bump commits re-trigger the cdk8s synth gate (GITHUB_TOKEN commits would not).
+  bump-prod-pins:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
     runs-on: ubuntu-latest
     steps:
@@ -419,15 +422,14 @@ jobs:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: adanalife
-          repositories: infra
+          repositories: tripbot
 
-      - name: Fire repository_dispatch to infra
+      - name: Trigger the bump-prs workflow for this release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/adanalife/infra/dispatches \
-            -f event_type=tripbot-release \
-            -f "client_payload[version]=${GITHUB_REF_NAME#v}"
+          gh workflow run bump-prs.yml --repo "$GITHUB_REPOSITORY" \
+            -f "version=${GITHUB_REF_NAME#v}"
 
   notify:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]


### PR DESCRIPTION
Now that the cdk8s manifests + `bump-prs.yml` live in this repo, flip the release workflow's final step from a cross-repo `repository_dispatch` to infra over to triggering the **in-repo** `bump-prs` workflow (`workflow_dispatch` with the released version).

Still mints the adanalife-automation GitHub App token (now scoped to this repo) so the bump commits re-fire the cdk8s synth gate — a plain `GITHUB_TOKEN` commit wouldn't. `bump-prs.yml` is already on `master` (carried by v3.3.2), so `gh workflow run` resolves it on the default branch.

Sibling to [infra#734](https://github.com/adanalife/infra/pull/734), which removes the tripbot app manifests + the old `bump-prs.yml` from infra.