### PR TITLE
Release v3.3.4: develop → master

### DIFF
--- a/.github/workflows/bump-prs.yml
+++ b/.github/workflows/bump-prs.yml
@@ -7,6 +7,10 @@ name: bump-prs
 # it now edits THIS repo's cdk8s/versions.yaml and the PRs target `master`
 # (the prod-tracking branch — prod-1 pins float to master, stage rides develop).
 #
+# Bump PRs are deploy gestures, not releases: both the commit message and the PR
+# title carry `#none` so auto-tag.yml skips the version bump when they land on
+# master. Without it, every merged pin edit would mint a tag and fire release.yml.
+#
 # Fired by this repo's release workflow (workflow_dispatch with the released
 # version) or by hand. Each component leg:
 #
@@ -141,7 +145,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add cdk8s/versions.yaml cdk8s/dist/
-          git commit -m "Bump prod $COMPONENT to $VERSION"
+          # `#none` tells auto-tag.yml (anothrNick/github-tag-action) to skip the
+          # version bump when this lands on master. Bump PRs are deploy gestures,
+          # not releases — without this each merged bump would mint a new tag and
+          # fire release.yml, spamming releases off a pin edit.
+          git commit -m "Bump prod $COMPONENT to $VERSION #none"
           git push -f origin "$BRANCH"
 
       - name: Create or refresh the bump PR
@@ -149,7 +157,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          TITLE="Bump prod $COMPONENT to $VERSION"
+          # `#none` in the title too (not just the commit) so the skip-tag
+          # marker survives a squash-merge, where GitHub derives the commit
+          # subject from the PR title.
+          TITLE="Bump prod $COMPONENT to $VERSION #none"
           case "$COMPONENT" in
             obs) IMPACT="⚠️ **Merging restarts the OBS pod — the stream goes down until it reconnects.** Pick a quiet moment." ;;
             vlc) IMPACT="⚠️ **Merging restarts vlc-server — the playing video drops briefly on stream.** Pick a quiet moment." ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,11 +404,14 @@ jobs:
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
 
-  # Tell infra a new version exists: its bump-prs workflow fans out one
-  # Dependabot-style "bump prod <component>" PR per image (merge = deploy).
+  # Fan out the prod version-bump PRs: the in-repo bump-prs workflow opens one
+  # Dependabot-style "bump prod <component>" PR per image against master (merge =
+  # deploy). Relocated here from infra once the manifests moved into this repo —
+  # it now edits this repo's cdk8s/versions.yaml.
   # Auths as the adanalife-automation GitHub App (credentials fanned out by
-  # infra's terraform/platform) — GITHUB_TOKEN can't dispatch cross-repo.
-  dispatch-infra-bumps:
+  # infra's terraform/platform): the App token mints workflow runs whose later
+  # bump commits re-trigger the cdk8s synth gate (GITHUB_TOKEN commits would not).
+  bump-prod-pins:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]
     runs-on: ubuntu-latest
     steps:
@@ -419,15 +422,14 @@ jobs:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           owner: adanalife
-          repositories: infra
+          repositories: tripbot
 
-      - name: Fire repository_dispatch to infra
+      - name: Trigger the bump-prs workflow for this release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/adanalife/infra/dispatches \
-            -f event_type=tripbot-release \
-            -f "client_payload[version]=${GITHUB_REF_NAME#v}"
+          gh workflow run bump-prs.yml --repo "$GITHUB_REPOSITORY" \
+            -f "version=${GITHUB_REF_NAME#v}"
 
   notify:
     needs: [tripbot-manifest, vlc-manifest, obs-manifest, onscreens-server-manifest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+## [v3.3.4] — 2026-06-14
+
+Patch release. CI/release-plumbing only — no runtime behavior change. Finishes wiring the in-repo prod bump-PR workflow into the release flow now that the cdk8s manifests live in this repo.
+
+### CI
+
+- **Release workflow fans out the prod bump PRs in-repo.** The release's final step now triggers this repo's `bump-prs` workflow (`workflow_dispatch` with the released version) instead of a cross-repo `repository_dispatch` to infra, matching the cdk8s manifests' move into this repo. Still mints the `adanalife-automation` App token so the bump commits re-fire the cdk8s synth gate — now scoped to this repo. ([#845])
+- **Bump-PR commits and titles marked `#none` so they don't fire releases.** Bump PRs target `master`, where every push auto-tags and triggers a release; a pin edit is a deploy gesture, not a release, so each merged bump was minting a spurious release. The `#none` skip-tag marker (honored by `anothrNick/github-tag-action`) now lives in both the commit message and the PR title, surviving whether the PR is merge-committed or squash-merged. ([#851])
+
 ## [v3.3.2] — 2026-06-13
 
 Patch release. Build/deploy plumbing only — no runtime behavior change. The Kubernetes manifest authoring for this repo's four images now lives in-repo, and the per-component prod-pin bump workflow moves here alongside it.
@@ -1586,3 +1595,5 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#840]: https://github.com/adanalife/tripbot/pull/840
 [#841]: https://github.com/adanalife/tripbot/pull/841
 [infra #717]: https://github.com/adanalife/infra/pull/717
+[#845]: https://github.com/adanalife/tripbot/pull/845
+[#851]: https://github.com/adanalife/tripbot/pull/851


### PR DESCRIPTION
Patch release. CI/release-plumbing only — no runtime behavior change.

Finishes wiring the in-repo prod bump-PR workflow into the release flow now that the cdk8s manifests live in this repo.

### CI

- Release workflow fans out the prod bump PRs in-repo via `workflow_dispatch` instead of a cross-repo `repository_dispatch` to infra ([#845](https://github.com/adanalife/tripbot/pull/845/changes))
- Bump-PR commits and titles marked `#none` so deploy-gesture pins don't mint spurious releases ([#851](https://github.com/adanalife/tripbot/pull/851/changes))

---

Default patch bump (no `#minor`/`#major` in the commit range). Merge with **"Create a merge commit"**, not squash.