### PR TITLE
cdk8s: drop vlc-server iGPU claim on prod + stage

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -47,6 +47,12 @@ class EnvConfig:
     )
     secret_source: str = "eso"  # eso | local
     gpu: bool = False  # request gpu.intel.com/i915
+    # vlc-server's iGPU claim is gated on (gpu and vlc_gpu). Default True keeps the
+    # claim wherever the env has a GPU; set False to drop just vlc's claim while OBS
+    # keeps the iGPU. vlc proved it doesn't need the GPU (stream-copy + trivial
+    # software decode — CPU flat at ~0.04 cores with and without /dev/dri,
+    # verified live on stage 2026-06-13). See VlcServer in constructs/vlc.py.
+    vlc_gpu: bool = True
     obs_encoder: str = "obs_x264"  # ffmpeg_vaapi_tex on GPU envs
     obs_quality: str = "low"  # low | high
     dashcam_mode: str = "hostpath"  # nfs | hostpath
@@ -163,6 +169,11 @@ ENVS: dict[str, EnvConfig] = {
         binary_env="production",
         deployment_env="prod-1",
         gpu=True,
+        # vlc doesn't need the iGPU (stream-copy + software decode); dropping its
+        # claim frees an iGPU slot and eases co-tenant contention (the 2026-06-11
+        # prod-stutter incident). OBS keeps the iGPU for VAAPI encode. Proven on
+        # stage first, then prod on the live twitch stream.
+        vlc_gpu=False,
         obs_encoder="ffmpeg_vaapi_tex",
         obs_quality="high",
         dashcam_mode="nfs",
@@ -197,6 +208,11 @@ ENVS: dict[str, EnvConfig] = {
         binary_env="staging",
         deployment_env="stage-1",
         gpu=True,
+        # vlc's iGPU claim proven unnecessary 2026-06-13 (stream-copy + trivial
+        # software decode). Re-asserting vlc_gpu=False here — it was lost when the
+        # app workloads moved from infra into this repo (the cdk8s-into-repo
+        # cutover dropped the flag, so stage vlc silently reclaimed the iGPU).
+        vlc_gpu=False,
         obs_encoder="ffmpeg_vaapi_tex",
         obs_quality="low",
         dashcam_mode="nfs",

--- a/cdk8s/adanalife_k8s/constructs/vlc.py
+++ b/cdk8s/adanalife_k8s/constructs/vlc.py
@@ -106,7 +106,10 @@ class VlcServer(Construct):
             "memory": k8s.Quantity.from_string("512Mi"),
         }
         limits = {"memory": k8s.Quantity.from_string("2Gi")}
-        if env.gpu:
+        # vlc does stream-copy + software decode and doesn't need the iGPU; the
+        # claim is gated on vlc_gpu so an env can keep its GPU (for OBS) while
+        # dropping just vlc's claim.
+        if env.gpu and env.vlc_gpu:
             requests["gpu.intel.com/i915"] = k8s.Quantity.from_string("1")
             limits["gpu.intel.com/i915"] = k8s.Quantity.from_string("1")
 

--- a/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
@@ -79,11 +79,9 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              gpu.intel.com/i915: "1"
               memory: 2Gi
             requests:
               cpu: "1"
-              gpu.intel.com/i915: "1"
               memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
@@ -80,11 +80,9 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              gpu.intel.com/i915: "1"
               memory: 2Gi
             requests:
               cpu: 200m
-              gpu.intel.com/i915: "1"
               memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Drops the `gpu.intel.com/i915` claim from vlc-server on **both prod-1 and stage-1**, re-introducing the `vlc_gpu` flag (the i915 claim now gates on `gpu and vlc_gpu`).

## Why

vlc does stream-copy + trivial software decode and doesn't need the iGPU. Proven live on stage 2026-06-13: with and without `/dev/dri`, CPU stayed flat at ~0.04 cores, RTSP watchdog up, frames decoding, 0 restarts. Dropping the claim frees two iGPU slots and eases the co-tenant contention behind the 2026-06-11 prod-stutter incident. OBS keeps its iGPU for VAAPI encode.

The original stage change ([infra#728](https://github.com/adanalife/infra/pull/728/changes)) lived in the infra repo's cdk8s. When the app workloads moved into this repo (the cdk8s-into-repo cutover, #732/#733/#734), the `vlc_gpu` flag didn't come along — `constructs/vlc.py` reverted to gating purely on `env.gpu`, so **both** stage and prod vlc silently reclaimed the iGPU (confirmed live). This re-asserts the flag and turns it off for both envs.

## Changes

- `config.py` — add `vlc_gpu: bool = True` to `EnvConfig`; set `vlc_gpu=False` on prod-1 + stage-1.
- `constructs/vlc.py` — gate the i915 claim on `env.gpu and env.vlc_gpu`.
- `dist/` — re-synthed; only change is the two i915 lines (request + limit) dropping from each vlc manifest.

## Rollout note

prod-1's `vlc-twitch` feeds the **live** Twitch stream — worth watching the pod roll while the stream is up. Stage burned this in already. No vlc-server code change; the claim is purely a scheduling request.