### PR TITLE
ci: make prod-deploy impact visible on PRs

### DIFF
--- a/.github/workflows/bump-prs.yml
+++ b/.github/workflows/bump-prs.yml
@@ -161,11 +161,23 @@ jobs:
           # marker survives a squash-merge, where GitHub derives the commit
           # subject from the PR title.
           TITLE="Bump prod $COMPONENT to $VERSION #none"
+          # DEPLOY describes what merging actually does. prod-1 apps autosync
+          # from master (AUTOSYNC_ENVS in infra's argocd.py), so merging deploys
+          # them with no manual step — EXCEPT prod OBS, which is held out of
+          # autosync (AUTOSYNC_HOLDOUTS) and still needs a deliberate Argo sync.
           case "$COMPONENT" in
-            obs) IMPACT="⚠️ **Merging restarts the OBS pod — the stream goes down until it reconnects.** Pick a quiet moment." ;;
-            vlc) IMPACT="⚠️ **Merging restarts vlc-server — the playing video drops briefly on stream.** Pick a quiet moment." ;;
-            tripbot) IMPACT="Restarts the chat bot only; no stream impact." ;;
-            *) IMPACT="Restarts the overlay server; overlays blip, the stream itself stays up." ;;
+            obs)
+              IMPACT="⚠️ **Merging restarts the OBS pod — the stream goes down until it reconnects.** Pick a quiet moment."
+              DEPLOY="Prod \`obs\` is held out of Argo autosync, so merging only stages the change on \`master\` — **then manually sync the \`obs\` app in Argo to deploy**." ;;
+            vlc)
+              IMPACT="⚠️ **Merging restarts vlc-server — the playing video drops briefly on stream.** Pick a quiet moment."
+              DEPLOY="Prod \`vlc\` autosyncs from \`master\`, so **merging deploys it** — no manual Argo step." ;;
+            tripbot)
+              IMPACT="Restarts the chat bot only; no stream impact."
+              DEPLOY="Prod \`tripbot\` autosyncs from \`master\`, so **merging deploys it** — no manual Argo step." ;;
+            *)
+              IMPACT="Restarts the overlay server; overlays blip, the stream itself stays up."
+              DEPLOY="Prod \`$COMPONENT\` autosyncs from \`master\`, so **merging deploys it** — no manual Argo step." ;;
           esac
           cat > /tmp/body.md <<EOF
           Offers prod \`$COMPONENT\`: **$CURRENT → $VERSION**.
@@ -173,8 +185,8 @@ jobs:
           $IMPACT
 
           - What changed: [v$CURRENT...v$VERSION](https://github.com/adanalife/tripbot/compare/v$CURRENT...v$VERSION) · [release notes](https://github.com/adanalife/tripbot/releases/tag/v$VERSION)
-          - Merging is the deploy gesture: after merge, sync the \`$COMPONENT\` app in Argo.
-          - Rollback: \`git revert\` the bump commit and sync again.
+          - $DEPLOY
+          - Rollback: \`git revert\` the bump commit (same deploy path as above).
           - The pin edit + the re-synthed \`dist/\` ride in the same commit on \`$BRANCH\`.
 
           This PR updates in place when newer releases ship (force-push to \`$BRANCH\`).

--- a/.github/workflows/prod-dist-warning.yml
+++ b/.github/workflows/prod-dist-warning.yml
@@ -1,0 +1,74 @@
+name: prod-dist-warning
+
+# Warn on PRs into master that change a prod (prod-1) app deploy unit. prod-1
+# apps autosync from master (AUTOSYNC_ENVS in infra's argocd.py), so MERGING
+# such a PR deploys the change to prod — no separate gesture. That's obvious on
+# the per-component version-bump PRs, but easy to miss on a release PR
+# (develop → master) that happens to carry a manifest-shape change to a prod
+# dist/ file (e.g. a resource-claim or env tweak). This posts a sticky comment
+# so the merge isn't done unaware.
+#
+# Lives on master so it runs against release PRs (pull_request uses the workflow
+# definition from the PR's base branch); reaches master via the normal release.
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  warn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect prod app dist/ changes
+        id: detect
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Three-dot diff = the PR's own changes (merge-base..head), so a stale
+          # master doesn't produce false positives. Scope to the per-component
+          # app units (`prod-1-*-twitch.k8s.yaml`) — these are the autosynced
+          # deploy targets; jobs/identity/seed units aren't.
+          FILES=$(git diff --name-only "$BASE...$HEAD" -- 'cdk8s/dist/prod-1-*-twitch.k8s.yaml')
+          if [ -n "$FILES" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "list<<LIST"
+              while IFS= read -r f; do
+                # \140 is a literal backtick (avoids a shellcheck SC2016 false positive)
+                printf -- '- \140%s\140\n' "$f"
+              done <<< "$FILES"
+              echo "LIST"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post warning
+        if: steps.detect.outputs.changed == 'true'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: prod-dist-warning
+          message: |
+            ⚠️ **This PR changes prod (`prod-1`) app deploy units.**
+
+            prod-1 apps **autosync from `master`**, so **merging this PR deploys the change to prod** — no separate step. A change to the `vlc` or `obs` unit means a brief stream impact when the pod restarts. (`obs` is held out of autosync, so an OBS change instead waits for a manual Argo sync.)
+
+            Changed:
+            ${{ steps.detect.outputs.list }}
+
+            Make sure that's intended before merging.
+
+      - name: Clear stale warning
+        if: steps.detect.outputs.changed == 'false'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: prod-dist-warning
+          delete: true


### PR DESCRIPTION
Two changes so it's obvious when merging a PR will deploy to prod (prod-1 apps autosync from `master`).

**1. Fix stale wording in the version-bump PR template (`bump-prs.yml`).**
The generated body claimed "after merge, sync the \`<app>\` app in Argo" for every component — but prod-1 apps autosync from master, so merging *is* the deploy with no manual step. Only prod OBS is held out of autosync (`AUTOSYNC_HOLDOUTS`) and genuinely needs a manual sync. The note is now component-aware.

**2. New `prod-dist-warning` workflow.**
Posts a sticky comment on any PR into `master` that modifies a prod app deploy unit (`cdk8s/dist/prod-1-*-twitch.k8s.yaml`), spelling out that merging deploys to prod. This is the gap that let the vlc iGPU-claim removal go live on a release merge rather than a deliberate gesture — obvious on bump PRs, easy to miss on a release PR carrying an incidental manifest change.

Notes:
- The warning workflow only fires once it's on `master` (pull_request uses the base branch's workflow definition) — it reaches master via the normal release.
- `marocchino/sticky-pull-request-comment@v3` (latest stable).
- actionlint + pre-commit clean.

The live PR #856 body still has the old wording; I'll update it separately (it's regenerated by the workflow on the next bump anyway).