### PR TITLE
Persist middle-text overlay across onscreens-server restarts

### DIFF
--- a/pkg/onscreens-events/events.go
+++ b/pkg/onscreens-events/events.go
@@ -29,6 +29,17 @@ type MiddleShow struct {
 	Msg string `json:"msg"`
 }
 
+// MiddleState is the last-value state onscreens-server publishes about the
+// middle-text overlay so the text (and its shown/hidden status) survives a
+// server restart. Unlike MiddleShow — a *command* from tripbot — this is
+// *state* the server emits about itself, read back from the
+// MaxMsgsPerSubject=1 stream on startup. Mirrors the vlc lastplayed cache.
+type MiddleState struct {
+	Envelope
+	Msg     string `json:"msg"`
+	Showing bool   `json:"showing"`
+}
+
 // LeaderboardShow is the payload for the leaderboard.show subject. The
 // server renders Rows into the on-screen HTML, so the wire carries
 // structured data rather than a pre-rendered blob.

--- a/pkg/onscreens-events/subjects.go
+++ b/pkg/onscreens-events/subjects.go
@@ -14,8 +14,16 @@ func subject(env, overlay, verb string) string {
 	return fmt.Sprintf("tripbot.%s.%s.%s.%s", env, domain, overlay, verb)
 }
 
-func MiddleShowSubject(env string) string      { return subject(env, "middle", "show") }
-func MiddleHideSubject(env string) string      { return subject(env, "middle", "hide") }
+func MiddleShowSubject(env string) string { return subject(env, "middle", "show") }
+func MiddleHideSubject(env string) string { return subject(env, "middle", "hide") }
+
+// MiddleStateSubject is the last-value state leaf onscreens-server publishes
+// the middle-text overlay's content + visibility to, so a restarted server
+// restores it (tripbot.<env>.onscreens.middle.state). Unlike middle.show /
+// middle.hide (commands from tripbot) this is *state* the server emits about
+// itself — backed by a MaxMsgsPerSubject=1 stream, the same shape as the vlc
+// lastplayed cache (tripbot.<env>.vlc.lastplayed.<platform>).
+func MiddleStateSubject(env string) string     { return subject(env, "middle", "state") }
 func LeaderboardShowSubject(env string) string { return subject(env, "leaderboard", "show") }
 func LeaderboardHideSubject(env string) string { return subject(env, "leaderboard", "hide") }
 func TimewarpShowSubject(env string) string    { return subject(env, "timewarp", "show") }

--- a/pkg/onscreens-server/middle-state.go
+++ b/pkg/onscreens-server/middle-state.go
@@ -1,0 +1,119 @@
+package onscreensServer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// middleStateStreamName is the JetStream stream holding the middle-text
+// overlay's last-published state — a last-value cache (MaxMsgsPerSubject=1)
+// over the single MiddleStateSubject. A restarted onscreens-server reads it
+// back to restore whatever text was on screen before the restart, so the
+// permanent middle overlay survives a reboot. Same shape as the vlc
+// TRIPBOT_VLC_LASTPLAYED cache.
+const middleStateStreamName = "TRIPBOT_ONSCREENS_MIDDLE"
+
+// EnsureMiddleStateStream idempotently declares the middle-text state stream.
+// Call it once at startup before the first show/hide is handled — a core
+// publish to a subject no stream covers is silently uncaptured, so the stream
+// has to exist before the first command for restore-on-restart to have
+// anything to read. No-op when js is nil (NATS off / JetStream unavailable);
+// the overlay then degrades to its previous behaviour (text lost on restart).
+func EnsureMiddleStateStream(ctx context.Context, js jetstream.JetStream, env string) error {
+	if js == nil {
+		return nil
+	}
+	cfg := jetstream.StreamConfig{
+		Name:        middleStateStreamName,
+		Description: "Last middle-text overlay state (content + visibility) for restore-on-restart.",
+		Subjects:    []string{oe.MiddleStateSubject(env)},
+		Storage:     jetstream.FileStorage,
+		Retention:   jetstream.LimitsPolicy,
+		Discard:     jetstream.DiscardOld,
+		// One retained message: exactly the latest middle-text state, nothing
+		// to prune.
+		MaxMsgsPerSubject: 1,
+	}
+	if _, err := js.CreateOrUpdateStream(ctx, cfg); err != nil {
+		return fmt.Errorf("ensure stream %s: %w", middleStateStreamName, err)
+	}
+	slog.InfoContext(ctx, "jetstream stream ensured", "stream", middleStateStreamName, "env", env)
+	return nil
+}
+
+// publishMiddleState publishes the middle overlay's current content +
+// visibility as the last-value state. Fire-and-forget core publish — the
+// stream captures it; when NATS is unconfigured it's a silent no-op (matching
+// the eventbus convention).
+func publishMiddleState(ctx context.Context, env, msg string, showing bool) {
+	conn := natsclient.Conn()
+	if conn == nil {
+		return
+	}
+	payload, err := json.Marshal(oe.MiddleState{Envelope: oe.NewEnvelope(), Msg: msg, Showing: showing})
+	if err != nil {
+		slog.ErrorContext(ctx, "middle state marshal failed", "err", err)
+		return
+	}
+	subj := oe.MiddleStateSubject(env)
+	if err := conn.Publish(subj, payload); err != nil {
+		slog.ErrorContext(ctx, "middle state publish failed", "err", err, "subject", subj)
+	}
+}
+
+// readMiddleState reads the last-value cache back: the content + visibility
+// onscreens-server most recently published, or ok=false when there's nothing
+// to restore (empty stream, NATS off, or any read error — restore is
+// best-effort, so errors are logged and swallowed).
+func readMiddleState(ctx context.Context, js jetstream.JetStream, env string) (msg string, showing, ok bool) {
+	if js == nil {
+		return "", false, false
+	}
+	stream, err := js.Stream(ctx, middleStateStreamName)
+	if err != nil {
+		slog.WarnContext(ctx, "middle state stream lookup failed", "err", err, "stream", middleStateStreamName)
+		return "", false, false
+	}
+	subj := oe.MiddleStateSubject(env)
+	raw, err := stream.GetLastMsgForSubject(ctx, subj)
+	if err != nil {
+		if !errors.Is(err, jetstream.ErrMsgNotFound) {
+			slog.WarnContext(ctx, "middle state read failed", "err", err, "subject", subj)
+		}
+		return "", false, false
+	}
+	var ev oe.MiddleState
+	if err := json.Unmarshal(raw.Data, &ev); err != nil {
+		slog.WarnContext(ctx, "middle state decode failed", "err", err, "subject", subj)
+		return "", false, false
+	}
+	return ev.Msg, ev.Showing, true
+}
+
+// RestoreMiddleText ensures the state stream exists, then restores the
+// middle-text overlay's content + visibility from the JetStream last-value
+// cache so the permanent overlay survives an onscreens-server restart.
+// Best-effort: a nil JetStream (NATS off) or an empty cache leaves the
+// overlay at its constructed default (empty content, showing).
+func (s *Server) RestoreMiddleText(ctx context.Context) {
+	js := natsclient.JetStream()
+	if err := EnsureMiddleStateStream(ctx, js, c.Conf.Environment); err != nil {
+		slog.ErrorContext(ctx, "couldn't ensure middle state stream", "err", err)
+		return
+	}
+	msg, showing, ok := readMiddleState(ctx, js, c.Conf.Environment)
+	if !ok {
+		return
+	}
+	s.MiddleText.Content = msg
+	s.MiddleText.IsShowing = showing
+	slog.InfoContext(ctx, "restored middle-text overlay from jetstream", "showing", showing)
+}

--- a/pkg/onscreens-server/middle-state_test.go
+++ b/pkg/onscreens-server/middle-state_test.go
@@ -1,0 +1,140 @@
+package onscreensServer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// TestMiddleStateRoundTrip proves the restore-on-restart store end to end
+// against an embedded JetStream server: the last published state wins
+// (last-value cache), and both content and visibility round-trip.
+func TestMiddleStateRoundTrip(t *testing.T) {
+	nc := connectEmbeddedJetStream(t)
+	natsclient.SetConn(nc)
+	t.Cleanup(func() { natsclient.SetConn(nil) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	const env = "testing"
+	js := natsclient.JetStream()
+	if js == nil {
+		t.Fatal("JetStream() returned nil against a JetStream-enabled server")
+	}
+	if err := EnsureMiddleStateStream(ctx, js, env); err != nil {
+		t.Fatalf("ensure stream: %v", err)
+	}
+
+	publishMiddleState(ctx, env, "first text", true)
+	publishMiddleState(ctx, env, "second text", true) // supersedes first
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// JetStream captures core publishes asynchronously; poll until the cache
+	// shows the superseding value.
+	waitMiddleState(t, ctx, js, env, "second text", true)
+
+	// A hide retains the content but flips visibility.
+	publishMiddleState(ctx, env, "second text", false)
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	waitMiddleState(t, ctx, js, env, "second text", false)
+}
+
+// TestRestoreMiddleText proves Server.RestoreMiddleText overrides the
+// overlay's constructed default with the persisted state.
+func TestRestoreMiddleText(t *testing.T) {
+	nc := connectEmbeddedJetStream(t)
+	natsclient.SetConn(nc)
+	t.Cleanup(func() { natsclient.SetConn(nil) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	// RestoreMiddleText reads under c.Conf.Environment ("testing" in tests);
+	// ensure + publish under the same env so the restore finds the state.
+	js := natsclient.JetStream()
+	env := c.Conf.Environment
+	if err := EnsureMiddleStateStream(ctx, js, env); err != nil {
+		t.Fatalf("ensure stream: %v", err)
+	}
+	publishMiddleState(ctx, env, "restored text", true)
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	waitMiddleState(t, ctx, js, env, "restored text", true)
+
+	s := &Server{MiddleText: newMiddleText()}
+	s.RestoreMiddleText(ctx)
+
+	if s.MiddleText.Content != "restored text" {
+		t.Errorf("MiddleText.Content = %q, want %q", s.MiddleText.Content, "restored text")
+	}
+	if !s.MiddleText.IsShowing {
+		t.Errorf("MiddleText.IsShowing = false, want true")
+	}
+}
+
+// TestMiddleStateNilJetStream proves the paths degrade to "nothing to
+// restore" when NATS is unconfigured.
+func TestMiddleStateNilJetStream(t *testing.T) {
+	if _, _, ok := readMiddleState(context.Background(), nil, "testing"); ok {
+		t.Errorf("readMiddleState with nil js = ok=true, want false")
+	}
+	if err := EnsureMiddleStateStream(context.Background(), nil, "testing"); err != nil {
+		t.Errorf("EnsureMiddleStateStream with nil js = %v, want nil", err)
+	}
+}
+
+// waitMiddleState polls the last-value cache until it reads wantMsg/wantShowing,
+// or fails after a short deadline.
+func waitMiddleState(t *testing.T, ctx context.Context, js jetstream.JetStream, env, wantMsg string, wantShowing bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var gotMsg string
+	var gotShowing, ok bool
+	for time.Now().Before(deadline) {
+		if gotMsg, gotShowing, ok = readMiddleState(ctx, js, env); ok && gotMsg == wantMsg && gotShowing == wantShowing {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("middle state = %q/showing=%v (ok=%v), want %q/showing=%v", gotMsg, gotShowing, ok, wantMsg, wantShowing)
+}
+
+// connectEmbeddedJetStream starts an in-process JetStream-enabled nats-server
+// on a random port with a temp store dir and returns a client connection.
+// (Same fixture shape as pkg/vlc-server's lastplayed_test.)
+func connectEmbeddedJetStream(t *testing.T) *nats.Conn {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{
+		Host:      "127.0.0.1",
+		Port:      -1,
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("new nats server: %v", err)
+	}
+	go ns.Start()
+	if !ns.ReadyForConnections(10 * time.Second) {
+		t.Fatal("embedded nats server not ready")
+	}
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := nats.Connect(ns.ClientURL())
+	if err != nil {
+		t.Fatalf("connect to embedded server: %v", err)
+	}
+	t.Cleanup(nc.Close)
+	return nc
+}

--- a/pkg/onscreens-server/middle-text.go
+++ b/pkg/onscreens-server/middle-text.go
@@ -6,14 +6,17 @@ import (
 
 // newMiddleText constructs the middle-text *Onscreen. Unlike the other
 // onscreens this one is permanent (DontExpire = true) and starts in the
-// "showing" state so the OBS browser source keeps rendering whatever
-// text was on screen before the bot restarted.
+// "showing" state. The actual pre-restart text is restored separately from
+// the JetStream last-value cache by Server.RestoreMiddleText (see
+// middle-state.go) — this constructor only sets the default before that
+// restore runs, so a brand-new server (empty cache) still shows-but-empty.
 func newMiddleText() *Onscreen {
 	slog.Info("creating onscreen", "kind", "middle-text")
 	osc := newOnscreen()
 	// this is a permanent onscreen
 	osc.DontExpire = true
-	// keep the same text from before the bot started
+	// default to showing; RestoreMiddleText overrides content + visibility
+	// from the persisted state when there is any
 	osc.IsShowing = true
 	return osc
 }

--- a/pkg/onscreens-server/nats.go
+++ b/pkg/onscreens-server/nats.go
@@ -65,6 +65,16 @@ func (s *Server) handleMiddleShow(m *nats.Msg) {
 		return
 	}
 	s.MiddleText.Show(ev.Msg)
+	// Persist the new state so the overlay survives a server restart.
+	publishMiddleState(context.Background(), c.Conf.Environment, ev.Msg, true)
+}
+
+// handleMiddleHide hides the middle text. Hide retains the overlay's Content,
+// so the persisted state keeps the text (showing=false) — a restart restores
+// it hidden, matching the live state rather than blanking it.
+func (s *Server) handleMiddleHide(_ *nats.Msg) {
+	s.MiddleText.Hide()
+	publishMiddleState(context.Background(), c.Conf.Environment, s.MiddleText.Content, false)
 }
 
 // handleLeaderboardShow renders the {title, rows} payload server-side and
@@ -81,7 +91,6 @@ func (s *Server) handleLeaderboardShow(m *nats.Msg) {
 // The hide + empty-payload show handlers below take no data beyond the
 // envelope, so the body isn't inspected: the subject is the whole intent.
 // Hides are lenient by construction (nothing to reject).
-func (s *Server) handleMiddleHide(_ *nats.Msg)      { s.MiddleText.Hide() }
 func (s *Server) handleLeaderboardHide(_ *nats.Msg) { s.Leaderboard.Hide() }
 func (s *Server) handleTimewarpShow(_ *nats.Msg)    { s.Timewarp.ShowFor("Timewarp!", timewarpDuration) }
 func (s *Server) handleTimewarpHide(_ *nats.Msg)    { s.Timewarp.Hide() }

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -91,6 +91,11 @@ func (s *Server) Start(ctx context.Context) error {
 	// nil (NATS_URL unset); HTTP remains the sole transport in that case.
 	s.StartNATSSubscribers(ctx)
 
+	// Restore the permanent middle-text overlay from its JetStream last-value
+	// cache so a server restart doesn't blank whatever text was on screen.
+	// Best-effort: a no-op without NATS / JetStream.
+	s.RestoreMiddleText(ctx)
+
 	r := mux.NewRouter()
 
 	// healthcheck endpoints


### PR DESCRIPTION
## Problem

Restarting onscreens-server blanked the middle-text overlay. The text lived only in memory — `newOnscreen()` resets `Content` to `""`, and `newMiddleText()` only set `IsShowing = true`, which kept the "showing" flag but not the text. The OBS browser source then rendered nothing.

## Fix

Back the overlay with a JetStream last-value cache, mirroring the vlc `lastplayed` pattern:

- onscreens-server publishes its middle-text state (content + visibility) to `tripbot.<env>.onscreens.middle.state` on every show/hide
- a `MaxMsgsPerSubject=1` stream (`TRIPBOT_ONSCREENS_MIDDLE`) keeps just the latest state
- on startup the server reads the last message back and restores both `Content` and `IsShowing`, so a restart resumes whatever was on screen

Best-effort: a nil JetStream (NATS off / unavailable) degrades to the previous behaviour. No infra change — JetStream is already in use by the vlc lastplayed cache on the same NATS.

## Tests

End-to-end round-trip against an embedded JetStream server (last-value supersession, hide-retains-content, and `RestoreMiddleText` overriding the constructed default), plus the nil-JetStream degradation path.