### PR TITLE
Remove the cv:stats Taskfile target (last pipeline producer-era trace)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -172,14 +172,6 @@ tasks:
     cmds:
       - mise exec -- go build -o bin/vlc-server ./cmd/vlc-server
 
-  cv:stats:
-    desc: 'Quick dashcam-cv coverage/size/rate via psql, no model load (NS=stage-1 default)'
-    vars:
-      NS: '{{.NS | default "stage-1"}}'
-    cmds:
-      - >-
-        kubectl -n {{.NS}} exec postgres-0 -- bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT (SELECT count(*) FROM videos WHERE NOT flagged) AS total_videos, (SELECT count(DISTINCT video_id) FROM frame_embeddings) AS embedded, (SELECT count(*) FROM frame_embeddings) AS frames, (SELECT count(DISTINCT video_id) FROM frame_embeddings WHERE date_created > now() - make_interval(hours => 1)) AS videos_last_hr, pg_size_pretty(pg_total_relation_size('"'"'frame_embeddings'"'"')) AS size;"'
-
   # cdk8s — the Python authoring layer for tripbot's app workload manifests
   # (cdk8s/). Synthesizes dist/<env>-<component>-<platform>.k8s.yaml (+ the
   # per-env identity unit + the one-shot Job files), which Argo delivers


### PR DESCRIPTION
Now that the video pipeline lives in its own `video-pipeline` repo, this removes the last producer-era trace from tripbot.

## Audit result
The cleanup surface turned out to be tiny — the heavy cv/gps-ocr code **never merged into tripbot** (the `cv/` subtree PR was closed as superseded), and the old in-repo OCR pass was removed previously. A full repo audit found exactly one stray producer-era artifact:

- **`Taskfile.yml` `cv:stats`** — a psql query monitoring embedding-fill coverage of `frame_embeddings`. Embedding production + monitoring now live in `video-pipeline` (which has its own `stats` command). Removed.

## Kept (consumer / DB / immutable / infra) — verified in the audit
- `frame_embeddings` table + migrations `015`/`016` — applied migrations are immutable; the table is in tripbot's DB (written by the pipeline, read by the future `!find`).
- The `pgvector` image (docker-compose + mirror-images) — required for that schema to apply.
- `pkg/video` `CoordSource*` provenance enums — consumer-side, read at runtime.
- `cmd/backfill-coords` — a coords-correction tool over tripbot's `videos` table (the OCR pass is already gone), i.e. DB maintenance like `cmd/backfill-miles`, not pipeline production. Used as recently as this week's prod rollout.
- `cdk8s` `dashcam-cv-low` / co-tenancy references (about the deploy neighbor + priority) and `CHANGELOG.md` history — left as-is.

Verified `task --list` parses clean and no code references the removed target. Tracked in `vault/tripbot/TODO.md`.