### PR TITLE
fix: break the corpus map route on cross-trip jumps

### DIFF
--- a/pkg/server/map.go
+++ b/pkg/server/map.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"log/slog"
+	"math"
 	"net/http"
 
 	"github.com/adanalife/tripbot/pkg/video"
@@ -17,16 +18,60 @@ var corpusRoute = video.CorpusRoute
 // light. Larger corpora are evenly downsampled.
 const maxCorpusPoints = 2500
 
+// maxRouteGapMiles is the jump between consecutive clips above which the route
+// is split into a new segment. The van often resumed recording hundreds of
+// miles away (a new trip), and drawing a straight line across that gap is a
+// rendering artifact, not real driving. Normal inter-clip spacing is a few
+// miles, so this threshold cleanly separates trip boundaries from real travel.
+const maxRouteGapMiles = 25
+
 // mapCorpusHandler serves GET /admin/map/corpus: the full dashcam route as JSON
-// [[lat,lng],…]. Loaded lazily by the map's "show full route" toggle, cached an
-// hour (the corpus rarely changes).
+// [[[lat,lng],…],…] — a list of segments, broken wherever consecutive clips
+// jump more than maxRouteGapMiles (trip boundaries). Leaflet renders a nested
+// array as a multi-polyline, so each segment draws as a disconnected line.
+// Loaded lazily by the map's "show full route" toggle, cached an hour (the
+// corpus rarely changes).
 func mapCorpusHandler(w http.ResponseWriter, r *http.Request) {
-	pts := downsample(corpusRoute(r.Context()), maxCorpusPoints)
+	segs := splitOnGaps(downsample(corpusRoute(r.Context()), maxCorpusPoints), maxRouteGapMiles)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
-	if err := json.NewEncoder(w).Encode(pts); err != nil {
+	if err := json.NewEncoder(w).Encode(segs); err != nil {
 		slog.ErrorContext(r.Context(), "couldn't encode corpus route", "err", err)
 	}
+}
+
+// splitOnGaps breaks an ordered point list into contiguous segments, starting a
+// new segment whenever the great-circle distance between consecutive points
+// exceeds maxMiles. Returns an empty (non-nil) slice for empty input so the JSON
+// is [] rather than null.
+func splitOnGaps(pts [][2]float64, maxMiles float64) [][][2]float64 {
+	segs := make([][][2]float64, 0)
+	if len(pts) == 0 {
+		return segs
+	}
+	cur := [][2]float64{pts[0]}
+	for i := 1; i < len(pts); i++ {
+		prev, p := pts[i-1], pts[i]
+		if milesBetween(prev[0], prev[1], p[0], p[1]) > maxMiles {
+			segs = append(segs, cur)
+			cur = [][2]float64{p}
+			continue
+		}
+		cur = append(cur, p)
+	}
+	return append(segs, cur)
+}
+
+// milesBetween returns the great-circle (haversine) distance in miles between
+// two lat/lng points.
+func milesBetween(lat1, lng1, lat2, lng2 float64) float64 {
+	const earthRadiusMiles = 3958.8
+	rad := math.Pi / 180
+	dLat := (lat2 - lat1) * rad
+	dLng := (lng2 - lng1) * rad
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(lat1*rad)*math.Cos(lat2*rad)*math.Sin(dLng/2)*math.Sin(dLng/2)
+	return earthRadiusMiles * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
 }
 
 // downsample returns at most max evenly-spaced points, always keeping the last

--- a/pkg/server/map_test.go
+++ b/pkg/server/map_test.go
@@ -24,12 +24,41 @@ func TestMapCorpusHandler(t *testing.T) {
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("Content-Type = %q, want application/json", ct)
 	}
-	var got [][2]float64
+	var got [][][2]float64
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("body not valid JSON: %v\n%s", err, rec.Body.String())
 	}
-	if len(got) != 2 || got[0][0] != 41.5 || got[1][1] != -110.3 {
-		t.Errorf("route = %v, want the two seeded points", got)
+	// The two seeded points are ~9 miles apart (< the gap threshold), so they
+	// stay in a single segment.
+	if len(got) != 1 || len(got[0]) != 2 || got[0][0][0] != 41.5 || got[0][1][1] != -110.3 {
+		t.Errorf("route = %v, want one segment of the two seeded points", got)
+	}
+}
+
+func TestSplitOnGaps(t *testing.T) {
+	// Two clusters of nearby points separated by a cross-country jump should
+	// split into two segments.
+	pts := [][2]float64{
+		{41.50, -110.20}, {41.51, -110.21}, // Wyoming
+		{34.05, -118.24}, {34.06, -118.25}, // Los Angeles — ~700mi away
+	}
+	segs := splitOnGaps(pts, maxRouteGapMiles)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %v", len(segs), segs)
+	}
+	if len(segs[0]) != 2 || len(segs[1]) != 2 {
+		t.Errorf("segment sizes = %d,%d, want 2,2", len(segs[0]), len(segs[1]))
+	}
+
+	// A contiguous run under the threshold stays a single segment.
+	near := [][2]float64{{41.50, -110.20}, {41.55, -110.25}, {41.60, -110.30}}
+	if segs := splitOnGaps(near, maxRouteGapMiles); len(segs) != 1 {
+		t.Errorf("contiguous run split into %d segments, want 1", len(segs))
+	}
+
+	// Empty input returns a non-nil empty slice (encodes as [] not null).
+	if segs := splitOnGaps(nil, maxRouteGapMiles); segs == nil || len(segs) != 0 {
+		t.Errorf("empty input = %v, want non-nil empty slice", segs)
 	}
 }
 


### PR DESCRIPTION
## What

The admin map's "show full route" overlay drew **one continuous polyline** through every clip ordered by film time. Each time the van resumed recording hundreds/thousands of miles away (a new trip), a straight line streaked across the country — a rendering artifact left over after the GPS-coord backfill (tripbot#846) cleaned up the actual OCR outliers.

## How

- `mapCorpusHandler` now splits the (downsampled) route into **segments**, starting a new one whenever consecutive points jump more than `maxRouteGapMiles` (25mi) apart — well above normal inter-clip spacing, well below a trip boundary.
- Distance via a small local haversine (`milesBetween`); no new dependency.
- The endpoint returns a nested array (`[[[lat,lng],…],…]`). **Leaflet renders a nested array as a multi-polyline**, so each segment draws as its own disconnected line — **no JS change needed** (the map already used multi-polylines for the live breadcrumb).

## Notes

This is a bugfix to the frozen in-tripbot panel, but the change lives in the durable `/admin/map/corpus` endpoint + `CorpusRoute` seam, so the console's eventual Leaflet map inherits the fix for free.

## Test

- New `TestSplitOnGaps` (two clusters split on a ~700mi jump; contiguous run stays one segment; empty input → non-nil `[]`).
- `TestMapCorpusHandler` updated for the segmented shape.
- Full suite green via `task test:macos`.