### PR TITLE
Register !guesslb alias for !guessleaderboard

### DIFF
--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -219,7 +219,7 @@ func (a *App) buildRegistry() []Command {
 		},
 		{
 			Trigger:        "!guessleaderboard",
-			Aliases:        []string{"!glb"},
+			Aliases:        []string{"!glb", "!guesslb"},
 			Handler:        a.monthlyGuessLeaderboardCmd,
 			RequiresFollow: true,
 		},


### PR DESCRIPTION
## Summary
- Register `!guesslb` as a static alias for `!guessleaderboard`.

## Test plan
- [x] task test:macos green
- [ ] Dana: confirm `!guesslb` responds in chat like `!guessleaderboard`