### PR TITLE
Label monthly-miles onscreen leaderboard with the month name

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -310,7 +310,7 @@ func (a *App) monthlyMilesLeaderboardCmd(ctx context.Context, user *users.User, 
 	leaderboard := scoreboards.TopMilesRows(ctx, leaderboardSize)
 
 	// display leaderboard on screen
-	a.Onscreens.ShowLeaderboard(ctx, "Monthly Miles", leaderboard)
+	a.Onscreens.ShowLeaderboard(ctx, scoreboards.CurrentMilesMonth()+" Miles", leaderboard)
 
 	// build a message to send to chat
 	msg := fmt.Sprintf("Top %d miles this month: ", len(leaderboard))

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -2,6 +2,7 @@ package chatbot
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/adanalife/tripbot/pkg/video"
 	"gorm.io/gorm"
@@ -977,7 +979,8 @@ func TestMonthlyMilesLeaderboardCmd_RendersTopUsers(t *testing.T) {
 	if !strings.HasPrefix(msg, "Top 2 miles this month:") {
 		t.Errorf("expected 'Top 2 miles this month:' prefix, got %q", msg)
 	}
-	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 2 rows)`) {
+	want := fmt.Sprintf(`ShowLeaderboard(%q, 2 rows)`, scoreboards.CurrentMilesMonth()+" Miles")
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], want) {
 		t.Errorf("expected one ShowLeaderboard overlay call with 2 rows, got %v", rec.Calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/pkg/chatbot/leaderboard_rotation.go
+++ b/pkg/chatbot/leaderboard_rotation.go
@@ -65,6 +65,6 @@ func (a *App) fetchLeaderboard(ctx context.Context, kind leaderboardKind) (strin
 	case guessLeaderboard:
 		return "Correct Guesses This Month", scoreboards.TopGuessRows(ctx, leaderboardSize)
 	default:
-		return "Monthly Miles", scoreboards.TopMilesRows(ctx, leaderboardSize)
+		return scoreboards.CurrentMilesMonth() + " Miles", scoreboards.TopMilesRows(ctx, leaderboardSize)
 	}
 }

--- a/pkg/chatbot/leaderboard_rotation_test.go
+++ b/pkg/chatbot/leaderboard_rotation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/video"
 )
 
@@ -43,8 +44,10 @@ func TestShowRotatingLeaderboard_MonthlyMiles(t *testing.T) {
 
 	app.showRotatingLeaderboard(context.Background(), 0.99) // monthly miles
 
-	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 2 rows)`) {
-		t.Errorf("expected one Monthly Miles overlay call, got %v", rec.Calls)
+	wantTitle := scoreboards.CurrentMilesMonth() + " Miles"
+	want := fmt.Sprintf(`ShowLeaderboard(%q, 2 rows)`, wantTitle)
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], want) {
+		t.Errorf("expected one %s overlay call, got %v", wantTitle, rec.Calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
@@ -91,8 +94,10 @@ func TestShowRotatingLeaderboard_EmptyGuess_FallsBackToMonthlyMiles(t *testing.T
 
 	app.showRotatingLeaderboard(context.Background(), 0.3) // guess → empty → miles
 
-	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], `ShowLeaderboard("Monthly Miles", 1 rows)`) {
-		t.Errorf("expected fallback to Monthly Miles overlay, got %v", rec.Calls)
+	wantTitle := scoreboards.CurrentMilesMonth() + " Miles"
+	want := fmt.Sprintf(`ShowLeaderboard(%q, 1 rows)`, wantTitle)
+	if len(rec.Calls) != 1 || !strings.Contains(rec.Calls[0], want) {
+		t.Errorf("expected fallback to %s overlay, got %v", wantTitle, rec.Calls)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)

--- a/pkg/scoreboards/miles.go
+++ b/pkg/scoreboards/miles.go
@@ -7,6 +7,13 @@ func CurrentMilesScoreboard() string {
 	return "miles_" + time.Now().Format("2006_01")
 }
 
+// CurrentMilesMonth returns the full name of the month the current monthly
+// miles scoreboard covers (e.g. "June"). Uses the same time.Now() basis as
+// CurrentMilesScoreboard so the label always matches the board's data.
+func CurrentMilesMonth() string {
+	return time.Now().Month().String()
+}
+
 func CurrentGuessScoreboard() string {
 	// uses YYYY_MM format
 	return "guess_state_" + time.Now().Format("2006_01")


### PR DESCRIPTION
## Summary
- Label the monthly-miles leaderboard overlay with the current month name (e.g. "June Miles") instead of the unlabeled "Monthly Miles" header.
- Adds `scoreboards.CurrentMilesMonth()`, which shares the same `time.Now()` basis as `CurrentMilesScoreboard` so the label always matches the board's data. Used at both onscreen call sites (the `!leaderboard` command and the rotating-leaderboard job).
- Lifetime and guess boards are untouched.

## Test plan
- [x] task test:macos green
- [ ] Dana: trigger the monthly-miles onscreen and confirm the month label renders