### PR TITLE
Add GET /api/db/migration endpoint reporting the schema version

### DIFF
--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/adanalife/tripbot/pkg/database"
+)
+
+// migrationVersion is the wire format the standalone tripbot-console reads via
+// GET /api/db/migration. The console holds no DB access of its own, so it
+// proxies here over the in-namespace Service to show which golang-migrate
+// migration the env's Postgres is on. version/dirty come straight from the
+// schema_migrations table golang-migrate maintains; ok is false when the row
+// couldn't be read (e.g. DB unreachable), so the console can render a graceful
+// "unknown" instead of a misleading 0.
+type migrationVersion struct {
+	OK      bool  `json:"ok"`
+	Version int64 `json:"version"`
+	Dirty   bool  `json:"dirty"`
+}
+
+// readSchemaMigration is the data seam the migration handler reads through,
+// overridable in tests so the handler renders without a real DB. golang-migrate
+// keeps a single row in schema_migrations holding the current version + a dirty
+// flag (set true when a migration failed partway).
+var readSchemaMigration = func(ctx context.Context) (version int64, dirty bool, err error) {
+	row := database.GormDB().WithContext(ctx).
+		Raw("SELECT version, dirty FROM schema_migrations LIMIT 1").Row()
+	if err := row.Err(); err != nil {
+		return 0, false, err
+	}
+	if err := row.Scan(&version, &dirty); err != nil {
+		return 0, false, err
+	}
+	return version, dirty, nil
+}
+
+// gatherMigrationVersion reads the current schema-migration version through the
+// DB seam. A read error (DB unreachable, missing table) returns OK=false so the
+// console can show "unknown" rather than a misleading version.
+func gatherMigrationVersion(ctx context.Context) migrationVersion {
+	version, dirty, err := readSchemaMigration(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "couldn't read schema migration version", "err", err)
+		return migrationVersion{OK: false}
+	}
+	return migrationVersion{OK: true, Version: version, Dirty: dirty}
+}
+
+// migrationVersionAPIHandler serves GET /api/db/migration: the current
+// golang-migrate schema version as JSON, for the standalone tripbot-console to
+// surface which migration the env's Postgres is on (the console holds no DB
+// access — it links over to here).
+func migrationVersionAPIHandler(w http.ResponseWriter, r *http.Request) {
+	mv := gatherMigrationVersion(r.Context())
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(mv); err != nil {
+		slog.ErrorContext(r.Context(), "couldn't encode migration version", "err", err)
+	}
+}

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// withMigrationSeam stubs the DB-backed schema_migrations read so the handler
+// renders without a real database.
+func withMigrationSeam(t *testing.T, version int64, dirty bool, err error) {
+	t.Helper()
+	saved := readSchemaMigration
+	t.Cleanup(func() { readSchemaMigration = saved })
+	readSchemaMigration = func(context.Context) (int64, bool, error) {
+		return version, dirty, err
+	}
+}
+
+func fetchMigration(t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	r := mux.NewRouter()
+	r.Handle("/api/db/migration", http.HandlerFunc(migrationVersionAPIHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/db/migration", nil))
+	return rec
+}
+
+func TestMigrationVersionAPIHandler_OK(t *testing.T) {
+	withMigrationSeam(t, 20, false, nil)
+	rec := fetchMigration(t)
+
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	var got migrationVersion
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, rec.Body.String())
+	}
+	if !got.OK || got.Version != 20 || got.Dirty {
+		t.Errorf("unexpected migration version: %+v", got)
+	}
+}
+
+func TestMigrationVersionAPIHandler_Dirty(t *testing.T) {
+	withMigrationSeam(t, 21, true, nil)
+	rec := fetchMigration(t)
+	var got migrationVersion
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.OK || got.Version != 21 || !got.Dirty {
+		t.Errorf("expected dirty version 21, got %+v", got)
+	}
+}
+
+// TestMigrationVersionAPIHandler_DBError covers an unreadable schema_migrations
+// row (DB unreachable, missing table): OK=false so the console renders
+// "unknown" instead of a misleading version 0.
+func TestMigrationVersionAPIHandler_DBError(t *testing.T) {
+	withMigrationSeam(t, 0, false, errors.New("connection refused"))
+	rec := fetchMigration(t)
+	var got migrationVersion
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OK {
+		t.Errorf("expected OK=false on read error, got %+v", got)
+	}
+	// snake_case wire format the console reads.
+	if !strings.Contains(rec.Body.String(), `"ok"`) {
+		t.Errorf("expected snake_case keys: %s", rec.Body.String())
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -117,6 +117,10 @@ func (s *Server) Start(ctx context.Context) {
 	// read-only JSON profile for the standalone tripbot-console's popover (it
 	// has no DB access and proxies here over the in-namespace Service).
 	r.Handle("/api/user/{username}", tagged("/api/user/{username}", userProfileAPIHandler)).Methods("GET")
+	// read-only JSON of the current golang-migrate schema version, for the
+	// standalone tripbot-console to surface which migration the env's DB is on
+	// (it has no DB access and proxies here over the in-namespace Service).
+	r.Handle("/api/db/migration", tagged("/api/db/migration", migrationVersionAPIHandler)).Methods("GET")
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
 	r.PathPrefix("/static/").Handler(staticHandler())
 


### PR DESCRIPTION
## Summary
- Add `GET /api/db/migration` returning the current golang-migrate schema version as JSON: `{"ok": true, "version": 20, "dirty": false}`.
- Reads `SELECT version, dirty FROM schema_migrations` through the existing gorm handle; `ok: false` on any read error so consumers render "unknown" instead of a misleading 0.
- Mirrors the existing console-facing `/api/user/{username}` JSON shape + its function-seam test pattern (no live DB needed).

This is the producer half of a cross-repo change: the standalone tripbot-console holds no DB access, so it fetches the migration version over HTTP to surface which migration each env's Postgres is on.

## Test plan
- [x] tests green (`task test:macos`)
- [ ] Dana: confirm the console shows the correct migration version per env

## Related
- Consumer: adanalife/tripbot-console#26