### PR TITLE
feat(cdk8s): config-driven OBS streaming toggle — turn on stage-youtube

### DIFF
--- a/cdk8s/adanalife_k8s/charts.py
+++ b/cdk8s/adanalife_k8s/charts.py
@@ -49,10 +49,10 @@ def emit_app_charts(scope: Construct, env: EnvConfig) -> None:
             chart = Chart(scope, f"{env.name}-{comp}-{platform}", namespace=ns)
             ctor(chart, platform, env=env)
 
-        # OBS — its own chart. twitch streams by default in prod (ESO stream-key);
-        # everything else boots idle until toggled on. youtube carries
-        # STREAM_PLATFORM=youtube.
-        streaming = platform == "twitch" and env.name == "prod-1"
+        # OBS — its own chart. A platform streams (ESO stream-key + --startstreaming)
+        # when it's listed in env.obs_streaming; otherwise it boots idle until
+        # toggled on. youtube carries STREAM_PLATFORM=youtube.
+        streaming = platform in env.obs_streaming
         obs_chart = Chart(scope, f"{env.name}-obs-{platform}", namespace=ns)
         ObsInstance(
             obs_chart,

--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -82,6 +82,13 @@ class EnvConfig:
     # Streaming platforms present in this env (obs instances). twitch everywhere;
     # youtube currently stage-only while the bot side is built out.
     platforms: tuple[str, ...] = ("twitch",)
+    # Subset of `platforms` whose OBS instance actually streams (emits its
+    # stream-key ExternalSecret from SM `k8s/obs/<platform>-stream-key` and boots
+    # with --startstreaming). Anything in `platforms` but not here boots idle
+    # (VNC-only). Per-env + per-platform so there's no hardcoded "prod-twitch is
+    # special" — a stream is turned on by listing it here, governed by the
+    # two-live-streams iGPU budget (prod-twitch + stage-youtube).
+    obs_streaming: tuple[str, ...] = ()
     # --- prod-stream protection (2026-06-11 stage-starves-prod incident) ---
     # PriorityClassName stamped on the env's app Deployment pods; when set,
     # SupportingChart also emits the PriorityClass itself. Prod outranks every
@@ -188,6 +195,7 @@ ENVS: dict[str, EnvConfig] = {
         # take years of irreplaceable data.
         data_namespace="prod-1-data",
         platforms=("twitch",),
+        obs_streaming=("twitch",),  # prod twitch is the always-live stream
         # The live stream always wins: prod app pods outrank default-priority
         # co-tenants (stage, dashcam-cv), and the encode/decode pair carries
         # real CPU requests so contention can't starve it (20-core node; the
@@ -240,6 +248,10 @@ ENVS: dict[str, EnvConfig] = {
         # streams total: prod-twitch + stage-youtube. Re-add "twitch" when
         # the burn-in ends.
         platforms=("youtube",),
+        # Stage streams to YouTube — the second half of the two-live-streams
+        # budget (prod-twitch + stage-youtube). Key from SM
+        # k8s/obs/youtube-stream-key (adanalife-stage account).
+        obs_streaming=("youtube",),
         # Guardrail from the same incident: cap what stage can request in
         # aggregate, so "accidentally scaled up too many stage deployments"
         # parks pods Unschedulable instead of crowding prod off the node.

--- a/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
@@ -17,6 +17,24 @@ data:
   STREAM_PLATFORM: youtube
   VLC_URL_BASE: http://vlc-youtube:8080
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: obs-youtube-stream-key
+  namespace: stage-1
+spec:
+  data:
+    - remoteRef:
+        key: k8s/obs/youtube-stream-key
+      secretKey: STREAM_KEY
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secretsmanager
+  target:
+    creationPolicy: Owner
+    name: obs-youtube-stream-key
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -97,3 +97,29 @@ def test_youtube_tripbot_emits_youtube_creds():
     objs = _objects("stage-1-tripbot-youtube")
     es_names = {o["metadata"]["name"] for o in objs if o["kind"] == "ExternalSecret"}
     assert "tripbot-youtube-creds" in es_names
+
+
+# Which (env, platform) OBS instances actually stream — must mirror
+# config.EnvConfig.obs_streaming. A streaming instance emits its stream-key
+# ExternalSecret; an idle one does not (and boots without the key).
+STREAMING = {("prod-1", "twitch"), ("stage-1", "youtube")}
+
+
+@pytest.mark.parametrize("env,comp,platform", list(_env_components()), ids=str)
+def test_obs_stream_key_secret_iff_streaming(env, comp, platform):
+    if comp != "obs":
+        pytest.skip("stream-key toggle is OBS-only")
+    objs = _objects(f"{env}-obs-{platform}")
+    es_names = {o["metadata"]["name"] for o in _by_kind(objs, "ExternalSecret")}
+    # twitch keeps the shared base name; other platforms get a distinct one.
+    key_name = (
+        "obs-stream-key" if platform == "twitch" else f"obs-{platform}-stream-key"
+    )
+    if (env, platform) in STREAMING:
+        assert key_name in es_names, (
+            f"{env}/{platform} should stream but has no stream-key ExternalSecret"
+        )
+    else:
+        assert key_name not in es_names, (
+            f"{env}/{platform} should be idle but emits a stream-key ExternalSecret"
+        )


### PR DESCRIPTION
Turns the stage YouTube stream on durably, and replaces the hardcoded streaming special-case with a per-env config knob (the cleanup flagged in `vault/tripbot/obs/TODO.md`).

## What changed
- **`EnvConfig.obs_streaming`** — new per-env tuple of platforms whose OBS instance actually streams (emits its stream-key ExternalSecret + boots `--startstreaming`). Replaces `streaming = platform == "twitch" and env.name == "prod-1"` in `charts.py`.
- **prod-1** → `obs_streaming=("twitch",)` (render byte-identical — the prod stream-key ExternalSecret is unchanged).
- **stage-1** → `obs_streaming=("youtube",)` — `stage-1-obs-youtube` now emits an `obs-youtube-stream-key` ExternalSecret reading SM `k8s/obs/youtube-stream-key`.
- Test asserting the stream-key ExternalSecret appears **iff** the instance is configured to stream.

## The "why two secrets" / consolidation
There weren't two stream keys at the same layer — there's the **SM** entry (`k8s/obs/youtube-stream-key`, the durable source you set) and a **hand-created k8s Secret** `obs-youtube-stream-key` in stage-1 that the currently-running OBS is using. This PR makes the cluster Secret **ESO-managed from SM** (`creationPolicy: Owner`), so SM becomes the single source of truth.

## Rollout (after merge → Argo syncs stage)
1. **Confirm** SM `k8s/obs/youtube-stream-key` holds the valid key (it's what ESO will materialize). If the only-good value is the hand-created Secret, copy it into SM first — ESO overwrites the cluster Secret from SM.
2. Once ESO owns `obs-youtube-stream-key`, **delete the hand-created Secret** if ESO didn't adopt it, so ownership is clean.
3. `kubectl rollout restart deploy/obs-youtube -n stage-1` to pick up the ESO-managed key. (The running pod keeps its current env until restart, so the live stream isn't interrupted while reconciling.)

No prod behavior change. The prod persistent-key + auto-start launch requirement is tracked separately in the obs TODO.