### PR TITLE
feat(eventbus): platform-scope video.changed and viewers.count

### DIFF
--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -109,21 +109,29 @@ func EmitChatMessage(ctx context.Context, env, platform, username, text string) 
 // --- viewers.count --------------------------------------------------------
 
 // ViewerCount is the wire format for tripbot.<env>.viewers.count — the
-// authoritative chatter total Twitch reports, published on each chatter-list
-// refresh so the admin panel's "in chat" number updates live.
+// authoritative chatter total the platform reports, published on each
+// chatter-list refresh so the console's "in chat" number updates live.
 type ViewerCount struct {
+	// Platform is the streaming platform this count is for ("twitch" /
+	// "youtube"). Both per-platform instances publish into the same env's
+	// subject, so this is what lets the console keep a separate count per
+	// platform instead of the instances clobbering one another. Empty on
+	// events emitted before the tag existed.
+	Platform  string `json:"platform,omitempty"`
 	Count     int    `json:"count"`
 	EmittedAt string `json:"emitted_at"`
 }
 
 // ViewerCountSubject returns the subscribe/publish subject for viewer-count
-// updates in env. The admin hub builds the same string to subscribe.
+// updates in env. The console builds the same string to subscribe.
 func ViewerCountSubject(env string) string { return subject(env, "viewers", "count") }
 
-// EmitViewerCount publishes the current chatter total. The admin hub compares
-// it to the previous value to flash the count green (rising) or red (falling).
-func EmitViewerCount(ctx context.Context, env string, count int) {
+// EmitViewerCount publishes the current chatter total for this instance's
+// platform. The console compares it to the previous value to flash the count
+// green (rising) or red (falling).
+func EmitViewerCount(ctx context.Context, env, platform string, count int) {
 	emit(ctx, ViewerCountSubject(env), ViewerCount{
+		Platform:  platform,
 		Count:     count,
 		EmittedAt: emittedAt(),
 	})
@@ -133,9 +141,16 @@ func EmitViewerCount(ctx context.Context, env string, count int) {
 
 // VideoChanged is the wire format for tripbot.<env>.video.changed — published
 // when VLC switches to a new clip. State is the full state name (e.g.
-// "Wyoming"); Flagged marks a no-GPS clip. The admin panel's "now playing"
-// card updates from this without a reload.
+// "Wyoming"); Flagged marks a no-GPS clip. The console's "now playing" card
+// updates from this without a reload.
 type VideoChanged struct {
+	// Platform is the streaming platform whose VLC switched clips ("twitch" /
+	// "youtube"). Each platform runs its own VLC at an independent corpus
+	// position, so both per-platform instances publish into the same env's
+	// subject; this is what lets the console keep a separate now-playing card
+	// and map trail per platform. Empty on events emitted before the tag
+	// existed.
+	Platform  string  `json:"platform,omitempty"`
 	File      string  `json:"file"`
 	State     string  `json:"state"`
 	Flagged   bool    `json:"flagged"`
@@ -148,10 +163,12 @@ type VideoChanged struct {
 // events in env.
 func VideoChangedSubject(env string) string { return subject(env, "video", "changed") }
 
-// EmitVideoChanged publishes a video switch. The emitted_at doubles as the
-// clip's start time, so the panel can tick an elapsed timer from it.
-func EmitVideoChanged(ctx context.Context, env, file, state string, flagged bool, lat, lng float64) {
+// EmitVideoChanged publishes a video switch for this instance's platform. The
+// emitted_at doubles as the clip's start time, so the console can tick an
+// elapsed timer from it.
+func EmitVideoChanged(ctx context.Context, env, platform, file, state string, flagged bool, lat, lng float64) {
 	emit(ctx, VideoChangedSubject(env), VideoChanged{
+		Platform:  platform,
 		File:      file,
 		State:     state,
 		Flagged:   flagged,

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -95,7 +95,7 @@ func TestEmitViewerCount(t *testing.T) {
 	nowFn = func() time.Time { return fixed }
 	t.Cleanup(func() { nowFn = func() time.Time { return time.Now().UTC() } })
 
-	EmitViewerCount(context.Background(), "development", 42)
+	EmitViewerCount(context.Background(), "development", "twitch", 42)
 
 	if len(rec.Publishes) != 1 {
 		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
@@ -108,6 +108,9 @@ func TestEmitViewerCount(t *testing.T) {
 	var ev ViewerCount
 	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
 		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Platform != "twitch" {
+		t.Errorf("platform = %q, want twitch", ev.Platform)
 	}
 	if ev.Count != 42 {
 		t.Errorf("count = %d, want 42", ev.Count)
@@ -132,7 +135,7 @@ func TestEmitVideoChanged(t *testing.T) {
 	nowFn = func() time.Time { return fixed }
 	t.Cleanup(func() { nowFn = func() time.Time { return time.Now().UTC() } })
 
-	EmitVideoChanged(context.Background(), "development", "wy_0042.MP4", "Wyoming", false, 41.5, -110.2)
+	EmitVideoChanged(context.Background(), "development", "youtube", "wy_0042.MP4", "Wyoming", false, 41.5, -110.2)
 
 	if len(rec.Publishes) != 1 {
 		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
@@ -145,6 +148,9 @@ func TestEmitVideoChanged(t *testing.T) {
 	var ev VideoChanged
 	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
 		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if ev.Platform != "youtube" {
+		t.Errorf("platform = %q, want youtube", ev.Platform)
 	}
 	if ev.File != "wy_0042.MP4" || ev.State != "Wyoming" || ev.Flagged {
 		t.Errorf("envelope = %+v, want file=wy_0042.MP4 state=Wyoming flagged=false", ev)

--- a/pkg/server/hub_jetstream_test.go
+++ b/pkg/server/hub_jetstream_test.go
@@ -46,8 +46,8 @@ func TestHub_Start_replaysHistoryFromJetStream(t *testing.T) {
 	// Publish history BEFORE the hub starts — the whole point is replay.
 	eventbus.EmitChatMessage(ctx, env, "twitch", "alice", "first")
 	eventbus.EmitChatMessage(ctx, env, "twitch", "bob", "second")
-	eventbus.EmitVideoChanged(ctx, env, "wy_0001.MP4", "Wyoming", false, 41.5, -110.2)
-	eventbus.EmitVideoChanged(ctx, env, "ut_0002.MP4", "Utah", false, 40.0, -111.0)
+	eventbus.EmitVideoChanged(ctx, env, "twitch", "wy_0001.MP4", "Wyoming", false, 41.5, -110.2)
+	eventbus.EmitVideoChanged(ctx, env, "twitch", "ut_0002.MP4", "Utah", false, 40.0, -111.0)
 	if err := nc.Flush(); err != nil {
 		t.Fatalf("flush: %v", err)
 	}

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -55,7 +55,7 @@ func (s *Sessions) UpdateSession(ctx context.Context) {
 
 	// Publish the authoritative chatter total so the admin panel's live console
 	// updates the "in chat" number (and flashes it on a change) without a reload.
-	eventbus.EmitViewerCount(ctx, c.Conf.Environment, s.source.ChatterCount())
+	eventbus.EmitViewerCount(ctx, c.Conf.Environment, c.Conf.Platform, s.source.ChatterCount())
 
 	// log out the people who aren't present
 	for username, user := range s.loggedIn {

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -81,7 +81,7 @@ func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 		// Announce the switch so the admin panel's "now playing" card updates
 		// live (no-op when NATS is unconfigured). emitted_at doubles as the
 		// clip start time for the panel's elapsed ticker.
-		eventbus.EmitVideoChanged(ctx, c.Conf.Environment,
+		eventbus.EmitVideoChanged(ctx, c.Conf.Environment, c.Conf.Platform,
 			p.CurrentlyPlaying.File(), p.CurrentlyPlaying.State, p.CurrentlyPlaying.Flagged,
 			p.CurrentlyPlaying.Lat, p.CurrentlyPlaying.Lng)
 
@@ -114,7 +114,7 @@ func (p *Player) EmitCurrentVideo(ctx context.Context) {
 	if p.CurrentlyPlaying.Slug == "" {
 		return
 	}
-	eventbus.EmitVideoChanged(ctx, c.Conf.Environment,
+	eventbus.EmitVideoChanged(ctx, c.Conf.Environment, c.Conf.Platform,
 		p.CurrentlyPlaying.File(), p.CurrentlyPlaying.State, p.CurrentlyPlaying.Flagged,
 		p.CurrentlyPlaying.Lat, p.CurrentlyPlaying.Lng)
 }


### PR DESCRIPTION
## What

Adds a `Platform` field to the `VideoChanged` and `ViewerCount` eventbus payloads, mirroring the existing `ChatMessage.Platform`, and threads `c.Conf.Platform` through at the emit sites.

## Why

Both per-platform tripbot instances (`tripbot-twitch`, `tripbot-youtube`) publish to the same env-scoped `tripbot.<env>.video.changed` and `tripbot.<env>.viewers.count` subjects. With both platforms live on prod, they **clobber each other** — each VLC is at an independent corpus position, so the console's now-playing card, map trail, and viewer count flicker between whichever instance published last.

`chat.message` already solved this (it carries `Platform`, disambiguated on the consumer side); `video.changed` and `viewers.count` didn't get the same treatment. This brings them to parity so the console can render a separate now-playing / map / viewer count per platform.

## Notes

- Single subject + `Platform` field (same pattern as `chat.message`), not a per-platform subject — the `TRIPBOT_VIDEO` JetStream replay still backfills both platforms' recent history on a cold console connect.
- `omitempty`: pre-upgrade events have no platform tag; the console falls back gracefully.
- Consumer-side rendering lands in the tripbot-console repo (separate PR, references this one).

## Test

- `pkg/eventbus` unit tests updated to assert the platform field round-trips.
- Frozen in-tripbot panel hub test updated for the new signature.