### PR TITLE
Drop stage obs-youtube iGPU claim (software-encode) to free the GPU

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -53,6 +53,13 @@ class EnvConfig:
     # software decode — CPU flat at ~0.04 cores with and without /dev/dri,
     # verified live on stage 2026-06-13). See VlcServer in constructs/vlc.py.
     vlc_gpu: bool = True
+    # OBS's iGPU claim is gated on (gpu and obs_gpu), same shape as vlc_gpu.
+    # Default True keeps the claim wherever the env has a GPU; set False to drop
+    # just OBS's claim so the env stops being a live VAAPI consumer on the shared
+    # iGPU. An env that sets obs_gpu=False must also set obs_encoder="obs_x264" —
+    # without /dev/dri the VAAPI encoder can't run, so OBS falls back to software
+    # x264. See ObsInstance in constructs/obs.py.
+    obs_gpu: bool = True
     obs_encoder: str = "obs_x264"  # ffmpeg_vaapi_tex on GPU envs
     obs_quality: str = "low"  # low | high
     dashcam_mode: str = "hostpath"  # nfs | hostpath
@@ -221,7 +228,16 @@ ENVS: dict[str, EnvConfig] = {
         # app workloads moved from infra into this repo (the cdk8s-into-repo
         # cutover dropped the flag, so stage vlc silently reclaimed the iGPU).
         vlc_gpu=False,
-        obs_encoder="ffmpeg_vaapi_tex",
+        # TEMPORARY (2026-06-15): stage obs-youtube dropped its iGPU claim so the
+        # only live VAAPI consumers on the shared Iris Xe are prod obs-twitch +
+        # the video-optimization job (2 concurrent encoders, not 3). A third
+        # concurrent consumer stuttered the prod stream on 2026-06-14. Stage
+        # youtube keeps streaming via software x264 (obs_encoder below); prod is
+        # CPU-protected by its priority class + requests. Revert (obs_gpu=True +
+        # obs_encoder="ffmpeg_vaapi_tex") once the optimization job no longer needs
+        # the iGPU, or once it's reworked to share the device with both streams.
+        obs_gpu=False,
+        obs_encoder="obs_x264",
         obs_quality="low",
         dashcam_mode="nfs",
         tailscale=True,
@@ -257,11 +273,11 @@ ENVS: dict[str, EnvConfig] = {
         # parks pods Unschedulable instead of crowding prod off the node.
         # CPU/memory sized roomy — youtube stack (~0.5 CPU / 1.3Gi requests) +
         # dashcam-cv embed jobs (2× 1 CPU / 5Gi) + one-shot jobs fit with
-        # headroom; the node has 20 CPU / 31Gi. iGPU claims sized TIGHT to
-        # what stage runs today: vlc + obs steady (2) + 1 surge slot for
-        # vlc's RollingUpdate maxSurge=1 (obs is Recreate, no surge). Claims,
-        # not GPU time — encode contention is governed by the two-stream
-        # budget above, not by quota. Bump alongside re-adding twitch.
+        # headroom; the node has 20 CPU / 31Gi. iGPU cap left at 3 even though
+        # stage's own pods no longer claim the device (obs_gpu=False +
+        # vlc_gpu=False as of 2026-06-15) — the budget now covers the
+        # video-optimization job's claim with surge headroom. Restore the
+        # "vlc + obs steady + surge" sizing when obs_gpu flips back to True.
         app_quota={
             "requests.cpu": "6",
             "requests.memory": "16Gi",

--- a/cdk8s/adanalife_k8s/constructs/obs.py
+++ b/cdk8s/adanalife_k8s/constructs/obs.py
@@ -97,7 +97,10 @@ class ObsInstance(Construct):
             "memory": k8s.Quantity.from_string("512Mi"),
         }
         limits = {"memory": k8s.Quantity.from_string("3Gi")}
-        if env.gpu:
+        # iGPU claim gated on (gpu and obs_gpu) — an env can drop just OBS's claim
+        # (env.obs_gpu=False) to stop being a live VAAPI consumer on the shared
+        # iGPU while still streaming via software x264 (env.obs_encoder).
+        if env.gpu and env.obs_gpu:
             requests["gpu.intel.com/i915"] = k8s.Quantity.from_string("1")
             limits["gpu.intel.com/i915"] = k8s.Quantity.from_string("1")
 

--- a/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   DASHCAM_RTSP_URL: rtsp://vlc-youtube:8554/dashcam
   OBS_QUALITY_PRESET: low
-  OBS_STREAM_ENCODER: ffmpeg_vaapi_tex
+  OBS_STREAM_ENCODER: obs_x264
   OBS_WEBSOCKET_PASSWD: adanalife
   ONSCREENS_URL_BASE: http://onscreens-youtube:8080
   STREAM_PLATFORM: youtube
@@ -55,7 +55,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 26804620b3
+        adanalife.dev/config-hash: 54bf302110
       labels:
         app: obs-youtube
         app.kubernetes.io/instance: obs-youtube
@@ -91,11 +91,9 @@ spec:
               name: obs-server
           resources:
             limits:
-              gpu.intel.com/i915: "1"
               memory: 3Gi
             requests:
               cpu: 200m
-              gpu.intel.com/i915: "1"
               memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Why

Three concurrent VAAPI consumers on the single mini-PC Iris Xe — prod `obs-twitch` + stage `obs-youtube` + the video-optimization job — stuttered the prod twitch stream (2026-06-14). The shared device's `-shared-dev-num=8` only governs scheduling slots, not actual GPU compute, so the slot headroom didn't help.

Goal (per Dana): get back to **two** live GPU consumers — prod `obs-twitch` + the video-optimization job — without touching prod.

## What

Add an `obs_gpu` knob that mirrors the existing `vlc_gpu` one: the OBS `gpu.intel.com/i915` claim is now gated on `(gpu and obs_gpu)` instead of `gpu` alone (`constructs/obs.py`).

Set stage-1:
- `obs_gpu=False` → stage `obs-youtube` drops its iGPU claim (requests + limits).
- `obs_encoder="obs_x264"` → without `/dev/dri` the VAAPI encoder can't run, so stage YouTube keeps streaming via **software x264**. Prod stays CPU-protected by its `prod-stream` priority class + real CPU requests, so the added CPU load can't starve it.

Synthed `dist/` diff is isolated to `stage-1-obs-youtube.k8s.yaml` (encoder env + both GPU claim lines + config-hash); prod and every other unit are byte-identical. `cdk8s:test` green, ruff clean.

## Temporary

This is a stopgap. Revert (`obs_gpu=True` + `obs_encoder="ffmpeg_vaapi_tex"`) once the optimization job no longer needs the iGPU, or once it's reworked to share the device alongside both streams. The stage `app_quota` iGPU cap is left at 3 (now covers the optimization job's claim + surge); its comment is updated to say so.