### PR TITLE
cdk8s: prefer the ephemeral rpi5 worker for stage stateless apps

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -119,6 +119,14 @@ class EnvConfig:
     # (EXTERNAL_URL, registered OAuth redirect URIs). Only dev needs it — k3d's
     # traefik is mapped to host :9443 because Colima can't bind :443.
     external_port: str = ""
+    # Bias this env's stateless app pods toward the ephemeral arm64 rpi5 worker
+    # (adanalife-rpi5) when it's present, falling back to the MS-01 when it's not.
+    # When True, the tripbot/vlc/onscreens constructs add a toleration for the
+    # node's dana.lol/rpi5 taint + a PREFERRED (never required) node affinity
+    # toward dana.lol/board=rpi5 (see scheduling.py). OBS deliberately opts
+    # out — the Pi 5 has no H.264 hw encoder. Stage only; prod stays on the MS-01
+    # (and the taint repels it regardless, since prod pods carry no toleration).
+    prefer_rpi5: bool = False
 
     def tag_for(self, component: str) -> str:
         """Image tag for a component: its pinned release tag when versions.yaml
@@ -241,6 +249,10 @@ ENVS: dict[str, EnvConfig] = {
         obs_quality="low",
         dashcam_mode="nfs",
         tailscale=True,
+        # Prefer the ephemeral arm64 rpi5 worker for stage's stateless app pods
+        # (tripbot/vlc/onscreens); they recover onto the MS-01 if the Pi is
+        # unplugged. See prefer_rpi5 on EnvConfig + scheduling.py.
+        prefer_rpi5=True,
         otel=False,
         postgres_size="10Gi",
         postgres_storage_class="local-path",

--- a/cdk8s/adanalife_k8s/constructs/onscreens.py
+++ b/cdk8s/adanalife_k8s/constructs/onscreens.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from constructs import Construct
 
 import imports.k8s as k8s
-from adanalife_k8s import appconfig, configmap
+from adanalife_k8s import appconfig, configmap, scheduling
 from adanalife_k8s.config import EnvConfig
 from adanalife_k8s.naming import app_name, meta_labels, selector
 
@@ -130,6 +130,18 @@ class OnscreensServer(Construct):
                             seccomp_profile=k8s.SeccompProfile(type="RuntimeDefault")
                         ),
                         priority_class_name=env.priority_class or None,
+                        # Prefer the ephemeral rpi5 worker when present, recover
+                        # to the MS-01 when it's gone (stage only). See scheduling.py.
+                        tolerations=(
+                            scheduling.prefer_rpi5_tolerations()
+                            if env.prefer_rpi5
+                            else None
+                        ),
+                        affinity=(
+                            scheduling.prefer_rpi5_affinity()
+                            if env.prefer_rpi5
+                            else None
+                        ),
                         containers=[container],
                         volumes=[
                             k8s.Volume(name="run", empty_dir=k8s.EmptyDirVolumeSource())

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -38,7 +38,7 @@ import cdk8s
 from constructs import Construct
 
 import imports.k8s as k8s
-from adanalife_k8s import appconfig, configmap, eso
+from adanalife_k8s import appconfig, configmap, eso, scheduling
 from adanalife_k8s.config import EnvConfig
 from adanalife_k8s.eso import ESData
 from adanalife_k8s.naming import app_name, meta_labels, selector
@@ -335,6 +335,18 @@ class Tripbot(Construct):
                             seccomp_profile=k8s.SeccompProfile(type="RuntimeDefault"),
                         ),
                         priority_class_name=env.priority_class or None,
+                        # Prefer the ephemeral rpi5 worker when present, recover
+                        # to the MS-01 when it's gone (stage only). See scheduling.py.
+                        tolerations=(
+                            scheduling.prefer_rpi5_tolerations()
+                            if env.prefer_rpi5
+                            else None
+                        ),
+                        affinity=(
+                            scheduling.prefer_rpi5_affinity()
+                            if env.prefer_rpi5
+                            else None
+                        ),
                         init_containers=[migrate],
                         containers=[container],
                     ),

--- a/cdk8s/adanalife_k8s/constructs/vlc.py
+++ b/cdk8s/adanalife_k8s/constructs/vlc.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from constructs import Construct
 
 import imports.k8s as k8s
-from adanalife_k8s import appconfig, configmap
+from adanalife_k8s import appconfig, configmap, scheduling
 from adanalife_k8s.config import EnvConfig
 from adanalife_k8s.naming import app_name, meta_labels, selector
 
@@ -183,6 +183,20 @@ class VlcServer(Construct):
                             seccomp_profile=k8s.SeccompProfile(type="RuntimeDefault")
                         ),
                         priority_class_name=env.priority_class or None,
+                        # Prefer the ephemeral rpi5 worker when present, recover
+                        # to the MS-01 when it's gone (stage only). The RTSP feed
+                        # to OBS crosses the LAN instead of localhost when vlc
+                        # lands on the Pi. See scheduling.py.
+                        tolerations=(
+                            scheduling.prefer_rpi5_tolerations()
+                            if env.prefer_rpi5
+                            else None
+                        ),
+                        affinity=(
+                            scheduling.prefer_rpi5_affinity()
+                            if env.prefer_rpi5
+                            else None
+                        ),
                         containers=[container],
                         volumes=[volume],
                     ),

--- a/cdk8s/adanalife_k8s/scheduling.py
+++ b/cdk8s/adanalife_k8s/scheduling.py
@@ -1,0 +1,72 @@
+"""Scheduling helpers for the ephemeral arm64 rpi5 worker.
+
+`adanalife-rpi5` is a Raspberry Pi 5 joined to the `adanalife-minipc` cluster as
+an arm64 worker (infra `talos/adanalife-minipc/worker.patch.yaml`). It's treated
+as *ephemeral*: nothing hard-requires it, but chosen stateless stage workloads
+PREFER it when it's present and recover onto the MS-01 when it's unplugged.
+
+The node carries:
+  - taint  `dana.lol/rpi5=true:NoSchedule`  (repels everything by default,
+    so prod pods never drift onto a weak SD-card node)
+  - label  `dana.lol/board=rpi5`
+
+A workload opts in (gated by `EnvConfig.prefer_rpi5`, stage-1 only) with two
+pieces:
+
+  1. a TOLERATION of the taint, so it's *allowed* to land on the Pi at all; and
+  2. a PREFERRED (`preferredDuringScheduling`) node affinity toward the board
+     label, so the scheduler *biases* to the Pi but still places the pod on the
+     MS-01 when the Pi is absent.
+
+The affinity is deliberately PREFERRED, never REQUIRED: a required term would
+pin the pod to the Pi and leave it Pending when the Pi is gone — the opposite of
+the ephemeral/recover-to-MS-01 contract. When the Pi is unplugged, the running
+pod is evicted by the standard `node.kubernetes.io/unreachable` toleration
+(~5 min default) and reschedules onto the MS-01.
+
+OBS opts OUT even in stage: the Pi 5's VideoCore VII has no H.264 hardware
+encoder, so OBS must stay on the MS-01's Iris Xe. Its construct simply never
+calls these helpers.
+"""
+
+from __future__ import annotations
+
+import imports.k8s as k8s
+
+RPI5_TAINT_KEY = "dana.lol/rpi5"
+RPI5_BOARD_LABEL = "dana.lol/board"
+RPI5_BOARD_VALUE = "rpi5"
+
+
+def prefer_rpi5_tolerations() -> list[k8s.Toleration]:
+    """Toleration for the rpi5 node taint — lets the pod schedule on the Pi."""
+    return [
+        k8s.Toleration(
+            key=RPI5_TAINT_KEY,
+            operator="Exists",
+            effect="NoSchedule",
+        )
+    ]
+
+
+def prefer_rpi5_affinity() -> k8s.Affinity:
+    """PREFERRED node affinity toward the rpi5 board label — biases scheduling to
+    the Pi when present, falls back to the MS-01 when it's not."""
+    return k8s.Affinity(
+        node_affinity=k8s.NodeAffinity(
+            preferred_during_scheduling_ignored_during_execution=[
+                k8s.PreferredSchedulingTerm(
+                    weight=100,
+                    preference=k8s.NodeSelectorTerm(
+                        match_expressions=[
+                            k8s.NodeSelectorRequirement(
+                                key=RPI5_BOARD_LABEL,
+                                operator="In",
+                                values=[RPI5_BOARD_VALUE],
+                            )
+                        ]
+                    ),
+                )
+            ]
+        )
+    )

--- a/cdk8s/dist/stage-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-onscreens-youtube.k8s.yaml
@@ -41,6 +41,16 @@ spec:
       labels:
         app: onscreens-youtube
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: dana.lol/board
+                    operator: In
+                    values:
+                      - rpi5
+              weight: 100
       containers:
         - envFrom:
             - configMapRef:
@@ -87,6 +97,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      tolerations:
+        - effect: NoSchedule
+          key: dana.lol/rpi5
+          operator: Exists
       volumes:
         - emptyDir: {}
           name: run

--- a/cdk8s/dist/stage-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-tripbot-youtube.k8s.yaml
@@ -70,6 +70,16 @@ spec:
       labels:
         app: tripbot-youtube
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: dana.lol/board
+                    operator: In
+                    values:
+                      - rpi5
+              weight: 100
       containers:
         - env:
             - name: USER
@@ -157,6 +167,10 @@ spec:
         runAsUser: 65532
         seccompProfile:
           type: RuntimeDefault
+      tolerations:
+        - effect: NoSchedule
+          key: dana.lol/rpi5
+          operator: Exists
 ---
 apiVersion: v1
 kind: Service

--- a/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
@@ -45,6 +45,16 @@ spec:
       labels:
         app: vlc-youtube
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: dana.lol/board
+                    operator: In
+                    values:
+                      - rpi5
+              weight: 100
       containers:
         - envFrom:
             - configMapRef:
@@ -96,6 +106,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      tolerations:
+        - effect: NoSchedule
+          key: dana.lol/rpi5
+          operator: Exists
       volumes:
         - name: dashcam
           persistentVolumeClaim:


### PR DESCRIPTION
[adanalife-rpi5](https://github.com/adanalife/infra/pull/726/changes) — a Raspberry Pi 5 (arm64) — joined `adanalife-minipc` as an **ephemeral** sandbox worker. This biases stage's stateless app pods toward it when it's present, recovering onto the MS-01 when it's unplugged. Nothing hard-requires the Pi.

### Mechanism (`adanalife_k8s/scheduling.py`)
A workload opts in (gated by the new `EnvConfig.prefer_rpi5`, **stage-1 only**) with:
- a **toleration** of the node's `dana.lol/rpi5=true:NoSchedule` taint — lets it land on the Pi at all;
- a **`preferredDuringScheduling`** node affinity (weight 100) toward `dana.lol/board=rpi5` — biases to the Pi, falls back to the MS-01 when it's gone.

Preferred, *never* required — a required term would pin the pod and leave it `Pending` when the Pi is gone. On an unplug, the standard `node.kubernetes.io/unreachable` eviction (~5 min default) reschedules onto the MS-01.

### Applied to
`tripbot`, `vlc`, `onscreens` constructs. **OBS opts out** — the Pi 5 has no H.264 hardware encoder, so it stays on the MS-01's Iris Xe. **Prod is untouched** (and the node taint repels it regardless — prod pods carry no toleration).

### Label prefix
Uses `dana.lol/` (an owned domain) rather than the older `adanalife.dev/` convention. The `adanalife.dev/config-hash` annotation migrates to `dana.lol/` separately (it re-rolls every deployment, so it's its own change).

### Not in scope: NATS
NATS is a single-pod JetStream StatefulSet on a `local-path` PVC. local-path pins the pod to its node, so moving it to the Pi would strand its store on the SD card and break recovery. Spreading NATS needs cluster mode (≥2 replicas, R3 JetStream) first — tracked separately in the infra vault.

### Verification
- `dist/` regenerated — **only** `stage-1-{tripbot,vlc,onscreens}-youtube` changed; `stage-1-obs-youtube` and all prod/dev manifests unchanged.
- `pytest` green, golden-file gate green, ruff clean.

Sibling: tripbot-console gets the same treatment in its own repo; infra follow-up renames the Pi node label/taint to `dana.lol/`.