### PR TITLE
vlc: dial OBS per-platform (vlc-youtube → obs-youtube)

### DIFF
--- a/cdk8s/adanalife_k8s/constructs/vlc.py
+++ b/cdk8s/adanalife_k8s/constructs/vlc.py
@@ -53,6 +53,12 @@ class VlcServer(Construct):
         # --- ConfigMap (stable name + content-hash annotation) ---
         data = dict(_BASE_CONFIG)
         data["VLC_SERVER_HOST"] = f"{name}:8080"  # self-reference
+        # OBS WebSocket control addr (:4455) — vlc-server polls OBS for streaming
+        # state, so it must dial its OWN platform's OBS (vlc-youtube → obs-youtube),
+        # not the baked-in obs-twitch default that left the YouTube vlc connecting
+        # to obs-twitch. Set explicitly per platform (same as tripbot.py); relying
+        # on the default already caused an incident (pkg/obs/control.go).
+        data["OBS_WEBSOCKET_ADDR"] = f"{app_name('obs', platform)}:4455"
         if appconfig.uses_local_stubs(env):
             data.update(appconfig.local_stubs())
         data.update(appconfig.telemetry_config(env, platform))

--- a/cdk8s/dist/development-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/development-vlc-twitch.k8s.yaml
@@ -17,6 +17,7 @@ data:
   ENV: staging
   FONTCONFIG_PATH: /etc/fonts
   NATS_URL: nats://nats.development-platform.svc.cluster.local:4222
+  OBS_WEBSOCKET_ADDR: obs-twitch:4455
   OTEL_RESOURCE_ATTRIBUTES: deployment.environment=development,service.namespace=tripbot,service.platform=twitch
   OTEL_SDK_DISABLED: "true"
   OTEL_TRACES_SAMPLER: parentbased_traceidratio
@@ -49,7 +50,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: f2314b6653
+        adanalife.dev/config-hash: fe241f2cff
       labels:
         app: vlc-twitch
     spec:

--- a/cdk8s/dist/local-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/local-vlc-twitch.k8s.yaml
@@ -16,6 +16,7 @@ data:
   DISPLAY: :0.0
   ENV: staging
   FONTCONFIG_PATH: /etc/fonts
+  OBS_WEBSOCKET_ADDR: obs-twitch:4455
   OTEL_RESOURCE_ATTRIBUTES: deployment.environment=development,service.namespace=tripbot,service.platform=twitch
   OTEL_SDK_DISABLED: "true"
   OTEL_TRACES_SAMPLER: parentbased_traceidratio
@@ -48,7 +49,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: c8eae83d8c
+        adanalife.dev/config-hash: a5cffb492b
       labels:
         app: vlc-twitch
     spec:

--- a/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
@@ -11,6 +11,7 @@ data:
   ENV: production
   FONTCONFIG_PATH: /etc/fonts
   NATS_URL: nats://nats.prod-1-platform.svc.cluster.local:4222
+  OBS_WEBSOCKET_ADDR: obs-twitch:4455
   OTEL_RESOURCE_ATTRIBUTES: deployment.environment=prod-1,service.namespace=tripbot,service.platform=twitch
   OTEL_SDK_DISABLED: "false"
   OTEL_TRACES_SAMPLER: parentbased_traceidratio
@@ -40,7 +41,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: "0575176656"
+        adanalife.dev/config-hash: d7525e4c17
       labels:
         app: vlc-twitch
     spec:

--- a/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
@@ -11,6 +11,7 @@ data:
   ENV: staging
   FONTCONFIG_PATH: /etc/fonts
   NATS_URL: nats://nats.stage-1-platform.svc.cluster.local:4222
+  OBS_WEBSOCKET_ADDR: obs-youtube:4455
   OTEL_RESOURCE_ATTRIBUTES: deployment.environment=stage-1,service.namespace=tripbot,service.platform=youtube
   OTEL_SDK_DISABLED: "true"
   OTEL_TRACES_SAMPLER: parentbased_traceidratio
@@ -41,7 +42,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 73ed43388d
+        adanalife.dev/config-hash: 6784eb9f44
       labels:
         app: vlc-youtube
     spec:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -50,6 +50,17 @@ def test_each_component_has_deployment_and_service(env, comp, platform):
 
 
 @pytest.mark.parametrize("env,platform", [("prod-1", "twitch"), ("stage-1", "youtube")])
+@pytest.mark.parametrize("comp", ["vlc", "tripbot"])
+def test_obs_websocket_addr_is_platform_scoped(env, comp, platform):
+    """Both OBS-websocket clients (tripbot + vlc-server poll/control OBS) must dial
+    their OWN platform's OBS — vlc-youtube → obs-youtube, not the baked-in
+    obs-twitch default that broke the YouTube vlc."""
+    cms = _by_kind(_objects(f"{env}-{comp}-{platform}"), "ConfigMap")
+    data = next(cm["data"] for cm in cms if "OBS_WEBSOCKET_ADDR" in cm.get("data", {}))
+    assert data["OBS_WEBSOCKET_ADDR"] == f"obs-{platform}:4455"
+
+
+@pytest.mark.parametrize("env,platform", [("prod-1", "twitch"), ("stage-1", "youtube")])
 def test_prod_pinned_stage_floats(env, platform):
     """prod deploys the exact versions.yaml pin with IfNotPresent; stage floats
     on develop with Always."""


### PR DESCRIPTION
## The bug

vlc-server polls the OBS WebSocket for streaming state, but the `VlcServer` cdk8s construct never set `OBS_WEBSOCKET_ADDR` — so `pkg/obs` fell back to its baked-in `obs-twitch:4455` default. After OBS went per-platform, that left **vlc-youtube dialing obs-twitch** (which only exists in the twitch env). It surfaced as `obs websocket connect failed addr=obs-twitch:4455 ... no such host` once stage cut over to the regenerated corpus — platform, not env, is the real axis (youtube just happens to run on stage today).

## Fix

Set `OBS_WEBSOCKET_ADDR = obs-<platform>:4455` in `vlc.py`, mirroring what `tripbot.py` already does for the bot. Explicit on **every** instance (not just non-twitch): relying on the default already caused one incident (`pkg/obs/control.go`), so twitch now carries `obs-twitch:4455` literally rather than leaning on the default.

## Effect (only vlc ConfigMaps change)

- **stage-1-vlc-youtube → `obs-youtube:4455`** ← the fix
- prod-1 / development / local vlc-twitch → `obs-twitch:4455` (was the implicit default; now explicit)

⚠️ The `prod-1-vlc-twitch` ConfigMap content changes (new key) → config-hash bumps → a **one-time vlc-twitch rollout** on the next prod sync. The value is identical to the old default, so it's purely implicit→explicit; the cost is a brief vlc restart (slow-TV blip), no behavior change for twitch.

New parametrized test asserts both OBS clients (vlc + tripbot) dial their own platform's OBS. 32 cdk8s tests pass; golden dist re-synthed; pre-commit clean.