### PR TITLE
cdk8s: schedule software-encoder OBS onto the rpi5 worker

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -123,9 +123,11 @@ class EnvConfig:
     # (adanalife-rpi5) when it's present, falling back to the MS-01 when it's not.
     # When True, the tripbot/vlc/onscreens constructs add a toleration for the
     # node's dana.lol/rpi5 taint + a PREFERRED (never required) node affinity
-    # toward dana.lol/board=rpi5 (see scheduling.py). OBS deliberately opts
-    # out — the Pi 5 has no H.264 hw encoder. Stage only; prod stays on the MS-01
-    # (and the taint repels it regardless, since prod pods carry no toleration).
+    # toward dana.lol/board=rpi5 (see scheduling.py). OBS opts in too, but only
+    # while it's a software encoder (not gpu and obs_gpu) — the Pi 5 has no H.264
+    # hw encoder, so a VAAPI OBS stays on the MS-01's Iris Xe. Stage only; prod
+    # stays on the MS-01 (and the taint repels it regardless, since prod pods
+    # carry no toleration).
     prefer_rpi5: bool = False
 
     def tag_for(self, component: str) -> str:

--- a/cdk8s/adanalife_k8s/constructs/obs.py
+++ b/cdk8s/adanalife_k8s/constructs/obs.py
@@ -19,6 +19,7 @@ import imports.k8s as k8s
 from adanalife_k8s.config import EnvConfig
 from adanalife_k8s.contract import load_contract
 from adanalife_k8s.naming import app_name
+from adanalife_k8s.scheduling import prefer_rpi5_affinity, prefer_rpi5_tolerations
 
 # (port-name, port-number) — order/names match k8s/apps/obs/base/{deployment,service}.yaml
 _PORTS = [
@@ -100,7 +101,8 @@ class ObsInstance(Construct):
         # iGPU claim gated on (gpu and obs_gpu) — an env can drop just OBS's claim
         # (env.obs_gpu=False) to stop being a live VAAPI consumer on the shared
         # iGPU while still streaming via software x264 (env.obs_encoder).
-        if env.gpu and env.obs_gpu:
+        obs_uses_gpu = env.gpu and env.obs_gpu
+        if obs_uses_gpu:
             requests["gpu.intel.com/i915"] = k8s.Quantity.from_string("1")
             limits["gpu.intel.com/i915"] = k8s.Quantity.from_string("1")
 
@@ -145,6 +147,19 @@ class ObsInstance(Construct):
                             seccomp_profile=k8s.SeccompProfile(type="RuntimeDefault")
                         ),
                         priority_class_name=env.priority_class or None,
+                        # OBS joins the ephemeral rpi5 worker ONLY when it's a
+                        # software encoder (no iGPU claim): the Pi 5's VideoCore
+                        # VII has no H.264 hw encoder, so a VAAPI OBS must stay on
+                        # the MS-01's Iris Xe. Gated on `not obs_uses_gpu` so when
+                        # obs_gpu flips back to True the affinity drops here AND
+                        # the i915 resource claim hard-gates the pod back to the
+                        # MS-01. Stage-only via env.prefer_rpi5; see scheduling.py.
+                        affinity=prefer_rpi5_affinity()
+                        if (env.prefer_rpi5 and not obs_uses_gpu)
+                        else None,
+                        tolerations=prefer_rpi5_tolerations()
+                        if (env.prefer_rpi5 and not obs_uses_gpu)
+                        else None,
                         containers=[container],
                     ),
                 ),

--- a/cdk8s/adanalife_k8s/scheduling.py
+++ b/cdk8s/adanalife_k8s/scheduling.py
@@ -24,9 +24,13 @@ the ephemeral/recover-to-MS-01 contract. When the Pi is unplugged, the running
 pod is evicted by the standard `node.kubernetes.io/unreachable` toleration
 (~5 min default) and reschedules onto the MS-01.
 
-OBS opts OUT even in stage: the Pi 5's VideoCore VII has no H.264 hardware
-encoder, so OBS must stay on the MS-01's Iris Xe. Its construct simply never
-calls these helpers.
+OBS opts in conditionally: the Pi 5's VideoCore VII has no H.264 hardware
+encoder, so a VAAPI OBS must stay on the MS-01's Iris Xe. But when OBS is a
+*software* encoder (no iGPU claim — `not (gpu and obs_gpu)`, e.g. stage
+obs-youtube as of 2026-06-15), the Pi can carry it, which also offloads the
+encode off the MS-01. So ObsInstance calls these helpers gated on
+`prefer_rpi5 and not obs_uses_gpu`; when obs_gpu flips back on, the i915 resource
+claim hard-gates the pod back to the MS-01 and the affinity drops out together.
 """
 
 from __future__ import annotations

--- a/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
@@ -62,6 +62,16 @@ spec:
         app.kubernetes.io/name: obs
         app.kubernetes.io/part-of: tripbot
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: dana.lol/board
+                    operator: In
+                    values:
+                      - rpi5
+              weight: 100
       containers:
         - envFrom:
             - configMapRef:
@@ -103,6 +113,10 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      tolerations:
+        - effect: NoSchedule
+          key: dana.lol/rpi5
+          operator: Exists
 ---
 apiVersion: v1
 kind: Service

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -134,3 +134,37 @@ def test_obs_stream_key_secret_iff_streaming(env, comp, platform):
         assert key_name not in es_names, (
             f"{env}/{platform} should be idle but emits a stream-key ExternalSecret"
         )
+
+
+def _pod_spec(stem: str) -> dict:
+    return _by_kind(_objects(stem), "Deployment")[0]["spec"]["template"]["spec"]
+
+
+def _prefers_rpi5(spec: dict) -> bool:
+    """True iff the pod tolerates the rpi5 taint AND prefers the board label."""
+    tolerates = any(
+        t.get("key") == "dana.lol/rpi5" for t in spec.get("tolerations", [])
+    )
+    prefs = (
+        spec.get("affinity", {})
+        .get("nodeAffinity", {})
+        .get("preferredDuringSchedulingIgnoredDuringExecution", [])
+    )
+    biases = any(
+        req.get("key") == "dana.lol/board" and "rpi5" in req.get("values", [])
+        for term in prefs
+        for req in term.get("preference", {}).get("matchExpressions", [])
+    )
+    return tolerates and biases
+
+
+def test_stage_software_obs_prefers_rpi5():
+    """Stage obs-youtube is a software x264 encoder (no iGPU claim), so it joins
+    the ephemeral rpi5 worker — offloading the encode off the MS-01."""
+    assert _prefers_rpi5(_pod_spec("stage-1-obs-youtube"))
+
+
+def test_prod_vaapi_obs_stays_on_msi():
+    """Prod obs-twitch is a VAAPI encoder (holds the i915 claim), so it must NOT
+    bias toward the Pi (no H.264 hw encoder there) — it stays on the MS-01."""
+    assert not _prefers_rpi5(_pod_spec("prod-1-obs-twitch"))


### PR DESCRIPTION
## What

Stage `obs-youtube` currently runs on the MS-01 doing **software x264** encoding (`obs_gpu=False`, no iGPU claim) — that's the 2026-06-15 temporary cap that keeps only 2 concurrent VAAPI consumers on the shared Iris Xe. Since it isn't using a hardware encoder anyway, it can run on the ephemeral arm64 `adanalife-rpi5` worker — which **offloads the x264 encode off the MS-01** (eases the recurring stream/pipeline CPU contention on the minipc).

## How

`ObsInstance` now opts into the rpi5 scheduling (toleration for the `dana.lol/rpi5` taint + a PREFERRED node affinity toward `dana.lol/board=rpi5`), gated on:

```
env.prefer_rpi5 and not (env.gpu and env.obs_gpu)
```

i.e. **only a software-encoder OBS** biases toward the Pi. The gating is belt-and-suspenders with the existing i915 resource claim:

- **Now** (stage, `obs_gpu=False`): no i915 claim → soft affinity lands it on the Pi.
- **Later** (when `obs_gpu` flips back to VAAPI): the affinity disappears here *and* the `gpu.intel.com/i915` request hard-gates the pod back to the MS-01's Iris Xe — there's no path to a hardware-encoder OBS landing on the encoderless Pi.

The affinity stays PREFERRED (never required), so if the Pi is unplugged OBS recovers onto the MS-01 — same ephemeral contract as tripbot/vlc/onscreens.

## Render impact

Only `dist/stage-1-obs-youtube.k8s.yaml` changes (adds `affinity` + `tolerations`). `prod-1-obs-twitch` (VAAPI) is untouched — verified in the golden dist and a new test asserting prod VAAPI OBS does *not* bias toward the Pi.

## Test

`task cdk8s:test` — added `test_stage_software_obs_prefers_rpi5` + `test_prod_vaapi_obs_stays_on_msi`. Golden gate green.

## Background

- Pi as ephemeral arm64 worker: rpi5-worker-bringup-and-cutover session (OBS was originally excluded because the Pi 5 has no H.264 hw encoder — this PR carves the exception for the *software* case).