### PR TITLE
onscreens: inline markdown on text overlays (monospace !command refs)

### DIFF
--- a/pkg/onscreens-server/browser.go
+++ b/pkg/onscreens-server/browser.go
@@ -63,11 +63,16 @@ type onscreenStyle struct {
 	AnchorXPx     int          // center-x within the browser-source viewport (0 = use flex-center fallback)
 	FitWidthPx    int          // single-line width budget for shrink-to-fit (0 = no fit pass)
 	RenderAsHTML  bool         // inject content via innerHTML instead of textContent (server emits HTML for this onscreen)
+	Markdown      bool         // run the onscreen's Content through renderInlineMarkdown before serving state.json (implies RenderAsHTML)
 }
 
 var onscreenRegistry = map[string]onscreenStyle{
 	SlugMiddleText: {
+		// Content supports inline markdown (see renderInlineMarkdown) so
+		// !command references render in monospace; RenderAsHTML opts the
+		// browser source into innerHTML.
 		Name: SlugMiddleText, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 18, ColorCSS: "#ffffff",
+		RenderAsHTML: true, Markdown: true,
 	},
 	SlugLeaderboard: {
 		// Server emits an HTML grid (see renderLeaderboard) so the
@@ -77,12 +82,13 @@ var onscreenRegistry = map[string]onscreenStyle{
 		RenderAsHTML: true,
 	},
 	SlugLeftMessage: {
+		// Rotator lines advertise !commands, so they render markdown too.
 		Name: SlugLeftMessage, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, MinFontSizePx: 18, ColorCSS: "#ffffff",
-		AnchorXPx: 282, FitWidthPx: 564,
+		AnchorXPx: 282, FitWidthPx: 564, RenderAsHTML: true, Markdown: true,
 	},
 	SlugRightMessage: {
 		Name: SlugRightMessage, FontCSS: `"Trebuchet MS", sans-serif`, FontSizePx: 28, MinFontSizePx: 18, ColorCSS: "#ffffff",
-		AnchorXPx: 456, FitWidthPx: 369,
+		AnchorXPx: 456, FitWidthPx: 369, RenderAsHTML: true, Markdown: true,
 	},
 	SlugTimewarp: {
 		Name: SlugTimewarp, FontCSS: `sans-serif`, FontSizePx: 72, ColorCSS: "#ffffff", DropShadow: true,
@@ -97,10 +103,25 @@ var onscreenRegistry = map[string]onscreenStyle{
 
 // onscreensStateHandler returns a JSON snapshot of every onscreen's current
 // state. The OBS browser-source HTML pages poll this endpoint and re-render.
+//
+// Markdown-flagged onscreens have their Content rendered to HTML here, at the
+// wire boundary, rather than at set time — so the stored Content (and the
+// JetStream-persisted middle-text state) stays the raw markdown source and only
+// the served copy is HTML. The browser injects it via innerHTML because those
+// onscreens are also RenderAsHTML.
 func (s *Server) onscreensStateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
-	if err := json.NewEncoder(w).Encode(s.Snapshot()); err != nil {
+	snap := s.Snapshot()
+	out := make(map[string]Onscreen, len(snap))
+	for slug, osc := range snap {
+		view := *osc
+		if onscreenRegistry[slug].Markdown {
+			view.Content = renderInlineMarkdown(view.Content)
+		}
+		out[slug] = view
+	}
+	if err := json.NewEncoder(w).Encode(out); err != nil {
 		slog.ErrorContext(r.Context(), "encoding onscreens state", "err", err)
 	}
 }

--- a/pkg/onscreens-server/handlers_test.go
+++ b/pkg/onscreens-server/handlers_test.go
@@ -1,6 +1,7 @@
 package onscreensServer
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -33,10 +34,9 @@ func TestRenderLeaderboardEmitsHTMLMode(t *testing.T) {
 	}
 }
 
-// A non-HTML onscreen should keep the legacy textContent path
-// (data-html="false") so middle-text et al. don't suddenly start parsing
-// chat content as HTML.
-func TestRenderMiddleTextStaysTextContent(t *testing.T) {
+// Middle-text renders inline markdown, so its browser source must opt into
+// innerHTML (data-html="true") and ship the monospace `code` styling.
+func TestRenderMiddleTextEmitsHTMLMode(t *testing.T) {
 	s := newTestServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/onscreens/render/middle-text", nil)
@@ -48,7 +48,41 @@ func TestRenderMiddleTextStaysTextContent(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got status %d, want 200", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), `data-html="false"`) {
-		t.Fatalf("expected data-html=\"false\" on middle-text root, got body:\n%s", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, `data-html="true"`) {
+		t.Fatalf("expected data-html=\"true\" on middle-text root, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "#root code") {
+		t.Fatalf("expected #root code CSS in middle-text render, got body:\n%s", body)
+	}
+}
+
+// state.json renders the markdown source of a Markdown-flagged onscreen to
+// HTML at the wire boundary, while the stored Content stays the raw source.
+func TestStateHandlerRendersMarkdown(t *testing.T) {
+	s := newTestServer(t)
+	s.MiddleText.Show("use `!find` to search")
+
+	req := httptest.NewRequest(http.MethodGet, "/onscreens/state.json", nil)
+	rec := httptest.NewRecorder()
+	s.onscreensStateHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", rec.Code)
+	}
+	// Decode the wire JSON (the encoder \u-escapes '<'/'>'; the browser's
+	// JSON.parse decodes them back to real tags before innerHTML).
+	var got map[string]struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding state.json: %v", err)
+	}
+	if want := "use <code>!find</code> to search"; got[SlugMiddleText].Content != want {
+		t.Fatalf("middle-text wire content = %q, want %q", got[SlugMiddleText].Content, want)
+	}
+	// Stored Content stays untouched raw markdown.
+	if c := s.MiddleText.Content; c != "use `!find` to search" {
+		t.Fatalf("stored Content was mutated: %q", c)
 	}
 }

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -13,13 +13,13 @@ var leftRotatorUpdateFrequency = time.Duration(45 * time.Second)
 // commands that silently no-op there. Weight 2 reproduces the old duplicated
 // entries (!discord, !commands each appeared twice).
 var possibleLeftMessages = []rotatorMessage{
-	{Text: "Crave something new? Try !timewarp"},
-	{Text: "Earn miles for every minute you watch (!miles)", Platforms: []string{platformTwitch}},
-	{Text: "Follow the project elsewhere on !socialmedia"},
-	{Text: "Join us on !discord", Weight: 2},
-	{Text: "Try and !guess what state we're in", Platforms: []string{platformTwitch}},
-	{Text: "Use !commands to interact with the bot", Weight: 2},
-	{Text: "Where are we? (!location)"},
+	{Text: "Crave something new? Try `!timewarp`"},
+	{Text: "Earn miles for every minute you watch (`!miles`)", Platforms: []string{platformTwitch}},
+	{Text: "Follow the project elsewhere on `!socialmedia`"},
+	{Text: "Join us on `!discord`", Weight: 2},
+	{Text: "Try and `!guess` what state we're in", Platforms: []string{platformTwitch}},
+	{Text: "Use `!commands` to interact with the bot", Weight: 2},
+	{Text: "Where are we? (`!location`)"},
 	// {Text: "LEADER"},
 	// {Text: "Looking for artist for emotes and more"},
 	// {Text: "Twitch Prime subs keep us on air :D"},

--- a/pkg/onscreens-server/markdown.go
+++ b/pkg/onscreens-server/markdown.go
@@ -1,0 +1,59 @@
+package onscreensServer
+
+import (
+	"html"
+	"regexp"
+	"strings"
+)
+
+// Inline-markdown markers recognised by renderInlineMarkdown. Deliberately a
+// tiny subset — these overlays are single lines over video, not documents, so
+// only the inline emphasis that reads at a glance is supported. html.EscapeString
+// leaves these marker bytes (`, *) untouched, so matching the escaped string is
+// safe.
+var (
+	// `code` — the motivating case: monospace !command references.
+	codeSpanRe = regexp.MustCompile("`([^`]+)`")
+	// **bold** — run before italicRe so the doubled markers aren't eaten as
+	// two adjacent emphasis spans.
+	boldRe = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	// *italic*
+	italicRe = regexp.MustCompile(`\*([^*]+)\*`)
+)
+
+// renderInlineMarkdown converts a small, safe subset of inline Markdown to
+// HTML for the text overlays:
+//
+//	`code`   -> <code>…</code>     (monospace; the motivating case is !command refs)
+//	**bold** -> <strong>…</strong>
+//	*italic* -> <em>…</em>
+//
+// The input is HTML-escaped first, so the only markup that reaches the browser
+// is the handful of tags emitted here — a stray '<' in chat-sourced text can't
+// inject DOM. Code spans win over emphasis: text inside backticks is taken
+// literally (so `a*b*c` keeps its asterisks rather than italicising), because
+// emphasis is only applied to the segments between code spans.
+func renderInlineMarkdown(s string) string {
+	s = html.EscapeString(s)
+
+	var b strings.Builder
+	last := 0
+	for _, m := range codeSpanRe.FindAllStringSubmatchIndex(s, -1) {
+		// m[0]:m[1] is the whole `…` match; m[2]:m[3] is the captured inner text.
+		b.WriteString(applyEmphasis(s[last:m[0]]))
+		b.WriteString("<code>")
+		b.WriteString(s[m[2]:m[3]])
+		b.WriteString("</code>")
+		last = m[1]
+	}
+	b.WriteString(applyEmphasis(s[last:]))
+	return b.String()
+}
+
+// applyEmphasis converts bold then italic markers in a code-free segment.
+// Bold goes first so **x** isn't consumed as two empty italic spans.
+func applyEmphasis(s string) string {
+	s = boldRe.ReplaceAllString(s, "<strong>$1</strong>")
+	s = italicRe.ReplaceAllString(s, "<em>$1</em>")
+	return s
+}

--- a/pkg/onscreens-server/markdown_test.go
+++ b/pkg/onscreens-server/markdown_test.go
@@ -1,0 +1,33 @@
+package onscreensServer
+
+import "testing"
+
+func TestRenderInlineMarkdown(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "just text", "just text"},
+		{"code span", "use `!find` to search", "use <code>!find</code> to search"},
+		{"two code spans", "`!miles` and `!guess`", "<code>!miles</code> and <code>!guess</code>"},
+		{"bold", "this is **important**", "this is <strong>important</strong>"},
+		{"italic", "a *subtle* hint", "a <em>subtle</em> hint"},
+		{"bold not eaten by italic", "**bold**", "<strong>bold</strong>"},
+		// Code wins over emphasis: asterisks inside backticks stay literal.
+		{"code wins over emphasis", "`a*b*c`", "<code>a*b*c</code>"},
+		// Escaping: a stray angle bracket can't inject markup.
+		{"escapes html", "1 < 2 & <b>x</b>", "1 &lt; 2 &amp; &lt;b&gt;x&lt;/b&gt;"},
+		// Escaping happens inside code spans too.
+		{"escapes inside code", "`<script>`", "<code>&lt;script&gt;</code>"},
+		// An unterminated backtick is left literal (no code span).
+		{"unterminated backtick", "oops `!find", "oops `!find"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderInlineMarkdown(tc.in); got != tc.want {
+				t.Errorf("renderInlineMarkdown(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -11,8 +11,8 @@ var rightRotatorUpdateFrequency = time.Duration(90 * time.Second)
 // in the YouTube allowlist). Weight 2 reproduces the old duplicated entries.
 var possibleRightMessages = []rotatorMessage{
 	{Text: "Don't forget to follow :)", Weight: 2},
-	{Text: "Try running !location", Weight: 2},
-	{Text: "Try running !timewarp"},
+	{Text: "Try running `!location`", Weight: 2},
+	{Text: "Try running `!timewarp`"},
 	{Text: "Streaming 24 hours a day"},
 }
 

--- a/pkg/onscreens-server/rotator_test.go
+++ b/pkg/onscreens-server/rotator_test.go
@@ -49,9 +49,9 @@ func TestLeftRotatorSurfacesTwitchOnlyOnTwitch(t *testing.T) {
 	var sawMiles, sawGuess bool
 	for i := 0; i < 5000 && !(sawMiles && sawGuess); i++ {
 		switch pickRotatorMessage(possibleLeftMessages) {
-		case "Earn miles for every minute you watch (!miles)":
+		case "Earn miles for every minute you watch (`!miles`)":
 			sawMiles = true
-		case "Try and !guess what state we're in":
+		case "Try and `!guess` what state we're in":
 			sawGuess = true
 		}
 	}

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -87,6 +87,16 @@
   {{end}}
   #root.image { width: 100%; height: 100%; }
   #root.image img { width: 100%; height: 100%; object-fit: contain; display: block; }
+  /* Inline markdown (renderInlineMarkdown): `code` becomes a monospace pill so
+     !command references stand out against the dashcam video. The dark backing
+     keeps it legible over arbitrary footage; bold/italic inherit by default. */
+  #root code {
+    font-family: "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.9em;
+    padding: 0.02em 0.32em;
+    border-radius: 0.25em;
+    background: rgba(0,0,0,0.4);
+  }
   /* Leaderboard onscreen (RenderAsHTML): CSS grid auto-sizes the score
      column to the widest entry, so digits align across rows in any font.
      LeaderboardContent in pkg/users emits the matching markup. */


### PR DESCRIPTION
## What

Adds inline-markdown support to the text onscreen overlays so `` `code` ``, `**bold**`, and `*italic*` render. The motivating case is **monospace `!command` references** — e.g. the middle-text overlay and the bottom-strip rotators advertising `` `!find` ``, `` `!timewarp` ``, etc.

## How

- New dependency-free `renderInlineMarkdown` (stdlib `html`/`regexp`/`strings`). Input is HTML-escaped first, then a tiny marker subset is converted; code spans win over emphasis so asterisks inside backticks stay literal.
- A `Markdown` flag on the onscreen registry. Rendering happens at the **state.json wire boundary**, so the stored `Content` (and the JetStream-persisted middle-text state) stays raw markdown source — only the served copy is HTML. Markdown onscreens are also `RenderAsHTML`, so the browser source injects via `innerHTML` (same path the leaderboard already uses).
- Enabled on `middle-text`, `left-message`, `right-message`.
- Template grows a monospace pill style for `` `code` `` (dark backing for legibility over the dashcam video).
- The rotator lines that mention commands now wrap them in backticks.

## Tests

- `renderInlineMarkdown` table test (code/bold/italic, code-wins-over-emphasis, HTML escaping, unterminated backtick).
- state.json renders markdown to HTML while leaving stored `Content` untouched.
- Updated the middle-text render test (now emits `data-html="true"` + ships the `#root code` CSS) and the rotator exact-match strings.

`ENV=testing go test ./pkg/onscreens-server/` passes; `go vet` + `gofmt` clean.