### PR TITLE
fix: stamp date_created on insert (events table frozen at 0001-01-01)

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 	"time"
 
@@ -13,12 +14,16 @@ import (
 )
 
 type Event struct {
-	ID          int `gorm:"primaryKey"`
-	Username    string
-	Platform    string
-	Event       string
-	SessionID   uuid.UUID
-	DateCreated time.Time
+	ID        int `gorm:"primaryKey"`
+	Username  string
+	Platform  string
+	Event     string
+	SessionID uuid.UUID
+	// autoCreateTime makes GORM stamp date_created with the current time on
+	// insert. Without it, GORM writes the zero value (0001-01-01) into the
+	// column — overriding its DEFAULT CURRENT_TIMESTAMP — which froze every
+	// event written after the GORM migration (#499) at year 1.
+	DateCreated time.Time `gorm:"autoCreateTime"`
 }
 
 func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
@@ -43,6 +48,33 @@ func Logout(ctx context.Context, user string, sessionID uuid.UUID) error {
 	}
 	instrumentation.Events.Inc("logout")
 	return nil
+}
+
+// preFixSentinel is safely after the 0001-01-01 zero-time the timestamp bug
+// wrote (between the GORM migration #499 and the autoCreateTime fix) but well
+// before any real stream data — the stream started May 2019. Used to exclude
+// the bogus zero-dated rows when reconstructing a user's first-seen date.
+var preFixSentinel = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// EarliestRealEventDate returns the earliest event timestamp for the user that
+// isn't the 0001-01-01 sentinel left by the date_created bug, i.e. the best
+// available evidence of when we first saw them. Returns the zero time if the
+// user has no real-dated events (all their events fell in the bug window, or
+// they have none). Cheap via the events_username_date index (migration 011).
+func EarliestRealEventDate(ctx context.Context, platform, username string) time.Time {
+	var earliest sql.NullTime
+	if err := database.GormDB().WithContext(ctx).
+		Model(&Event{}).
+		Where("platform = ? AND username = ? AND date_created > ?", platform, username, preFixSentinel).
+		Select("MIN(date_created)").
+		Scan(&earliest).Error; err != nil {
+		slog.ErrorContext(ctx, "earliest event date failed", "err", err, "username", username)
+		return time.Time{}
+	}
+	if !earliest.Valid {
+		return time.Time{}
+	}
+	return earliest.Time
 }
 
 // SessionCount returns how many sessions the user has started — i.e. their

--- a/pkg/scoreboards/scoreboards.go
+++ b/pkg/scoreboards/scoreboards.go
@@ -13,9 +13,12 @@ import (
 
 // Scoreboard represents a bucket of scores, and has a name to identify it
 type Scoreboard struct {
-	ID          uint16 `gorm:"primaryKey"`
-	Name        string
-	DateCreated time.Time
+	ID   uint16 `gorm:"primaryKey"`
+	Name string
+	// autoCreateTime stamps date_created on insert; createScoreboard() doesn't
+	// set it, so without the tag GORM writes the 0001-01-01 zero value over the
+	// column's DEFAULT CURRENT_TIMESTAMP. See pkg/events for the full story.
+	DateCreated time.Time `gorm:"autoCreateTime"`
 }
 
 type topUserResult struct {

--- a/pkg/scoreboards/scores.go
+++ b/pkg/scoreboards/scores.go
@@ -18,7 +18,10 @@ type Score struct {
 	UserID       uint16
 	ScoreboardID uint16
 	Value        float32
-	DateCreated  time.Time
+	// autoCreateTime stamps date_created on insert; createScore() doesn't set
+	// it, so without the tag GORM writes the 0001-01-01 zero value over the
+	// column's DEFAULT CURRENT_TIMESTAMP. See pkg/events for the full story.
+	DateCreated time.Time `gorm:"autoCreateTime"`
 }
 
 // GetScoreByName returns the score value for a given username and scoreboard name

--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -20,12 +20,32 @@ import (
 // Each is an operator-triggered read (one click), not a hot path, so the extra
 // monthly-score query is fine.
 var (
-	findUser     = users.Find
-	sessionCount = events.SessionCount
-	monthlyMiles = func(ctx context.Context, u users.User) float32 {
+	findUser      = users.Find
+	sessionCount  = events.SessionCount
+	earliestEvent = events.EarliestRealEventDate
+	monthlyMiles  = func(ctx context.Context, u users.User) float32 {
 		return u.GetScore(ctx, scoreboards.CurrentMilesScoreboard())
 	}
 )
+
+// bestEffortFirstSeen picks the earliest non-zero timestamp among the user
+// row's own dates and their earliest real event. The users row is authoritative
+// when present (FirstSeen/DateCreated are stamped on insert now), but accounts
+// created during the date_created bug window have zero-value dates there — for
+// those, the earliest non-bug event row is the best surviving evidence of when
+// we first saw them. Returns the zero time only when nothing real is available.
+func bestEffortFirstSeen(times ...time.Time) time.Time {
+	var best time.Time
+	for _, t := range times {
+		if t.IsZero() {
+			continue
+		}
+		if best.IsZero() || t.Before(best) {
+			best = t
+		}
+	}
+	return best
+}
 
 // userProfile is the chat-console popover payload — a small at-a-glance view of
 // a chatter, events-derived per the tripbot-events-table-design ADR. The JSON
@@ -56,7 +76,7 @@ func gatherUserProfile(ctx context.Context, username string) userProfile {
 		prof.IsBot = u.IsBot
 		prof.Miles = u.Miles
 		prof.MonthlyMiles = monthlyMiles(ctx, u)
-		prof.FirstSeen = u.DateCreated
+		prof.FirstSeen = bestEffortFirstSeen(u.FirstSeen, u.DateCreated, earliestEvent(ctx, u.Platform, username))
 		prof.LastSeen = u.LastSeen
 		prof.Sessions = sessionCount(ctx, username)
 	}

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -17,11 +17,16 @@ import (
 // a real database.
 func withProfileSeams(t *testing.T, u users.User, sessions int64, monthly float32) {
 	t.Helper()
-	savedFind, savedCount, savedMonthly := findUser, sessionCount, monthlyMiles
-	t.Cleanup(func() { findUser, sessionCount, monthlyMiles = savedFind, savedCount, savedMonthly })
+	savedFind, savedCount, savedMonthly, savedEarliest := findUser, sessionCount, monthlyMiles, earliestEvent
+	t.Cleanup(func() {
+		findUser, sessionCount, monthlyMiles, earliestEvent = savedFind, savedCount, savedMonthly, savedEarliest
+	})
 	findUser = func(context.Context, string) users.User { return u }
 	sessionCount = func(context.Context, string) int64 { return sessions }
 	monthlyMiles = func(context.Context, users.User) float32 { return monthly }
+	// default: no surviving event history. Tests exercising the first-seen
+	// fallback override earliestEvent after calling withProfileSeams.
+	earliestEvent = func(context.Context, string, string) time.Time { return time.Time{} }
 }
 
 func renderProfile(t *testing.T, username string) string {
@@ -138,5 +143,37 @@ func TestUserProfileHandler_UnknownDates(t *testing.T) {
 	}
 	if !strings.Contains(body, "unknown") {
 		t.Errorf("expected 'unknown' for zero-value seen dates: %q", body)
+	}
+}
+
+// TestUserProfileHandler_FirstSeenFallback covers an account created during the
+// date_created bug window: its User row dates are zero, but a surviving real
+// event reconstructs first-seen. The earliest such event should win.
+func TestUserProfileHandler_FirstSeenFallback(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 11, Username: "olduser"}, 5, 0)
+	earliestEvent = func(context.Context, string, string) time.Time {
+		return time.Date(2021, 3, 14, 0, 0, 0, 0, time.UTC)
+	}
+	body := renderProfile(t, "olduser")
+	if !strings.Contains(body, "first seen</dt><dd>2021-03-14") {
+		t.Errorf("expected event-derived first seen 2021-03-14, got %q", body)
+	}
+}
+
+// TestUserProfileHandler_FirstSeenPrefersEarliest covers a user whose row has a
+// real DateCreated but whose earliest event predates it — first-seen takes the
+// earlier of the two.
+func TestUserProfileHandler_FirstSeenPrefersEarliest(t *testing.T) {
+	withProfileSeams(t, users.User{
+		ID:          12,
+		Username:    "veteran",
+		DateCreated: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	}, 9, 0)
+	earliestEvent = func(context.Context, string, string) time.Time {
+		return time.Date(2019, 6, 2, 0, 0, 0, 0, time.UTC)
+	}
+	body := renderProfile(t, "veteran")
+	if !strings.Contains(body, "2019-06-02") {
+		t.Errorf("expected earliest (event) first seen 2019-06-02, got %q", body)
 	}
 }

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -17,16 +17,22 @@ import (
 )
 
 type User struct {
-	ID          uint16 `gorm:"primaryKey"`
-	Username    string
-	Platform    string
-	Miles       float32
-	NumVisits   uint16
-	HasDonated  bool
-	IsBot       bool
-	FirstSeen   time.Time
-	LastSeen    time.Time
-	DateCreated time.Time
+	ID         uint16 `gorm:"primaryKey"`
+	Username   string
+	Platform   string
+	Miles      float32
+	NumVisits  uint16
+	HasDonated bool
+	IsBot      bool
+	// autoCreateTime stamps these with the current time on insert. create()
+	// builds a User without setting them, so without the tag GORM writes the
+	// zero value (0001-01-01) into columns whose DEFAULT is CURRENT_TIMESTAMP —
+	// which is why first_seen/date_created read back as "unknown" for every
+	// account created after the GORM migration (#499). LastSeen self-heals on
+	// the first save(), but is tagged for the same correctness on insert.
+	FirstSeen   time.Time `gorm:"autoCreateTime"`
+	LastSeen    time.Time `gorm:"autoCreateTime"`
+	DateCreated time.Time `gorm:"autoCreateTime"`
 	// in-memory session fields, not stored in DB
 	LoggedIn     time.Time `gorm:"-"`
 	sessionID    uuid.UUID `gorm:"-"`

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -69,14 +69,14 @@ func create(ctx context.Context, file string) (Video, error) {
 		return newVid, err
 	}
 
-	// create new (mostly) empty vid
+	// create new (mostly) empty vid. DateCreated is left unset so GORM's
+	// autoCreateTime stamps it on insert (see Video struct in type.go).
 	newVid = Video{
-		Slug:        slug,
-		Lat:         0,
-		Lng:         0,
-		Flagged:     false,
-		DateFilmed:  blankDate,
-		DateCreated: blankDate,
+		Slug:       slug,
+		Lat:        0,
+		Lng:        0,
+		Flagged:    false,
+		DateFilmed: blankDate,
 	}
 
 	// store the video in the DB

--- a/pkg/video/type.go
+++ b/pkg/video/type.go
@@ -33,7 +33,11 @@ type Video struct {
 	State       string
 	CoordSource string
 	DateFilmed  time.Time
-	DateCreated time.Time
+	// autoCreateTime stamps date_created on insert. A runtime-created clip (one
+	// not already in the DB) is built without setting it, so without the tag
+	// GORM writes the 0001-01-01 zero value over the column's DEFAULT
+	// CURRENT_TIMESTAMP. See pkg/events for the full story.
+	DateCreated time.Time `gorm:"autoCreateTime"`
 }
 
 // Location returns a lat/lng pair


### PR DESCRIPTION
## What

Every `events` row (and `users` / `scoreboards` / `scores` / runtime-created `videos`) created since **2026-05-15** was being stamped `date_created = 0001-01-01` instead of the current time. This is why the events table looked like it "stopped updating" — rows were being inserted fine, but with a year-1 timestamp, so anything that filters/orders by date saw nothing recent.

## Root cause

The GORM migration (#499) replaced raw INSERTs that **omitted** `date_created` (letting the column's `DEFAULT CURRENT_TIMESTAMP` apply) with `GormDB().Create(&Event{...})`. GORM writes every struct field — including the zero-value `time.Time` — into the row, and only skips a zero-valued field when it carries a `default` tag or is the auto-increment PK. None of these date columns did, so GORM wrote `0001-01-01` over the DB default.

`SessionCount` kept working (it counts `event='login'` with no date filter), so miles and visit counts looked healthy — masking the bug.

## Fix

- Tag the create-time columns with `gorm:"autoCreateTime"` so GORM stamps them with the current time on insert: `events.Event`, `users.User` (`FirstSeen`/`LastSeen`/`DateCreated`), `scoreboards.Scoreboard`, `scores.Score`, `video.Video`.
- Add `events.EarliestRealEventDate` — the earliest non-sentinel event for a user, i.e. the best surviving evidence of when we first saw them.
- The user-profile popover (`/api/user/{username}`, consumed by the console) now computes **best-effort first-seen**: the earliest non-zero of the user row's `FirstSeen`/`DateCreated` and the earliest real event. Pre-bug accounts are unchanged; bug-window accounts recover a real date when any non-sentinel event survives, and only show "unknown" when nothing real is left.

## Not covered

- The already-written `0001-01-01` rows are not back-filled — their real timestamps are unrecoverable. New rows are correct from merge forward. A one-off corrective `UPDATE` could re-derive some event dates from session adjacency if it's ever worth it, but it's out of scope here.

## Test

- New profile tests cover the first-seen fallback (event-derived) and the "prefer earliest" path; existing unknown-dates test still passes.
- `task test:macos` green.