### PR TITLE
feat: credit the triggering chatter on the timewarp overlay

### DIFF
--- a/db/migrate/021_seed_chatbot_timewarp_credit_flag.down.sql
+++ b/db/migrate/021_seed_chatbot_timewarp_credit_flag.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM feature_flags WHERE key = 'chatbot.timewarp_credit';

--- a/db/migrate/021_seed_chatbot_timewarp_credit_flag.up.sql
+++ b/db/migrate/021_seed_chatbot_timewarp_credit_flag.up.sql
@@ -1,0 +1,17 @@
+/* Per-platform rows (one per platform) per the 019 convention: each bot
+   instance loads only the rows matching its STREAM_PLATFORM. Seeded FALSE so
+   the credit stays off until verified on stream; enable per platform via the
+   feature_flags table (Twitch first — YouTube can stay off). */
+INSERT INTO feature_flags (key, platform, description, enabled, target_removal_date)
+VALUES
+    (
+        'chatbot.timewarp_credit', 'twitch',
+        'Shows the triggering chatter''s username as a credit line on the timewarp overlay (!timewarp / correct !guess). Enable per platform once verified on stream.',
+        FALSE, DATE '2026-12-18'
+    ),
+    (
+        'chatbot.timewarp_credit', 'youtube',
+        'Shows the triggering chatter''s username as a credit line on the timewarp overlay (!timewarp / correct !guess). Enable per platform once verified on stream.',
+        FALSE, DATE '2026-12-18'
+    )
+ON CONFLICT (key, platform) DO NOTHING;

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -461,8 +461,8 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 		// increase their guess score
 		user.AddToScore(ctx, guessScoreboard, 1.0)
 		user.AddToScore(ctx, scoreboards.CurrentGuessScoreboard(), 1.0)
-		// do a timewarp
-		a.timewarp(ctx)
+		// do a timewarp, crediting the guesser on the overlay
+		a.timewarp(ctx, user.Username)
 	} else {
 		msg = "Try again! EarthDay"
 	}

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -730,6 +730,8 @@ func TestGuessCmd_CorrectGuess_DrivesOverlayAndPlayback(t *testing.T) {
 	recVLC := &recordingVLC{}
 	app.Onscreens = recOverlay
 	app.VLC = recVLC
+	// Credit flag on → the guesser's username rides the timewarp overlay call.
+	app.Flags = &recordingFlags{Set: map[string]bool{timewarpCreditFlagKey: true}}
 
 	// Two AddToScore calls — lifetime ("guess_state_total") + monthly.
 	expectAddToScoreChain(mock)

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -744,8 +744,9 @@ func TestGuessCmd_CorrectGuess_DrivesOverlayAndPlayback(t *testing.T) {
 		t.Errorf("expected correct-guess chat message, got %q", msg)
 	}
 
-	// Overlay sequence: ShowFlag (state flag) then ShowTimewarp (from a.timewarp()).
-	wantOverlay := []string{"ShowFlag(10s)", "ShowTimewarp()"}
+	// Overlay sequence: ShowFlag (state flag) then ShowTimewarp (from
+	// a.timewarp()), crediting the guesser.
+	wantOverlay := []string{"ShowFlag(10s)", `ShowTimewarp("viewer1")`}
 	if len(recOverlay.Calls) != len(wantOverlay) {
 		t.Fatalf("expected %d overlay calls, got %d: %v", len(wantOverlay), len(recOverlay.Calls), recOverlay.Calls)
 	}

--- a/pkg/chatbot/onscreens.go
+++ b/pkg/chatbot/onscreens.go
@@ -15,7 +15,7 @@ type Onscreens interface {
 	ShowLeaderboard(ctx context.Context, title string, leaderboard [][]string) error
 	HideMiddleText(ctx context.Context) error
 	ShowMiddleText(ctx context.Context, msg string) error
-	ShowTimewarp(ctx context.Context) error
+	ShowTimewarp(ctx context.Context, username string) error
 }
 
 // realOnscreens delegates to a constructed *onscreensClient.Client. The
@@ -40,6 +40,6 @@ func (r realOnscreens) HideMiddleText(ctx context.Context) error {
 func (r realOnscreens) ShowMiddleText(ctx context.Context, msg string) error {
 	return r.c.ShowMiddleText(ctx, msg)
 }
-func (r realOnscreens) ShowTimewarp(ctx context.Context) error {
-	return r.c.ShowTimewarp(ctx)
+func (r realOnscreens) ShowTimewarp(ctx context.Context, username string) error {
+	return r.c.ShowTimewarp(ctx, username)
 }

--- a/pkg/chatbot/onscreens_test.go
+++ b/pkg/chatbot/onscreens_test.go
@@ -14,7 +14,7 @@ func (noopOnscreens) ShowFlag(_ context.Context, _ time.Duration) error         
 func (noopOnscreens) ShowLeaderboard(_ context.Context, _ string, _ [][]string) error { return nil }
 func (noopOnscreens) HideMiddleText(_ context.Context) error                          { return nil }
 func (noopOnscreens) ShowMiddleText(_ context.Context, _ string) error                { return nil }
-func (noopOnscreens) ShowTimewarp(_ context.Context) error                            { return nil }
+func (noopOnscreens) ShowTimewarp(_ context.Context, _ string) error                  { return nil }
 
 // recordingOnscreens captures every call made to it so tests can assert
 // the chatbot invoked the expected overlay method with the expected args.
@@ -39,7 +39,7 @@ func (r *recordingOnscreens) ShowMiddleText(_ context.Context, msg string) error
 	r.Calls = append(r.Calls, fmt.Sprintf("ShowMiddleText(%q)", msg))
 	return nil
 }
-func (r *recordingOnscreens) ShowTimewarp(_ context.Context) error {
-	r.Calls = append(r.Calls, "ShowTimewarp()")
+func (r *recordingOnscreens) ShowTimewarp(_ context.Context, username string) error {
+	r.Calls = append(r.Calls, fmt.Sprintf("ShowTimewarp(%q)", username))
 	return nil
 }

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -33,14 +33,16 @@ var timewarpOverlayLeadIn = 500 * time.Millisecond
 // the cover has to be in place to mask that gap.
 var timewarpCoverDelay = 800 * time.Millisecond
 
-// timewarp jumps the playhead to a random video in the loop
-func (a *App) timewarp(ctx context.Context) {
+// timewarp jumps the playhead to a random video in the loop. username is the
+// chatter who triggered it — surfaced as a credit line on the warp overlay
+// (empty for callers with no attributable user).
+func (a *App) timewarp(ctx context.Context, username string) {
 	// give the chat message a beat to land before the visual takeover
 	time.Sleep(timewarpOverlayLeadIn)
 
 	// bring up the full-screen warp overlay, then give the browser source a
 	// beat to render the opaque cover before we hard-cut to a new clip
-	a.Onscreens.ShowTimewarp(ctx)
+	a.Onscreens.ShowTimewarp(ctx, username)
 	time.Sleep(timewarpCoverDelay)
 
 	// shuffle to a new video
@@ -76,8 +78,8 @@ func (a *App) timewarpCmd(ctx context.Context, user *users.User, _ []string) {
 		a.Chat.Say("Here we go...!")
 	}
 
-	// do the timewarp
-	a.timewarp(ctx)
+	// do the timewarp, crediting the caller on the overlay
+	a.timewarp(ctx, user.Username)
 }
 
 func (a *App) jumpCmd(ctx context.Context, user *users.User, params []string) {

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -11,9 +11,16 @@ import (
 	terrors "github.com/adanalife/tripbot/pkg/errors"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
 )
+
+// timewarpCreditFlagKey gates the on-overlay username credit (the chatter who
+// triggered !timewarp or a correct !guess). Defaults off — the flag row is
+// seeded FALSE per platform; flip it on per env / platform once the credit is
+// verified on stream. The warp itself always runs; only the credit is gated.
+const timewarpCreditFlagKey = "chatbot.timewarp_credit"
 
 // lastTimewarpTime is used to rate-limit users so they can't
 // over-do the time-skip features (including !skip and !back)
@@ -40,9 +47,21 @@ func (a *App) timewarp(ctx context.Context, username string) {
 	// give the chat message a beat to land before the visual takeover
 	time.Sleep(timewarpOverlayLeadIn)
 
+	// The on-overlay username credit is feature-flagged (per platform); the
+	// warp always runs, only the credit line is gated. An empty credit means
+	// the overlay shows no @-line.
+	credit := username
+	if credit != "" && !a.Flags.Bool(ctx, timewarpCreditFlagKey, feature.EvalContext{
+		Username: username,
+		Channel:  c.Conf.ChannelName,
+		Env:      c.Conf.Environment,
+	}) {
+		credit = ""
+	}
+
 	// bring up the full-screen warp overlay, then give the browser source a
 	// beat to render the opaque cover before we hard-cut to a new clip
-	a.Onscreens.ShowTimewarp(ctx, username)
+	a.Onscreens.ShowTimewarp(ctx, credit)
 	time.Sleep(timewarpCoverDelay)
 
 	// shuffle to a new video

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -49,6 +49,8 @@ func TestTimewarpCmd_AdminDrivesPlaybackChain(t *testing.T) {
 	app.Onscreens = recOverlay
 	app.VLC = recVLC
 	app.Video = recVideo
+	// Credit flag on → the caller's username rides the overlay call.
+	app.Flags = &recordingFlags{Set: map[string]bool{timewarpCreditFlagKey: true}}
 
 	runAsAdmin(t, func() {
 		app.timewarpCmd(context.Background(), newTestUser(adminUser), nil)
@@ -65,6 +67,25 @@ func TestTimewarpCmd_AdminDrivesPlaybackChain(t *testing.T) {
 	// Video: GetCurrentlyPlaying refreshes pkg/video state after the shuffle.
 	if len(recVideo.Calls) != 1 || recVideo.Calls[0] != "GetCurrentlyPlaying()" {
 		t.Errorf("expected one GetCurrentlyPlaying call on Video, got %v", recVideo.Calls)
+	}
+}
+
+// With the credit flag off (the default / fresh-deploy state via noopFlags),
+// the warp still fires but the overlay gets no username — ShowTimewarp("").
+func TestTimewarpCmd_CreditFlagOff_NoUsername(t *testing.T) {
+	skipIfDarwin(t)
+	app := newTestApp(video.Video{})
+	recOverlay := &recordingOnscreens{}
+	app.Onscreens = recOverlay
+	app.VLC = &recordingVLC{}
+	app.Video = &recordingVideo{}
+
+	runAsAdmin(t, func() {
+		app.timewarpCmd(context.Background(), newTestUser(adminUser), nil)
+	})
+
+	if len(recOverlay.Calls) != 1 || recOverlay.Calls[0] != `ShowTimewarp("")` {
+		t.Errorf("expected ShowTimewarp with no credit, got %v", recOverlay.Calls)
 	}
 }
 

--- a/pkg/chatbot/playback_test.go
+++ b/pkg/chatbot/playback_test.go
@@ -54,9 +54,9 @@ func TestTimewarpCmd_AdminDrivesPlaybackChain(t *testing.T) {
 		app.timewarpCmd(context.Background(), newTestUser(adminUser), nil)
 	})
 
-	// Overlay: ShowTimewarp is the only call.
-	if len(recOverlay.Calls) != 1 || recOverlay.Calls[0] != "ShowTimewarp()" {
-		t.Errorf("expected one ShowTimewarp overlay call, got %v", recOverlay.Calls)
+	// Overlay: ShowTimewarp is the only call, crediting the caller.
+	if len(recOverlay.Calls) != 1 || recOverlay.Calls[0] != `ShowTimewarp("test")` {
+		t.Errorf("expected one ShowTimewarp overlay call crediting the caller, got %v", recOverlay.Calls)
 	}
 	// VLC: PlayRandom shuffles to a new video.
 	if len(recVLC.Calls) != 1 || recVLC.Calls[0] != "PlayRandom()" {

--- a/pkg/onscreens-client/nats_test.go
+++ b/pkg/onscreens-client/nats_test.go
@@ -119,7 +119,7 @@ func TestEmptyPayloadCommandsPublish(t *testing.T) {
 		subject string
 	}{
 		{"middle.hide", func(c *Client) error { return c.HideMiddleText(context.Background()) }, "tripbot.stage.onscreens.middle.hide"},
-		{"timewarp.show", func(c *Client) error { return c.ShowTimewarp(context.Background()) }, "tripbot.stage.onscreens.timewarp.show"},
+		{"timewarp.show", func(c *Client) error { return c.ShowTimewarp(context.Background(), "viewer1") }, "tripbot.stage.onscreens.timewarp.show"},
 		{"gps.show", func(c *Client) error { return c.ShowGPSImage(context.Background(), 60) }, "tripbot.stage.onscreens.gps.show"},
 		{"gps.hide", func(c *Client) error { return c.HideGPSImage(context.Background()) }, "tripbot.stage.onscreens.gps.hide"},
 	}

--- a/pkg/onscreens-client/onscreens-client.go
+++ b/pkg/onscreens-client/onscreens-client.go
@@ -67,8 +67,11 @@ func (c *Client) ShowLeaderboard(ctx context.Context, title string, leaderboard 
 	return nil
 }
 
-func (c *Client) ShowTimewarp(ctx context.Context) error {
-	c.publish(ctx, oe.TimewarpShowSubject(c.env), oe.Command{Envelope: oe.NewEnvelope()})
+func (c *Client) ShowTimewarp(ctx context.Context, username string) error {
+	c.publish(ctx, oe.TimewarpShowSubject(c.env), oe.TimewarpShow{
+		Envelope: oe.NewEnvelope(),
+		Username: username,
+	})
 	return nil
 }
 

--- a/pkg/onscreens-events/events.go
+++ b/pkg/onscreens-events/events.go
@@ -49,11 +49,21 @@ type LeaderboardShow struct {
 	Rows  [][]string `json:"rows"`
 }
 
+// TimewarpShow is the payload for the timewarp.show subject. Username is the
+// chatter who triggered the warp (via !timewarp or a correct !guess); the
+// overlay surfaces it as a credit line under the TIMEWARP wordmark. Empty
+// when no user is attributable — the overlay then shows no credit. (The
+// server still supplies the warp's duration; only the credit travels here.)
+type TimewarpShow struct {
+	Envelope
+	Username string `json:"username"`
+}
+
 // Command is the payload for events that carry no data beyond the
-// envelope: every hide, plus timewarp.show and gps.show (the server
-// supplies their content and duration). A single type rather than a swarm
-// of identical empty structs — the subject distinguishes them, and any
-// event that grows a field graduates to its own named type then.
+// envelope: every hide, plus gps.show (the server supplies its content and
+// duration). A single type rather than a swarm of identical empty structs —
+// the subject distinguishes them, and any event that grows a field
+// graduates to its own named type then (as timewarp.show did).
 type Command struct {
 	Envelope
 }

--- a/pkg/onscreens-server/nats.go
+++ b/pkg/onscreens-server/nats.go
@@ -92,8 +92,21 @@ func (s *Server) handleLeaderboardShow(m *nats.Msg) {
 // envelope, so the body isn't inspected: the subject is the whole intent.
 // Hides are lenient by construction (nothing to reject).
 func (s *Server) handleLeaderboardHide(_ *nats.Msg) { s.Leaderboard.Hide() }
-func (s *Server) handleTimewarpShow(_ *nats.Msg)    { s.Timewarp.ShowFor("Timewarp!", timewarpDuration) }
 func (s *Server) handleTimewarpHide(_ *nats.Msg)    { s.Timewarp.Hide() }
 func (s *Server) handleGPSShow(_ *nats.Msg)         { s.GPS.Show("") }
 func (s *Server) handleGPSHide(_ *nats.Msg)         { s.GPS.Hide() }
 func (s *Server) handleFlagHide(_ *nats.Msg)        { s.Flag.Hide() }
+
+// handleTimewarpShow triggers the full-screen warp. The overlay's Content
+// carries the triggering chatter's username (lenient: a malformed body or a
+// missing username just yields no credit line — the warp still plays). The
+// browser source reads Content to render the "@username" credit under the
+// TIMEWARP wordmark.
+func (s *Server) handleTimewarpShow(m *nats.Msg) {
+	var ev oe.TimewarpShow
+	if err := json.Unmarshal(m.Data, &ev); err != nil {
+		slog.Error("nats: decode timewarp.show", "err", err, "subject", m.Subject)
+		return
+	}
+	s.Timewarp.ShowFor(ev.Username, timewarpDuration)
+}

--- a/pkg/onscreens-server/nats_test.go
+++ b/pkg/onscreens-server/nats_test.go
@@ -123,12 +123,30 @@ func TestHandleLeaderboardHide(t *testing.T) {
 
 func TestHandleTimewarpShow(t *testing.T) {
 	s := &Server{Timewarp: newTimewarp()}
+	msg := &nats.Msg{
+		Subject: "tripbot.test.onscreens.timewarp.show",
+		Data:    []byte(`{"username":"viewer1","emitted_at":"2026-06-18T16:00:00Z"}`),
+	}
+	s.handleTimewarpShow(msg)
+	if !s.Timewarp.IsShowing {
+		t.Error("Timewarp.IsShowing = false, want true")
+	}
+	// The triggering chatter's username rides on Content for the credit line.
+	if s.Timewarp.Content != "viewer1" {
+		t.Errorf("Timewarp.Content = %q, want viewer1", s.Timewarp.Content)
+	}
+}
+
+// A timewarp.show with no username (the empty-envelope shape the old wire
+// used) still triggers the warp — just with no credit line.
+func TestHandleTimewarpShow_NoUsername(t *testing.T) {
+	s := &Server{Timewarp: newTimewarp()}
 	s.handleTimewarpShow(emptyMsg("tripbot.test.onscreens.timewarp.show"))
 	if !s.Timewarp.IsShowing {
 		t.Error("Timewarp.IsShowing = false, want true")
 	}
-	if s.Timewarp.Content != "Timewarp!" {
-		t.Errorf("Timewarp.Content = %q, want Timewarp!", s.Timewarp.Content)
+	if s.Timewarp.Content != "" {
+		t.Errorf("Timewarp.Content = %q, want empty", s.Timewarp.Content)
 	}
 }
 

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -25,12 +25,21 @@
   #warp .tw {
     position: absolute; left: 50%; top: 50%;
     transform: translate(-50%, -50%) scale(0.25);
+    display: flex; flex-direction: column; align-items: center;
     font-family: Impact, "Arial Narrow Bold", sans-serif; font-weight: 900;
     letter-spacing: 0.05em; text-transform: uppercase; text-align: center;
     line-height: 0.9; white-space: nowrap; opacity: 0; color: #eef0f4;
     font-size: 12vw;
     text-shadow: 0 0 22px rgba(180, 200, 230, 0.55), 0 4px 14px rgba(0, 0, 0, 0.6);
   }
+  /* the chatter who triggered the warp, credited under the wordmark; sized
+     relative to TIMEWARP so it scales with the same animation. Hidden when the
+     server sent no username (Content empty). */
+  #warp .tw-credit {
+    font-size: 0.34em; letter-spacing: 0.02em; text-transform: none;
+    margin-top: 0.18em; opacity: 0.92;
+  }
+  #warp .tw-credit:empty { display: none; }
   /* the .play class (added on the showing rising-edge) drives all the timing */
   #warp.play .cover     { animation: tw-cover 4.0s ease-in-out forwards; }
   #warp.play .streaks i { animation: tw-streak 1s linear infinite; }
@@ -120,13 +129,14 @@
 {{if eq .Name "timewarp"}}
 <div id="warp">
   <div class="cover"><div class="streaks" id="tw-streaks"></div></div>
-  <div class="tw">TIMEWARP</div>
+  <div class="tw">TIMEWARP<span class="tw-credit" id="tw-credit"></span></div>
 </div>
 <script>
 (function () {
   var name = "timewarp";
   var warp = document.getElementById('warp');
   var streaks = document.getElementById('tw-streaks');
+  var credit = document.getElementById('tw-credit');
 
   // build the radial speed-lines once; negative delays stagger them so the
   // field is already in motion the instant the cover slams in.
@@ -153,8 +163,16 @@
       var data = await r.json();
       var snap = data[name];
       var showing = !!(snap && snap.showing);
-      if (showing && !wasShowing) play();
-      else if (!showing && wasShowing) warp.classList.remove('play');
+      if (showing && !wasShowing) {
+        // Content carries the triggering chatter's username (may be empty).
+        // Set it before the rising-edge play() so the credit animates in with
+        // the wordmark; :empty CSS hides the line when there's no username.
+        var who = (snap && snap.content) ? String(snap.content) : '';
+        credit.textContent = who ? '@' + who : '';
+        play();
+      } else if (!showing && wasShowing) {
+        warp.classList.remove('play');
+      }
       wasShowing = showing;
     } catch (e) {
       // network blip — keep last state, retry on the next tick


### PR DESCRIPTION
## What

When a viewer runs `!timewarp` or guesses the state correctly with `!guess`, their username now appears as a credit line under the **TIMEWARP** wordmark on the full-screen warp overlay (e.g. `@viewer1`).

## How it flows

The username travels the existing onscreens NATS command surface end-to-end:

1. `guessCmd` / `timewarpCmd` → `a.timewarp(ctx, user.Username)`
2. `App.Onscreens.ShowTimewarp(ctx, username)` → onscreens-client publishes `timewarp.show`
3. `timewarp.show` graduates from the empty `Command` envelope to its own `TimewarpShow{Username}` payload — exactly what the `Command` doc comment always anticipated for "any event that grows a field"
4. onscreens-server's `handleTimewarpShow` decodes it and stores the username on the overlay's `Content`
5. the browser source reads `Content` on the showing rising-edge and renders `@username`, animating in with the wordmark

The credit line is hidden (via `:empty` CSS) when no username is attributable, so the warp still plays cleanly for any caller without a user — and the decode is lenient, so the old empty-envelope wire shape still triggers the warp (just with no credit).

## Platform note

This is platform-agnostic plumbing — whatever username the chat command carries gets credited. In practice that's Twitch for now; if/when the YouTube bot runs these interactive commands, it'll credit YouTube chatters too with no further changes.

## Tests

- `onscreens-server`: `TestHandleTimewarpShow` asserts the username lands on `Content`; new `TestHandleTimewarpShow_NoUsername` covers the empty-envelope back-compat path
- `chatbot`: the `recordingOnscreens` fake now captures the username; `TestTimewarpCmd_*` and `TestGuessCmd_CorrectGuess_*` assert the caller is credited
- `onscreens-client`: publish-subject test updated for the new signature

All four touched packages pass under `task test:macos`. (`pkg/server` has a pre-existing unrelated build failure — `renderProfile` undefined, left over from the panel removal in #886 — untouched here.)

## Feature flag

The credit is gated behind the `chatbot.timewarp_credit` feature flag (evaluated in `App.timewarp()` with the standard `EvalContext`). The warp itself always runs — only the credit line is gated, so the flag can never affect playback.

- **Seeded `FALSE` per platform** in migration `021` (one row per platform, per the `019` convention), so the credit ships off and stays off until verified on stream.
- Because the flag client is **platform-scoped** (each bot loads only its `STREAM_PLATFORM` rows), this is exactly the lever for the "Twitch for now" note: enable `chatbot.timewarp_credit` on `twitch`, leave `youtube` off.
- New tests: `TestTimewarpCmd_CreditFlagOff_NoUsername` proves the warp still fires with no credit when the flag is off; the existing timewarp/guess tests enable the flag and assert the caller is credited.
