### PR TITLE
fix: !km <username> shows the named user's kilometres

### DIFF
--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -226,11 +226,32 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 	a.Chat.Say(msg)
 }
 
-func (a *App) kilometresCmd(ctx context.Context, user *users.User, _ []string) {
+func (a *App) kilometresCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !kilometres", "username", user.Username)
-	km := a.Sessions.CurrentMiles(ctx, *user) * 1.609344
+
+	var username string
+	var miles float32
+
+	// check to see if an arg was provided (mirror milesCmd's other-user lookup)
+	if len(params) == 0 {
+		username = user.Username
+		miles = a.Sessions.CurrentMiles(ctx, *user)
+	} else {
+		username = helpers.StripAtSign(params[0])
+		u := a.Sessions.Find(ctx, username)
+
+		// check to see if they are in our DB
+		if u.ID == 0 {
+			a.Chat.Say("I don't know them, sorry!")
+			return
+		}
+
+		miles = a.Sessions.CurrentMiles(ctx, u)
+	}
+
+	km := miles * 1.609344
 	msg := "@%s has %.2f kilometres."
-	msg = fmt.Sprintf(msg, user.Username, km)
+	msg = fmt.Sprintf(msg, username, km)
 	a.Chat.Say(msg)
 }
 

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -438,6 +438,73 @@ func TestKilometresCmd_ZeroMiles(t *testing.T) {
 	}
 }
 
+func TestKilometresCmd_OtherUser_Found(t *testing.T) {
+	app := newTestApp(video.Video{})
+
+	// Stage Sessions.Find to return a known user, plus the miles the seam
+	// reports for them (the GetScore math is covered in pkg/users).
+	rec := &recordingSessions{
+		FindResult: users.User{ID: 42, Username: "viewer1", Miles: 10.0},
+		Miles:      10.0,
+	}
+	app.Sessions = rec
+
+	out := captureSay(t, app)
+
+	app.kilometresCmd(context.Background(), newTestUser("caller"), []string{"viewer1"})
+
+	msg := out()
+	// the target's km, not the caller's: 10 miles * 1.609344 = "16.09"
+	if !strings.Contains(msg, "@viewer1 has 16.09 kilometres") {
+		t.Errorf("expected target user's km, got %q", msg)
+	}
+	// other-user path looks the user up via Sessions.Find, then reads their miles
+	want := []string{`Find("viewer1")`, `CurrentMiles("viewer1")`}
+	if !slices.Equal(rec.Calls, want) {
+		t.Errorf("expected %v, got %v", want, rec.Calls)
+	}
+}
+
+func TestKilometresCmd_OtherUser_NotInDB(t *testing.T) {
+	app := newTestApp(video.Video{})
+
+	// recordingSessions.FindResult defaults to users.User{} (ID == 0),
+	// which mirrors pkg/users.Find's "not found" contract.
+	rec := &recordingSessions{}
+	app.Sessions = rec
+
+	out := captureSay(t, app)
+
+	app.kilometresCmd(context.Background(), newTestUser("caller"), []string{"ghost"})
+
+	if !strings.Contains(out(), "I don't know them") {
+		t.Errorf("expected unknown-user message, got %q", out())
+	}
+	if len(rec.Calls) != 1 || rec.Calls[0] != `Find("ghost")` {
+		t.Errorf("expected Sessions.Find(\"ghost\") call, got %v", rec.Calls)
+	}
+}
+
+func TestKilometresCmd_OtherUser_StripsAtSign(t *testing.T) {
+	app := newTestApp(video.Video{})
+
+	// FindResult defaults to User{} (ID == 0) — the "@ghost" arg should be
+	// normalized to "ghost" before the Find call.
+	rec := &recordingSessions{}
+	app.Sessions = rec
+
+	out := captureSay(t, app)
+
+	app.kilometresCmd(context.Background(), newTestUser("caller"), []string{"@ghost"})
+
+	if !strings.Contains(out(), "I don't know them") {
+		t.Errorf("expected unknown-user message, got %q", out())
+	}
+	if len(rec.Calls) != 1 || rec.Calls[0] != `Find("ghost")` {
+		t.Errorf("expected Sessions.Find(\"ghost\") with @ stripped, got %v", rec.Calls)
+	}
+}
+
 // --- versionCmd ---
 
 func TestVersionCmd_UsesCachedVersion(t *testing.T) {


### PR DESCRIPTION
## Summary
- `!km <username>` previously ignored its argument and always reported the *caller's* kilometres (`!km woodercz` returned Dana's own km).
- `kilometresCmd` now mirrors `milesCmd`'s other-user lookup: when an arg is given it strips a leading `@`, looks the user up via `Sessions.Find`, and reports *their* miles (with the same "I don't know them, sorry!" message when the user isn't in the DB). With no arg it falls back to the caller as before.
- Added three chatbot tests mirroring the milesCmd other-user coverage (found / not-in-DB / strips-@-sign).

## Test plan
- [x] `task test:macos` — `pkg/chatbot` passes, including the new other-user km tests.
- [ ] In chat: `!km <someuser>` shows that user's kilometres; `!km` (no arg) still shows your own; `!km <unknown>` replies "I don't know them, sorry!".

---
Note: `task test:macos` shows a pre-existing build failure in `pkg/server` (`pkg/server/profile_test.go: undefined: renderProfile`) that is present on clean `develop` and unrelated to this change — not chased here.