### PR TITLE
chore(telemetry): drop http_server body-size histograms via OTel views

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -83,11 +83,13 @@ func Init(ctx context.Context, serviceName, serviceVersion string) (ShutdownFunc
 	if err != nil {
 		return noopShutdown, fmt.Errorf("prometheus exporter: %w", err)
 	}
-	mp := sdkmetric.NewMeterProvider(
+	mpOpts := []sdkmetric.Option{
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExp)),
 		sdkmetric.WithReader(promExp),
 		sdkmetric.WithResource(res),
-	)
+	}
+	mpOpts = append(mpOpts, dropBodySizeHistograms()...)
+	mp := sdkmetric.NewMeterProvider(mpOpts...)
 	otel.SetMeterProvider(mp)
 
 	if err := otelruntime.Start(otelruntime.WithMinimumReadMemStatsInterval(15 * time.Second)); err != nil {
@@ -139,6 +141,26 @@ func Init(ctx context.Context, serviceName, serviceVersion string) (ShutdownFunc
 		}
 		return errors.Join(errs...)
 	}, nil
+}
+
+// dropBodySizeHistograms returns MeterProvider options that drop the
+// http_server_{request,response}_body_size_bytes histograms via OTel SDK
+// views. These auto-instrumented histograms are pushed OTLP-direct to the
+// metrics backend (bypassing Alloy, so they can't be relabeled chart-side)
+// and account for ~700 active series with no panels reading them. The
+// http_server_request_duration_seconds histogram is deliberately left
+// untouched — its buckets back the p50/p95/p99 latency panels.
+func dropBodySizeHistograms() []sdkmetric.Option {
+	drop := func(name string) sdkmetric.Option {
+		return sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{Name: name},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+		))
+	}
+	return []sdkmetric.Option{
+		drop("http.server.request.body.size"),
+		drop("http.server.response.body.size"),
+	}
 }
 
 func disabled() bool {


### PR DESCRIPTION
## Summary
- Register OTel SDK `NewView`s on the OTLP `MeterProvider` that drop the `http.server.request.body.size` and `http.server.response.body.size` histograms (exported as `http_server_*_body_size_bytes_bucket`) via `AggregationDrop{}`. These auto-instrumented histograms are pushed OTLP-direct to Grafana Cloud (bypassing Alloy), so they can't be relabeled chart-side — the drop has to happen in Go. They account for ~700 active series and back no panels.
- The `http.server.request.duration` histogram is left untouched — its buckets back the p50/p95/p99 latency panels.
- Single shared `pkg/telemetry` package, so the change covers all three binaries (tripbot, vlc-server, onscreens-server).

## Test plan
- [x] `task test:macos` — `pkg/telemetry` passes; instrument names confirmed against otelhttp v0.69.0 (`http.server.request.body.size` / `http.server.response.body.size`). (Pre-existing `pkg/server` build failure from `renderProfile` is unrelated and owned separately.)
- [ ] Confirm `http_server_request_body_size_bytes_bucket` and `http_server_response_body_size_bytes_bucket` series stop appearing in Grafana Cloud after deploy, and that the duration histogram buckets (`http_server_request_duration_seconds_bucket`) are still present.