### PR TITLE
fix(telemetry): drop process-owner detector so OTel works without $USER

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -152,7 +152,21 @@ func disabled() bool {
 func newResource(ctx context.Context, name, version string) (*resource.Resource, error) {
 	return resource.New(ctx,
 		resource.WithFromEnv(),
-		resource.WithProcess(),
+		// Granular process detectors instead of resource.WithProcess(): the
+		// bundled WithProcessOwner detector calls os/user.Current(), which
+		// fails with "user: Current requires cgo or $USER set in environment"
+		// in our static CGO_ENABLED=0 binaries running as a uid with no
+		// /etc/passwd entry — that error silently disables the whole SDK.
+		// Enumerate every process detector WithProcess() bundles *except*
+		// the owner one, so process.* attributes are still emitted without
+		// requiring a $USER workaround.
+		resource.WithProcessPID(),
+		resource.WithProcessExecutableName(),
+		resource.WithProcessExecutablePath(),
+		resource.WithProcessCommandArgs(),
+		resource.WithProcessRuntimeName(),
+		resource.WithProcessRuntimeVersion(),
+		resource.WithProcessRuntimeDescription(),
 		resource.WithHost(),
 		resource.WithTelemetrySDK(),
 		resource.WithAttributes(


### PR DESCRIPTION
## Summary
- `resource.WithProcess()` bundles `WithProcessOwner()`, which calls `os/user.Current()`. In tripbot's static `CGO_ENABLED=0` binaries running as a uid with no `/etc/passwd` entry, that call fails with `user: Current requires cgo or $USER set in environment` — and that error propagates out of `newResource` → `Init`'s `build resource:` path, silently disabling the entire OTel SDK.
- Replaced `WithProcess()` with the seven other granular process detectors (`WithProcessPID`, `WithProcessExecutableName`, `WithProcessExecutablePath`, `WithProcessCommandArgs`, `WithProcessRuntimeName`, `WithProcessRuntimeVersion`, `WithProcessRuntimeDescription`) — every detector `WithProcess()` bundles *except* the owner one. `process.*` attributes are still emitted; `os/user.Current()` is never called.
- `pkg/telemetry` is shared, so tripbot, vlc-server, and onscreens-server all benefit from this single edit (all three route through `telemetry.Init` → `newResource`).
- No resource attributes that dashboards key off (`service.name`, `service.version`, host, OTLP `WithFromEnv` attrs) are dropped — only the process-owner detector is removed.

Once this ships, the infra-side `env: USER=tripbot` patch on the tripbot Deployment can be dropped (separate infra change).

## Test plan
- [x] `task test:macos` — `pkg/telemetry` passes; only failure is the pre-existing, unrelated `pkg/server` build error (`profile_test.go: undefined: renderProfile`) owned by another change.
- [x] `go build ./pkg/telemetry/ ./cmd/tripbot/ ./cmd/onscreens-server/` succeeds (vlc-server needs libvlc CGO headers, out of scope for this build check).
- [ ] Confirm OTel still emits with the infra `USER=tripbot` env var removed from the Deployment (deploy without the workaround and verify traces/metrics/logs still flow and `process.*` resource attributes are present).