### PR TITLE
test(server): fix undefined renderProfile in profile_test.go

### DIFF
--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -92,6 +92,20 @@ func TestUserProfileAPIHandler_BotFlag(t *testing.T) {
 	}
 }
 
+// fetchProfile drives the JSON user-profile API and decodes the payload.
+func fetchProfile(t *testing.T, username string) userProfile {
+	t.Helper()
+	r := mux.NewRouter()
+	r.Handle("/api/user/{username}", http.HandlerFunc(userProfileAPIHandler)).Methods("GET")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/user/"+username, nil))
+	var got userProfile
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, rec.Body.String())
+	}
+	return got
+}
+
 // TestUserProfileHandler_FirstSeenFallback covers an account created during the
 // date_created bug window: its User row dates are zero, but a surviving real
 // event reconstructs first-seen. The earliest such event should win.
@@ -100,9 +114,10 @@ func TestUserProfileHandler_FirstSeenFallback(t *testing.T) {
 	earliestEvent = func(context.Context, string, string) time.Time {
 		return time.Date(2021, 3, 14, 0, 0, 0, 0, time.UTC)
 	}
-	body := renderProfile(t, "olduser")
-	if !strings.Contains(body, "first seen</dt><dd>2021-03-14") {
-		t.Errorf("expected event-derived first seen 2021-03-14, got %q", body)
+	got := fetchProfile(t, "olduser")
+	want := time.Date(2021, 3, 14, 0, 0, 0, 0, time.UTC)
+	if !got.FirstSeen.Equal(want) {
+		t.Errorf("expected event-derived first seen %s, got %s", want, got.FirstSeen)
 	}
 }
 
@@ -118,8 +133,9 @@ func TestUserProfileHandler_FirstSeenPrefersEarliest(t *testing.T) {
 	earliestEvent = func(context.Context, string, string) time.Time {
 		return time.Date(2019, 6, 2, 0, 0, 0, 0, time.UTC)
 	}
-	body := renderProfile(t, "veteran")
-	if !strings.Contains(body, "2019-06-02") {
-		t.Errorf("expected earliest (event) first seen 2019-06-02, got %q", body)
+	got := fetchProfile(t, "veteran")
+	want := time.Date(2019, 6, 2, 0, 0, 0, 0, time.UTC)
+	if !got.FirstSeen.Equal(want) {
+		t.Errorf("expected earliest (event) first seen %s, got %s", want, got.FirstSeen)
 	}
 }


### PR DESCRIPTION
## Summary
- `pkg/server/profile_test.go` failed to build on `develop` — `undefined: renderProfile` — breaking the whole `pkg/server` test package under `task test:macos`.
- Root cause is an interaction between two recently-merged PRs:
  - #886 removed the in-tripbot admin panel, including the HTML `userProfileHandler` (`/admin/user/{username}`) and the `renderProfile` test helper, migrating the surviving profile tests to the JSON `userProfileAPIHandler` (`/api/user/{username}`).
  - #887 then added two new first-seen tests (`TestUserProfileHandler_FirstSeenFallback` / `TestUserProfileHandler_FirstSeenPrefersEarliest`) that resurrected the deleted `renderProfile(t, …)` helper and asserted on HTML output (`first seen</dt><dd>…`) the JSON handler no longer produces — written against the pre-#886 shape and not reconciled with the merged state.
- Fix chosen: **rewrite, not delete.** The behavior these tests cover (`bestEffortFirstSeen` — first-seen computed from the earliest of the user row's dates and the earliest real event) is live in the JSON handler. The two tests now drive `userProfileAPIHandler` via a small `fetchProfile` helper (mirroring the other migrated tests) and assert on the `userProfile.FirstSeen` field. Coverage preserved; no live code path lost.

## Test plan
- [x] `task test:macos` no longer fails to build pkg/server (`ok github.com/adanalife/tripbot/pkg/server`)
- [x] All five profile tests pass, including both first-seen cases
- [ ] Sanity-check that asserting on the `FirstSeen` JSON field is the intended coverage (the old HTML `first seen` row is gone with the panel)