### PR TITLE
feat(cdk8s): expose prod vlc RTSP via NodePort for off-cluster pulls

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -119,6 +119,15 @@ class EnvConfig:
     # (EXTERNAL_URL, registered OAuth redirect URIs). Only dev needs it — k3d's
     # traefik is mapped to host :9443 because Colima can't bind :443.
     external_port: str = ""
+    # Fixed NodePort exposing vlc-twitch's RTSP listener on the node IP, so a LAN
+    # box (e.g. OBS on a desktop) can pull rtsp://<node-ip>:<port>/dashcam without
+    # kubectl/port-forward. 0 = no NodePort (default). Only the twitch instance
+    # emits it. The minipc has no LoadBalancer controller, so this is the stable-
+    # host-endpoint equivalent of the k3d-only `<name>-host` LoadBalancer. prod-1
+    # and stage-1 co-tenant the one minipc node, and a pinned NodePort can't be
+    # claimed twice on the same node — each env that wants one must pick a distinct
+    # number in the 30000-32767 range. RTSP only; VNC/HTTP stay in-cluster.
+    vlc_rtsp_node_port: int = 0
     # Bias this env's stateless app pods toward the ephemeral arm64 rpi5 worker
     # (adanalife-rpi5) when it's present, falling back to the MS-01 when it's not.
     # When True, the tripbot/vlc/onscreens constructs add a toleration for the
@@ -220,6 +229,10 @@ ENVS: dict[str, EnvConfig] = {
         priority_class="prod-stream",
         obs_cpu_request="2",
         vlc_cpu_request="1",
+        # Stable LAN endpoint for pulling the dashcam RTSP feed off-cluster
+        # (e.g. OBS on a desktop) without kubectl: rtsp://<minipc-ip>:30854/dashcam
+        # (TCP transport). Distinct from any future stage NodePort (same node).
+        vlc_rtsp_node_port=30854,
     ),
     "stage-1": EnvConfig(
         name="stage-1",

--- a/cdk8s/adanalife_k8s/constructs/vlc.py
+++ b/cdk8s/adanalife_k8s/constructs/vlc.py
@@ -222,6 +222,37 @@ class VlcServer(Construct):
             spec=k8s.ServiceSpec(type="ClusterIP", selector=sel, ports=svc_ports),
         )
 
+        # --- RTSP NodePort (minipc convenience: a stable host endpoint for pulling
+        # the dashcam feed off-cluster — e.g. OBS on a LAN desktop — without
+        # kubectl port-forward. The minipc has no LoadBalancer controller, so this
+        # is the NodePort analogue of the k3d-only `<name>-host` LoadBalancer.
+        # Gated on the twitch platform + a configured port: prod-1 + stage-1
+        # co-tenant the one node, and a pinned NodePort can't be claimed twice, so
+        # only an env that sets vlc_rtsp_node_port (prod) emits one. RTSP only —
+        # VNC/HTTP stay in-cluster. Pull over TCP:
+        # rtsp://<node-ip>:<nodePort>/dashcam with rtsp_transport=tcp so the RTSP
+        # control + RTP media share the single forwarded port. ---
+        if env.vlc_rtsp_node_port and platform == "twitch":
+            k8s.KubeService(
+                self,
+                "rtsp-nodeport",
+                metadata=k8s.ObjectMeta(
+                    name=f"{name}-rtsp", namespace=ns, labels=labels
+                ),
+                spec=k8s.ServiceSpec(
+                    type="NodePort",
+                    selector=sel,
+                    ports=[
+                        k8s.ServicePort(
+                            name="rtsp",
+                            port=8554,
+                            target_port=k8s.IntOrString.from_string("rtsp"),
+                            node_port=env.vlc_rtsp_node_port,
+                        )
+                    ],
+                ),
+            )
+
         # --- host-access LoadBalancer (k3d-only convenience: local + dev, which
         # extends local). Overlay-added, so no metadata labels (matches render). ---
         if appconfig.uses_local_stubs(env):

--- a/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-vlc-twitch.k8s.yaml
@@ -126,6 +126,24 @@ spec:
     app: vlc-twitch
   type: ClusterIP
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: vlc-twitch
+    app.kubernetes.io/part-of: tripbot
+  name: vlc-twitch-rtsp
+  namespace: prod-1
+spec:
+  ports:
+    - name: rtsp
+      nodePort: 30854
+      port: 8554
+      targetPort: rtsp
+  selector:
+    app: vlc-twitch
+  type: NodePort
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -49,6 +49,27 @@ def test_each_component_has_deployment_and_service(env, comp, platform):
     assert "Service" in kinds, f"{env}-{comp}-{platform} missing Service"
 
 
+def test_prod_vlc_rtsp_nodeport():
+    """prod vlc-twitch emits a fixed RTSP NodePort so a LAN box (OBS on a desktop)
+    can pull rtsp://<node-ip>:30854/dashcam without kubectl. The minipc has no
+    LoadBalancer controller, so it's a NodePort not an LB. Pinned at 30854."""
+    svcs = _by_kind(_objects("prod-1-vlc-twitch"), "Service")
+    np = next((s for s in svcs if s["metadata"]["name"] == "vlc-twitch-rtsp"), None)
+    assert np is not None, "prod vlc-twitch missing the vlc-twitch-rtsp NodePort"
+    assert np["spec"]["type"] == "NodePort"
+    [port] = np["spec"]["ports"]
+    assert port["nodePort"] == 30854
+    assert port["port"] == 8554 and port["targetPort"] == "rtsp"
+
+
+@pytest.mark.parametrize("stem", ["stage-1-vlc-youtube", "development-vlc-twitch"])
+def test_non_prod_has_no_rtsp_nodeport(stem):
+    """The RTSP NodePort is prod-only — stage/dev don't set vlc_rtsp_node_port (a
+    pinned NodePort can't be claimed twice on the co-tenant minipc node)."""
+    svcs = _by_kind(_objects(stem), "Service")
+    assert not any(s["spec"].get("type") == "NodePort" for s in svcs)
+
+
 @pytest.mark.parametrize("env,platform", [("prod-1", "twitch"), ("stage-1", "youtube")])
 @pytest.mark.parametrize("comp", ["vlc", "tripbot"])
 def test_obs_websocket_addr_is_platform_scoped(env, comp, platform):


### PR DESCRIPTION
## What

Adds a fixed RTSP **NodePort (30854)** on the prod `vlc-twitch` Service so a LAN box — e.g. OBS on a Windows/desktop machine — can pull the dashcam feed directly:

```
rtsp://<minipc-ip>:30854/dashcam        (use rtsp_transport=tcp in OBS)
```

…without installing kubectl / running `kubectl port-forward`. The minipc has no LoadBalancer controller (traefik runs hostNetwork; LB Services sit `<pending>`), so this is the NodePort analogue of the existing k3d-only `<name>-host` LoadBalancer convenience.

## How

- New `vlc_rtsp_node_port` knob on `EnvConfig` (default `0` = no NodePort).
- Set only on `prod-1` (`30854`); emitted only for the `twitch` instance.
- `prod-1` and `stage-1` co-tenant the one minipc node, and a pinned NodePort can't be claimed twice on the same node — so any other env that wants one must pick a distinct number in the 30000–32767 range. Documented inline.
- RTSP only; VNC/HTTP stay in-cluster (ClusterIP unchanged, so in-cluster `vlc-twitch:8554` DNS for OBS is untouched).

## Notes

- The off-cluster feed is **raw dashcam video only** — overlays (leaderboard/flags/tips) are composited inside the OBS container from `run/*` files, not carried in RTSP.
- Reachable on the node IP regardless of which node the pod lands on (Cilium NodePort). prod vlc stays on the MS-01 anyway (rpi5 preference is stage-only).
- Tests assert the prod NodePort exists at 30854 and that stage/dev emit none.

## Deploy

Argo-delivered. After merge, the prod `vlc-twitch-rtsp` Service appears on next sync; the NodePort is then live at `<minipc-ip>:30854`.