### PR TITLE
feat(server): /api/flags read + toggle endpoints for the console

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -265,7 +265,8 @@ func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 		return
 	}
 	t.flagClient = fc
-	t.app.Flags = fc // command-time flag gating reads the same Postgres-backed client
+	t.app.Flags = fc   // command-time flag gating reads the same Postgres-backed client
+	t.srv.SetFlags(fc) // the console's /api/flags endpoints read/toggle the same client
 	go fc.Start(ctx)
 }
 

--- a/pkg/server/flags.go
+++ b/pkg/server/flags.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/gorilla/mux"
+)
+
+// flagDTO is the JSON shape the standalone console renders for the feature-flag
+// panel. It mirrors feature.Flag, exposing the targeting allowlists and the
+// target-removal date for read-only display — the console can only flip the
+// global default (the FlagToggler write surface), not edit allowlists.
+type flagDTO struct {
+	Key                 string   `json:"key"`
+	Description         string   `json:"description"`
+	Enabled             bool     `json:"enabled"`
+	EnabledForUsernames []string `json:"enabled_for_usernames,omitempty"`
+	EnabledForRoles     []string `json:"enabled_for_roles,omitempty"`
+	TargetRemovalDate   string   `json:"target_removal_date,omitempty"`
+}
+
+func toFlagDTO(f feature.Flag) flagDTO {
+	d := flagDTO{
+		Key:                 f.Key,
+		Description:         f.Description,
+		Enabled:             f.Enabled,
+		EnabledForUsernames: f.EnabledForUsernames,
+		EnabledForRoles:     f.EnabledForRoles,
+	}
+	if !f.TargetRemovalDate.IsZero() {
+		d.TargetRemovalDate = f.TargetRemovalDate.UTC().Format(time.RFC3339)
+	}
+	return d
+}
+
+// flagsHandler serves the current feature-flag snapshot as JSON for the
+// standalone console (which holds no DB access of its own). Reports ok=false
+// with an empty list when no flag client is wired — the in-memory fallback
+// window before the Postgres-backed client loads.
+func (s *Server) flagsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.flags == nil {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "flags": []flagDTO{}})
+		return
+	}
+	snap := s.flags.Snapshot(r.Context())
+	out := make([]flagDTO, 0, len(snap))
+	for _, f := range snap {
+		out = append(out, toFlagDTO(f))
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "flags": out})
+}
+
+// flagToggleHandler flips a flag's global-default enabled state. The console
+// POSTs {"enabled": bool} to /api/flags/{key}. Requires the wired client to
+// implement feature.FlagToggler (the Postgres client does; the in-memory
+// fallback doesn't), so a toggle before the DB client loads returns 503. An
+// unknown key returns 404 (SetEnabled errors). Internal-only, like the rest of
+// the /api surface — the console reaches it over the in-namespace Service.
+func (s *Server) flagToggleHandler(w http.ResponseWriter, r *http.Request) {
+	key := mux.Vars(r)["key"]
+	toggler, ok := s.flags.(feature.FlagToggler)
+	if !ok {
+		http.Error(w, "flag toggling unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request body", http.StatusBadRequest)
+		return
+	}
+	if err := toggler.SetEnabled(r.Context(), key, body.Enabled); err != nil {
+		slog.WarnContext(r.Context(), "feature flag toggle failed", "flag", key, "err", err)
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	slog.InfoContext(r.Context(), "feature flag toggled via console",
+		"flag", key, "enabled", body.Enabled)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "key": key, "enabled": body.Enabled})
+}

--- a/pkg/server/flags_test.go
+++ b/pkg/server/flags_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/gorilla/mux"
+)
+
+// fakeFlags is a FlagClient (+ FlagToggler) seam for the /api/flags handlers.
+type fakeFlags struct {
+	snap     []feature.Flag
+	setCalls []struct {
+		key     string
+		enabled bool
+	}
+	setErr error
+}
+
+func (f *fakeFlags) Bool(context.Context, string, feature.EvalContext) bool { return false }
+func (f *fakeFlags) Snapshot(context.Context) []feature.Flag                { return f.snap }
+func (f *fakeFlags) SetEnabled(_ context.Context, key string, enabled bool) error {
+	f.setCalls = append(f.setCalls, struct {
+		key     string
+		enabled bool
+	}{key, enabled})
+	return f.setErr
+}
+
+func flagsRouter(s *Server) *mux.Router {
+	r := mux.NewRouter()
+	r.Handle("/api/flags", http.HandlerFunc(s.flagsHandler)).Methods("GET")
+	r.Handle("/api/flags/{key}", http.HandlerFunc(s.flagToggleHandler)).Methods("POST")
+	return r
+}
+
+func TestFlagsHandler_Snapshot(t *testing.T) {
+	fc := &fakeFlags{snap: []feature.Flag{
+		{
+			Key:                 "chatbot.report_to_discord",
+			Description:         "mirror chat to discord",
+			Enabled:             true,
+			EnabledForUsernames: []string{"danalol"},
+			TargetRemovalDate:   time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{Key: "ascii_video", Enabled: false},
+	}}
+	s := New()
+	s.SetFlags(fc)
+
+	rec := httptest.NewRecorder()
+	flagsRouter(s).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/flags", nil))
+
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	var got struct {
+		OK    bool      `json:"ok"`
+		Flags []flagDTO `json:"flags"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, rec.Body.String())
+	}
+	if !got.OK || len(got.Flags) != 2 {
+		t.Fatalf("ok=%v flags=%d, want ok=true 2 flags", got.OK, len(got.Flags))
+	}
+	if got.Flags[0].Key != "chatbot.report_to_discord" || !got.Flags[0].Enabled {
+		t.Errorf("flag[0] = %+v", got.Flags[0])
+	}
+	if got.Flags[0].TargetRemovalDate != "2026-07-01T00:00:00Z" {
+		t.Errorf("target removal date = %q", got.Flags[0].TargetRemovalDate)
+	}
+}
+
+func TestFlagsHandler_NoClientReportsNotOK(t *testing.T) {
+	s := New() // no SetFlags
+	rec := httptest.NewRecorder()
+	flagsRouter(s).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/flags", nil))
+
+	var got struct {
+		OK    bool      `json:"ok"`
+		Flags []flagDTO `json:"flags"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OK || len(got.Flags) != 0 {
+		t.Errorf("ok=%v flags=%d, want ok=false empty", got.OK, len(got.Flags))
+	}
+}
+
+func TestFlagToggleHandler_TogglesViaToggler(t *testing.T) {
+	fc := &fakeFlags{}
+	s := New()
+	s.SetFlags(fc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/flags/ascii_video",
+		strings.NewReader(`{"enabled":true}`))
+	flagsRouter(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\n%s", rec.Code, rec.Body.String())
+	}
+	if len(fc.setCalls) != 1 || fc.setCalls[0].key != "ascii_video" || !fc.setCalls[0].enabled {
+		t.Errorf("setCalls = %+v, want one ascii_video=true", fc.setCalls)
+	}
+}
+
+func TestFlagToggleHandler_UnknownKeyIs404(t *testing.T) {
+	fc := &fakeFlags{setErr: errors.New("feature flag \"nope\" not found")}
+	s := New()
+	s.SetFlags(fc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/flags/nope",
+		strings.NewReader(`{"enabled":true}`))
+	flagsRouter(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestFlagToggleHandler_NonTogglerIs503(t *testing.T) {
+	// A client that satisfies FlagClient but not FlagToggler (the in-memory
+	// fallback before the Postgres client loads) can't be toggled.
+	s := New()
+	s.SetFlags(feature.NewInMemoryClient(nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/flags/ascii_video",
+		strings.NewReader(`{"enabled":true}`))
+	flagsRouter(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/server/oauthstate"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	myyoutube "github.com/adanalife/tripbot/pkg/youtube"
@@ -42,6 +43,14 @@ func (s *Server) SetVersion(v string) {
 	if v != "" {
 		s.versionTag = v
 	}
+}
+
+// SetFlags injects the feature-flag client backing the console's /api/flags
+// endpoints. Called from cmd/tripbot's startFeatureFlags, before Start runs
+// the HTTP server (so there's no race on the field). Left nil when the
+// Postgres client fails to load — /api/flags then reports ok=false.
+func (s *Server) SetFlags(fc feature.FlagClient) {
+	s.flags = fc
 }
 
 // startedAt is when the process began; /version reports it so callers can derive

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	terrors "github.com/adanalife/tripbot/pkg/errors"
+	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/httpmw"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -26,12 +27,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Server holds the web server's runtime state. Since the in-tripbot admin panel
-// was retired in favor of the standalone tripbot-console, that's just the build
-// version tag the /version endpoint reports. cmd/tripbot constructs one via New
-// and installs the tag through SetVersion before Start runs.
+// Server holds the web server's runtime state: the build version tag the
+// /version endpoint reports, and the feature-flag client the console's
+// /api/flags endpoints read/toggle. cmd/tripbot constructs one via New and
+// installs both (SetVersion, SetFlags) before Start runs.
 type Server struct {
 	versionTag string
+	flags      feature.FlagClient
 }
 
 // New constructs a Server with the default "dev" version tag (overridden by
@@ -100,6 +102,11 @@ func (s *Server) Start(ctx context.Context) {
 	r.Handle("/api/db/migration", tagged("/api/db/migration", migrationVersionAPIHandler)).Methods("GET")
 	// the full dashcam route as JSON, for the console's map overlay.
 	r.Handle("/admin/map/corpus", tagged("/admin/map/corpus", mapCorpusHandler)).Methods("GET")
+	// read-only JSON of the feature-flag snapshot, and a write to flip a flag's
+	// global default — the console's feature-flag panel. Internal-only like the
+	// rest of /api (no Ingress; reached over the in-namespace Service).
+	r.Handle("/api/flags", tagged("/api/flags", s.flagsHandler)).Methods("GET")
+	r.Handle("/api/flags/{key}", tagged("/api/flags/{key}", s.flagToggleHandler)).Methods("POST")
 
 	// catch everything else
 	r.NotFoundHandler = tagged("/", catchAllHandler)


### PR DESCRIPTION
Adds the tripbot HTTP surface the standalone console's feature-flag view/edit UI needs. The console has no DB access, so it proxies tripbot.

## Endpoints (internal-only, like the rest of `/api`)
- `GET /api/flags` → `{ok, flags:[{key, description, enabled, enabled_for_usernames, enabled_for_roles, target_removal_date}]}` from the existing `feature.FlagClient.Snapshot`.
- `POST /api/flags/{key}` with `{"enabled": bool}` → flips the flag's **global default** via `feature.FlagToggler.SetEnabled`.

## Wiring
The flag client is injected into `Server` via a new `SetFlags`, called from `startFeatureFlags` before the HTTP server starts (race-free, mirrors `SetVersion`). Left nil if the Postgres client fails to load → `GET` reports `ok:false`, `POST` returns 503. Unknown key → 404.

The existing homegrown `pkg/feature` already exposed exactly `Snapshot` (read) + `SetEnabled` (write), so this is a thin wrapper — **no OpenFeature dependency** (that adoption is a separate, orthogonal decision; it wouldn't make this UI any easier).

`go list -deps ./cmd/vlc-server` confirms vlc-server doesn't pull `pkg/feature` or `pkg/server` (no package-boundary regression).

## Related
- Console UI that consumes this: adanalife/tripbot-console#42.
- (Rebased onto develop now that the develop-compile fix #902 has merged.)