### PR TITLE
feat(chatbot): route App.Twitch through the platform-gateway when configured

### DIFF
--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -154,7 +154,7 @@ func New() *App {
 		Cron:       noopCron{},
 		Geocoder:   realGeocoder{},
 		Weather:    realWeather{},
-		Twitch:     realTwitch{},
+		Twitch:     newTwitch(),
 		OBS:        realOBS{},
 	}
 	a.indexCommands()

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -154,9 +154,12 @@ func New() *App {
 		Cron:       noopCron{},
 		Geocoder:   realGeocoder{},
 		Weather:    realWeather{},
-		Twitch:     newTwitch(),
 		OBS:        realOBS{},
 	}
+	// Twitch is wired after the literal so the gateway/in-process selector can
+	// hold the App and read its (later-reassigned) Flags client at call time —
+	// cmd/tripbot swaps in the Postgres-backed flag client after New().
+	a.Twitch = newTwitch(a)
 	a.indexCommands()
 	return a
 }

--- a/pkg/chatbot/gateway_twitch_test.go
+++ b/pkg/chatbot/gateway_twitch_test.go
@@ -1,0 +1,80 @@
+package chatbot
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGatewayTwitch_FollowedAt_Following(t *testing.T) {
+	followedAt := time.Now().Add(-72 * time.Hour).UTC().Truncate(time.Second)
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"followed_at":"` + followedAt.Format(time.RFC3339) + `"}`))
+	}))
+	defer srv.Close()
+
+	when, ok := newGatewayTwitch(srv.URL).FollowedAt("Viewer1")
+	if !ok {
+		t.Fatal("expected ok=true for a follower")
+	}
+	if !when.Equal(followedAt) {
+		t.Errorf("followed_at = %v, want %v", when, followedAt)
+	}
+	if gotPath != "/v1/followed-at/Viewer1" {
+		t.Errorf("request path = %q, want /v1/followed-at/Viewer1", gotPath)
+	}
+}
+
+func TestGatewayTwitch_FollowedAt_NotAFollower(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not a follower"}`))
+	}))
+	defer srv.Close()
+
+	if _, ok := newGatewayTwitch(srv.URL).FollowedAt("viewer1"); ok {
+		t.Error("expected ok=false on 404")
+	}
+}
+
+func TestGatewayTwitch_FollowedAt_FailsClosedOnError(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"upstream 502", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}},
+		{"malformed body", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`not json`))
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+			if _, ok := newGatewayTwitch(srv.URL).FollowedAt("viewer1"); ok {
+				t.Error("expected ok=false (fail closed)")
+			}
+		})
+	}
+}
+
+func TestGatewayTwitch_FollowedAt_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // closed server → connection refused
+
+	if _, ok := newGatewayTwitch(srv.URL).FollowedAt("viewer1"); ok {
+		t.Error("expected ok=false on transport error")
+	}
+}
+
+func TestNewGatewayTwitch_TrimsTrailingSlash(t *testing.T) {
+	if got := newGatewayTwitch("http://twitch-api:8080/").baseURL; got != "http://twitch-api:8080" {
+		t.Errorf("baseURL = %q, want trailing slash trimmed", got)
+	}
+}

--- a/pkg/chatbot/gateway_twitch_test.go
+++ b/pkg/chatbot/gateway_twitch_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/adanalife/tripbot/pkg/feature"
 )
 
 func TestGatewayTwitch_FollowedAt_Following(t *testing.T) {
@@ -76,5 +78,35 @@ func TestGatewayTwitch_FollowedAt_TransportError(t *testing.T) {
 func TestNewGatewayTwitch_TrimsTrailingSlash(t *testing.T) {
 	if got := newGatewayTwitch("http://twitch-api:8080/").baseURL; got != "http://twitch-api:8080" {
 		t.Errorf("baseURL = %q, want trailing slash trimmed", got)
+	}
+}
+
+func TestFlaggedTwitch_DispatchesOnFlag(t *testing.T) {
+	gw := &recordingTwitch{Result: time.Unix(100, 0), OK: true}
+	inproc := &recordingTwitch{Result: time.Unix(200, 0), OK: true}
+
+	flagOn := feature.NewInMemoryClient(map[string]feature.Flag{
+		twitchGatewayFlagKey: {Key: twitchGatewayFlagKey, Enabled: true},
+	})
+	flagOff := feature.NewInMemoryClient(nil) // unknown key → off
+
+	// flag on → gateway
+	ft := flaggedTwitch{app: &App{Flags: flagOn}, gateway: gw, inproc: inproc}
+	if when, _ := ft.FollowedAt("viewer1"); !when.Equal(time.Unix(100, 0)) {
+		t.Errorf("flag on should route to the gateway; got %v", when)
+	}
+
+	// flag off → in-process (the default until toggled)
+	ft = flaggedTwitch{app: &App{Flags: flagOff}, gateway: gw, inproc: inproc}
+	if when, _ := ft.FollowedAt("viewer1"); !when.Equal(time.Unix(200, 0)) {
+		t.Errorf("flag off should route in-process; got %v", when)
+	}
+}
+
+func TestNewTwitch_NoURLSkipsGatewayWrapper(t *testing.T) {
+	// With no gateway URL there's nothing to flag — it's the plain in-process
+	// adapter, not a flaggedTwitch wrapper.
+	if _, ok := newTwitch(&App{}).(realTwitch); !ok {
+		t.Error("expected realTwitch when TWITCH_API_URL is empty")
 	}
 }

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -1,6 +1,7 @@
 package chatbot
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -9,8 +10,16 @@ import (
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/feature"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 )
+
+// twitchGatewayFlagKey is the runtime kill-switch for routing the chatbot's
+// Helix calls through the platform-gateway. It defaults off (the flag row
+// doesn't exist until toggled), so even an env wired with TWITCH_API_URL stays
+// in-process until the flag is flipped on — the cutover (and instant revert,
+// no restart) is a console toggle. Only meaningful when TWITCH_API_URL is set.
+const twitchGatewayFlagKey = "chatbot.twitch_gateway"
 
 // Twitch is the command-time Twitch Helix surface the chatbot needs. Today
 // that's only follow lookups (followageCmd); it grows as admin-panel Helix
@@ -23,16 +32,37 @@ type Twitch interface {
 	FollowedAt(username string) (time.Time, bool)
 }
 
-// newTwitch picks the production Twitch adapter: the platform-gateway HTTP
-// client when TWITCH_API_URL is set, otherwise the in-process pkg/twitch path.
-// This is the Phase 3 flip — selecting by config keeps the in-process path as
-// the zero-config default, so envs that haven't been pointed at a gateway are
-// unchanged.
-func newTwitch() Twitch {
-	if c.Conf.TwitchAPIURL != "" {
-		return newGatewayTwitch(c.Conf.TwitchAPIURL)
+// newTwitch wires the production Twitch adapter. With no TWITCH_API_URL there's
+// no gateway to reach, so it's the plain in-process path (zero-config default).
+// When a gateway IS wired, it returns a flaggedTwitch that dispatches per call
+// based on the twitchGatewayFlagKey runtime flag — so the gateway is wired but
+// dormant until flipped on, and revertible without a restart.
+func newTwitch(a *App) Twitch {
+	if c.Conf.TwitchAPIURL == "" {
+		return realTwitch{}
 	}
-	return realTwitch{}
+	return flaggedTwitch{
+		app:     a,
+		gateway: newGatewayTwitch(c.Conf.TwitchAPIURL),
+		inproc:  realTwitch{},
+	}
+}
+
+// flaggedTwitch routes each call to the gateway or the in-process adapter based
+// on the live twitchGatewayFlagKey value, read from the App's flag client at
+// call time (cmd/tripbot reassigns a.Flags to the Postgres-backed, console-
+// toggleable client after New(), so the flag flips without a bot restart).
+type flaggedTwitch struct {
+	app     *App
+	gateway Twitch
+	inproc  Twitch
+}
+
+func (f flaggedTwitch) FollowedAt(username string) (time.Time, bool) {
+	if f.app.Flags.Bool(context.Background(), twitchGatewayFlagKey, feature.EvalContext{}) {
+		return f.gateway.FollowedAt(username)
+	}
+	return f.inproc.FollowedAt(username)
 }
 
 // realTwitch is the in-process adapter — used when no gateway URL is

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -1,8 +1,14 @@
 package chatbot
 
 import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 )
 
@@ -17,11 +23,71 @@ type Twitch interface {
 	FollowedAt(username string) (time.Time, bool)
 }
 
-// realTwitch is the production adapter the App is wired with in New().
-// Delegates to the package-level pkg/twitch shim (defaultClient). Mirrors the
-// realVLC / realOnscreens shape.
+// newTwitch picks the production Twitch adapter: the platform-gateway HTTP
+// client when TWITCH_API_URL is set, otherwise the in-process pkg/twitch path.
+// This is the Phase 3 flip — selecting by config keeps the in-process path as
+// the zero-config default, so envs that haven't been pointed at a gateway are
+// unchanged.
+func newTwitch() Twitch {
+	if c.Conf.TwitchAPIURL != "" {
+		return newGatewayTwitch(c.Conf.TwitchAPIURL)
+	}
+	return realTwitch{}
+}
+
+// realTwitch is the in-process adapter — used when no gateway URL is
+// configured. Delegates to the package-level pkg/twitch shim (defaultClient).
+// Mirrors the realVLC / realOnscreens shape.
 type realTwitch struct{}
 
 func (realTwitch) FollowedAt(username string) (time.Time, bool) {
 	return mytwitch.FollowedAt(username)
+}
+
+// gatewayTwitch is the HTTP adapter — it reaches the platform-gateway
+// twitch-api instance instead of calling Helix in-process. It satisfies the
+// same Twitch interface, so command code is untouched (the payoff of the
+// #738/#739 injection seam).
+type gatewayTwitch struct {
+	baseURL string
+	client  *http.Client
+}
+
+func newGatewayTwitch(baseURL string) gatewayTwitch {
+	return gatewayTwitch{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// FollowedAt asks the gateway when username followed the channel
+// (GET /v1/followed-at/{login}). It fails closed (ok=false) on any transport,
+// decode, or non-2xx error — matching the in-process adapter, so gateway
+// trouble degrades a follow check rather than blocking the command. A 404 is
+// the gateway's "not a follower" answer and is expected, not logged.
+func (g gatewayTwitch) FollowedAt(username string) (time.Time, bool) {
+	endpoint := g.baseURL + "/v1/followed-at/" + url.PathEscape(username)
+	resp, err := g.client.Get(endpoint)
+	if err != nil {
+		slog.Warn("gateway FollowedAt request failed", "username", username, "err", err)
+		return time.Time{}, false
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var body struct {
+			FollowedAt time.Time `json:"followed_at"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			slog.Warn("gateway FollowedAt decode failed", "username", username, "err", err)
+			return time.Time{}, false
+		}
+		return body.FollowedAt, true
+	case http.StatusNotFound:
+		return time.Time{}, false // not a follower — expected
+	default:
+		slog.Warn("gateway FollowedAt non-2xx", "username", username, "status", resp.StatusCode)
+		return time.Time{}, false
+	}
 }

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -69,6 +69,14 @@ type TripbotConfig struct {
 	// for the "restart obs" button. Optional — blank skips the OBS row.
 	ObsServerHost string `envconfig:"OBS_SERVER_HOST"`
 
+	// TwitchAPIURL points the chatbot's command-time Twitch Helix calls at
+	// the platform-gateway twitch-api instance over HTTP, instead of the
+	// in-process pkg/twitch path. Empty (the default) keeps the in-process
+	// adapter, so existing envs are unaffected. When set — e.g.
+	// http://twitch-api.<env>.svc.cluster.local:8080 — App.Twitch becomes an
+	// HTTP client behind the same interface, with no command code changes.
+	TwitchAPIURL string `envconfig:"TWITCH_API_URL"`
+
 	// NatsURL is the in-cluster NATS endpoint used for fire-and-forget
 	// inter-component events. Format:
 	// nats://nats.<env-platform-ns>.svc.cluster.local:4222.


### PR DESCRIPTION
## What

**Phase 3** of the platform-gateway work: flip the chatbot's command-time Twitch Helix surface from the in-process `pkg/twitch` path to an HTTP client hitting the `twitch-api` gateway — behind the existing `App.Twitch` interface, so **no command code changes** (the payoff of the [#738](https://github.com/adanalife/tripbot/pull/738/changes)/[#739](https://github.com/adanalife/tripbot/pull/739/changes) injection seam).

`newTwitch()` picks the adapter by config:
- `TWITCH_API_URL` set → `gatewayTwitch` (`GET /v1/followed-at/{login}`)
- empty → `realTwitch{}`, the zero-config default → **existing envs are unchanged**

The gateway client **fails closed** (`ok=false`) on transport / decode / non-2xx errors, matching the in-process adapter — gateway trouble degrades a follow check rather than blocking the command. A 404 is the gateway's "not a follower" answer.

## Sibling PR

Depends on the gateway serving the user-token endpoint: [platform-gateway#8](https://github.com/adanalife/platform-gateway/pull/8/changes) (Postgres token store — `FollowedAt` uses the broadcaster credential).

## Scope

This is the minimal end-to-end slice (`followageCmd` is the only `App.Twitch` consumer today) so the gateway path can be verified on stage. Repointing the *other* in-process Helix callers (`pkg/users/source`, `pkg/server/chatters`, `pkg/obs/watchdog`) to make the gateway the **single** Helix caller — the prerequisite for the SM token move — is separate follow-up work.

## Testing

- New httptest-backed tests for `gatewayTwitch`: follower (200 + path assertion), not-a-follower (404), fail-closed (502 / malformed body / transport error), trailing-slash trim.
- `go vet` + `go test ./pkg/chatbot/... ./pkg/config/...` green.

## Deploy (separate, not in this PR)

Bringing it up on stage needs: `twitch` added to stage platforms, `TWITCH_API_URL` in stage tripbot's ConfigMap, the Argo selfHeal/replicas change, and a stage Twitch re-auth so the broadcaster token row exists.

## Runtime kill-switch (added)

Two layers now: `TWITCH_API_URL` = the gateway is wired and where (deploy-time); the **`chatbot.twitch_gateway` feature flag** = whether to use it (runtime, default off, toggled from the console). Gateway is used iff URL set **and** flag on — so an env deploys with the gateway configured-but-dormant (true shadow), then cuts over (or reverts) from the console **without a bot restart**. Matters for the eventual prod flip on the live stream. With no `TWITCH_API_URL` it's the plain in-process path (no wrapper, no flag lookup).