### PR TITLE
feat(db): seed chatbot.twitch_gateway feature flag (off)

### DIFF
--- a/db/migrate/021_seed_chatbot_twitch_gateway_flag.down.sql
+++ b/db/migrate/021_seed_chatbot_twitch_gateway_flag.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM feature_flags WHERE key = 'chatbot.twitch_gateway';

--- a/db/migrate/021_seed_chatbot_twitch_gateway_flag.up.sql
+++ b/db/migrate/021_seed_chatbot_twitch_gateway_flag.up.sql
@@ -1,0 +1,22 @@
+/* Seeds chatbot.twitch_gateway — the runtime kill-switch for routing the Twitch
+   bot's command-time Helix calls through the platform-gateway (twitch-api). The
+   code-level flag landed in #904; without this row the console toggle errors
+   ("flag not found"), so the gateway path can never be turned on.
+
+   Twitch-only: the flag is consulted solely by the twitch instance (the youtube
+   instance has no gateway wired, so flaggedTwitch is never constructed there).
+   Unlike the 019 "one row per platform" guidance there is deliberately no
+   youtube row — toggling it there would do nothing.
+
+   Defaults off: an env wired with TWITCH_API_URL stays in-process until this is
+   flipped on from the console, and flipping it back off reverts without a bot
+   restart. */
+INSERT INTO feature_flags (key, platform, description, enabled, target_removal_date)
+VALUES (
+    'chatbot.twitch_gateway',
+    'twitch',
+    'Routes the chatbot''s command-time Twitch Helix calls (e.g. !followage) through the platform-gateway twitch-api instead of the in-process pkg/twitch path. Enable once the gateway is verified on the env; disable to revert without a bot restart.',
+    FALSE,
+    DATE '2026-12-19'
+)
+ON CONFLICT (key, platform) DO NOTHING;


### PR DESCRIPTION
## What

[#904](https://github.com/adanalife/tripbot/pull/904/changes) added the `chatbot.twitch_gateway` code-level flag — the runtime kill-switch for routing the Twitch bot's command-time Helix calls through the platform-gateway — but no DB row to back it. `feature.SetEnabled` only **UPDATEs** an existing row (`RowsAffected == 0` → "flag not found"), so the console toggle can't create it and the gateway path can never be turned on.

Migration `021` seeds the row (`platform=twitch`, **disabled**) so it's toggleable from the console.

## Notes

- **Twitch-only**: the youtube instance never constructs the gateway wrapper (`TWITCH_API_URL` is twitch-only), so there's deliberately no youtube row — departing from the `019` "one row per platform" guidance, which assumes a cross-platform flag. A youtube row would be a dead toggle.
- Defaults **off**: an env stays in-process until flipped on; flipping back off reverts without a bot restart.

## Why now

This is the missing piece to actually exercise the gateway on stage — without it, step "flip `chatbot.twitch_gateway` on" in [#905](https://github.com/adanalife/tripbot/pull/905/changes)'s bring-up has no flag to flip.

## Related

- [#904](https://github.com/adanalife/tripbot/pull/904/changes) — the code-level flag + `flaggedTwitch` dispatch.
- [#905](https://github.com/adanalife/tripbot/pull/905/changes) — stage twitch deploy.