### PR TITLE
fix(vlc-server): prime media player so restart resumes its clip (libvlc 3.0.x bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### Fixes
+
+- **vlc-server actually resumes its last-played clip on restart.** libvlc 3.0.x's `libvlc_media_list_player_play_item_at_index` reads the player's *existing* media before swapping in the requested one and returns `-1` when that prior media is nil — i.e. on the very first play against a freshly-created list player — even though playback actually starts. So the first startup play (resume-from-marker / resume-from-lastplayed) saw a spurious "cannot play the requested media", fell through to `PlayRandom`, and a restart almost never resumed where it left off. The media player is now primed with the first loaded clip at construction, so the first real play returns correctly and resume-on-restart lands on the right clip with the position seek following. ([#907])
+
 ### Cleanup
 
 - **Remove the in-tripbot admin panel in favor of tripbot-console.** Now that the standalone tripbot-console covers the admin dashboard, the in-process panel and its live-console SSE hub retire (`admin.go`, `hub.go`, `events.go`, the chat-send publisher form, `somafm.go`, `authcard.go`, and the vendored htmx/leaflet/sse assets). The HTTP surface the console and operators still need stays: `/auth/init` + `/auth/callback` (now fronted by a minimal landing page at `/` linking the bot/broadcaster/YouTube login flows), the read-only `/api/user`, `/api/chatters`, `/api/db/migration`, and `/admin/map/corpus` endpoints the console proxies over the in-namespace Service, plus `/version`, `/health`, and `/metrics`. The `chat.send` NATS subscriber stays in cmd/tripbot (the Twitch-identity owner), ready for the console to publish to once its chat-send feature lands. ([#886])
@@ -1685,6 +1689,7 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#763]: https://github.com/adanalife/tripbot/pull/763
 [#853]: https://github.com/adanalife/tripbot/pull/853
 [#886]: https://github.com/adanalife/tripbot/pull/886
+[#907]: https://github.com/adanalife/tripbot/pull/907
 [#861]: https://github.com/adanalife/tripbot/pull/861
 [#863]: https://github.com/adanalife/tripbot/pull/863
 [#864]: https://github.com/adanalife/tripbot/pull/864

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -14,7 +14,9 @@ import (
 // TODO: should we handle the case where index is outside range?
 // or just explicitly pass in what we get here?
 func (s *Server) playAtIndex(index int) error {
-	// start playing the media
+	// start playing the media. The underlying media player is primed with a
+	// media at construction (see primePlayer) so this returns correctly even
+	// when it's the very first play against the freshly-created list player.
 	if err := s.Playlist.PlayAtIndex(uint(index)); err != nil {
 		return err
 	}

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -110,7 +110,40 @@ func (s *Server) initPlayer() error {
 	if err := s.setToLoop(); err != nil {
 		return err
 	}
-	return s.loadMedia()
+	if err := s.loadMedia(); err != nil {
+		return err
+	}
+	return s.primePlayer()
+}
+
+// primePlayer sets the underlying media player's media to the first loaded
+// clip so it is non-nil before the first PlayAtIndex.
+//
+// This works around a libvlc 3.0.x bug: libvlc_media_list_player_play_item_-
+// at_index reads the player's *existing* media (libvlc_media_player_get_media)
+// before swapping in the requested one, and returns -1 when that prior media
+// is nil — i.e. on the very first play against a freshly-created list player —
+// even though set_current_playing_item succeeds and playback actually starts.
+// Without priming, the first play after boot (the startup resume) reports a
+// spurious failure, so ResumeFromLastPlayed falls back to PlayRandom and a
+// restart never resumes the clip it left off on. The prime doesn't start
+// playback; it only seeds the player so the first real play returns correctly.
+func (s *Server) primePlayer() error {
+	count, err := s.MediaList.Count()
+	if err != nil {
+		return fmt.Errorf("counting media to prime player: %w", err)
+	}
+	if count == 0 {
+		return nil
+	}
+	media, err := s.MediaList.MediaAtIndex(0)
+	if err != nil {
+		return fmt.Errorf("fetching media to prime player: %w", err)
+	}
+	if err := s.Player.SetMedia(media); err != nil {
+		return fmt.Errorf("priming player media: %w", err)
+	}
+	return nil
 }
 
 // Health returns nil when the server is ready to serve a viewer, or an


### PR DESCRIPTION
## What

vlc-server has a resume-on-restart feature (shipped in v3.3.0, #830): on startup it tries to resume the clip + position it was playing, via a watchdog file marker → JetStream `lastplayed` last-value cache → `PlayRandom` fallback. The position seek is already wired into both resume paths.

In practice it almost never worked. Bumping prod vlc to v3.6.0 restarted it and it came up on a *random* clip, not the one it left off on.

## Root cause — a libvlc 3.0.x bug

`libvlc_media_list_player_play_item_at_index` (3.0.x) reads the player's **existing** media *before* swapping in the requested one, and returns `-1` when that prior media is nil:

```c
int libvlc_media_list_player_play_item_at_index(libvlc_media_list_player_t * p_mlp, int i_index)
{
    lock(p_mlp);
    libvlc_media_list_path_t path = libvlc_media_list_path_with_root_index(i_index);
    libvlc_media_t *p_md = libvlc_media_player_get_media(p_mlp->p_mi);  // the player's CURRENT media, before the swap
    int ret = set_current_playing_item(p_mlp, path);                    // succeeds, sets the new media
    libvlc_media_player_play(p_mlp->p_mi);                              // playback actually starts
    unlock(p_mlp);

    if (!p_md)        // ← returns -1 when the player had no media beforehand
        return -1;
    ...
    return ret;
}
```

The `!p_md` guard is meant only to gate the event-send below, but it wrongly gates the **return value** too. On a freshly-created list player the underlying media player has no media yet, so `p_md` is nil → `-1` is returned **even though `set_current_playing_item` succeeded and playback started**.

So the first startup play returned a spurious "cannot play the requested media", `ResumeFromLastPlayed` treated it as failure and fell to `PlayRandom` — which is the *second* play call, so the player now has a media, so it returns 0 and a random clip plays. That's exactly the observed behavior.

### Evidence

- **Prod Loki logs:** every restart since the feature shipped logs `lastplayed resume failed; falling back  err="cannot play the requested media"` on the first attempt. The one time resume *worked* (Jun 18, pod `nbbj4`), a watchdog marker *and* a lastplayed signal both pointed at the same clip — the marker attempt (1st call) "failed", the lastplayed attempt (2nd call) succeeded, position resumed to 70154ms. That two-signal coincidence was the only path that ever resumed.
- **Local repro** against libvlc 3.0.20: the first `PlayAtIndex` returns the error and the second succeeds, independent of media-list index and of the RTSP sout options. The libvlc verbose log shows the input for the correct clip *is* created on the failing first call — confirming playback starts despite the `-1`.

## Fix

Prime the underlying media player with the first loaded clip at construction (`primePlayer`), so its media is non-nil before the first `PlayAtIndex`. The prime doesn't start playback; it only seeds the player so the first real play returns correctly. Verified in the repro: priming makes the first `PlayAtIndex` return `nil` (with and without sout).

This replaces an earlier retry-based attempt (which papered over the symptom); the prime addresses the actual cause.

## Test

- `pkg/vlc-server` suite green via `task test:macos`; `go vet` clean.
- Behavior verified end-to-end with a standalone libvlc 3.0.20 harness.