### PR TITLE
fix(ci): rebuild the develop tripbot image on db/migrate changes

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -38,6 +38,13 @@ jobs:
             tripbot:
               - 'cmd/tripbot/**'
               - 'pkg/**'
+              # DB migrations are baked into the tripbot image and run by its
+              # migrate initContainer at pod boot — so a migration-only PR must
+              # rebuild the image, or the new migration never ships and the
+              # initContainer reports "no change" against a stale image. (Bit us
+              # 2026-06-19: #906's seed migration didn't reach :develop because
+              # this filter didn't watch db/migrate.)
+              - 'db/migrate/**'
               - 'infra/docker/tripbot/**'
               - 'go.mod'
               - 'go.sum'


### PR DESCRIPTION
## The bug

DB migrations are baked into the tripbot image and applied by its **`migrate` initContainer** at pod boot. But `release-development.yml`'s per-image path filter for `tripbot` watched `cmd/tripbot/**` + `pkg/**` + the Dockerfile — **not `db/migrate/**`**. So a migration-only PR never rebuilt the `:develop` image: the migration silently never shipped, and on the next pod roll the initContainer logged `no change` against a stale image.

## How it bit us (2026-06-19)

[#906](https://github.com/adanalife/tripbot/pull/906/changes) seeded the `chatbot.twitch_gateway` flag, but its `tripbot-build` was skipped (filter miss), so `:develop` stayed at migration `020`. The flag row never got created on stage → the gateway couldn't be enabled. (Compounded by [#904](https://github.com/adanalife/tripbot/pull/904/changes)'s build being concurrency-cancelled and [#905](https://github.com/adanalife/tripbot/pull/905/changes) being cdk8s-only — so `:develop` was stale on the flag *code* too.)

## Fix

Add `db/migrate/**` to the `tripbot` filter. Merging this also touches `release-development.yml` (already in the filter), so it triggers a fresh `tripbot-build` from develop HEAD — which picks up the stale #904 code + #906 migration in one go.

Prod's `release.yml` builds all images unconditionally on a release tag, so it's unaffected.

## After merge

`:develop` rebuilds → `kubectl rollout restart deploy/tripbot-twitch -n stage-1` (Always pull) → initContainer applies `021` (creates the flag row) and the binary now has the flag-gated gateway client.