### PR TITLE
ci: standing draft release PR (develop → master)

### DIFF
--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -82,16 +82,26 @@ jobs:
 
           LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
 
-          # --- Suggested bump, from the Unreleased changelog section ----------
-          # Heuristic only: Removed/breaking -> major, Added -> minor, else
-          # patch. The real bump is whatever token lands in the merge commit.
+          # --- Suggested bump ------------------------------------------------
+          # Heuristic only; the real bump is whatever token lands in the merge
+          # commit. Two signals, strongest wins:
+          #   1. Conventional-commit prefixes on the queued commits — the most
+          #      reliable signal (changelog section names vary): `feat!:` or a
+          #      `BREAKING CHANGE` body -> major, any `feat:` -> minor.
+          #   2. The Unreleased changelog section — breaking/Removed -> major,
+          #      Added -> minor.
           UNREL=""
           if [ -f CHANGELOG.md ]; then
             UNREL=$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
           fi
-          if echo "$UNREL" | grep -qiE 'breaking|^### *Removed'; then
+          SUBJECTS=$(git log --no-merges --pretty=format:'%s' "origin/master..HEAD")
+          BODIES=$(git log --no-merges --pretty=format:'%b' "origin/master..HEAD")
+          if echo "$SUBJECTS" | grep -qE '^[a-z]+(\(.+\))?!:' \
+            || echo "$BODIES" | grep -q 'BREAKING CHANGE' \
+            || echo "$UNREL" | grep -qiE 'breaking|^### *Removed'; then
             BUMP="major"
-          elif echo "$UNREL" | grep -qiE '^### *Added'; then
+          elif echo "$SUBJECTS" | grep -qE '^feat(\(.+\))?:' \
+            || echo "$UNREL" | grep -qiE '^### *Added'; then
             BUMP="minor"
           else
             BUMP="patch"
@@ -123,7 +133,7 @@ jobs:
             echo
             echo "$BUMP_LINE"
             echo
-            echo "_Bump is a guess from the Unreleased changelog (Added → minor, Removed/breaking → major, else patch). Your call._"
+            echo "_Bump is a guess from the queued commits + Unreleased changelog (\`feat\`/Added → minor, \`feat!\`/BREAKING/Removed → major, else patch). Your call — set the real bump via \`#minor\`/\`#major\` in the merge commit._"
             echo
             echo "**Diff:** [\`$RANGE\`](https://github.com/$REPO/compare/$RANGE) · **$AHEAD** commit(s) ahead of \`master\`."
             echo

--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -1,0 +1,151 @@
+name: pending-release
+
+# Maintains a single standing DRAFT PR from develop -> master that shows what
+# the NEXT release would contain, so the version-bump decision can be made
+# against a real diff + changelog instead of guessed up front. Modeled on
+# bump-prs.yml's update-in-place pattern.
+#
+# This is a staging VIEW, not a release tool: it never merges anything. To cut
+# a release, rename this PR to "Release vX.Y.Z", mark it ready, and merge it
+# with the bump token (#minor / #major; default patch) in the MERGE COMMIT
+# message — auto-tag.yml reads the token from commits landing on master.
+#
+# Once the PR is promoted out of draft (i.e. you've started cutting), this
+# workflow stops touching it, so it won't clobber a body/title you've edited.
+#
+# The PR is created via the automation GitHub App token (same as bump-prs) so
+# its pull_request events fire CI; GITHUB_TOKEN-created PRs don't trigger
+# downstream workflows.
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pending-release
+  cancel-in-progress: true
+
+jobs:
+  pending-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: develop
+
+      - name: Manage the pending-release draft PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git fetch origin master -q
+
+          AHEAD=$(git rev-list --count origin/master..HEAD)
+
+          # Find an existing open develop -> master PR (draft or not).
+          PR_JSON=$(gh pr list --base master --head develop --state open \
+            --json number,isDraft --jq '.[0] // empty')
+          NUM=$(echo "$PR_JSON" | jq -r '.number // empty')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft // empty')
+
+          # Nothing queued (develop is in sync with master, e.g. just after a
+          # release): retire the standing draft if one is open, then stop.
+          if [ "$AHEAD" -eq 0 ]; then
+            if [ -n "$NUM" ] && [ "$IS_DRAFT" = "true" ]; then
+              gh pr close "$NUM" --comment "develop is in sync with master — nothing pending. A fresh draft opens when new work lands on develop."
+            fi
+            echo "develop has no commits ahead of master; nothing to stage."
+            exit 0
+          fi
+
+          # If a maintainer has promoted the PR out of draft, it's now a real
+          # release PR being cut by hand — hands off.
+          if [ -n "$NUM" ] && [ "$IS_DRAFT" != "true" ]; then
+            echo "PR #$NUM is no longer a draft (release in progress); leaving it alone."
+            exit 0
+          fi
+
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+
+          # --- Suggested bump, from the Unreleased changelog section ----------
+          # Heuristic only: Removed/breaking -> major, Added -> minor, else
+          # patch. The real bump is whatever token lands in the merge commit.
+          UNREL=""
+          if [ -f CHANGELOG.md ]; then
+            UNREL=$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+          fi
+          if echo "$UNREL" | grep -qiE 'breaking|^### *Removed'; then
+            BUMP="major"
+          elif echo "$UNREL" | grep -qiE '^### *Added'; then
+            BUMP="minor"
+          else
+            BUMP="patch"
+          fi
+
+          # Project the resulting version off the latest tag.
+          NEXT=""
+          if echo "$LATEST_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            v=${LATEST_TAG#v}
+            MA=${v%%.*}; rest=${v#*.}; MI=${rest%%.*}; PA=${rest#*.}
+            case "$BUMP" in
+              major) MA=$((MA+1)); MI=0; PA=0 ;;
+              minor) MI=$((MI+1)); PA=0 ;;
+              patch) PA=$((PA+1)) ;;
+            esac
+            NEXT="v$MA.$MI.$PA"
+          fi
+
+          BUMP_LINE="**Suggested bump:** \`$BUMP\`"
+          if [ -n "$NEXT" ]; then
+            BUMP_LINE="$BUMP_LINE → would tag **$NEXT** (from ${LATEST_TAG:-no prior tag})"
+          fi
+
+          # --- Compose the body ---------------------------------------------
+          RANGE="${LATEST_TAG:-origin/master}...develop"
+          {
+            echo "> **Draft / staging view — not meant to merge as-is.** Rebuilt automatically on every push to \`develop\`."
+            echo "> To cut a release: rename this PR to \`Release vX.Y.Z\`, mark it **Ready for review**, then **merge it with a merge commit** whose message carries the bump token (\`#minor\` / \`#major\`; default \`patch\`). \`auto-tag.yml\` reads the token off the commit landing on \`master\`. Once promoted out of draft, this workflow stops editing the PR."
+            echo
+            echo "$BUMP_LINE"
+            echo
+            echo "_Bump is a guess from the Unreleased changelog (Added → minor, Removed/breaking → major, else patch). Your call._"
+            echo
+            echo "**Diff:** [\`$RANGE\`](https://github.com/$REPO/compare/$RANGE) · **$AHEAD** commit(s) ahead of \`master\`."
+            echo
+            echo "### Changelog — Unreleased"
+            echo
+            if [ -n "$UNREL" ] && echo "$UNREL" | grep -q '[^[:space:]]'; then
+              echo "$UNREL"
+            else
+              echo "_No \`## [Unreleased]\` entries in CHANGELOG.md._"
+            fi
+            echo
+            echo "### Queued since ${LATEST_TAG:-the last release}"
+            echo
+            git log --no-merges --pretty=format:'- %s' "origin/master..HEAD"
+            echo
+          } > /tmp/pending-body.md
+
+          if [ -z "$NUM" ]; then
+            gh pr create --draft --base master --head develop \
+              --title "📦 Pending release (develop → master)" \
+              --body-file /tmp/pending-body.md
+          else
+            gh pr edit "$NUM" --body-file /tmp/pending-body.md
+            echo "Refreshed draft PR #$NUM."
+          fi


### PR DESCRIPTION
## What

Adds `pending-release.yml`, a workflow that keeps **one standing draft PR** open from `develop → master` so the next release is always visible before it has to be named.

On every push to `develop` (and on `workflow_dispatch`) it rebuilds that draft PR's body with:

- a `master...develop` **compare link** + how many commits are ahead,
- the **`## [Unreleased]` section** of `CHANGELOG.md`,
- the **list of queued commits** since the last tag,
- a **heuristic version-bump suggestion** (Unreleased has Added → minor, Removed/breaking → major, else patch) with the projected `vX.Y.Z`.

It **closes** the draft when `develop` is in sync with `master` (e.g. right after a release), and **stops touching** the PR once it's promoted out of draft — so a release you've started cutting by hand is never clobbered.

## Why

Removes the "is this a minor or just a patch?" guess at release time: the decision is now made against a real diff + changelog instead of up front. Replaces the manual "open a Release vX.Y.Z PR" step with an always-present staging view.

## How a release gets cut

The downstream pipeline is unchanged. To ship:

1. Open the standing draft PR, read the diff / changelog / suggested bump.
2. Rename it to `Release vX.Y.Z`, mark it **Ready for review**.
3. **Merge with a merge commit** whose message carries the bump token (`#minor` / `#major`; default `patch`). `auto-tag.yml` reads the token off the commit landing on `master`, mints the tag, and `release.yml` fires.

## Notes

- Modeled on `bump-prs.yml`'s update-in-place pattern; created via the automation GitHub App token so the PR's `pull_request` events fire CI.
- This is a prototype for `tripbot`; once it looks right the same pattern goes to `website` and `tripbot-console`.
- A standing open PR means `testing.yml` runs on both `push: develop` and the PR's `synchronize` — a draft-guard on `testing.yml` can suppress the duplicate later if it's noisy.
