### PR TITLE
Point TWITCH_API_URL at renamed gateway-twitch Service

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -152,10 +152,10 @@ class EnvConfig:
         scaled) when manual_replicas, else 1."""
         return None if self.manual_replicas else 1
 
-    # The platform-gateway twitch-api URL the chatbot routes its command-time
+    # The platform-gateway gateway-twitch URL the chatbot routes its command-time
     # Helix calls through (Phase 3). Empty keeps tripbot's in-process pkg/twitch
     # path; set per env to flip App.Twitch to the HTTP client. Stage points at
-    # its in-namespace twitch-api Service; prod stays in-process until the
+    # its in-namespace gateway-twitch Service; prod stays in-process until the
     # gateway's prod release is cut + proven.
     twitch_api_url: str = ""
 
@@ -304,7 +304,7 @@ ENVS: dict[str, EnvConfig] = {
         # pass.
         #
         # twitch is back ON (2026-06-19) to test the platform-gateway end to
-        # end: stage tripbot-twitch routes its Helix calls through twitch-api
+        # end: stage tripbot-twitch routes its Helix calls through gateway-twitch
         # (twitch_api_url below). The 2026-06-11 prod-stutter that forced twitch
         # OFF here was the stage twitch *VLC decode + OBS render* contending for
         # the shared iGPU — so only tripbot-twitch (no GPU) is meant to run;
@@ -316,9 +316,9 @@ ENVS: dict[str, EnvConfig] = {
         # for the gateway test); omit replicas so Argo doesn't reset them.
         manual_replicas=True,
         # Route stage tripbot's command-time Helix calls through the in-namespace
-        # twitch-api gateway (Phase 3). prod stays in-process until its gateway
+        # gateway-twitch gateway (Phase 3). prod stays in-process until its gateway
         # release is cut.
-        twitch_api_url="http://twitch-api.stage-1.svc.cluster.local:8080",
+        twitch_api_url="http://gateway-twitch.stage-1.svc.cluster.local:8080",
         # Stage streams to YouTube — the second half of the two-live-streams
         # budget (prod-twitch + stage-youtube). Key from SM
         # k8s/obs/youtube-stream-key (adanalife-stage account).

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -176,7 +176,7 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
     if env.nats_url:
         data["NATS_URL"] = env.nats_url
     # Route the twitch instance's command-time Helix calls through the
-    # platform-gateway twitch-api (Phase 3) where the env opts in. Only the
+    # platform-gateway gateway-twitch (Phase 3) where the env opts in. Only the
     # twitch platform talks Helix, so the youtube instance never carries it.
     if platform == "twitch" and env.twitch_api_url:
         data["TWITCH_API_URL"] = env.twitch_api_url

--- a/cdk8s/dist/stage-1-tripbot-twitch.k8s.yaml
+++ b/cdk8s/dist/stage-1-tripbot-twitch.k8s.yaml
@@ -26,7 +26,7 @@ data:
   READ_ONLY: "false"
   SENTRY_ENVIRONMENT: stage-1
   TRIPBOT_SERVER_PORT: "8080"
-  TWITCH_API_URL: http://twitch-api.stage-1.svc.cluster.local:8080
+  TWITCH_API_URL: http://gateway-twitch.stage-1.svc.cluster.local:8080
   VERBOSE: "false"
   VLC_SERVER_HOST: vlc-twitch:8080
 ---
@@ -45,7 +45,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: a77c1be5de
+        adanalife.dev/config-hash: c009764bbb
       labels:
         app: tripbot-twitch
     spec:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -152,7 +152,7 @@ def test_stage_twitch_routes_through_gateway():
 
     assert (
         _cm_data("stage-1-tripbot-twitch").get("TWITCH_API_URL")
-        == "http://twitch-api.stage-1.svc.cluster.local:8080"
+        == "http://gateway-twitch.stage-1.svc.cluster.local:8080"
     )
     assert "TWITCH_API_URL" not in _cm_data("stage-1-tripbot-youtube")
     assert "TWITCH_API_URL" not in _cm_data("prod-1-tripbot-twitch")

--- a/pkg/chatbot/gateway_twitch_test.go
+++ b/pkg/chatbot/gateway_twitch_test.go
@@ -76,7 +76,7 @@ func TestGatewayTwitch_FollowedAt_TransportError(t *testing.T) {
 }
 
 func TestNewGatewayTwitch_TrimsTrailingSlash(t *testing.T) {
-	if got := newGatewayTwitch("http://twitch-api:8080/").baseURL; got != "http://twitch-api:8080" {
+	if got := newGatewayTwitch("http://gateway-twitch:8080/").baseURL; got != "http://gateway-twitch:8080" {
 		t.Errorf("baseURL = %q, want trailing slash trimmed", got)
 	}
 }

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -75,7 +75,7 @@ func (realTwitch) FollowedAt(username string) (time.Time, bool) {
 }
 
 // gatewayTwitch is the HTTP adapter — it reaches the platform-gateway
-// twitch-api instance instead of calling Helix in-process. It satisfies the
+// gateway-twitch instance instead of calling Helix in-process. It satisfies the
 // same Twitch interface, so command code is untouched (the payoff of the
 // #738/#739 injection seam).
 type gatewayTwitch struct {

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -70,10 +70,10 @@ type TripbotConfig struct {
 	ObsServerHost string `envconfig:"OBS_SERVER_HOST"`
 
 	// TwitchAPIURL points the chatbot's command-time Twitch Helix calls at
-	// the platform-gateway twitch-api instance over HTTP, instead of the
+	// the platform-gateway gateway-twitch instance over HTTP, instead of the
 	// in-process pkg/twitch path. Empty (the default) keeps the in-process
 	// adapter, so existing envs are unaffected. When set — e.g.
-	// http://twitch-api.<env>.svc.cluster.local:8080 — App.Twitch becomes an
+	// http://gateway-twitch.<env>.svc.cluster.local:8080 — App.Twitch becomes an
 	// HTTP client behind the same interface, with no command code changes.
 	TwitchAPIURL string `envconfig:"TWITCH_API_URL"`
 


### PR DESCRIPTION
The platform-gateway pod is renamed `twitch-api` → `gateway-twitch` to join the `<app>-<platform>` fleet convention. This updates the consumer side: stage `tripbot-twitch`'s `TWITCH_API_URL`.

## Changes
- `cdk8s/adanalife_k8s/config.py`: `twitch_api_url` → `http://gateway-twitch.stage-1.svc.cluster.local:8080`.
- `cdk8s/tests/test_cdk8s.py`: assertion updated; re-synthed `stage-1-tripbot-twitch`.
- Doc/comment refs (`pkg/config/tripbot/type.go`, `pkg/chatbot/twitch.go`, construct comment) + the `gateway_twitch_test.go` fixture string.

## Merge ordering (stage is live)
Stage `tripbot-twitch` routes `FollowedAt` through the gateway behind the `chatbot.twitch_gateway` flag. Safe sequence: flag **off** (console) → merge platform-gateway#9 (Service rename) → merge this + restart `tripbot-twitch` → flag **on** → re-verify `!followage`. Stage-only blast radius; fails closed.

Sibling PRs (cross-repo `gateway-<platform>` rename):
- platform-gateway#9 (the Service rename — source of truth)
- infra (Argo descriptions)
- tripbot-console (live name parsing)