### PR TITLE
ci: auto-open a standing master→develop back-merge PR

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,111 @@
+name: backmerge
+
+# After anything lands on master (a release merge, a bump-prs pin edit), open or
+# refresh ONE standing PR that merges master back into develop, so develop never
+# drifts from master. Skipping this back-merge is what caused the v3.6.0
+# phantom-divergence cleanup; this automates it (see merge-strategy-by-target-
+# branch + the cutting-a-release notes).
+#
+# ⚠️ The PR it opens MUST be merged with a MERGE COMMIT, never squashed/rebased.
+# Squash copies the file contents without making master's commits ancestors of
+# develop, so the divergence stays in place and the next release PR conflicts on
+# CHANGELOG.md (exactly what happened when the manual v3.6.0 back-merge was
+# squash-merged). The PR body repeats this warning.
+#
+# Mechanics mirror bump-prs.yml: a well-known branch (backmerge/master-to-develop)
+# is recreated from develop with master merged in and force-pushed, so there is
+# at most one open back-merge PR, always reflecting the latest master. Conflicts
+# are auto-resolved in master's favour (-X theirs) — right after a release the
+# only conflict is the CHANGELOG [Unreleased] -> [version] stamp, and master's
+# version is the correct post-release state.
+#
+# Authenticates as the automation GitHub App (same as bump-prs) so the PR's
+# pull_request events fire CI; GITHUB_TOKEN-created PRs don't trigger workflows.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: backmerge
+  cancel-in-progress: true
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: backmerge/master-to-develop
+    steps:
+      - name: Mint automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Open or refresh the back-merge PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git fetch origin master develop --tags -q
+
+          AHEAD=$(git rev-list --count origin/develop..origin/master)
+
+          NUM=$(gh pr list --base develop --head "$BRANCH" --state open \
+            --json number --jq '.[0].number // empty')
+
+          # develop already contains everything on master — nothing to do.
+          if [ "$AHEAD" -eq 0 ]; then
+            if [ -n "$NUM" ]; then
+              gh pr close "$NUM" --comment "develop is back in sync with master — nothing to back-merge." --delete-branch
+            fi
+            echo "develop is in sync with master; nothing to back-merge."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Recreate the branch from develop and merge master in. -X theirs
+          # resolves conflicts in master's favour; the merge commit still carries
+          # master as a parent, so merging this PR heals the ancestry.
+          git checkout -B "$BRANCH" origin/develop
+          if ! git merge --no-ff -X theirs origin/master \
+              -m "Merge branch 'master' into develop (back-merge)"; then
+            git merge --abort || true
+            echo "::error::back-merge could not be auto-resolved; merge master into develop by hand."
+            exit 1
+          fi
+          git push -f origin "$BRANCH"
+
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' origin/master 2>/dev/null || echo "")
+          TITLE="⏪ Back-merge master → develop${LATEST_TAG:+ ($LATEST_TAG)}"
+          cat > /tmp/body.md <<EOF
+          Merges \`master\` back into \`develop\` so the two don't diverge${LATEST_TAG:+ after $LATEST_TAG}. **$AHEAD** commit(s) on \`master\` are not yet on \`develop\`.
+
+          ## ⚠️ Merge with a MERGE COMMIT — do NOT squash or rebase
+
+          Squashing copies the file contents but does **not** make master's commits ancestors of develop, so the divergence stays and the next release PR conflicts on \`CHANGELOG.md\`. Use the **"Create a merge commit"** option. No bump token needed (this targets \`develop\`).
+
+          - CHANGELOG (and any other) conflicts were auto-resolved in **master's** favour — the correct post-release state. If develop had already picked up new \`[Unreleased]\` entries, re-add them here before merging.
+          - Recreated and force-pushed on every push to \`master\`, so it always reflects the latest master.
+          EOF
+          if [ -n "$NUM" ]; then
+            gh pr edit "$NUM" --title "$TITLE" --body-file /tmp/body.md
+            echo "Refreshed back-merge PR #$NUM."
+          else
+            gh pr create --base develop --head "$BRANCH" --title "$TITLE" --body-file /tmp/body.md
+          fi


### PR DESCRIPTION
## What

Adds `backmerge.yml`, the recurring automation for keeping `master` and `develop` in sync — the missing step that caused the v3.6.0 phantom-divergence cleanup.

On every push to `master` (release merge, or a `bump-prs` pin edit) it maintains **one standing PR** merging `master` back into `develop`:

- recreates a well-known branch (`backmerge/master-to-develop`) from develop with master merged in, force-pushed — so there's always exactly one, always current (same update-in-place pattern as `bump-prs.yml`);
- auto-resolves conflicts in **master's** favour (`-X theirs`) — right after a release the only conflict is the CHANGELOG `[Unreleased] → [version]` stamp, where master's version is the correct post-release state;
- **closes** the PR when develop has caught up.

## ⚠️ The PRs it opens must be merged with a merge commit

Squashing copies the file contents but doesn't make master's commits ancestors of develop, so the divergence persists — that's exactly how the manual v3.6.0 back-merge (#912) broke. The PR body repeats this loudly. GitHub has no per-PR "disallow squash" setting, so this stays a convention enforced by the warning; if it keeps getting mis-merged we can revisit (e.g. drop squash repo-wide, which would also affect feature PRs).

## Relationship to the other release-flow work

Complements the standing release view in #910 (`pending-release.yml`): that one shows what's queued *forward* (develop→master); this one keeps develop synced *backward* (master→develop) after each ship.
