### PR TITLE
onscreens: fix rotators going blank in OBS (remove OSR compositing layer)

### DIFF
--- a/pkg/onscreens-server/browser.go
+++ b/pkg/onscreens-server/browser.go
@@ -66,6 +66,17 @@ type onscreenStyle struct {
 	Markdown      bool         // run the onscreen's Content through renderInlineMarkdown before serving state.json (implies RenderAsHTML)
 }
 
+// ContentMarginLeftPx is the left margin (in px) that positions a
+// FitWidthPx-wide, text-centered content box so its center sits at AnchorXPx
+// within the browser-source viewport. It backs the anchored rotator layout's
+// normal-flow centering (see templates/onscreen.html.tmpl) — the layout
+// deliberately avoids position:absolute + transform, which promote the content
+// to a separate compositing layer that OBS's offscreen renderer fails to
+// repaint on update.
+func (s onscreenStyle) ContentMarginLeftPx() int {
+	return s.AnchorXPx - s.FitWidthPx/2
+}
+
 var onscreenRegistry = map[string]onscreenStyle{
 	SlugMiddleText: {
 		// Content supports inline markdown (see renderInlineMarkdown) so

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -70,19 +70,26 @@
   #root.hidden { visibility: hidden; }
   {{if and (not .IsImage) (gt .FitWidthPx 0)}}
   /* Anchored mode: the browser-source viewport overhangs a smaller on-canvas
-     overlay (the bottom-strip rotators' grey-box). Text centers on AnchorXPx
-     within the viewport and shrinks to fit FitWidthPx. */
+     overlay (the bottom-strip rotators' grey-box). A fixed-width, text-centered
+     content box is offset via margin-left so its center sits at AnchorXPx, and
+     shrinks to fit FitWidthPx.
+
+     Deliberately normal-flow (flex + margin) rather than position:absolute +
+     transform. An absolutely-positioned/transformed box becomes its own
+     compositing layer, and OBS's offscreen browser renderer (CEF OSR) fails to
+     push that layer's repaints into the shared texture after the first paint —
+     so the rotators rendered once on load, then went blank on their first
+     content rotation. Middle-text never hit this because it's normal-flow;
+     matching that flow keeps the rotators painting across updates. */
   #root.text {
-    position: relative;
     width: 100%; height: 100%;
+    display: flex; align-items: center;
   }
   #root.text .content {
-    position: absolute;
-    top: 50%;
-    left: {{.AnchorXPx}}px;
-    transform: translate(-50%, -50%);
+    flex: 0 0 auto;
+    width: {{.FitWidthPx}}px;
+    margin-left: {{.ContentMarginLeftPx}}px;
     text-align: center;
-    max-width: {{.FitWidthPx}}px;
     white-space: nowrap;
     word-wrap: break-word;
   }


### PR DESCRIPTION
The left/right rotator overlays render correctly on load, then go **blank on their first content rotation** in OBS. onscreens-server was serving valid content the whole time, and the page renders + rotates cleanly in a normal browser — the fault is specific to OBS's offscreen browser renderer (CEF OSR).

## Root cause

The rotators centered their text with `position:absolute` + `transform`, which promotes the content to its own **compositing layer**. OBS's OSR captures that layer on first paint but fails to push subsequent repaints into the shared texture, so the next rotation leaves a stale/blank layer. Middle-text never hit this because it's normal-flow.

It surfaced now because #885 (first shipped in `3.6.0`) flipped the rotators to swap `innerHTML` (node-level mutation, for the `<code>` pills) on the composited layer every tick — the prior `textContent` path didn't trip the OSR repaint bug.

## Fix

Replace the absolute/transform centering with the same normal-flow approach middle-text uses: a fixed-width, text-centered content box offset via `margin-left` so its center still lands on `AnchorXPx`. No separate compositing layer → OSR repaints it like it does middle-text.

## Verification

- `go test ./pkg/onscreens-server/` green; template parses.
- Reproduced against the **live prod page + content** in a headless Chrome at the exact OBS source size (640×47): old template renders + rotates fine in a real browser (confirming it's OSR-specific, not page logic).
- New template: centering math reproduces the prior placement exactly — left text-center **282** (want 282), right **457** (want 456) — and stays visible across rotations.
- Final validation is in real OBS OSR (can't be reproduced in a normal browser), i.e. the live trial.