### PR TITLE
fix(ci): label back-merge PR from CHANGELOG, not racy git tag

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -91,7 +91,11 @@ jobs:
           fi
           git push -f origin "$BRANCH"
 
-          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' origin/master 2>/dev/null || echo "")
+          # Label from the CHANGELOG's top released version, not git tags:
+          # backmerge runs on the same master push as auto-tag.yml, so the new
+          # tag often doesn't exist yet and `git describe` would label the PR
+          # with the PREVIOUS release. The stamped CHANGELOG entry is race-free.
+          LATEST_TAG=$(grep -m1 -oE '^## \[v[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
           TITLE="⏪ Back-merge master → develop${LATEST_TAG:+ ($LATEST_TAG)}"
           cat > /tmp/body.md <<EOF
           Merges \`master\` back into \`develop\` so the two don't diverge${LATEST_TAG:+ after $LATEST_TAG}. **$AHEAD** commit(s) on \`master\` are not yet on \`develop\`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### Onscreens
+
+- **Rotator overlays no longer go blank in OBS after their first rotation.** The left/right rotators centered text with `position:absolute` + `transform`, promoting it to its own compositing layer that OBS's offscreen renderer (CEF OSR) captured once but failed to repaint on later rotations. Switched to the same normal-flow, `margin-left`-offset centering middle-text uses, so OSR repaints it correctly. (Surfaced when #885 moved the rotators to `innerHTML` swaps on the composited layer.) ([#916])
+
 ### CI / Tooling
 
 - **Back-merge PR title shows the correct release version.** `backmerge.yml` read the version via `git describe`, which races `auto-tag.yml` on the same master push and labeled the back-merge PR with the *previous* release (e.g. v3.6.0 right after v3.7.0 shipped); it now reads the just-released version from the CHANGELOG, which is race-free. ([#919])
@@ -1768,3 +1772,4 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#911]: https://github.com/adanalife/tripbot/pull/911
 [#913]: https://github.com/adanalife/tripbot/pull/913
 [#919]: https://github.com/adanalife/tripbot/pull/919
+[#916]: https://github.com/adanalife/tripbot/pull/916

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### CI / Tooling
+
+- **Back-merge PR title shows the correct release version.** `backmerge.yml` read the version via `git describe`, which races `auto-tag.yml` on the same master push and labeled the back-merge PR with the *previous* release (e.g. v3.6.0 right after v3.7.0 shipped); it now reads the just-released version from the CHANGELOG, which is race-free. ([#919])
+
 ## [v3.7.0] — 2026-06-19
 
 Minor release. Lands the groundwork for routing the Twitch bot's command-time Helix calls through the standalone platform-gateway (staged on stage-1, off by default), credits the triggering viewer on the timewarp overlay, adds a console-facing feature-flag API, and automates the develop↔master release flow. Plus fixes to vlc-server resume-on-restart, the auth-bootstrap retry path, and the `:develop` image-rebuild filter for migrations.
@@ -1763,3 +1767,4 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#909]: https://github.com/adanalife/tripbot/pull/909
 [#911]: https://github.com/adanalife/tripbot/pull/911
 [#913]: https://github.com/adanalife/tripbot/pull/913
+[#919]: https://github.com/adanalife/tripbot/pull/919


### PR DESCRIPTION
Follow-up from the v3.7.0 cut: `backmerge.yml` opened #917 titled "(v3.6.0)" right after **v3.7.0** shipped, because it runs on the same master push as `auto-tag.yml` and `git describe` read the tag before v3.7.0 was created.

Reads the just-released version from the top `## [vX.Y.Z]` entry in `CHANGELOG.md` instead — race-free, since the stamped changelog is already in the merged code.

Doubles as the small change to cut **v3.7.1** with, exercising the new pending-release → `#patch` → auto-back-merge flow end-to-end.