### PR TITLE
gateway 3b (1/2): shared client + route watchdog live-check & broadcaster send through the gateway

### DIFF
--- a/cmd/tripbot/chatsend.go
+++ b/cmd/tripbot/chatsend.go
@@ -8,6 +8,7 @@ import (
 	chatEvents "github.com/adanalife/tripbot/pkg/chat-events"
 	"github.com/adanalife/tripbot/pkg/chatsend"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/gateway"
 	"github.com/adanalife/tripbot/pkg/natsclient"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 	"github.com/nats-io/nats.go"
@@ -38,11 +39,22 @@ func (t *Tripbot) startChatSendSubscriber(ctx context.Context) {
 		}
 		chatsend.Dispatch(ctx, ev,
 			func(text string) { t.app.Chat.Say(text) },
-			mytwitch.SendChatMessageAsBroadcaster,
+			t.sendChatAsBroadcaster,
 		)
 	}); err != nil {
 		slog.ErrorContext(ctx, "chat.send subscribe failed", "err", err, "subject", subject)
 		return
 	}
 	slog.InfoContext(ctx, "nats subscribed", "subject", subject)
+}
+
+// sendChatAsBroadcaster posts text to the channel's chat as the broadcaster:
+// through the platform-gateway when useGateway reports the runtime flag is on,
+// else the in-process Helix send. Fail-open semantics are the caller's
+// (chatsend.Dispatch logs and drops on error).
+func (t *Tripbot) sendChatAsBroadcaster(ctx context.Context, text string) error {
+	if t.useGateway(ctx) {
+		return t.gateway.SendChat(ctx, gateway.IdentityBroadcaster, text)
+	}
+	return mytwitch.SendChatMessageAsBroadcaster(ctx, text)
 }

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/eventsub"
 	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/adanalife/tripbot/pkg/gateway"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/natsclient"
@@ -135,6 +136,33 @@ type Tripbot struct {
 	// startup window before startFeatureFlags swaps in the Postgres-backed
 	// client — same fail-closed contract as pkg/feature.
 	flagClient feature.FlagClient
+
+	// gateway is the HTTP client for the platform-gateway, or nil when no
+	// TWITCH_API_URL is configured (the in-process default). When non-nil it's
+	// the shared client the non-chatbot Helix callers (the OBS watchdog's
+	// live-check, the chat-send path) route through once useGateway reports the
+	// runtime flag is on — the same gate chatbot's flaggedTwitch uses.
+	gateway *gateway.Client
+}
+
+// newGatewayClient builds the platform-gateway client when TWITCH_API_URL is
+// set, else returns nil (the in-process default). Stateless and side-effect
+// free, so it's safe to construct at NewTripbot time.
+func newGatewayClient() *gateway.Client {
+	if c.Conf.TwitchAPIURL == "" {
+		return nil
+	}
+	return gateway.New(c.Conf.TwitchAPIURL)
+}
+
+// useGateway reports whether this instance should route a Helix call through
+// the platform-gateway rather than calling Helix in-process: the gateway must
+// be wired (TWITCH_API_URL set → gateway non-nil) AND the runtime flag on. Read
+// per call so cutover and revert need no restart, mirroring chatbot's
+// flaggedTwitch — one gate for "tripbot uses the gateway".
+func (t *Tripbot) useGateway(ctx context.Context) bool {
+	return t.gateway != nil &&
+		t.flagClient.Bool(ctx, chatbot.TwitchGatewayFlagKey, feature.EvalContext{})
 }
 
 // NewTripbot constructs a Tripbot with default runtime state. Dependencies
@@ -151,6 +179,7 @@ func NewTripbot(version string) *Tripbot {
 		),
 		sessions:   users.NewDefault(),
 		flagClient: feature.NewInMemoryClient(nil),
+		gateway:    newGatewayClient(),
 	}
 }
 
@@ -365,7 +394,25 @@ func youtubeAuthAccounts() []eventbus.AuthAccount {
 // 3 consecutive minute-spaced misalignments. First seen in prod on
 // 2026-05-27, ~30h into an OBS session.
 func (t *Tripbot) startSilentDisconnectWatchdog(ctx context.Context) {
-	go watchdog.WatchSilentDisconnect(ctx, watchdog.DefaultWatchdogDeps(), 60*time.Second, 3, 10*time.Minute)
+	deps := watchdog.DefaultWatchdogDeps()
+	if t.gateway != nil {
+		// Route the live-check through the gateway when the flag is on, falling
+		// back to the in-process check otherwise. The gateway/flag choice lives
+		// here in cmd (not in pkg/obs/watchdog) per package-boundary-init-discipline;
+		// the gauge set mirrors DefaultWatchdogDeps's in-process path.
+		inproc := deps.TwitchLive
+		deps.TwitchLive = func(ctx context.Context) (bool, error) {
+			if !t.useGateway(ctx) {
+				return inproc(ctx)
+			}
+			live, err := t.gateway.IsLive(ctx, c.Conf.ChannelName)
+			if err == nil {
+				instrumentation.TwitchChannelLive.Set(live)
+			}
+			return live, err
+		}
+	}
+	go watchdog.WatchSilentDisconnect(ctx, deps, 60*time.Second, 3, 10*time.Minute)
 }
 
 // startDiscord brings up the bot's Discord slash-command session when

--- a/pkg/chatbot/gateway_twitch_test.go
+++ b/pkg/chatbot/gateway_twitch_test.go
@@ -75,12 +75,6 @@ func TestGatewayTwitch_FollowedAt_TransportError(t *testing.T) {
 	}
 }
 
-func TestNewGatewayTwitch_TrimsTrailingSlash(t *testing.T) {
-	if got := newGatewayTwitch("http://gateway-twitch:8080/").baseURL; got != "http://gateway-twitch:8080" {
-		t.Errorf("baseURL = %q, want trailing slash trimmed", got)
-	}
-}
-
 func TestFlaggedTwitch_DispatchesOnFlag(t *testing.T) {
 	gw := &recordingTwitch{Result: time.Unix(100, 0), OK: true}
 	inproc := &recordingTwitch{Result: time.Unix(200, 0), OK: true}

--- a/pkg/chatbot/gateway_twitch_test.go
+++ b/pkg/chatbot/gateway_twitch_test.go
@@ -80,7 +80,7 @@ func TestFlaggedTwitch_DispatchesOnFlag(t *testing.T) {
 	inproc := &recordingTwitch{Result: time.Unix(200, 0), OK: true}
 
 	flagOn := feature.NewInMemoryClient(map[string]feature.Flag{
-		twitchGatewayFlagKey: {Key: twitchGatewayFlagKey, Enabled: true},
+		TwitchGatewayFlagKey: {Key: TwitchGatewayFlagKey, Enabled: true},
 	})
 	flagOff := feature.NewInMemoryClient(nil) // unknown key → off
 

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -11,12 +11,16 @@ import (
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 )
 
-// twitchGatewayFlagKey is the runtime kill-switch for routing the chatbot's
-// Helix calls through the platform-gateway. It defaults off (the flag row
-// doesn't exist until toggled), so even an env wired with TWITCH_API_URL stays
-// in-process until the flag is flipped on — the cutover (and instant revert,
-// no restart) is a console toggle. Only meaningful when TWITCH_API_URL is set.
-const twitchGatewayFlagKey = "chatbot.twitch_gateway"
+// TwitchGatewayFlagKey is the runtime kill-switch for routing Helix calls
+// through the platform-gateway. It defaults off (the flag row doesn't exist
+// until toggled), so even an env wired with TWITCH_API_URL stays in-process
+// until the flag is flipped on — the cutover (and instant revert, no restart)
+// is a console toggle. Only meaningful when TWITCH_API_URL is set.
+//
+// Exported so cmd/tripbot can gate the non-chatbot Helix callers (the OBS
+// watchdog's live-check, the chat-send path) on the same flag — one gate for
+// "tripbot uses the gateway", with a single consistent revert story.
+const TwitchGatewayFlagKey = "chatbot.twitch_gateway"
 
 // Twitch is the command-time Twitch Helix surface the chatbot needs. Today
 // that's only follow lookups (followageCmd); it grows as admin-panel Helix
@@ -32,7 +36,7 @@ type Twitch interface {
 // newTwitch wires the production Twitch adapter. With no TWITCH_API_URL there's
 // no gateway to reach, so it's the plain in-process path (zero-config default).
 // When a gateway IS wired, it returns a flaggedTwitch that dispatches per call
-// based on the twitchGatewayFlagKey runtime flag — so the gateway is wired but
+// based on the TwitchGatewayFlagKey runtime flag — so the gateway is wired but
 // dormant until flipped on, and revertible without a restart.
 func newTwitch(a *App) Twitch {
 	if c.Conf.TwitchAPIURL == "" {
@@ -46,7 +50,7 @@ func newTwitch(a *App) Twitch {
 }
 
 // flaggedTwitch routes each call to the gateway or the in-process adapter based
-// on the live twitchGatewayFlagKey value, read from the App's flag client at
+// on the live TwitchGatewayFlagKey value, read from the App's flag client at
 // call time (cmd/tripbot reassigns a.Flags to the Postgres-backed, console-
 // toggleable client after New(), so the flag flips without a bot restart).
 type flaggedTwitch struct {
@@ -56,7 +60,7 @@ type flaggedTwitch struct {
 }
 
 func (f flaggedTwitch) FollowedAt(username string) (time.Time, bool) {
-	if f.app.Flags.Bool(context.Background(), twitchGatewayFlagKey, feature.EvalContext{}) {
+	if f.app.Flags.Bool(context.Background(), TwitchGatewayFlagKey, feature.EvalContext{}) {
 		return f.gateway.FollowedAt(username)
 	}
 	return f.inproc.FollowedAt(username)

--- a/pkg/chatbot/twitch.go
+++ b/pkg/chatbot/twitch.go
@@ -2,15 +2,12 @@ package chatbot
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
-	"net/http"
-	"net/url"
-	"strings"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/adanalife/tripbot/pkg/gateway"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
 )
 
@@ -75,49 +72,27 @@ func (realTwitch) FollowedAt(username string) (time.Time, bool) {
 }
 
 // gatewayTwitch is the HTTP adapter — it reaches the platform-gateway
-// gateway-twitch instance instead of calling Helix in-process. It satisfies the
-// same Twitch interface, so command code is untouched (the payoff of the
-// #738/#739 injection seam).
+// gateway-twitch instance (via the shared pkg/gateway client) instead of
+// calling Helix in-process. It satisfies the same Twitch interface, so command
+// code is untouched (the payoff of the #738/#739 injection seam).
 type gatewayTwitch struct {
-	baseURL string
-	client  *http.Client
+	client *gateway.Client
 }
 
 func newGatewayTwitch(baseURL string) gatewayTwitch {
-	return gatewayTwitch{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		client:  &http.Client{Timeout: 5 * time.Second},
-	}
+	return gatewayTwitch{client: gateway.New(baseURL)}
 }
 
-// FollowedAt asks the gateway when username followed the channel
-// (GET /v1/followed-at/{login}). It fails closed (ok=false) on any transport,
-// decode, or non-2xx error — matching the in-process adapter, so gateway
-// trouble degrades a follow check rather than blocking the command. A 404 is
-// the gateway's "not a follower" answer and is expected, not logged.
+// FollowedAt asks the gateway when username followed the channel. It fails
+// closed (ok=false) on any transport, decode, or non-2xx error — matching the
+// in-process adapter, so gateway trouble degrades a follow check rather than
+// blocking the command. The gateway's "not a follower" answer (a clean 404)
+// comes back as ok=false with no error and is not logged.
 func (g gatewayTwitch) FollowedAt(username string) (time.Time, bool) {
-	endpoint := g.baseURL + "/v1/followed-at/" + url.PathEscape(username)
-	resp, err := g.client.Get(endpoint)
+	when, ok, err := g.client.FollowedAt(context.Background(), username)
 	if err != nil {
-		slog.Warn("gateway FollowedAt request failed", "username", username, "err", err)
+		slog.Warn("gateway FollowedAt failed", "username", username, "err", err)
 		return time.Time{}, false
 	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var body struct {
-			FollowedAt time.Time `json:"followed_at"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-			slog.Warn("gateway FollowedAt decode failed", "username", username, "err", err)
-			return time.Time{}, false
-		}
-		return body.FollowedAt, true
-	case http.StatusNotFound:
-		return time.Time{}, false // not a follower — expected
-	default:
-		slog.Warn("gateway FollowedAt non-2xx", "username", username, "status", resp.StatusCode)
-		return time.Time{}, false
-	}
+	return when, ok
 }

--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -1,0 +1,130 @@
+// Package gateway is tripbot's HTTP client for the platform-gateway
+// (gateway-twitch / gateway-youtube) — the per-platform API service that owns
+// the Helix / YouTube-Data-API call surface. tripbot reaches it instead of
+// calling the platform API in-process, so the gateway can become the single
+// token holder (the Secrets-Manager token-move prerequisite).
+//
+// The client is a thin, stateless request/response wrapper over the gateway's
+// v1 JSON endpoints. It holds no platform-specific knowledge and triggers no
+// init-time side effects, so any binary or package may import it (see the
+// package-boundary-init-discipline ADR). Callers decide their own
+// fail-open/fail-closed posture from the returned error.
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// defaultTimeout bounds every gateway call. The gateway is an in-cluster
+// neighbour, so a few seconds is generous; a hung gateway must not wedge a
+// caller (a chat command, the watchdog tick, the chat-send path).
+const defaultTimeout = 5 * time.Second
+
+// Client talks to one platform-gateway instance over its v1 JSON API.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New builds a Client for the gateway reachable at baseURL (e.g.
+// http://gateway-twitch:8080). A trailing slash is tolerated.
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: defaultTimeout},
+	}
+}
+
+// BaseURL returns the normalised gateway base URL (trailing slash trimmed).
+func (c *Client) BaseURL() string { return c.baseURL }
+
+// FollowedAt asks when login followed the channel (GET /v1/followed-at/{login}).
+// A returned ok=false with a nil error is the gateway's 404 "not a follower"
+// answer — an expected result, not a failure. A non-nil error means the call
+// itself failed (transport, decode, or upstream non-2xx); callers choose how to
+// degrade.
+func (c *Client) FollowedAt(ctx context.Context, login string) (time.Time, bool, error) {
+	resp, err := c.get(ctx, "/v1/followed-at/"+url.PathEscape(login))
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var body struct {
+			FollowedAt time.Time `json:"followed_at"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return time.Time{}, false, fmt.Errorf("gateway followed-at decode: %w", err)
+		}
+		return body.FollowedAt, true, nil
+	case http.StatusNotFound:
+		return time.Time{}, false, nil // not a follower — expected
+	default:
+		return time.Time{}, false, fmt.Errorf("gateway followed-at: unexpected status %d", resp.StatusCode)
+	}
+}
+
+// IsLive reports whether login is currently streaming (GET /v1/live/{login}).
+func (c *Client) IsLive(ctx context.Context, login string) (bool, error) {
+	resp, err := c.get(ctx, "/v1/live/"+url.PathEscape(login))
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("gateway live: unexpected status %d", resp.StatusCode)
+	}
+	var body struct {
+		Live bool `json:"live"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false, fmt.Errorf("gateway live decode: %w", err)
+	}
+	return body.Live, nil
+}
+
+// SendChat posts text to the channel's chat as identity ("bot" / "broadcaster";
+// "" lets the gateway pick its default) via POST /v1/chat.
+func (c *Client) SendChat(ctx context.Context, identity, text string) error {
+	payload, err := json.Marshal(map[string]string{"identity": identity, "text": text})
+	if err != nil {
+		return fmt.Errorf("gateway send-chat encode: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/chat", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("gateway send-chat request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("gateway send-chat: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("gateway send-chat: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// get issues a GET against the gateway, joining path onto the base URL.
+func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("gateway request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gateway request: %w", err)
+	}
+	return resp, nil
+}

--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -27,6 +27,13 @@ import (
 // caller (a chat command, the watchdog tick, the chat-send path).
 const defaultTimeout = 5 * time.Second
 
+// Chat identities accepted by SendChat, matching the gateway's
+// provider.Identity values. The empty string lets the gateway pick its default.
+const (
+	IdentityBot         = "bot"
+	IdentityBroadcaster = "broadcaster"
+)
+
 // Client talks to one platform-gateway instance over its v1 JSON API.
 type Client struct {
 	baseURL string

--- a/pkg/gateway/client_test.go
+++ b/pkg/gateway/client_test.go
@@ -1,0 +1,158 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNew_TrimsTrailingSlash(t *testing.T) {
+	if got := New("http://gateway-twitch:8080/").BaseURL(); got != "http://gateway-twitch:8080" {
+		t.Errorf("baseURL = %q, want trailing slash trimmed", got)
+	}
+}
+
+func TestFollowedAt_Following(t *testing.T) {
+	followedAt := time.Now().Add(-72 * time.Hour).UTC().Truncate(time.Second)
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"followed_at":"` + followedAt.Format(time.RFC3339) + `"}`))
+	}))
+	defer srv.Close()
+
+	when, ok, err := New(srv.URL).FollowedAt(context.Background(), "Viewer1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true for a follower")
+	}
+	if !when.Equal(followedAt) {
+		t.Errorf("followed_at = %v, want %v", when, followedAt)
+	}
+	if gotPath != "/v1/followed-at/Viewer1" {
+		t.Errorf("request path = %q, want /v1/followed-at/Viewer1", gotPath)
+	}
+}
+
+func TestFollowedAt_NotAFollower(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not a follower"}`))
+	}))
+	defer srv.Close()
+
+	when, ok, err := New(srv.URL).FollowedAt(context.Background(), "viewer1")
+	if err != nil {
+		t.Fatalf("404 is not a follower, not an error; got %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false on 404")
+	}
+	if !when.IsZero() {
+		t.Errorf("expected zero time on 404, got %v", when)
+	}
+}
+
+func TestFollowedAt_ErrorsOnBadResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"upstream 502", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}},
+		{"malformed body", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`not json`))
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+			if _, _, err := New(srv.URL).FollowedAt(context.Background(), "viewer1"); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+func TestFollowedAt_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // closed server → connection refused
+
+	if _, _, err := New(srv.URL).FollowedAt(context.Background(), "viewer1"); err == nil {
+		t.Error("expected a transport error")
+	}
+}
+
+func TestIsLive(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"live":true}`))
+	}))
+	defer srv.Close()
+
+	live, err := New(srv.URL).IsLive(context.Background(), "adanalife_")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !live {
+		t.Error("expected live=true")
+	}
+	if gotPath != "/v1/live/adanalife_" {
+		t.Errorf("request path = %q, want /v1/live/adanalife_", gotPath)
+	}
+}
+
+func TestIsLive_ErrorsOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).IsLive(context.Background(), "adanalife_"); err == nil {
+		t.Error("expected an error on non-200")
+	}
+}
+
+func TestSendChat(t *testing.T) {
+	var gotBody struct{ Identity, Text string }
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"sent"}`))
+	}))
+	defer srv.Close()
+
+	if err := New(srv.URL).SendChat(context.Background(), "broadcaster", "hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/chat" {
+		t.Errorf("request = %s %s, want POST /v1/chat", gotMethod, gotPath)
+	}
+	if gotBody.Identity != "broadcaster" || gotBody.Text != "hello" {
+		t.Errorf("body = %+v, want {broadcaster hello}", gotBody)
+	}
+}
+
+func TestSendChat_ErrorsOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented) // e.g. a platform with no chat send
+	}))
+	defer srv.Close()
+
+	if err := New(srv.URL).SendChat(context.Background(), "broadcaster", "hi"); err == nil {
+		t.Error("expected an error on non-2xx")
+	}
+}


### PR DESCRIPTION
Phase 3b of the platform-gateway work — making the gateway the single Helix caller. This is the **clean half** (1 of 2): the two low-frequency, uncached Helix callers. The cached half (audience pollers) follows in a stacked PR.

## What
1. **`pkg/gateway` shared client** — a thin, stateless HTTP client over the gateway's v1 endpoints (`FollowedAt`, `IsLive`, `SendChat`). One client implementation for every in-process Helix caller to route through.
2. **chatbot routed through it** — `gatewayTwitch`'s inline HTTP/JSON (from 3a) now delegates to the shared client; behaviour identical, no second copy of the FollowedAt logic.
3. **Clean half repointed, flag-gated:**
   - OBS watchdog live-check → `gateway.IsLive`
   - chat-send broadcaster path → `gateway.SendChat(broadcaster)`
   - Both gate on the **same** `chatbot.twitch_gateway` runtime flag as 3a's `FollowedAt` — one gate for "tripbot uses the gateway", with the same no-restart cutover/revert. The flag key is exported from `pkg/chatbot`; the gateway/flag choice lives in `cmd/tripbot` (not in `pkg/obs/watchdog`) per `package-boundary-init-discipline`.

## What this is NOT
The in-process paths stay as the flag-off fallback — exactly like 3a kept `realTwitch`. **Deleting** `pkg/twitch`'s query funcs is deferred until after the prod cutover (when the flag is removed and the gateway is the permanent single caller).

## Design notes
- Cached audience reads (`IsSubscriber`/`IsFollower`/`Chatters`) are deliberately **not** here — they're hot-path in-memory reads refreshed by pollers, and the chosen approach is to keep the cache in tripbot and repoint only the *refresh* at the gateway (no per-message HTTP). That's the stacked follow-up PR.

## Test
`pkg/gateway` has full client coverage; chatbot + chatsend suites green; full `go build ./...` clean.