### PR TITLE
gateway 3b (2/2): route cached audience refresh through the gateway

### DIFF
--- a/cmd/tripbot/gateway_audience.go
+++ b/cmd/tripbot/gateway_audience.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
+)
+
+// gatewayChatterSource is the cmd-wired users.ChatterSource for instances that
+// may use the platform-gateway. Chatter refresh and the live follower check
+// route through the gateway when useGateway reports the runtime flag is on, else
+// in-process. The cached reads (Chatters / ChatterCount / IsSubscriber) always
+// read tripbot's in-process audience cache — which the refresh populates from
+// whichever source is active — so they need no dispatch.
+//
+// With no gateway wired (t.gateway == nil) useGateway is always false, so this
+// behaves exactly like the plain in-process Twitch source; that's why it can be
+// the source unconditionally.
+type gatewayChatterSource struct{ t *Tripbot }
+
+func (s gatewayChatterSource) Chatters() map[string]struct{} { return mytwitch.Chatters() }
+func (s gatewayChatterSource) ChatterCount() int             { return mytwitch.ChatterCount() }
+
+func (s gatewayChatterSource) IsSubscriber(username string) bool {
+	return mytwitch.UserIsSubscriber(username)
+}
+
+// UpdateChatters refreshes the cached chatter set, from the gateway when the
+// flag is on, else the in-process Helix poll. A gateway error keeps the prior
+// cached set, matching UpdateChatters' don't-zero-on-error posture.
+func (s gatewayChatterSource) UpdateChatters() {
+	ctx := context.Background()
+	if !s.t.useGateway(ctx) {
+		mytwitch.UpdateChatters()
+		return
+	}
+	count, logins, err := s.t.gateway.Chatters(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "gateway chatters refresh failed; keeping cached set", "err", err)
+		return
+	}
+	mytwitch.SetChatters(logins, count)
+}
+
+// IsFollower reports whether username follows the channel, via the gateway when
+// the flag is on, else in-process. Mirrors UserIsFollower's admin short-circuit
+// (the broadcaster can't follow themselves) and its fail-closed-on-error posture.
+func (s gatewayChatterSource) IsFollower(username string) bool {
+	ctx := context.Background()
+	if !s.t.useGateway(ctx) {
+		return mytwitch.UserIsFollower(username)
+	}
+	if c.UserIsAdmin(username) {
+		return true
+	}
+	_, ok, err := s.t.gateway.FollowedAt(ctx, username)
+	if err != nil {
+		slog.WarnContext(ctx, "gateway follower check failed; treating as non-follower",
+			"username", username, "err", err)
+		return false
+	}
+	return ok
+}
+
+// refreshSubscribers refreshes the cached subscriber list — from the gateway
+// when the flag is on, else the in-process Helix poll. Driven at startup and by
+// the 5-minute cron. A gateway error keeps the prior cached list.
+func (t *Tripbot) refreshSubscribers(ctx context.Context) {
+	if !t.useGateway(ctx) {
+		mytwitch.GetSubscribers(ctx)
+		return
+	}
+	subs, err := t.gateway.Subscribers(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "gateway subscribers refresh failed; keeping cached list", "err", err)
+		return
+	}
+	mytwitch.SetSubscribers(subs)
+}
+
+// refreshFollowerCount refreshes the follower-count gauge — from the gateway
+// when the flag is on, else the in-process Helix poll.
+func (t *Tripbot) refreshFollowerCount(ctx context.Context) {
+	if !t.useGateway(ctx) {
+		mytwitch.GetFollowerCount(ctx)
+		return
+	}
+	total, err := t.gateway.Followers(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "gateway follower-count refresh failed", "err", err)
+		return
+	}
+	instrumentation.TwitchAudience.SetFollowers(int64(total))
+}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -169,7 +169,7 @@ func (t *Tripbot) useGateway(ctx context.Context) bool {
 // that need I/O or ordering (the IRC client, scheduler, Discord session,
 // Postgres-backed flag client) are filled in by the boot-sequence methods.
 func NewTripbot(version string) *Tripbot {
-	return &Tripbot{
+	t := &Tripbot{
 		version: version,
 		app:     chatbot.New(),
 		srv:     server.New(),
@@ -177,10 +177,15 @@ func NewTripbot(version string) *Tripbot {
 			onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment),
 			vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
 		),
-		sessions:   users.NewDefault(),
 		flagClient: feature.NewInMemoryClient(nil),
 		gateway:    newGatewayClient(),
 	}
+	// The audience source dispatches chatter refresh + the follower check to the
+	// gateway (when the flag is on) or in-process; with no gateway wired it's the
+	// plain in-process source. Reads t.gateway/t.flagClient lazily, so wiring it
+	// here against the partially-built t is fine.
+	t.sessions = users.New(gatewayChatterSource{t: t})
+	return t
 }
 
 func main() {
@@ -624,10 +629,10 @@ func (t *Tripbot) setUpTwitchClient() {
 	t.irc = t.app.ConnectIRC()
 }
 
-// updateSubscribers gets the list of current subscribers
+// updateSubscribers gets the list of current subscribers (gateway-or-in-process
+// per the runtime flag — see refreshSubscribers).
 func (t *Tripbot) updateSubscribers() {
-	// update subscribers list
-	mytwitch.GetSubscribers(context.Background())
+	t.refreshSubscribers(context.Background())
 }
 
 // getCurrentUsers gets the users watching the stream
@@ -742,8 +747,8 @@ func (t *Tripbot) scheduleBackgroundJobs() {
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
 	t.addJob(5*time.Minute, "chatbot.ShowRotatingLeaderboard", t.app.ShowRotatingLeaderboard)
 	t.addJob(5*time.Minute, "users.PrintCurrentSession", t.sessions.PrintCurrentSession)
-	t.addJob(5*time.Minute, "twitch.GetSubscribers", mytwitch.GetSubscribers)
-	t.addJob(5*time.Minute, "twitch.GetFollowerCount", mytwitch.GetFollowerCount)
+	t.addJob(5*time.Minute, "twitch.GetSubscribers", t.refreshSubscribers)
+	t.addJob(5*time.Minute, "twitch.GetFollowerCount", t.refreshFollowerCount)
 	t.addJob(1*time.Hour, "twitch.RefreshUserAccessToken", func(ctx context.Context) {
 		mytwitch.RefreshUserAccessToken(ctx)
 		// Keep the IRC client's stored token in sync with the rotated credentials.

--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -123,6 +123,60 @@ func (c *Client) SendChat(ctx context.Context, identity, text string) error {
 	return nil
 }
 
+// Chatters returns the channel's current chatter logins and the authoritative
+// total (GET /v1/chatters). The total can exceed len(logins) when the channel
+// has more chatters than the API returns in one page.
+func (c *Client) Chatters(ctx context.Context) (count int, logins []string, err error) {
+	var body struct {
+		Count    int      `json:"count"`
+		Chatters []string `json:"chatters"`
+	}
+	if err := c.getJSON(ctx, "/v1/chatters", &body); err != nil {
+		return 0, nil, err
+	}
+	return body.Count, body.Chatters, nil
+}
+
+// Subscribers returns the channel's current subscriber logins
+// (GET /v1/subscribers).
+func (c *Client) Subscribers(ctx context.Context) ([]string, error) {
+	var body struct {
+		Subscribers []string `json:"subscribers"`
+	}
+	if err := c.getJSON(ctx, "/v1/subscribers", &body); err != nil {
+		return nil, err
+	}
+	return body.Subscribers, nil
+}
+
+// Followers returns the channel's total follower count (GET /v1/followers).
+func (c *Client) Followers(ctx context.Context) (int, error) {
+	var body struct {
+		Total int `json:"total"`
+	}
+	if err := c.getJSON(ctx, "/v1/followers", &body); err != nil {
+		return 0, err
+	}
+	return body.Total, nil
+}
+
+// getJSON issues a GET and decodes a 200 JSON body into dest; any non-200 or
+// decode failure is returned as an error.
+func (c *Client) getJSON(ctx context.Context, path string, dest any) error {
+	resp, err := c.get(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("gateway %s: unexpected status %d", path, resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		return fmt.Errorf("gateway %s decode: %w", path, err)
+	}
+	return nil
+}
+
 // get issues a GET against the gateway, joining path onto the base URL.
 func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)

--- a/pkg/gateway/client_test.go
+++ b/pkg/gateway/client_test.go
@@ -146,6 +146,86 @@ func TestSendChat(t *testing.T) {
 	}
 }
 
+func TestChatters(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"count":3,"chatters":["alice","bob"]}`))
+	}))
+	defer srv.Close()
+
+	count, logins, err := New(srv.URL).Chatters(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v1/chatters" {
+		t.Errorf("path = %q, want /v1/chatters", gotPath)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3 (total can exceed len(logins))", count)
+	}
+	if len(logins) != 2 || logins[0] != "alice" || logins[1] != "bob" {
+		t.Errorf("logins = %v, want [alice bob]", logins)
+	}
+}
+
+func TestSubscribers(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"subscribers":["sub1","sub2"]}`))
+	}))
+	defer srv.Close()
+
+	subs, err := New(srv.URL).Subscribers(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v1/subscribers" {
+		t.Errorf("path = %q, want /v1/subscribers", gotPath)
+	}
+	if len(subs) != 2 || subs[0] != "sub1" {
+		t.Errorf("subscribers = %v, want [sub1 sub2]", subs)
+	}
+}
+
+func TestFollowers(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"total":42}`))
+	}))
+	defer srv.Close()
+
+	total, err := New(srv.URL).Followers(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v1/followers" {
+		t.Errorf("path = %q, want /v1/followers", gotPath)
+	}
+	if total != 42 {
+		t.Errorf("total = %d, want 42", total)
+	}
+}
+
+func TestCachedReads_ErrorOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	c := New(srv.URL)
+	if _, _, err := c.Chatters(context.Background()); err == nil {
+		t.Error("Chatters: expected error on non-200")
+	}
+	if _, err := c.Subscribers(context.Background()); err == nil {
+		t.Error("Subscribers: expected error on non-200")
+	}
+	if _, err := c.Followers(context.Background()); err == nil {
+		t.Error("Followers: expected error on non-200")
+	}
+}
+
 func TestSendChat_ErrorsOnNon2xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotImplemented) // e.g. a platform with no chat send

--- a/pkg/twitch/shims.go
+++ b/pkg/twitch/shims.go
@@ -47,6 +47,11 @@ func Chatters() map[string]struct{} { return defaultClient.Chatters() }
 func UpdateChatters()               { defaultClient.UpdateChatters() }
 func ChannelID() string             { return defaultClient.ChannelID() }
 
+// SetSubscribers / SetChatters feed the cached audience state from out-of-band
+// (the platform-gateway) instead of an in-process Helix poll.
+func SetSubscribers(logins []string)         { defaultClient.SetSubscribers(logins) }
+func SetChatters(logins []string, count int) { defaultClient.SetChatters(logins, count) }
+
 func SendChatMessageAsBroadcaster(ctx context.Context, text string) error {
 	return defaultClient.SendChatMessageAsBroadcaster(ctx, text)
 }

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -122,6 +122,34 @@ func (cl *API) GetFollowerCount(ctx context.Context) {
 	slog.InfoContext(ctx, "follower count", "channel", c.Conf.ChannelName, "total", resp.Data.Total)
 }
 
+// SetSubscribers replaces the cached subscriber list with logins sourced
+// out-of-band — the platform-gateway path, which polls Helix in the gateway
+// rather than in-process. Logins are lowercased to match GetSubscribers, so
+// UserIsSubscriber compares consistently regardless of which path populated the
+// cache. The audience gauge is set here too, mirroring GetSubscribers.
+func (cl *API) SetSubscribers(logins []string) {
+	subs := make([]string, len(logins))
+	for i, login := range logins {
+		subs[i] = strings.ToLower(login)
+	}
+	cl.subscribers = subs
+	instrumentation.TwitchAudience.SetSubscribers(int64(len(subs)))
+}
+
+// SetChatters replaces the cached chatter set and total with values sourced
+// out-of-band (the platform-gateway). count is the authoritative total (it may
+// exceed len(logins) when the channel has more chatters than one page);
+// Chatters() reads the logins, ChatterCount() reads the total — matching how
+// UpdateChatters populates them from a Helix response.
+func (cl *API) SetChatters(logins []string, count int) {
+	chatters := make([]helix.ChatChatter, len(logins))
+	for i, login := range logins {
+		chatters[i] = helix.ChatChatter{UserLogin: login}
+	}
+	cl.currentChatters = chatters
+	cl.chatterCount = count
+}
+
 // UserIsSubscriber returns true if the user subscribes to the channel
 func (cl *API) UserIsSubscriber(username string) bool {
 	for _, sub := range cl.subscribers {


### PR DESCRIPTION
Phase 3b of the platform-gateway work, **cached half** (2 of 2) — follows #920 (now merged). With this, every in-process Helix caller routes through the gateway when the flag is on, so the gateway is the **single Helix caller** (the SM-token-move prerequisite).

## Approach — keep the cache in tripbot, repoint the refresh
The audience reads (`IsSubscriber`/`Chatters`/`ChatterCount`, and `pkg/server`'s chatters view) are **hot-path in-memory reads** refreshed by background pollers. Rather than move polling+cache into the gateway (which would make it stateful and risk per-message HTTP), the chosen design keeps the cache in tripbot and points only the *refresh* at the gateway — so the hot path stays a local map lookup. The Elixir-rewrite-later plan reinforces this: the gateway stays a thin, stateless token/transport layer; audience state stays application-owned.

## What
1. **`pkg/gateway`**: add `Chatters` / `Subscribers` / `Followers` reads.
2. **`pkg/twitch`**: `SetSubscribers` / `SetChatters` cache setters, so gateway-sourced refresh feeds the **same** cache the reads already serve from — no read site changes.
3. **`cmd/tripbot`**: 
   - the subscriber + follower-count pollers and the chatter refresh dispatch to the gateway (flag on) or in-process, via the `gatewayChatterSource` (a `users.ChatterSource`) + `refreshSubscribers`/`refreshFollowerCount`.
   - the live follower check (`UserIsFollower`, already a per-call Helix lookup) routes through `gateway.FollowedAt` — preserving the admin self-follow short-circuit and fail-closed posture.
   - all gated on the same `chatbot.twitch_gateway` runtime flag; the gateway/flag choice lives in cmd (not pkg/users/pkg/twitch) per `package-boundary-init-discipline`.

## Not in scope
- **Deleting** `pkg/twitch`'s query funcs — deferred until after the prod cutover (when the flag is removed), exactly as 3a/PR1 kept the in-process fallback.
- The prod cutover itself (Dana-driven; gated on cutting the first gateway develop→master release).

## Test
`pkg/gateway` covers the three new reads; `pkg/twitch`/`pkg/users`/`pkg/chatbot` suites green; cmd/tripbot builds clean. The cmd-level dispatch isn't unit-tested (the `banner/autoload` `init()` makes `package main` untestable under `go test` — same constraint that split out `pkg/chatsend`); the dispatch is a trivial flag check mirroring the tested `flaggedTwitch`.