### PR TITLE
fix: resolve EventSub channelID via the gateway when the flag is on

### DIFF
--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -458,6 +458,18 @@ func (t *Tripbot) startEventSub(ctx context.Context) {
 			"reauth_url", mytwitch.AuthInitURL("broadcaster"))
 		return
 	}
+	if mytwitch.ChannelID() == "" && t.useGateway(ctx) {
+		// When Helix calls route through the gateway, the in-process audience
+		// polls (updateSubscribers / UpdateChatters) that used to populate
+		// channelID as a side effect no longer run, so it's still "" here.
+		// Resolve it via the gateway's /v1/users/{login} so EventSub gets a
+		// BroadcasterUserID. Non-fatal — falls through to the skip below on error.
+		if id, err := t.gateway.UserID(ctx, c.Conf.ChannelName); err != nil {
+			slog.ErrorContext(ctx, "eventsub: resolving channel id via gateway failed", "err", err)
+		} else {
+			mytwitch.SetChannelID(id)
+		}
+	}
 	if mytwitch.ChannelID() == "" {
 		// getChannelID is lazy on first call; calling GetSubscribers /
 		// GetFollowerCount typically populates it. updateSubscribers()

--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -100,6 +100,23 @@ func (c *Client) IsLive(ctx context.Context, login string) (bool, error) {
 	return body.Live, nil
 }
 
+// UserID resolves login to the platform's internal user/channel ID
+// (GET /v1/users/{login}). It's the gateway-routed replacement for the
+// in-process getChannelID side effect that EventSub's BroadcasterUserID needs —
+// once Helix calls route through the gateway, nothing else populates the ID.
+func (c *Client) UserID(ctx context.Context, login string) (string, error) {
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := c.getJSON(ctx, "/v1/users/"+url.PathEscape(login), &body); err != nil {
+		return "", err
+	}
+	if body.ID == "" {
+		return "", fmt.Errorf("gateway users/%s: empty id", login)
+	}
+	return body.ID, nil
+}
+
 // SendChat posts text to the channel's chat as identity ("bot" / "broadcaster";
 // "" lets the gateway pick its default) via POST /v1/chat.
 func (c *Client) SendChat(ctx context.Context, identity, text string) error {

--- a/pkg/gateway/client_test.go
+++ b/pkg/gateway/client_test.go
@@ -123,6 +123,37 @@ func TestIsLive_ErrorsOnNon200(t *testing.T) {
 	}
 }
 
+func TestUserID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"id":"12345","login":"adanalife_","display_name":"ADanaLife_"}`))
+	}))
+	defer srv.Close()
+
+	id, err := New(srv.URL).UserID(context.Background(), "adanalife_")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "12345" {
+		t.Errorf("id = %q, want 12345", id)
+	}
+	if gotPath != "/v1/users/adanalife_" {
+		t.Errorf("request path = %q, want /v1/users/adanalife_", gotPath)
+	}
+}
+
+func TestUserID_ErrorsOnEmptyID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"","login":"ghost"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).UserID(context.Background(), "ghost"); err == nil {
+		t.Error("expected an error on empty id")
+	}
+}
+
 func TestSendChat(t *testing.T) {
 	var gotBody struct{ Identity, Text string }
 	var gotMethod, gotPath string

--- a/pkg/twitch/shims.go
+++ b/pkg/twitch/shims.go
@@ -47,10 +47,11 @@ func Chatters() map[string]struct{} { return defaultClient.Chatters() }
 func UpdateChatters()               { defaultClient.UpdateChatters() }
 func ChannelID() string             { return defaultClient.ChannelID() }
 
-// SetSubscribers / SetChatters feed the cached audience state from out-of-band
-// (the platform-gateway) instead of an in-process Helix poll.
+// SetSubscribers / SetChatters / SetChannelID feed cached state from
+// out-of-band (the platform-gateway) instead of an in-process Helix poll.
 func SetSubscribers(logins []string)         { defaultClient.SetSubscribers(logins) }
 func SetChatters(logins []string, count int) { defaultClient.SetChatters(logins, count) }
+func SetChannelID(id string)                 { defaultClient.SetChannelID(id) }
 
 func SendChatMessageAsBroadcaster(ctx context.Context, text string) error {
 	return defaultClient.SendChatMessageAsBroadcaster(ctx, text)

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -15,6 +15,15 @@ func (cl *API) ChannelID() string {
 	return cl.channelID
 }
 
+// SetChannelID seeds the cached channel ID from out-of-band (the
+// platform-gateway's /v1/users/{login}) instead of an in-process getChannelID
+// lookup. Needed when Helix calls route through the gateway — the in-process
+// audience polls that used to populate channelID as a side effect no longer
+// run, so EventSub setup would otherwise see "".
+func (cl *API) SetChannelID(id string) {
+	cl.channelID = id
+}
+
 // ChatterCount returns the number of chatters as reported by Twitch.
 func (cl *API) ChatterCount() int {
 	return cl.chatterCount


### PR DESCRIPTION
## What

Fixes the **cutover blocker** surfaced in the 3b parity audit: EventSub loses its `ChannelID` when the `chatbot.twitch_gateway` flag is on.

`cmd/tripbot`'s `startEventSub` needs `mytwitch.ChannelID()` for `BroadcasterUserID`, but `channelID` was only ever populated as a *side effect* of an in-process Helix call (`getChannelID`, via `updateSubscribers` / `UpdateChatters`). After phase 3b ([#921](https://github.com/adanalife/tripbot/pull/921/changes)) those calls route through the gateway when the flag is on, so `channelID` stays `""` → **EventSub is silently skipped → no new-follower / new-subscriber announcements.**

Latent today; would bite on the next stage `tripbot-twitch` restart with the flag on (`skipping eventsub: ChannelID not yet resolved` in the logs).

## How

- **`pkg/gateway`** — add `Client.UserID(login)` over the gateway's existing `GET /v1/users/{login}` (returns the platform's internal user ID).
- **`pkg/twitch`** — add `API.SetChannelID` + a package shim, mirroring the `SetSubscribers`/`SetChatters` out-of-band setters from 3b.
- **`cmd/tripbot`** — in `startEventSub`, when `useGateway` and `ChannelID()` is still empty, resolve it via the gateway and seed it. Non-fatal: on error it falls through to the existing skip-with-warning. The in-process path is unchanged when the flag is off.

## Testing

- New `pkg/gateway` tests for `UserID` (happy path + empty-id error).
- `go build ./cmd/tripbot/... ./pkg/gateway/... ./pkg/twitch/...` + `go test ./pkg/gateway/... ./pkg/twitch/...` green locally.

## Notes

Closes the highpri EventSub cutover blocker. The remaining cutover-parity gap is gateway observability (success access-log + Helix rate-limit/error metrics) — tracked separately in the platform-gateway TODO.