### PR TITLE
Re-enable VAAPI iGPU encode for stage obs-youtube

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -271,17 +271,19 @@ ENVS: dict[str, EnvConfig] = {
         # app workloads moved from infra into this repo (the cdk8s-into-repo
         # cutover dropped the flag, so stage vlc silently reclaimed the iGPU).
         vlc_gpu=False,
-        # TEMPORARY (2026-06-15): stage obs-youtube dropped its iGPU claim so the
-        # only live VAAPI consumers on the shared Iris Xe are prod obs-twitch +
-        # the video-optimization job (2 concurrent encoders, not 3). A third
-        # concurrent consumer stuttered the prod stream on 2026-06-14. Stage
-        # youtube keeps streaming via software x264 (obs_encoder below); prod is
-        # CPU-protected by its priority class + requests. Revert (obs_gpu=True +
-        # obs_encoder="ffmpeg_vaapi_tex") once the optimization job no longer needs
-        # the iGPU, or once it's reworked to share the device with both streams.
-        obs_gpu=False,
-        obs_encoder="obs_x264",
-        obs_quality="low",
+        # stage obs-youtube streams via VAAPI on the shared Iris Xe again
+        # (re-enabled 2026-06-19). Live iGPU consumers are now prod obs-twitch +
+        # stage obs-youtube = 2 concurrent encoders, which is within budget — 3
+        # concurrent stuttered the prod stream on 2026-06-14, 2 is fine. The
+        # video-pipeline transcode job is CPU x264 (no iGPU claim), so it doesn't
+        # count against the iGPU budget. obs_gpu=True hard-gates obs-youtube onto
+        # the MS-01 (the i915 resource claim) and drops the rpi5 preferred
+        # affinity (see obs.py / scheduling.py); vlc/onscreens/tripbot-youtube
+        # stay on the Pi. High quality matches prod — VAAPI on the iGPU carries
+        # the 60fps encode cheaply.
+        obs_gpu=True,
+        obs_encoder="ffmpeg_vaapi_tex",
+        obs_quality="high",
         dashcam_mode="nfs",
         tailscale=True,
         # Prefer the ephemeral arm64 rpi5 worker for stage's stateless app pods
@@ -328,11 +330,10 @@ ENVS: dict[str, EnvConfig] = {
         # parks pods Unschedulable instead of crowding prod off the node.
         # CPU/memory sized roomy — youtube stack (~0.5 CPU / 1.3Gi requests) +
         # dashcam-cv embed jobs (2× 1 CPU / 5Gi) + one-shot jobs fit with
-        # headroom; the node has 20 CPU / 31Gi. iGPU cap left at 3 even though
-        # stage's own pods no longer claim the device (obs_gpu=False +
-        # vlc_gpu=False as of 2026-06-15) — the budget now covers the
-        # video-optimization job's claim with surge headroom. Restore the
-        # "vlc + obs steady + surge" sizing when obs_gpu flips back to True.
+        # headroom; the node has 20 CPU / 31Gi. iGPU cap of 3 covers stage
+        # obs-youtube's own claim (1, re-enabled 2026-06-19) plus the
+        # video-optimization job's claim with surge headroom; vlc_gpu stays False
+        # (stream-copy needs no device).
         app_quota={
             "requests.cpu": "6",
             "requests.memory": "16Gi",

--- a/cdk8s/dist/stage-1-obs-twitch.k8s.yaml
+++ b/cdk8s/dist/stage-1-obs-twitch.k8s.yaml
@@ -10,8 +10,8 @@ metadata:
   namespace: stage-1
 data:
   DASHCAM_RTSP_URL: rtsp://vlc-twitch:8554/dashcam
-  OBS_QUALITY_PRESET: low
-  OBS_STREAM_ENCODER: obs_x264
+  OBS_QUALITY_PRESET: high
+  OBS_STREAM_ENCODER: ffmpeg_vaapi_tex
   OBS_WEBSOCKET_PASSWD: adanalife
   ONSCREENS_URL_BASE: http://onscreens-twitch:8080
   VLC_URL_BASE: http://vlc-twitch:8080
@@ -35,23 +35,13 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: dff69591c7
+        adanalife.dev/config-hash: 8d09643251
       labels:
         app: obs-twitch
         app.kubernetes.io/instance: obs-twitch
         app.kubernetes.io/name: obs
         app.kubernetes.io/part-of: tripbot
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: dana.lol/board
-                    operator: In
-                    values:
-                      - rpi5
-              weight: 100
       containers:
         - envFrom:
             - configMapRef:
@@ -81,9 +71,11 @@ spec:
               name: obs-server
           resources:
             limits:
+              gpu.intel.com/i915: "1"
               memory: 3Gi
             requests:
               cpu: 200m
+              gpu.intel.com/i915: "1"
               memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
@@ -93,10 +85,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      tolerations:
-        - effect: NoSchedule
-          key: dana.lol/rpi5
-          operator: Exists
 ---
 apiVersion: v1
 kind: Service

--- a/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-obs-youtube.k8s.yaml
@@ -10,8 +10,8 @@ metadata:
   namespace: stage-1
 data:
   DASHCAM_RTSP_URL: rtsp://vlc-youtube:8554/dashcam
-  OBS_QUALITY_PRESET: low
-  OBS_STREAM_ENCODER: obs_x264
+  OBS_QUALITY_PRESET: high
+  OBS_STREAM_ENCODER: ffmpeg_vaapi_tex
   OBS_WEBSOCKET_PASSWD: adanalife
   ONSCREENS_URL_BASE: http://onscreens-youtube:8080
   STREAM_PLATFORM: youtube
@@ -54,23 +54,13 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 54bf302110
+        adanalife.dev/config-hash: 1aa871d64c
       labels:
         app: obs-youtube
         app.kubernetes.io/instance: obs-youtube
         app.kubernetes.io/name: obs
         app.kubernetes.io/part-of: tripbot
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: dana.lol/board
-                    operator: In
-                    values:
-                      - rpi5
-              weight: 100
       containers:
         - envFrom:
             - configMapRef:
@@ -100,9 +90,11 @@ spec:
               name: obs-server
           resources:
             limits:
+              gpu.intel.com/i915: "1"
               memory: 3Gi
             requests:
               cpu: 200m
+              gpu.intel.com/i915: "1"
               memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
@@ -112,10 +104,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      tolerations:
-        - effect: NoSchedule
-          key: dana.lol/rpi5
-          operator: Exists
 ---
 apiVersion: v1
 kind: Service

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -206,10 +206,23 @@ def _prefers_rpi5(spec: dict) -> bool:
     return tolerates and biases
 
 
-def test_stage_software_obs_prefers_rpi5():
-    """Stage obs-youtube is a software x264 encoder (no iGPU claim), so it joins
-    the ephemeral rpi5 worker — offloading the encode off the MS-01."""
-    assert _prefers_rpi5(_pod_spec("stage-1-obs-youtube"))
+def test_stage_stateless_apps_prefer_rpi5():
+    """Stage's lightweight stateless app pods (vlc/onscreens/tripbot-youtube)
+    opt into the ephemeral rpi5 worker — they tolerate the taint and bias toward
+    the board label, recovering onto the MS-01 when the Pi is gone."""
+    for stem in (
+        "stage-1-vlc-youtube",
+        "stage-1-onscreens-youtube",
+        "stage-1-tripbot-youtube",
+    ):
+        assert _prefers_rpi5(_pod_spec(stem)), stem
+
+
+def test_stage_vaapi_obs_stays_on_msi():
+    """Stage obs-youtube is a VAAPI encoder (holds the i915 claim), so it must
+    NOT bias toward the Pi (no H.264 hw encoder there) — the resource claim
+    hard-gates it onto the MS-01 and the rpi5 affinity drops out together."""
+    assert not _prefers_rpi5(_pod_spec("stage-1-obs-youtube"))
 
 
 def test_prod_vaapi_obs_stays_on_msi():


### PR DESCRIPTION
Re-enables hardware (VAAPI) encoding for the stage YouTube stream and moves it onto the MS-01.

## What
- stage-1 `obs_gpu` → `True`, `obs_encoder` → `ffmpeg_vaapi_tex`, `obs_quality` → `high` (matches prod obs-twitch).
- The `gpu.intel.com/i915` claim hard-gates `obs-youtube` onto the minipc and drops the rpi5 preferred affinity/toleration — so the 60fps encode runs on the Iris Xe instead of saturating the Pi with software x264.
- `vlc_gpu` stays `False`; `vlc/onscreens/tripbot-youtube` stay on the Pi.

## Why
Bringing the stage YouTube stream back up. The 2026-06-15 park dropped obs-youtube's iGPU claim to keep concurrent VAAPI encoders at 2 during prod burn-in. Live consumers are now back to **prod obs-twitch + stage obs-youtube = 2**, within the budget that only stuttered prod at 3 — and the video-pipeline transcode job is CPU x264 (no iGPU claim), so it doesn't count.

## Notes
- Stage `obs-twitch` picks up the same config (per-env, not per-platform) but is parked at 0, so no runtime effect.
- Golden dist regenerated (`task cdk8s:synth`); `task cdk8s:check` passes on the committed tree.