### PR TITLE
feat: propagate trace context from the gateway client

### DIFF
--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -20,6 +20,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // defaultTimeout bounds every gateway call. The gateway is an in-cluster
@@ -42,10 +44,20 @@ type Client struct {
 
 // New builds a Client for the gateway reachable at baseURL (e.g.
 // http://gateway-twitch:8080). A trailing slash is tolerated.
+//
+// The transport is otelhttp-wrapped so every call starts a client span and
+// injects the W3C traceparent header (via the global propagator that
+// telemetry.Init installs). The gateway's otelhttp handler extracts it, making
+// its server span a child of this one — so a chat command and the Helix call it
+// triggers form a single cross-service trace. With tracing disabled the
+// propagator is a no-op, so this is inert.
 func New(baseURL string) *Client {
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		http:    &http.Client{Timeout: defaultTimeout},
+		http: &http.Client{
+			Timeout:   defaultTimeout,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
 	}
 }
 


### PR DESCRIPTION
The inject half of cross-service tracing. Wraps the platform-gateway HTTP client's transport with `otelhttp` so every call starts a client span and injects the W3C `traceparent` header (via the global propagator `telemetry.Init` installs).

The gateway's `otelhttp` handler extracts it, nesting its server span under tripbot's — so a chat command (e.g. `!followage`) and the Helix call it triggers through the gateway form **one** cross-service trace instead of two disjoint ones. Inert when tracing is disabled (the propagator is a no-op).

One-line transport change; `pkg/gateway` builds + tests green, gofmt clean.

Sibling PR (the extract half, gateway-side): adanalife/platform-gateway#15