### PR TITLE
Route YouTube chat sends through the gateway (behind a flag)

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -158,6 +158,12 @@ class EnvConfig:
     # its in-namespace gateway-twitch Service; prod stays in-process until the
     # gateway's prod release is cut + proven.
     twitch_api_url: str = ""
+    # Like twitch_api_url, but for a youtube instance's outbound chat sends:
+    # gateway-youtube's URL routes them through the platform-gateway (gated at
+    # runtime by chatbot.youtube_gateway). Empty keeps the in-process pkg/youtube
+    # send. The inbound chat poll stays in-process regardless (no gateway
+    # streaming endpoint).
+    youtube_api_url: str = ""
 
     def tag_for(self, component: str) -> str:
         """Image tag for a component: its pinned release tag when versions.yaml
@@ -321,6 +327,10 @@ ENVS: dict[str, EnvConfig] = {
         # gateway-twitch gateway (Phase 3). prod stays in-process until its gateway
         # release is cut.
         twitch_api_url="http://gateway-twitch.stage-1.svc.cluster.local:8080",
+        # Route stage tripbot-youtube's outbound chat sends through the
+        # in-namespace gateway-youtube (gated by chatbot.youtube_gateway). The
+        # inbound poll stays in-process. prod has no youtube instance yet.
+        youtube_api_url="http://gateway-youtube.stage-1.svc.cluster.local:8080",
         # Stage streams to YouTube — the second half of the two-live-streams
         # budget (prod-twitch + stage-youtube). Key from SM
         # k8s/obs/youtube-stream-key (adanalife-stage account).

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -180,6 +180,11 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
     # twitch platform talks Helix, so the youtube instance never carries it.
     if platform == "twitch" and env.twitch_api_url:
         data["TWITCH_API_URL"] = env.twitch_api_url
+    # Route the youtube instance's outbound chat sends through gateway-youtube
+    # where the env opts in. Only the youtube platform sends YouTube chat, so the
+    # twitch instance never carries it. Gated at runtime by chatbot.youtube_gateway.
+    if platform == "youtube" and env.youtube_api_url:
+        data["YOUTUBE_API_URL"] = env.youtube_api_url
     return data
 
 

--- a/cdk8s/dist/stage-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-tripbot-youtube.k8s.yaml
@@ -29,6 +29,7 @@ data:
   TRIPBOT_SERVER_PORT: "8080"
   VERBOSE: "false"
   VLC_SERVER_HOST: vlc-youtube:8080
+  YOUTUBE_API_URL: http://gateway-youtube.stage-1.svc.cluster.local:8080
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -65,7 +66,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: a2657ba240
+        adanalife.dev/config-hash: bb3a1ae800
       labels:
         app: tripbot-youtube
     spec:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -158,6 +158,20 @@ def test_stage_twitch_routes_through_gateway():
     assert "TWITCH_API_URL" not in _cm_data("prod-1-tripbot-twitch")
 
 
+def test_stage_youtube_routes_sends_through_gateway():
+    """Stage tripbot-youtube carries YOUTUBE_API_URL (outbound send via the
+    gateway); the twitch instance does not."""
+
+    def _cm_data(stem):
+        return _by_kind(_objects(stem), "ConfigMap")[0]["data"]
+
+    assert (
+        _cm_data("stage-1-tripbot-youtube").get("YOUTUBE_API_URL")
+        == "http://gateway-youtube.stage-1.svc.cluster.local:8080"
+    )
+    assert "YOUTUBE_API_URL" not in _cm_data("stage-1-tripbot-twitch")
+
+
 # Which (env, platform) OBS instances actually stream — must mirror
 # config.EnvConfig.obs_streaming. A streaming instance emits its stream-key
 # ExternalSecret; an idle one does not (and boots without the key).

--- a/db/migrate/023_seed_chatbot_youtube_gateway_flag.down.sql
+++ b/db/migrate/023_seed_chatbot_youtube_gateway_flag.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM feature_flags WHERE key = 'chatbot.youtube_gateway';

--- a/db/migrate/023_seed_chatbot_youtube_gateway_flag.up.sql
+++ b/db/migrate/023_seed_chatbot_youtube_gateway_flag.up.sql
@@ -1,0 +1,23 @@
+/* Seeds chatbot.youtube_gateway — the runtime kill-switch for routing a
+   PLATFORM=youtube instance's outbound chat sends through the platform-gateway
+   (gateway-youtube). The code-level flag landed alongside the YOUTUBE_API_URL
+   wiring; without this row the console toggle errors ("flag not found"), so the
+   gateway path can never be turned on.
+
+   YouTube-only: the flag is consulted solely by the youtube instance (the
+   twitch instance has no YouTube gateway wired, so flaggedYouTubeSend is never
+   constructed there). Seeded for the youtube platform to match the youtube
+   instance's flag client (NewPostgresClient is constructed with STREAM_PLATFORM).
+
+   Defaults off: an env wired with YOUTUBE_API_URL stays in-process until this is
+   flipped on from the console, and flipping it back off reverts without a bot
+   restart. Mirrors 021 (chatbot.twitch_gateway). */
+INSERT INTO feature_flags (key, platform, description, enabled, target_removal_date)
+VALUES (
+    'chatbot.youtube_gateway',
+    'youtube',
+    'Routes a youtube instance''s outbound chat sends through the platform-gateway gateway-youtube instead of the in-process pkg/youtube path. The inbound chat poll stays in-process. Enable once the gateway is verified on the env; disable to revert without a bot restart.',
+    FALSE,
+    DATE '2026-12-19'
+)
+ON CONFLICT (key, platform) DO NOTHING;

--- a/pkg/chatbot/gateway_youtube_test.go
+++ b/pkg/chatbot/gateway_youtube_test.go
@@ -1,0 +1,103 @@
+package chatbot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/adanalife/tripbot/pkg/gateway"
+)
+
+// recordingYouTubeSend records send calls so the flag-dispatch test can assert
+// which path a send took.
+type recordingYouTubeSend struct {
+	calls  int
+	chatID string
+	text   string
+}
+
+func (r *recordingYouTubeSend) send(_ context.Context, chatID, text string) error {
+	r.calls++
+	r.chatID = chatID
+	r.text = text
+	return nil
+}
+
+func TestGatewayYouTubeSend_PostsToChat(t *testing.T) {
+	var gotPath, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	// chatID is deliberately ignored — the gateway resolves the active chat.
+	if err := (gatewayYouTubeSend{client: gateway.New(srv.URL)}).
+		send(context.Background(), "ignored-chat-id", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/v1/chat" {
+		t.Errorf("path = %q, want /v1/chat", gotPath)
+	}
+	// identity is "" (gateway default) and the chatID is not sent.
+	if !strings.Contains(gotBody, `"text":"hello"`) || !strings.Contains(gotBody, `"identity":""`) {
+		t.Errorf("body = %q, want text=hello identity=empty", gotBody)
+	}
+	if strings.Contains(gotBody, "ignored-chat-id") {
+		t.Errorf("body should not carry the chatID; got %q", gotBody)
+	}
+}
+
+func TestGatewayYouTubeSend_ErrorsOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	if err := (gatewayYouTubeSend{client: gateway.New(srv.URL)}).
+		send(context.Background(), "", "hi"); err == nil {
+		t.Error("expected an error on a 502 from the gateway")
+	}
+}
+
+func TestFlaggedYouTubeSend_DispatchesOnFlag(t *testing.T) {
+	gw := &recordingYouTubeSend{}
+	inproc := &recordingYouTubeSend{}
+
+	flagOn := feature.NewInMemoryClient(map[string]feature.Flag{
+		YouTubeGatewayFlagKey: {Key: YouTubeGatewayFlagKey, Enabled: true},
+	})
+	flagOff := feature.NewInMemoryClient(nil) // unknown key → off
+
+	// flag on → gateway
+	on := flaggedYouTubeSend{app: &App{Flags: flagOn}, gateway: gw, inproc: inproc}
+	if err := on.send(context.Background(), "c1", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if gw.calls != 1 || inproc.calls != 0 {
+		t.Errorf("flag on should route to the gateway; gw=%d inproc=%d", gw.calls, inproc.calls)
+	}
+
+	// flag off → in-process (the default until toggled)
+	off := flaggedYouTubeSend{app: &App{Flags: flagOff}, gateway: gw, inproc: inproc}
+	if err := off.send(context.Background(), "c1", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if inproc.calls != 1 {
+		t.Errorf("flag off should route in-process; inproc=%d", inproc.calls)
+	}
+}
+
+func TestNewYouTubeSend_NoURLSkipsGatewayWrapper(t *testing.T) {
+	// With no YOUTUBE_API_URL there's nothing to flag — it's the plain in-process
+	// adapter, not a flaggedYouTubeSend wrapper.
+	if _, ok := newYouTubeSend(&App{}).(realYouTubeSend); !ok {
+		t.Error("expected realYouTubeSend when YOUTUBE_API_URL is empty")
+	}
+}

--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -11,6 +11,8 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/eventbus"
+	"github.com/adanalife/tripbot/pkg/feature"
+	"github.com/adanalife/tripbot/pkg/gateway"
 	"github.com/adanalife/tripbot/pkg/geo"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/users"
@@ -112,13 +114,85 @@ func (a *App) ConnectYouTube(ctx context.Context) (*liveChatBinding, error) {
 	a.Chat = consoleMirror{
 		inner: youtubeChat{
 			binding: binding,
-			insert:  myyoutube.InsertChatMessage,
+			insert:  newYouTubeSend(a).send,
 		},
 		env:         c.Conf.Environment,
 		platform:    c.Conf.Platform,
 		botUsername: c.Conf.BotUsername,
 	}
 	return binding, nil
+}
+
+// YouTubeGatewayFlagKey is the runtime kill-switch for routing outbound YouTube
+// chat sends through the platform-gateway (gateway-youtube). It defaults off
+// (the flag row doesn't exist until toggled), so even an instance wired with
+// YOUTUBE_API_URL stays in-process until the flag is flipped on — the cutover
+// (and instant revert, no restart) is a console toggle. Only meaningful when
+// YOUTUBE_API_URL is set. Mirrors TwitchGatewayFlagKey; the YouTube analog only
+// covers the outbound send — the inbound poll has no gateway endpoint.
+const YouTubeGatewayFlagKey = "chatbot.youtube_gateway"
+
+// youtubeSend is the outbound YouTube chat-send seam. The in-process path
+// inserts into the tripbot-bound live chat (chatID); the gateway path posts via
+// gateway-youtube's SendChat, which resolves the active live chat itself (so it
+// ignores chatID). Same signature as youtubeChat.insert so youtubeChat is
+// untouched. Mirrors the Twitch interface in twitch.go.
+type youtubeSend interface {
+	send(ctx context.Context, chatID, text string) error
+}
+
+// newYouTubeSend wires the production send path. With no YOUTUBE_API_URL there's
+// no gateway to reach, so it's the plain in-process insert (zero-config
+// default). When a gateway IS wired, it returns a flaggedYouTubeSend that
+// dispatches per call based on the YouTubeGatewayFlagKey runtime flag — wired
+// but dormant until flipped on, revertible without a restart. Mirrors newTwitch.
+func newYouTubeSend(a *App) youtubeSend {
+	if c.Conf.YouTubeAPIURL == "" {
+		return realYouTubeSend{}
+	}
+	return flaggedYouTubeSend{
+		app:     a,
+		gateway: gatewayYouTubeSend{client: gateway.New(c.Conf.YouTubeAPIURL)},
+		inproc:  realYouTubeSend{},
+	}
+}
+
+// realYouTubeSend is the in-process adapter — inserts into the bound live chat
+// via pkg/youtube. Used when no YOUTUBE_API_URL is configured.
+type realYouTubeSend struct{}
+
+func (realYouTubeSend) send(ctx context.Context, chatID, text string) error {
+	return myyoutube.InsertChatMessage(ctx, chatID, text)
+}
+
+// gatewayYouTubeSend posts through the platform-gateway gateway-youtube instance
+// via the shared pkg/gateway client. chatID is ignored — the gateway-youtube
+// adapter resolves the channel's active live chat itself. identity is "" so the
+// gateway uses its default (YouTube has a single channel-owner token).
+type gatewayYouTubeSend struct {
+	client *gateway.Client
+}
+
+func (g gatewayYouTubeSend) send(ctx context.Context, _, text string) error {
+	return g.client.SendChat(ctx, "", text)
+}
+
+// flaggedYouTubeSend routes each send to the gateway or the in-process adapter
+// based on the live YouTubeGatewayFlagKey value, read from the App's flag client
+// at call time (cmd/tripbot reassigns a.Flags to the Postgres-backed, console-
+// toggleable client after New(), so the flag flips without a bot restart).
+// Mirrors flaggedTwitch.
+type flaggedYouTubeSend struct {
+	app     *App
+	gateway youtubeSend
+	inproc  youtubeSend
+}
+
+func (f flaggedYouTubeSend) send(ctx context.Context, chatID, text string) error {
+	if f.app.Flags.Bool(ctx, YouTubeGatewayFlagKey, feature.EvalContext{}) {
+		return f.gateway.send(ctx, chatID, text)
+	}
+	return f.inproc.send(ctx, chatID, text)
 }
 
 // HandleYouTubeMessage processes one inbound YouTube chat message. Identical

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -77,6 +77,15 @@ type TripbotConfig struct {
 	// HTTP client behind the same interface, with no command code changes.
 	TwitchAPIURL string `envconfig:"TWITCH_API_URL"`
 
+	// YouTubeAPIURL points a PLATFORM=youtube instance's outbound chat sends at
+	// the platform-gateway gateway-youtube instance over HTTP, instead of the
+	// in-process pkg/youtube path. Empty (the default) keeps the in-process
+	// adapter. When set — e.g. http://gateway-youtube.<env>.svc.cluster.local:8080
+	// — outbound chat send routes through the gateway's SendChat (which resolves
+	// the active live chat itself), gated by the chatbot.youtube_gateway flag. The
+	// inbound chat poll stays in-process (no gateway streaming endpoint).
+	YouTubeAPIURL string `envconfig:"YOUTUBE_API_URL"`
+
 	// NatsURL is the in-cluster NATS endpoint used for fire-and-forget
 	// inter-component events. Format:
 	// nats://nats.<env-platform-ns>.svc.cluster.local:4222.


### PR DESCRIPTION
The YouTube analog of the Twitch 3a cutover — routes `tripbot-youtube`'s **outbound chat send** through `gateway-youtube`, behind a runtime flag.

## What
- **`pkg/chatbot`** — `youtubeChat`'s send now dispatches through a `youtubeSend` seam: in-process `pkg/youtube` insert by default, or `gateway.SendChat` (which self-resolves the active live chat) when wired + the flag is on. Mirrors `flaggedTwitch`: two-layer gate (`YOUTUBE_API_URL` = wired; `chatbot.youtube_gateway` = whether to use it), per-call dispatch on the live `a.Flags`, default off, fails over to in-process.
- **`pkg/config/tripbot`** — new `YOUTUBE_API_URL`.
- **Migration 023** — seeds `chatbot.youtube_gateway` (youtube platform, disabled), since `SetEnabled` is UPDATE-only and the console can't create the row.
- **cdk8s** — `EnvConfig.youtube_api_url`, emitted on the youtube tripbot instance; stage-1 → `gateway-youtube`. prod has no youtube instance yet.

## Scope (intentional)
Only the **outbound send** maps onto the gateway. The **inbound chat poll** (`ActiveLiveChatID` + paged `ListChatMessages`) stays in-process — there's no gateway streaming endpoint, exactly as Twitch IRC stays in-process. So `tripbot-youtube` still reads the YouTube token for the poll; this does not remove youtube auth from tripbot entirely (a gateway chat-streaming endpoint would, tracked separately).

## Testing
- `pkg/chatbot`: gateway send posts to `/v1/chat` with `identity:""` and no chatID; non-2xx errors; flag-dispatch routes gateway-vs-in-process; no-URL skips the wrapper.
- cdk8s: stage tripbot-youtube carries `YOUTUBE_API_URL`, twitch instance does not.
- Full `pkg/chatbot` + `pkg/config` Go tests and the cdk8s suite pass; gofmt clean.

## Deploy ordering
Depends on [platform-gateway#18](https://github.com/adanalife/platform-gateway/pull/18/changes) (the gateway token-refresh fix) being deployed — `SendChat` exercises the same refresh path. After both land + stage syncs: flip `chatbot.youtube_gateway` on from the console to cut over, off to revert (no restart).