### PR TITLE
Co-locate vlc/onscreens with their OBS pod instead of preferring rpi5

### DIFF
--- a/cdk8s/adanalife_k8s/constructs/onscreens.py
+++ b/cdk8s/adanalife_k8s/constructs/onscreens.py
@@ -130,15 +130,19 @@ class OnscreensServer(Construct):
                             seccomp_profile=k8s.SeccompProfile(type="RuntimeDefault")
                         ),
                         priority_class_name=env.priority_class or None,
-                        # Prefer the ephemeral rpi5 worker when present, recover
-                        # to the MS-01 when it's gone (stage only). See scheduling.py.
+                        # Co-locate with this platform's OBS pod so the overlay
+                        # browser source reaches OBS on localhost, not across the
+                        # LAN. OBS owns the rpi5 node-preference; onscreens just
+                        # follows wherever OBS landed (toleration kept so it can
+                        # follow OBS onto the Pi). Stage only via env.prefer_rpi5.
+                        # See scheduling.py.
                         tolerations=(
                             scheduling.prefer_rpi5_tolerations()
                             if env.prefer_rpi5
                             else None
                         ),
                         affinity=(
-                            scheduling.prefer_rpi5_affinity()
+                            scheduling.colocate_with_obs_affinity(platform)
                             if env.prefer_rpi5
                             else None
                         ),

--- a/cdk8s/adanalife_k8s/constructs/vlc.py
+++ b/cdk8s/adanalife_k8s/constructs/vlc.py
@@ -189,17 +189,18 @@ class VlcServer(Construct):
                             seccomp_profile=k8s.SeccompProfile(type="RuntimeDefault")
                         ),
                         priority_class_name=env.priority_class or None,
-                        # Prefer the ephemeral rpi5 worker when present, recover
-                        # to the MS-01 when it's gone (stage only). The RTSP feed
-                        # to OBS crosses the LAN instead of localhost when vlc
-                        # lands on the Pi. See scheduling.py.
+                        # Co-locate with this platform's OBS pod so the RTSP feed
+                        # reaches OBS on localhost, not across the LAN. OBS owns the
+                        # rpi5 node-preference; vlc just follows wherever OBS landed
+                        # (toleration kept so it can follow OBS onto the Pi). Stage
+                        # only via env.prefer_rpi5. See scheduling.py.
                         tolerations=(
                             scheduling.prefer_rpi5_tolerations()
                             if env.prefer_rpi5
                             else None
                         ),
                         affinity=(
-                            scheduling.prefer_rpi5_affinity()
+                            scheduling.colocate_with_obs_affinity(platform)
                             if env.prefer_rpi5
                             else None
                         ),

--- a/cdk8s/adanalife_k8s/scheduling.py
+++ b/cdk8s/adanalife_k8s/scheduling.py
@@ -31,11 +31,22 @@ obs-youtube as of 2026-06-15), the Pi can carry it, which also offloads the
 encode off the MS-01. So ObsInstance calls these helpers gated on
 `prefer_rpi5 and not obs_uses_gpu`; when obs_gpu flips back on, the i915 resource
 claim hard-gates the pod back to the MS-01 and the affinity drops out together.
+
+OBS is the streaming pipeline's *anchor*: it owns the rpi5 node-preference, and
+its two feeders — vlc (RTSP) and onscreens (browser-source overlays) — must reach
+it on localhost, not across the LAN. So the feeders do NOT take the rpi5
+node-affinity themselves; they take `colocate_with_obs_affinity(platform)`
+instead, which follows OBS to whichever node it landed on (keeping the rpi5
+toleration so they can follow it onto the Pi). Giving the feeders an independent
+rpi5 pull is what split the pipeline across the LAN when OBS spilled to the MS-01
+under load while a feeder stayed on the Pi — the 2026-06-19 stage obs-youtube
+stutter.
 """
 
 from __future__ import annotations
 
 import imports.k8s as k8s
+from adanalife_k8s.naming import app_name, selector
 
 RPI5_TAINT_KEY = "dana.lol/rpi5"
 RPI5_BOARD_LABEL = "dana.lol/board"
@@ -69,6 +80,44 @@ def prefer_rpi5_affinity() -> k8s.Affinity:
                                 values=[RPI5_BOARD_VALUE],
                             )
                         ]
+                    ),
+                )
+            ]
+        )
+    )
+
+
+def colocate_with_obs_affinity(platform: str) -> k8s.Affinity:
+    """PREFERRED pod affinity co-locating a stream feeder (vlc / onscreens) onto
+    the same node as its platform's OBS pod.
+
+    OBS is the anchor of the streaming pipeline: the RTSP feed (vlc→obs) and the
+    browser-source overlays (onscreens→obs) reach OBS continuously, and must do so
+    on localhost rather than across the LAN. OBS is the pod that owns the rpi5
+    node-preference (when it's a software encoder); the feeders don't pick a node
+    independently — they follow wherever OBS landed.
+
+    This REPLACES the feeders' own `prefer_rpi5_affinity()`. That node-affinity
+    pulled a feeder toward the Pi on its own, so when OBS spilled onto the MS-01
+    under load while a feeder stayed on the Pi, the pipeline split across the LAN
+    — the 2026-06-19 stage obs-youtube stutter. Anchoring the feeders to OBS keeps
+    the whole pipeline on one node whichever node that turns out to be.
+
+    PREFERRED, never required: a feeder still schedules if OBS is briefly absent
+    (e.g. mid-rollout), it just won't be co-located until the next placement.
+    Pair with `prefer_rpi5_tolerations()` so the feeder is *allowed* to follow OBS
+    onto the Pi when OBS lands there.
+    """
+    return k8s.Affinity(
+        pod_affinity=k8s.PodAffinity(
+            preferred_during_scheduling_ignored_during_execution=[
+                k8s.WeightedPodAffinityTerm(
+                    weight=100,
+                    pod_affinity_term=k8s.PodAffinityTerm(
+                        topology_key="kubernetes.io/hostname",
+                        label_selector=k8s.LabelSelector(
+                            match_labels=selector(app_name("obs", platform))
+                        ),
                     ),
                 )
             ]

--- a/cdk8s/dist/stage-1-onscreens-twitch.k8s.yaml
+++ b/cdk8s/dist/stage-1-onscreens-twitch.k8s.yaml
@@ -41,14 +41,13 @@ spec:
         app: onscreens-twitch
     spec:
       affinity:
-        nodeAffinity:
+        podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: dana.lol/board
-                    operator: In
-                    values:
-                      - rpi5
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: obs-twitch
+                topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - envFrom:

--- a/cdk8s/dist/stage-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-onscreens-youtube.k8s.yaml
@@ -41,14 +41,13 @@ spec:
         app: onscreens-youtube
     spec:
       affinity:
-        nodeAffinity:
+        podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: dana.lol/board
-                    operator: In
-                    values:
-                      - rpi5
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: obs-youtube
+                topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - envFrom:

--- a/cdk8s/dist/stage-1-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/stage-1-vlc-twitch.k8s.yaml
@@ -45,14 +45,13 @@ spec:
         app: vlc-twitch
     spec:
       affinity:
-        nodeAffinity:
+        podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: dana.lol/board
-                    operator: In
-                    values:
-                      - rpi5
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: obs-twitch
+                topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - envFrom:

--- a/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-vlc-youtube.k8s.yaml
@@ -46,14 +46,13 @@ spec:
         app: vlc-youtube
     spec:
       affinity:
-        nodeAffinity:
+        podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: dana.lol/board
-                    operator: In
-                    values:
-                      - rpi5
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: obs-youtube
+                topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - envFrom:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -220,16 +220,47 @@ def _prefers_rpi5(spec: dict) -> bool:
     return tolerates and biases
 
 
-def test_stage_stateless_apps_prefer_rpi5():
-    """Stage's lightweight stateless app pods (vlc/onscreens/tripbot-youtube)
-    opt into the ephemeral rpi5 worker — they tolerate the taint and bias toward
-    the board label, recovering onto the MS-01 when the Pi is gone."""
-    for stem in (
-        "stage-1-vlc-youtube",
-        "stage-1-onscreens-youtube",
-        "stage-1-tripbot-youtube",
-    ):
-        assert _prefers_rpi5(_pod_spec(stem)), stem
+def _colocates_with_obs(spec: dict, obs_app: str) -> bool:
+    """True iff the pod prefers (podAffinity) the node running `obs_app`."""
+    prefs = (
+        spec.get("affinity", {})
+        .get("podAffinity", {})
+        .get("preferredDuringSchedulingIgnoredDuringExecution", [])
+    )
+    return any(
+        term.get("podAffinityTerm", {}).get("topologyKey") == "kubernetes.io/hostname"
+        and term.get("podAffinityTerm", {})
+        .get("labelSelector", {})
+        .get("matchLabels", {})
+        .get("app")
+        == obs_app
+        for term in prefs
+    )
+
+
+def test_stage_tripbot_prefers_rpi5():
+    """tripbot-youtube is control-plane (chat/EventSub), not a realtime OBS feeder,
+    so it keeps the independent rpi5 node-preference — tolerate the taint and bias
+    toward the board label, recovering onto the MS-01 when the Pi is gone."""
+    assert _prefers_rpi5(_pod_spec("stage-1-tripbot-youtube"))
+
+
+def test_stage_obs_feeders_colocate_with_obs():
+    """vlc + onscreens feed OBS continuously (RTSP / browser-source) and must reach
+    it on localhost, not across the LAN. They anchor to their platform's OBS pod
+    via podAffinity instead of pulling toward the Pi on their own — keeping the
+    rpi5 toleration so they can follow OBS onto the Pi, but NOT the board
+    node-affinity that previously split the pipeline when OBS spilled to the MS-01
+    (the 2026-06-19 stage obs-youtube stutter)."""
+    for stem in ("stage-1-vlc-youtube", "stage-1-onscreens-youtube"):
+        spec = _pod_spec(stem)
+        assert _colocates_with_obs(spec, "obs-youtube"), stem
+        # follows OBS onto the Pi if OBS lands there ...
+        assert any(
+            t.get("key") == "dana.lol/rpi5" for t in spec.get("tolerations", [])
+        ), stem
+        # ... but no longer carries an independent rpi5 board pull.
+        assert not _prefers_rpi5(spec), stem
 
 
 def test_stage_vaapi_obs_stays_on_msi():


### PR DESCRIPTION
## Problem

Streaming on stage `obs-youtube` was choppy. The stage streaming pipeline had split across the LAN:

- `obs-youtube` (the sink) → **minipc** (holds the i915/GPU claim)
- `vlc-youtube` (RTSP feed → OBS) → **rpi5**
- `onscreens-youtube` (browser-source overlays → OBS) → **rpi5**

OBS is the pipeline's anchor, but its two feeders carried their *own* preferred rpi5 node-affinity, so they were pulled onto the Pi independently. With OBS on the minipc and the feeders on the Pi, the continuous video feed + overlays crossed the WiFi link to reach OBS instead of staying on localhost → stutter.

The split is a steady-state consequence of the ephemeral-rpi5 offload design (`scheduling.py`): both OBS (when software-encode) and the feeders *prefer* the Pi, but OBS is heavy and spills to the minipc under load while the light feeders stay on the Pi.

## Fix

Replace the feeders' independent rpi5 node-affinity with a **preferred `podAffinity` anchoring them to their platform's OBS pod** (`topologyKey: kubernetes.io/hostname`). OBS stays the only pod that picks the node; the feeders follow wherever it lands. The rpi5 **toleration is kept** so they can still follow OBS *onto* the Pi if OBS ever runs there.

`tripbot-youtube` is control-plane (chat/EventSub), not a realtime feeder, so it keeps its independent rpi5 preference.

Scoped to stage via `env.prefer_rpi5` — **prod and local render unchanged** (only the 4 stage feeder manifests changed: vlc/onscreens × twitch/youtube).

## Verification

- A live `kubectl` patch pinning `vlc-youtube` to the minipc cleared the choppiness mid-stream, confirming the cross-node hop was the cause. This PR makes that permanent and also covers the onscreens feeder.
- `task cdk8s:test` — 47 passed (added `test_stage_obs_feeders_colocate_with_obs`, split `tripbot` out into `test_stage_tripbot_prefers_rpi5`).
- `task cdk8s:synth` golden dist regenerated; diff limited to the 4 stage feeder manifests.