### PR TITLE
Stage the prod-youtube stack parked at replicas=0

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -145,12 +145,26 @@ class EnvConfig:
     # Pairs with stage selfHeal being off in the Argo apps set (infra
     # SELFHEAL_OFF_ENVS). prod keeps replicas declared so Argo holds it at 1.
     manual_replicas: bool = False
+    # Subset of `platforms` whose app Deployments render with spec.replicas=0 —
+    # the whole platform stack (tripbot/vlc/onscreens/obs) is emitted and Argo
+    # manages it, but parked off so it consumes no node resources until turned
+    # on by removing the platform from this set (a config edit + redeploy; under
+    # prod selfHeal a hand `kubectl scale` would just be reverted to 0). Lets a
+    # platform be staged on an env ahead of being made live. prod-youtube sits
+    # here until stage-youtube is shut down and prod-youtube is turned on, so the
+    # minipc never runs two youtube stacks at once.
+    parked_platforms: tuple[str, ...] = ()
 
     @property
     def replicas(self) -> int | None:
         """spec.replicas for the app Deployments: None (omitted, manually
         scaled) when manual_replicas, else 1."""
         return None if self.manual_replicas else 1
+
+    def replicas_for(self, platform: str) -> int | None:
+        """spec.replicas for a given platform's app Deployments: 0 when the
+        platform is parked (rendered but off), else the env-wide `replicas`."""
+        return 0 if platform in self.parked_platforms else self.replicas
 
     # The platform-gateway gateway-twitch URL the chatbot routes its command-time
     # Helix calls through (Phase 3). Empty keeps tripbot's in-process pkg/twitch
@@ -246,8 +260,19 @@ ENVS: dict[str, EnvConfig] = {
         # The DB lives in its own namespace so a `kubectl delete ns prod-1` can't
         # take years of irreplaceable data.
         data_namespace="prod-1-data",
-        platforms=("twitch",),
-        obs_streaming=("twitch",),  # prod twitch is the always-live stream
+        # youtube is staged here but parked at replicas=0 (parked_platforms): the
+        # full prod-youtube stack renders + Argo manages it, but it runs nothing
+        # until stage-youtube is shut down and prod-youtube is turned on, so the
+        # minipc never runs two youtube stacks at once. Turn on = drop "youtube"
+        # from parked_platforms (and, to stream, add it to obs_streaming + create
+        # the prod-account SM key k8s/obs/youtube-stream-key). The youtube tripbot
+        # instance pulls tripbot-youtube-creds from prod-account SM
+        # k8s/tripbot/youtube-creds regardless — that must exist for its
+        # ExternalSecret to sync.
+        platforms=("twitch", "youtube"),
+        parked_platforms=("youtube",),
+        # prod twitch is the always-live stream; youtube boots idle until flip-on
+        obs_streaming=("twitch",),
         # The live stream always wins: prod app pods outrank default-priority
         # co-tenants (stage, dashcam-cv), and the encode/decode pair carries
         # real CPU requests so contention can't starve it (20-core node; the

--- a/cdk8s/adanalife_k8s/constructs/obs.py
+++ b/cdk8s/adanalife_k8s/constructs/obs.py
@@ -133,7 +133,7 @@ class ObsInstance(Construct):
             "deployment",
             metadata=k8s.ObjectMeta(name=name, namespace=ns, labels=labels),
             spec=k8s.DeploymentSpec(
-                replicas=env.replicas,
+                replicas=env.replicas_for(platform),
                 # Recreate: one Xvfb/VNC owner, no overlapping handoff.
                 strategy=k8s.DeploymentStrategy(type="Recreate"),
                 selector=k8s.LabelSelector(match_labels={"app": name}),

--- a/cdk8s/adanalife_k8s/constructs/onscreens.py
+++ b/cdk8s/adanalife_k8s/constructs/onscreens.py
@@ -112,7 +112,7 @@ class OnscreensServer(Construct):
             "deployment",
             metadata=k8s.ObjectMeta(name=name, namespace=ns, labels=labels),
             spec=k8s.DeploymentSpec(
-                replicas=env.replicas,
+                replicas=env.replicas_for(platform),
                 strategy=k8s.DeploymentStrategy(
                     type="RollingUpdate",
                     rolling_update=k8s.RollingUpdateDeployment(

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -331,7 +331,7 @@ class Tripbot(Construct):
             "deployment",
             metadata=k8s.ObjectMeta(name=name, namespace=ns, labels=labels),
             spec=k8s.DeploymentSpec(
-                replicas=env.replicas,
+                replicas=env.replicas_for(platform),
                 selector=k8s.LabelSelector(match_labels=sel),
                 template=k8s.PodTemplateSpec(
                     metadata=k8s.ObjectMeta(

--- a/cdk8s/adanalife_k8s/constructs/vlc.py
+++ b/cdk8s/adanalife_k8s/constructs/vlc.py
@@ -171,7 +171,7 @@ class VlcServer(Construct):
             "deployment",
             metadata=k8s.ObjectMeta(name=name, namespace=ns, labels=labels),
             spec=k8s.DeploymentSpec(
-                replicas=env.replicas,
+                replicas=env.replicas_for(platform),
                 strategy=k8s.DeploymentStrategy(
                     type="RollingUpdate",
                     rolling_update=k8s.RollingUpdateDeployment(

--- a/cdk8s/dist/prod-1-obs-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-obs-youtube.k8s.yaml
@@ -1,0 +1,160 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: obs-youtube
+    app.kubernetes.io/instance: obs-youtube
+    app.kubernetes.io/name: obs
+    app.kubernetes.io/part-of: tripbot
+  name: obs-youtube-config
+  namespace: prod-1
+data:
+  DASHCAM_RTSP_URL: rtsp://vlc-youtube:8554/dashcam
+  OBS_QUALITY_PRESET: high
+  OBS_STREAM_ENCODER: ffmpeg_vaapi_tex
+  OBS_WEBSOCKET_PASSWD: adanalife
+  ONSCREENS_URL_BASE: http://onscreens-youtube:8080
+  STREAM_PLATFORM: youtube
+  VLC_URL_BASE: http://vlc-youtube:8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: obs-youtube
+    app.kubernetes.io/instance: obs-youtube
+    app.kubernetes.io/name: obs
+    app.kubernetes.io/part-of: tripbot
+  name: obs-youtube
+  namespace: prod-1
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: obs-youtube
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        adanalife.dev/config-hash: 1aa871d64c
+      labels:
+        app: obs-youtube
+        app.kubernetes.io/instance: obs-youtube
+        app.kubernetes.io/name: obs
+        app.kubernetes.io/part-of: tripbot
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: obs-youtube-config
+            - secretRef:
+                name: obs-youtube-stream-key
+                optional: true
+          image: adanalife/obs:3.4.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /opt/obs/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
+          name: obs
+          ports:
+            - containerPort: 5900
+              name: vnc
+            - containerPort: 4455
+              name: websocket
+            - containerPort: 6080
+              name: novnc
+            - containerPort: 8080
+              name: obs-server
+          resources:
+            limits:
+              gpu.intel.com/i915: "1"
+              memory: 3Gi
+            requests:
+              cpu: "2"
+              gpu.intel.com/i915: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      priorityClassName: prod-stream
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: obs-youtube
+    app.kubernetes.io/instance: obs-youtube
+    app.kubernetes.io/name: obs
+    app.kubernetes.io/part-of: tripbot
+  name: obs-youtube
+  namespace: prod-1
+spec:
+  ports:
+    - name: vnc
+      port: 5900
+      targetPort: vnc
+    - name: websocket
+      port: 4455
+      targetPort: websocket
+    - name: novnc
+      port: 6080
+      targetPort: novnc
+    - name: obs-server
+      port: 8080
+      targetPort: obs-server
+  selector:
+    app: obs-youtube
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/issuer: letsencrypt-route53
+    external-dns.alpha.kubernetes.io/hostname: obs-youtube.prod.whereisdana.today
+  name: obs-youtube
+  namespace: prod-1
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: obs-youtube.prod.whereisdana.today
+      http:
+        paths:
+          - backend:
+              service:
+                name: obs-youtube
+                port:
+                  name: novnc
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - obs-youtube.prod.whereisdana.today
+      secretName: obs-youtube-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: obs-youtube-ts
+  namespace: prod-1
+spec:
+  defaultBackend:
+    service:
+      name: obs-youtube
+      port:
+        number: 6080
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - obs-youtube-prod

--- a/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: onscreens-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: onscreens-youtube-config
+  namespace: prod-1
+data:
+  ENV: production
+  NATS_URL: nats://nats.prod-1-platform.svc.cluster.local:4222
+  ONSCREENS_SERVER_PLATFORM: youtube
+  OTEL_RESOURCE_ATTRIBUTES: deployment.environment=prod-1,service.namespace=tripbot,service.platform=youtube
+  OTEL_SDK_DISABLED: "false"
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.1"
+  SENTRY_ENVIRONMENT: prod-1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: onscreens-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: onscreens-youtube
+  namespace: prod-1
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: onscreens-youtube
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        adanalife.dev/config-hash: "9313331745"
+      labels:
+        app: onscreens-youtube
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: onscreens-youtube-config
+            - secretRef:
+                name: sentry-vlc-server
+                optional: false
+            - secretRef:
+                name: grafana-cloud-otlp
+                optional: false
+          image: adanalife/onscreens-server:3.8.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: onscreens-youtube
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 25m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data/run
+              name: run
+      priorityClassName: prod-stream
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - emptyDir: {}
+          name: run
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: onscreens-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: onscreens-youtube
+  namespace: prod-1
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app: onscreens-youtube
+  type: ClusterIP

--- a/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
@@ -1,0 +1,221 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: tripbot-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: tripbot-youtube-config
+  namespace: prod-1
+data:
+  BOT_USERNAME: tripbot4000
+  CHANNEL_NAME: adanalife_
+  DATABASE_HOST: postgres.prod-1-data.svc.cluster.local
+  ENV: production
+  EXTERNAL_URL: https://tripbot-youtube.prod.whereisdana.today
+  GOOGLE_APPS_PROJECT_ID: tripbot-prod
+  MAPS_OUTPUT_DIR: /opt/data/maps
+  NATS_URL: nats://nats.prod-1-platform.svc.cluster.local:4222
+  OBS_SERVER_HOST: obs-youtube:8080
+  OBS_WEBSOCKET_ADDR: obs-youtube:4455
+  ONSCREENS_SERVER_HOST: onscreens-youtube:8080
+  OTEL_RESOURCE_ATTRIBUTES: deployment.environment=prod-1,service.namespace=tripbot,service.platform=youtube
+  OTEL_SDK_DISABLED: "false"
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.1"
+  READ_ONLY: "false"
+  SENTRY_ENVIRONMENT: prod-1
+  STREAM_PLATFORM: youtube
+  TRIPBOT_SERVER_PORT: "8080"
+  VERBOSE: "false"
+  VLC_SERVER_HOST: vlc-youtube:8080
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  labels:
+    app.kubernetes.io/name: tripbot-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: tripbot-youtube-creds
+  namespace: prod-1
+spec:
+  dataFrom:
+    - extract:
+        key: k8s/tripbot/youtube-creds
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secretsmanager
+  target:
+    creationPolicy: Owner
+    name: tripbot-youtube-creds
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: tripbot-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: tripbot-youtube
+  namespace: prod-1
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: tripbot-youtube
+  template:
+    metadata:
+      annotations:
+        adanalife.dev/config-hash: 6ad4f51ca5
+      labels:
+        app: tripbot-youtube
+    spec:
+      containers:
+        - env:
+            - name: USER
+              value: tripbot
+          envFrom:
+            - configMapRef:
+                name: tripbot-youtube-config
+            - secretRef:
+                name: tripbot-database-creds
+            - secretRef:
+                name: grafana-cloud-otlp
+            - secretRef:
+                name: sentry-tripbot
+            - secretRef:
+                name: tripbot-twitch-creds
+            - secretRef:
+                name: tripbot-google-maps-api-key
+            - secretRef:
+                name: tripbot-discord-alerts-webhook
+                optional: true
+            - secretRef:
+                name: tripbot-discord-bot-token
+                optional: true
+            - secretRef:
+                name: tripbot-youtube-creds
+          image: adanalife/tripbot:3.8.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: tripbot-youtube
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      initContainers:
+        - args:
+            - -path
+            - /migrations
+            - -database
+            - postgres://$(DATABASE_USER):$(DATABASE_PASS)@$(DATABASE_HOST):5432/$(DATABASE_DB)?sslmode=disable
+            - up
+          command:
+            - migrate
+          envFrom:
+            - configMapRef:
+                name: tripbot-youtube-config
+            - secretRef:
+                name: tripbot-database-creds
+          image: adanalife/tripbot:3.8.0
+          imagePullPolicy: IfNotPresent
+          name: migrate
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      priorityClassName: prod-stream
+      securityContext:
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: tripbot-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: tripbot-youtube
+  namespace: prod-1
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app: tripbot-youtube
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/issuer: letsencrypt-route53
+    external-dns.alpha.kubernetes.io/hostname: tripbot-youtube.prod.whereisdana.today
+  labels:
+    app.kubernetes.io/name: tripbot-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: tripbot-youtube
+  namespace: prod-1
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: tripbot-youtube.prod.whereisdana.today
+      http:
+        paths:
+          - backend:
+              service:
+                name: tripbot-youtube
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - tripbot-youtube.prod.whereisdana.today
+      secretName: tripbot-youtube-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tripbot-youtube-ts
+  namespace: prod-1
+spec:
+  defaultBackend:
+    service:
+      name: tripbot-youtube
+      port:
+        number: 8080
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - tripbot-youtube-prod

--- a/cdk8s/dist/prod-1-vlc-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-vlc-youtube.k8s.yaml
@@ -1,0 +1,170 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: vlc-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: vlc-youtube-config
+  namespace: prod-1
+data:
+  DISPLAY: :0.0
+  ENV: production
+  FONTCONFIG_PATH: /etc/fonts
+  NATS_URL: nats://nats.prod-1-platform.svc.cluster.local:4222
+  OBS_WEBSOCKET_ADDR: obs-youtube:4455
+  OTEL_RESOURCE_ATTRIBUTES: deployment.environment=prod-1,service.namespace=tripbot,service.platform=youtube
+  OTEL_SDK_DISABLED: "false"
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.1"
+  SENTRY_ENVIRONMENT: prod-1
+  STREAM_PLATFORM: youtube
+  VLC_SERVER_HOST: vlc-youtube:8080
+  XDG_RUNTIME_DIR: /root/.cache/xdgr
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: vlc-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: vlc-youtube
+  namespace: prod-1
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: vlc-youtube
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        adanalife.dev/config-hash: 7d4652c56e
+      labels:
+        app: vlc-youtube
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: vlc-youtube-config
+            - secretRef:
+                name: sentry-vlc-server
+                optional: false
+            - secretRef:
+                name: grafana-cloud-otlp
+                optional: false
+          image: adanalife/vlc:3.8.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: vlc-youtube
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 5900
+              name: vnc
+            - containerPort: 8554
+              name: rtsp
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data/Dashcam/_all
+              name: dashcam
+              readOnly: true
+      priorityClassName: prod-stream
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: dashcam
+          persistentVolumeClaim:
+            claimName: vlc-dashcam
+            readOnly: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: vlc-youtube
+    app.kubernetes.io/part-of: tripbot
+  name: vlc-youtube
+  namespace: prod-1
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+    - name: rtsp
+      port: 8554
+      targetPort: rtsp
+    - name: vnc
+      port: 5900
+      targetPort: vnc
+  selector:
+    app: vlc-youtube
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/issuer: letsencrypt-route53
+    external-dns.alpha.kubernetes.io/hostname: vlc-youtube.prod.whereisdana.today
+  name: vlc-youtube
+  namespace: prod-1
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: vlc-youtube.prod.whereisdana.today
+      http:
+        paths:
+          - backend:
+              service:
+                name: vlc-youtube
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - vlc-youtube.prod.whereisdana.today
+      secretName: vlc-youtube-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vlc-youtube-ts
+  namespace: prod-1
+spec:
+  defaultBackend:
+    service:
+      name: vlc-youtube
+      port:
+        number: 8080
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - vlc-youtube-prod


### PR DESCRIPTION
Sets up the prod-youtube deployment but parks it at `replicas=0` for now — we have YouTube running on stage and don't want to starve the minipc until stage-youtube is shut down and prod-youtube is turned on (the minipc never runs two youtube stacks at once).

## What

- New `EnvConfig.parked_platforms` knob + `env.replicas_for(platform)`: a platform listed in `parked_platforms` renders its whole stack (tripbot/vlc/onscreens/obs) with `spec.replicas=0` — Argo manages it, but it runs nothing.
- The four app constructs now resolve replicas per-platform. Non-parked platforms render byte-identically (only the four new `prod-1-*-youtube` files appear in `dist/`).
- `prod-1` gains `youtube` as a parked platform.

`obs-youtube` boots idle — `youtube` stays out of `obs_streaming`, so no stream-key ExternalSecret is emitted. `tripbot-youtube` still pulls `tripbot-youtube-creds` from the prod-account SM `k8s/tripbot/youtube-creds`.

## Turning prod-youtube on later

1. Drop `"youtube"` from `prod-1` `parked_platforms`.
2. To stream: add `youtube` to `prod-1` `obs_streaming` **and** create the prod-account SM key `k8s/obs/youtube-stream-key`.
3. Shut down stage-youtube first (two-live-streams iGPU budget: prod-twitch + one youtube).

## Prerequisites for the parked stack to go green

- The prod-account SM secret `k8s/tripbot/youtube-creds` must exist, or `tripbot-youtube`'s ExternalSecret stays unhealthy (pods are at 0, so no resource cost).

## Cross-repo

- Companion infra PR adds `youtube` to prod-1's Argo fan-out so the four prod-youtube Applications get created: adanalife/infra#771. **prod reads this repo at `master`**, so the infra appset change must not sync live until these prod-youtube dist files have reached `master` (i.e. after the next tripbot release).
