### PR TITLE
feat(youtube): route gateway chat-send flag-less; drop chatbot.youtube_gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to TripBot. Format follows [Keep a Changelog](https://keepac
 
 ## [Unreleased]
 
+### Platform gateway
+
+- **YouTube outbound chat-send routes through `gateway-youtube` unconditionally — the `chatbot.youtube_gateway` flag is gone.** A `tripbot-youtube` instance wired with `YOUTUBE_API_URL` now sends through the gateway with no runtime toggle. Unlike the Twitch cutover (which keeps a flag to de-risk the live-prod swap), YouTube has no live-prod stakes, so it cuts straight over — a revert is a `git revert` + redeploy. Drops the `flaggedYouTubeSend` wrapper; migration 024 removes the seeded flag row. The inbound chat poll still stays in-process (no gateway streaming endpoint yet). ([#935])
+
 ## [v3.8.0] — 2026-06-20
 
 Minor release. Completes phase 3b of the platform-gateway migration: with the `chatbot.twitch_gateway` flag on, every in-process Helix caller — OBS watchdog live-check, broadcaster chat-send, cached audience refresh, and EventSub channel-ID resolution — now routes through the standalone gateway, making it the single Helix caller (the prerequisite for moving the Twitch token out of tripbot). Adds the YouTube outbound-chat-send analog behind its own flag, plus cross-service trace propagation from the gateway client. Rounds out with a `!km <username>` fix and two stage streaming-pipeline fixes: re-enabling VAAPI iGPU encode for obs-youtube and co-locating the vlc/onscreens feeders with their OBS pod to stop cross-node stutter.
@@ -1801,3 +1805,4 @@ The repo dates to 2018. v1.x covered the original development and steady-state o
 [#924]: https://github.com/adanalife/tripbot/pull/924
 [#925]: https://github.com/adanalife/tripbot/pull/925
 [#926]: https://github.com/adanalife/tripbot/pull/926
+[#935]: https://github.com/adanalife/tripbot/pull/935

--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -159,10 +159,10 @@ class EnvConfig:
     # gateway's prod release is cut + proven.
     twitch_api_url: str = ""
     # Like twitch_api_url, but for a youtube instance's outbound chat sends:
-    # gateway-youtube's URL routes them through the platform-gateway (gated at
-    # runtime by chatbot.youtube_gateway). Empty keeps the in-process pkg/youtube
-    # send. The inbound chat poll stays in-process regardless (no gateway
-    # streaming endpoint).
+    # gateway-youtube's URL routes them through the platform-gateway
+    # unconditionally (no runtime flag — unlike Twitch). Empty keeps the
+    # in-process pkg/youtube send. The inbound chat poll stays in-process
+    # regardless (no gateway streaming endpoint).
     youtube_api_url: str = ""
 
     def tag_for(self, component: str) -> str:
@@ -328,8 +328,8 @@ ENVS: dict[str, EnvConfig] = {
         # release is cut.
         twitch_api_url="http://gateway-twitch.stage-1.svc.cluster.local:8080",
         # Route stage tripbot-youtube's outbound chat sends through the
-        # in-namespace gateway-youtube (gated by chatbot.youtube_gateway). The
-        # inbound poll stays in-process. prod has no youtube instance yet.
+        # in-namespace gateway-youtube (unconditionally — no flag). The inbound
+        # poll stays in-process. prod has no youtube instance yet.
         youtube_api_url="http://gateway-youtube.stage-1.svc.cluster.local:8080",
         # Stage streams to YouTube — the second half of the two-live-streams
         # budget (prod-twitch + stage-youtube). Key from SM

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -182,7 +182,7 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
         data["TWITCH_API_URL"] = env.twitch_api_url
     # Route the youtube instance's outbound chat sends through gateway-youtube
     # where the env opts in. Only the youtube platform sends YouTube chat, so the
-    # twitch instance never carries it. Gated at runtime by chatbot.youtube_gateway.
+    # twitch instance never carries it. Routed unconditionally when wired (no flag).
     if platform == "youtube" and env.youtube_api_url:
         data["YOUTUBE_API_URL"] = env.youtube_api_url
     return data

--- a/db/migrate/024_remove_chatbot_youtube_gateway_flag.down.sql
+++ b/db/migrate/024_remove_chatbot_youtube_gateway_flag.down.sql
@@ -1,0 +1,11 @@
+/* Re-seeds the chatbot.youtube_gateway flag (disabled), restoring 023's state
+   so a downgrade lands on a tripbot build that still consults the flag. */
+INSERT INTO feature_flags (key, platform, description, enabled, target_removal_date)
+VALUES (
+    'chatbot.youtube_gateway',
+    'youtube',
+    'Routes a youtube instance''s outbound chat sends through the platform-gateway gateway-youtube instead of the in-process pkg/youtube path. The inbound chat poll stays in-process. Enable once the gateway is verified on the env; disable to revert without a bot restart.',
+    FALSE,
+    DATE '2026-12-19'
+)
+ON CONFLICT (key, platform) DO NOTHING;

--- a/db/migrate/024_remove_chatbot_youtube_gateway_flag.up.sql
+++ b/db/migrate/024_remove_chatbot_youtube_gateway_flag.up.sql
@@ -1,0 +1,11 @@
+/* Removes the chatbot.youtube_gateway flag seeded by 023. YouTube outbound
+   chat-send now routes through the platform-gateway (gateway-youtube)
+   unconditionally whenever YOUTUBE_API_URL is wired — there is no runtime
+   toggle, so the flag row is dead weight (and a console toggle that does
+   nothing). Unlike the Twitch cutover, YouTube has no live-prod stakes that
+   warrant a flag; a revert is a git revert + redeploy.
+
+   Safe across a rollout: the pre-deletion code reads the flag as off when the
+   row is gone (in-process send), and the post-deploy code ignores the flag
+   entirely. */
+DELETE FROM feature_flags WHERE key = 'chatbot.youtube_gateway';

--- a/pkg/chatbot/gateway_youtube_test.go
+++ b/pkg/chatbot/gateway_youtube_test.go
@@ -8,24 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/adanalife/tripbot/pkg/feature"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/gateway"
 )
-
-// recordingYouTubeSend records send calls so the flag-dispatch test can assert
-// which path a send took.
-type recordingYouTubeSend struct {
-	calls  int
-	chatID string
-	text   string
-}
-
-func (r *recordingYouTubeSend) send(_ context.Context, chatID, text string) error {
-	r.calls++
-	r.chatID = chatID
-	r.text = text
-	return nil
-}
 
 func TestGatewayYouTubeSend_PostsToChat(t *testing.T) {
 	var gotPath, gotBody string
@@ -66,38 +51,25 @@ func TestGatewayYouTubeSend_ErrorsOnNon2xx(t *testing.T) {
 	}
 }
 
-func TestFlaggedYouTubeSend_DispatchesOnFlag(t *testing.T) {
-	gw := &recordingYouTubeSend{}
-	inproc := &recordingYouTubeSend{}
+func TestNewYouTubeSend_NoURLUsesInProcess(t *testing.T) {
+	// With no YOUTUBE_API_URL there's no gateway to reach — fall back to the
+	// in-process insert.
+	prev := c.Conf.YouTubeAPIURL
+	c.Conf.YouTubeAPIURL = ""
+	defer func() { c.Conf.YouTubeAPIURL = prev }()
 
-	flagOn := feature.NewInMemoryClient(map[string]feature.Flag{
-		YouTubeGatewayFlagKey: {Key: YouTubeGatewayFlagKey, Enabled: true},
-	})
-	flagOff := feature.NewInMemoryClient(nil) // unknown key → off
-
-	// flag on → gateway
-	on := flaggedYouTubeSend{app: &App{Flags: flagOn}, gateway: gw, inproc: inproc}
-	if err := on.send(context.Background(), "c1", "hi"); err != nil {
-		t.Fatal(err)
-	}
-	if gw.calls != 1 || inproc.calls != 0 {
-		t.Errorf("flag on should route to the gateway; gw=%d inproc=%d", gw.calls, inproc.calls)
-	}
-
-	// flag off → in-process (the default until toggled)
-	off := flaggedYouTubeSend{app: &App{Flags: flagOff}, gateway: gw, inproc: inproc}
-	if err := off.send(context.Background(), "c1", "hi"); err != nil {
-		t.Fatal(err)
-	}
-	if inproc.calls != 1 {
-		t.Errorf("flag off should route in-process; inproc=%d", inproc.calls)
+	if _, ok := newYouTubeSend().(realYouTubeSend); !ok {
+		t.Error("expected realYouTubeSend when YOUTUBE_API_URL is empty")
 	}
 }
 
-func TestNewYouTubeSend_NoURLSkipsGatewayWrapper(t *testing.T) {
-	// With no YOUTUBE_API_URL there's nothing to flag — it's the plain in-process
-	// adapter, not a flaggedYouTubeSend wrapper.
-	if _, ok := newYouTubeSend(&App{}).(realYouTubeSend); !ok {
-		t.Error("expected realYouTubeSend when YOUTUBE_API_URL is empty")
+func TestNewYouTubeSend_WithURLUsesGateway(t *testing.T) {
+	// A wired instance routes through the gateway unconditionally — no flag.
+	prev := c.Conf.YouTubeAPIURL
+	c.Conf.YouTubeAPIURL = "http://gateway-youtube:8080"
+	defer func() { c.Conf.YouTubeAPIURL = prev }()
+
+	if _, ok := newYouTubeSend().(gatewayYouTubeSend); !ok {
+		t.Error("expected gatewayYouTubeSend when YOUTUBE_API_URL is set")
 	}
 }

--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -11,7 +11,6 @@ import (
 	mylog "github.com/adanalife/tripbot/pkg/chatbot/log"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/eventbus"
-	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/gateway"
 	"github.com/adanalife/tripbot/pkg/geo"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
@@ -114,7 +113,7 @@ func (a *App) ConnectYouTube(ctx context.Context) (*liveChatBinding, error) {
 	a.Chat = consoleMirror{
 		inner: youtubeChat{
 			binding: binding,
-			insert:  newYouTubeSend(a).send,
+			insert:  newYouTubeSend().send,
 		},
 		env:         c.Conf.Environment,
 		platform:    c.Conf.Platform,
@@ -123,38 +122,28 @@ func (a *App) ConnectYouTube(ctx context.Context) (*liveChatBinding, error) {
 	return binding, nil
 }
 
-// YouTubeGatewayFlagKey is the runtime kill-switch for routing outbound YouTube
-// chat sends through the platform-gateway (gateway-youtube). It defaults off
-// (the flag row doesn't exist until toggled), so even an instance wired with
-// YOUTUBE_API_URL stays in-process until the flag is flipped on — the cutover
-// (and instant revert, no restart) is a console toggle. Only meaningful when
-// YOUTUBE_API_URL is set. Mirrors TwitchGatewayFlagKey; the YouTube analog only
-// covers the outbound send — the inbound poll has no gateway endpoint.
-const YouTubeGatewayFlagKey = "chatbot.youtube_gateway"
-
 // youtubeSend is the outbound YouTube chat-send seam. The in-process path
 // inserts into the tripbot-bound live chat (chatID); the gateway path posts via
 // gateway-youtube's SendChat, which resolves the active live chat itself (so it
 // ignores chatID). Same signature as youtubeChat.insert so youtubeChat is
-// untouched. Mirrors the Twitch interface in twitch.go.
+// untouched.
 type youtubeSend interface {
 	send(ctx context.Context, chatID, text string) error
 }
 
-// newYouTubeSend wires the production send path. With no YOUTUBE_API_URL there's
-// no gateway to reach, so it's the plain in-process insert (zero-config
-// default). When a gateway IS wired, it returns a flaggedYouTubeSend that
-// dispatches per call based on the YouTubeGatewayFlagKey runtime flag — wired
-// but dormant until flipped on, revertible without a restart. Mirrors newTwitch.
-func newYouTubeSend(a *App) youtubeSend {
+// newYouTubeSend wires the production send path. A youtube instance wired with
+// YOUTUBE_API_URL routes sends through the platform-gateway (gateway-youtube)
+// unconditionally — no runtime flag. Unlike the Twitch cutover (which keeps a
+// flag as a de-risking tool for the live-prod swap), YouTube cuts straight over;
+// a revert is a git revert + redeploy. With no YOUTUBE_API_URL there's no
+// gateway to reach, so it falls back to the in-process insert — the zero-config
+// default for an un-wired instance, which goes away once pkg/youtube is deleted
+// (after the gateway owns the inbound poll too).
+func newYouTubeSend() youtubeSend {
 	if c.Conf.YouTubeAPIURL == "" {
 		return realYouTubeSend{}
 	}
-	return flaggedYouTubeSend{
-		app:     a,
-		gateway: gatewayYouTubeSend{client: gateway.New(c.Conf.YouTubeAPIURL)},
-		inproc:  realYouTubeSend{},
-	}
+	return gatewayYouTubeSend{client: gateway.New(c.Conf.YouTubeAPIURL)}
 }
 
 // realYouTubeSend is the in-process adapter — inserts into the bound live chat
@@ -175,24 +164,6 @@ type gatewayYouTubeSend struct {
 
 func (g gatewayYouTubeSend) send(ctx context.Context, _, text string) error {
 	return g.client.SendChat(ctx, "", text)
-}
-
-// flaggedYouTubeSend routes each send to the gateway or the in-process adapter
-// based on the live YouTubeGatewayFlagKey value, read from the App's flag client
-// at call time (cmd/tripbot reassigns a.Flags to the Postgres-backed, console-
-// toggleable client after New(), so the flag flips without a bot restart).
-// Mirrors flaggedTwitch.
-type flaggedYouTubeSend struct {
-	app     *App
-	gateway youtubeSend
-	inproc  youtubeSend
-}
-
-func (f flaggedYouTubeSend) send(ctx context.Context, chatID, text string) error {
-	if f.app.Flags.Bool(ctx, YouTubeGatewayFlagKey, feature.EvalContext{}) {
-		return f.gateway.send(ctx, chatID, text)
-	}
-	return f.inproc.send(ctx, chatID, text)
 }
 
 // HandleYouTubeMessage processes one inbound YouTube chat message. Identical

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -82,8 +82,9 @@ type TripbotConfig struct {
 	// in-process pkg/youtube path. Empty (the default) keeps the in-process
 	// adapter. When set — e.g. http://gateway-youtube.<env>.svc.cluster.local:8080
 	// — outbound chat send routes through the gateway's SendChat (which resolves
-	// the active live chat itself), gated by the chatbot.youtube_gateway flag. The
-	// inbound chat poll stays in-process (no gateway streaming endpoint).
+	// the active live chat itself) unconditionally; there is no runtime flag
+	// (unlike Twitch — YouTube cuts straight over). The inbound chat poll stays
+	// in-process (no gateway streaming endpoint).
 	YouTubeAPIURL string `envconfig:"YOUTUBE_API_URL"`
 
 	// NatsURL is the in-cluster NATS endpoint used for fire-and-forget


### PR DESCRIPTION
## What

Routes `tripbot-youtube`'s outbound chat-send through `gateway-youtube` **unconditionally** when `YOUTUBE_API_URL` is wired, removing the `chatbot.youtube_gateway` runtime flag and its `flaggedYouTubeSend` dispatch wrapper.

This resolves the standing conflict from [#925](https://github.com/adanalife/tripbot/pull/925/changes): that PR shipped the YouTube send slice *with* a flag mirroring Twitch's 3a, but the decision was to route YouTube **gateway-only, no flag**. Unlike the Twitch cutover (where the flag de-risks the live-prod swap), YouTube has no live-prod stakes, so a revert is just a `git revert` + redeploy — a second maintained flag + in-process dual path isn't worth it.

## Changes

- `pkg/chatbot/youtube.go` — drop `YouTubeGatewayFlagKey` + `flaggedYouTubeSend`; `newYouTubeSend()` returns `gatewayYouTubeSend` directly when `YOUTUBE_API_URL` is set, else the in-process `realYouTubeSend` fallback (the zero-config default for an un-wired instance; goes away when `pkg/youtube` is deleted later).
- `db/migrate/024_*` — removes the flag row seeded by 023. Safe across a rollout either ordering (pre-deploy code reads a missing flag as off → in-process; post-deploy code ignores it).
- Comment-only updates in `pkg/config/tripbot/type.go` + the two cdk8s files (no synth output change).
- Tests: drop the flag-dispatch test, add a `YOUTUBE_API_URL`-set → gateway assertion.

## Scope

This is **step 1** of the YouTube → gateway full cutover (runtime routing). The inbound chat poll still runs in-process — removing tripbot's YouTube **auth** entirely is gated on the gateway growing an inbound capability + owning OAuth, tracked separately.

The in-process send path stays for un-wired instances until `pkg/youtube` is deleted in a later phase.