### PR TITLE
fix(pending-release): keep the towncrier draft (banner is on stderr)

### DIFF
--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -124,9 +124,10 @@ jobs:
           fi
 
           # Render the pending changelog from the fragments in changelog.d/.
+          # towncrier writes its progress banner to stderr and the rendered
+          # notes to stdout, so 2>/dev/null leaves just the changelog body.
           NEXTBARE=${NEXT#v}; NEXTBARE=${NEXTBARE:-Unreleased}
-          DRAFT=$(uvx towncrier build --draft --config towncrier.toml --version "$NEXTBARE" 2>/dev/null \
-            | sed '1,/What is seen below is what would be written./d')
+          DRAFT=$(uvx towncrier build --draft --config towncrier.toml --version "$NEXTBARE" 2>/dev/null)
 
           BUMP_LINE="**Suggested bump:** \`$BUMP\`"
           if [ -n "$NEXT" ]; then


### PR DESCRIPTION
Follow-up to #933. The standing pending-release PR was reporting **"No changelog fragments"** even though develop has fragments.

**Cause:** the draft capture did `uvx towncrier build --draft ... 2>/dev/null | sed '1,/What is seen below.../d'` to strip towncrier's progress banner. But that banner goes to **stderr** (suppressed by `2>/dev/null`), so the `sed` range never matched and deleted the entire draft. (My pre-merge tests used `2>&1`, which masked it.)

**Fix:** drop the `sed` — stdout is already just the rendered notes. Verified locally: the draft now renders the queued fragments (#935 + the two CI entries).

Labeled `skip-changelog`: this corrects unreleased tooling whose end-state is already described by #933's pending-release changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)