### PR TITLE
fix: two bugs in the #933 release-automation tooling

### DIFF
--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -72,11 +72,14 @@ jobs:
 
           # Nothing queued (develop is in sync with master, e.g. just after a
           # release): retire the standing draft if one is open, then stop.
-          if [ "$AHEAD" -eq 0 ]; then
+          # Use the net file diff, not the commit count — right after a release
+          # the back-merge leaves develop "ahead" by merge commits with no
+          # actual changes, and `gh pr create` errors on an empty diff.
+          if [ "$AHEAD" -eq 0 ] || git diff --quiet "origin/master...HEAD"; then
             if [ -n "$NUM" ] && [ "$IS_DRAFT" = "true" ]; then
               gh pr close "$NUM" --comment "develop is in sync with master — nothing pending. A fresh draft opens when new work lands on develop."
             fi
-            echo "develop has no commits ahead of master; nothing to stage."
+            echo "develop has no net changes over master; nothing to stage."
             exit 0
           fi
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -103,19 +103,19 @@ tasks:
     vars:
       TYPE: '{{.TYPE | default "misc"}}'
     cmds:
-      - uvx towncrier create -c towncrier.toml --edit {{.PR}}.{{.TYPE}}.md
+      - uvx towncrier create --config towncrier.toml --edit {{.PR}}.{{.TYPE}}.md
 
   changelog:preview:
     desc: Preview the pending changelog from the current fragments (towncrier draft)
     cmds:
-      - uvx towncrier build --draft -c towncrier.toml --version {{.VERSION | default "Unreleased"}}
+      - uvx towncrier build --draft --config towncrier.toml --version {{.VERSION | default "Unreleased"}}
 
   changelog:build:
     desc: Collate fragments into CHANGELOG.md for a release + delete them (VERSION=3.9.0)
     requires:
       vars: [VERSION]
     cmds:
-      - uvx towncrier build --yes -c towncrier.toml --version {{trimPrefix "v" .VERSION}}
+      - uvx towncrier build --yes --config towncrier.toml --version {{trimPrefix "v" .VERSION}}
 
   # Release smoke flow.
   # Targets the local k3d cluster running the stage-1 overlay


### PR DESCRIPTION
Two fixes to the towncrier/release-automation tooling from #933 (both unreleased, so `skip-changelog`):

1. **`changelog:{add,preview,build}` tasks used `-c` instead of `--config`.** `-c` errors on `towncrier build` and means `--content` on `create` — all three tasks were broken. Verified `task changelog:preview` works now.
2. **`pending-release` failed after a release + back-merge.** develop ends up 'ahead' of master only by merge commits with no net diff, so `gh pr create` errored on an empty diff and `set -e` killed the run. Now gates on `git diff --quiet origin/master...HEAD`. (Caught live on platform-gateway's first release with this system — same code, latent here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)