### PR TITLE
feat: onscreens-server reports to its own Sentry project

### DIFF
--- a/cdk8s/adanalife_k8s/constructs/onscreens.py
+++ b/cdk8s/adanalife_k8s/constructs/onscreens.py
@@ -69,10 +69,10 @@ class OnscreensServer(Construct):
                 k8s.EnvFromSource(
                     config_map_ref=k8s.ConfigMapEnvSource(name=f"{name}-config")
                 ),
-                # onscreens-server reuses the vlc-server Sentry DSN for now.
+                # onscreens-server reports to its own Sentry project.
                 k8s.EnvFromSource(
                     secret_ref=k8s.SecretEnvSource(
-                        name="sentry-vlc-server", optional=False
+                        name="sentry-onscreens-server", optional=False
                     )
                 ),
                 k8s.EnvFromSource(

--- a/cdk8s/dist/development-onscreens-twitch.k8s.yaml
+++ b/cdk8s/dist/development-onscreens-twitch.k8s.yaml
@@ -46,7 +46,7 @@ spec:
             - configMapRef:
                 name: onscreens-twitch-config
             - secretRef:
-                name: sentry-vlc-server
+                name: sentry-onscreens-server
                 optional: false
             - secretRef:
                 name: grafana-cloud-otlp

--- a/cdk8s/dist/local-onscreens-twitch.k8s.yaml
+++ b/cdk8s/dist/local-onscreens-twitch.k8s.yaml
@@ -45,7 +45,7 @@ spec:
             - configMapRef:
                 name: onscreens-twitch-config
             - secretRef:
-                name: sentry-vlc-server
+                name: sentry-onscreens-server
                 optional: false
             - secretRef:
                 name: grafana-cloud-otlp

--- a/cdk8s/dist/prod-1-onscreens-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-onscreens-twitch.k8s.yaml
@@ -46,7 +46,7 @@ spec:
             - configMapRef:
                 name: onscreens-twitch-config
             - secretRef:
-                name: sentry-vlc-server
+                name: sentry-onscreens-server
                 optional: false
             - secretRef:
                 name: grafana-cloud-otlp

--- a/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
@@ -46,7 +46,7 @@ spec:
             - configMapRef:
                 name: onscreens-youtube-config
             - secretRef:
-                name: sentry-vlc-server
+                name: sentry-onscreens-server
                 optional: false
             - secretRef:
                 name: grafana-cloud-otlp

--- a/cdk8s/dist/stage-1-onscreens-twitch.k8s.yaml
+++ b/cdk8s/dist/stage-1-onscreens-twitch.k8s.yaml
@@ -54,7 +54,7 @@ spec:
             - configMapRef:
                 name: onscreens-twitch-config
             - secretRef:
-                name: sentry-vlc-server
+                name: sentry-onscreens-server
                 optional: false
             - secretRef:
                 name: grafana-cloud-otlp

--- a/cdk8s/dist/stage-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-onscreens-youtube.k8s.yaml
@@ -54,7 +54,7 @@ spec:
             - configMapRef:
                 name: onscreens-youtube-config
             - secretRef:
-                name: sentry-vlc-server
+                name: sentry-onscreens-server
                 optional: false
             - secretRef:
                 name: grafana-cloud-otlp

--- a/changelog.d/944.onscreens.md
+++ b/changelog.d/944.onscreens.md
@@ -1,0 +1,1 @@
+**onscreens-server reports to its own Sentry project.** Its Sentry `envFrom` swaps from the shared `sentry-vlc-server` Secret to a dedicated `sentry-onscreens-server`, so onscreens errors no longer masquerade as vlc-server's. SM container + ExternalSecret provisioned in infra; per the one-project-per-binary model.


### PR DESCRIPTION
Swaps the onscreens-server deployment's Sentry `envFrom` from the shared `sentry-vlc-server` Secret to its own `sentry-onscreens-server`, so its errors land in a dedicated Sentry project instead of being attributed to vlc-server.

Per the per-component model (one Sentry project per binary; `observability-projects-by-component` ADR). The SM container + ExternalSecret are provisioned by sibling infra PR adanalife/infra#775.

## Handoff notes
- **Seed order:** seed the `k8s/sentry-onscreens-server` DSN *before* this rolls, or onscreens loses Sentry capture in the gap (new Secret starts as a placeholder with no `SENTRY_DSN`, so Sentry is inert until seeded).
- Local dev that runs onscreens now references the `sentry-onscreens-server` secret name (was `sentry-vlc-server`) — same `optional=False` as before.

Closes the `infra/TODO.md` "Mint a dedicated sentry-onscreens-server DSN" item (with #775).