### PR TITLE
ci: validate PR title follows Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: PR title
+name: pr-title
 
 # Conventional Commits enforcement for the SQUASH SUBJECT. The commit-msg
 # pre-commit hook only guards local commits; because PRs squash-merge, the PR

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,22 @@
+name: PR title
+
+# Conventional Commits enforcement for the SQUASH SUBJECT. The commit-msg
+# pre-commit hook only guards local commits; because PRs squash-merge, the PR
+# *title* becomes the commit subject written to history, so it is validated
+# here. Mark this check "required" in branch protection to block non-conforming
+# titles. See vault/decisions/conventional-commits.md.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional:
+    name: conventional
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/+pr-title-conventional.ci.md
+++ b/changelog.d/+pr-title-conventional.ci.md
@@ -1,0 +1,1 @@
+**PR titles are now checked against [Conventional Commits](https://www.conventionalcommits.org) in CI.** A `pr-title` workflow (`amannn/action-semantic-pull-request`) fails a PR whose title isn't `type(scope): summary`. This closes the gap where the local `commit-msg` hook couldn't reach the squash subject — since develop PRs squash-merge, the PR title is what lands in history.


### PR DESCRIPTION
Closes the CI gap on the Conventional Commits standard.

The `conventional-pre-commit` hook is a **`commit-msg`-stage** hook, so it only fires on local `git commit` — `pre-commit run --all-files` in CI skips it. And since this repo squash-merges, the **PR title** becomes the commit subject written to history, which nothing validated until now.

This adds `amannn/action-semantic-pull-request@v6` to check the PR title is `type(scope): summary`. To make it blocking, mark the `conventional` check **required** in branch protection.
Part of a cross-repo CI rollout for the commit-message standard:
- [tripbot#946](https://github.com/adanalife/tripbot/pull/946/changes)
- [infra#777](https://github.com/adanalife/infra/pull/777/changes)
- [website#240](https://github.com/adanalife/website/pull/240/changes)
- [tripbot-console#58](https://github.com/adanalife/tripbot-console/pull/58/changes)
- [video-pipeline#56](https://github.com/adanalife/video-pipeline/pull/56/changes)
- [platform-gateway#36](https://github.com/adanalife/platform-gateway/pull/36/changes) (also adds `pre-commit.yml`)

Follows the standard rolled out in [the earlier batch](https://github.com/adanalife/tripbot/pull/943/changes).