### PR TITLE
ci: match ARC runner by name prefix, not label

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -106,8 +106,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # ARC scale-set runners route by scale-set NAME (runs-on:
+          # arc-arm64-tripbot) and report empty .labels via this API, so match on
+          # the runner name prefix, not a label.
           online=$(gh api "repos/${{ github.repository }}/actions/runners" \
-            --jq 'any(.runners[]; .status=="online" and (.labels|any(.name=="arc-arm64-tripbot")))')
+            --jq 'any(.runners[]; .status=="online" and (.name|startswith("arc-arm64-tripbot")))')
           if [ "$online" = "true" ]; then
             echo "arm64_runner=arc-arm64-tripbot" >> "$GITHUB_OUTPUT"
             echo "::notice::arm64 legs → self-hosted rpi5 runner (arc-arm64-tripbot)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # ARC scale-set runners route by scale-set NAME (runs-on:
+          # arc-arm64-tripbot) and report empty .labels via this API, so match on
+          # the runner name prefix, not a label.
           online=$(gh api "repos/${{ github.repository }}/actions/runners" \
-            --jq 'any(.runners[]; .status=="online" and (.labels|any(.name=="arc-arm64-tripbot")))')
+            --jq 'any(.runners[]; .status=="online" and (.name|startswith("arc-arm64-tripbot")))')
           if [ "$online" = "true" ]; then
             echo "arm64_runner=arc-arm64-tripbot" >> "$GITHUB_OUTPUT"
             echo "::notice::arm64 legs → self-hosted rpi5 runner (arc-arm64-tripbot)"


### PR DESCRIPTION
Follow-up to #948. On the first develop merge that exercised the picker, the arm64 legs **fell back to GitHub-hosted** even though the Pi runner was online and idle — they ran on `GitHub Actions 1000027…` runners, not `arc-arm64-tripbot`.

**Cause:** the `pick-runner` probe matched a runner *label* (`.labels|any(.name=="arc-arm64-tripbot")`), but ARC v2 scale-set runners are routed by the scale-set **name** (`runs-on: arc-arm64-tripbot`) and register with **empty `.labels`** via the runners API. So the predicate was always false → always fell back.

```
$ gh api repos/adanalife/tripbot/actions/runners --jq '.runners[]|{name,status,labels:[.labels[].name]}'
{"name":"arc-arm64-tripbot-vrgrg-runner-9l28v","status":"online","labels":[]}
```

**Fix:** match the runner **name prefix** (`.name|startswith("arc-arm64-tripbot")`) — the ephemeral runners are named `arc-arm64-tripbot-<…>-runner-<…>`. Verified live: the name-prefix probe returns `true` where the label probe returned `false`.

The fallback machinery itself worked correctly (gh-hosted builds succeeded) — only the detection predicate was wrong. `skip-changelog`: this corrects the still-unreleased #948 fragment, so the eventual release entry already describes the working behavior.

Once merged, the next develop merge should route the arm64 legs to the Pi (watch `kubectl -n arc-runners get pods` scale to 2).