### PR TITLE
fix(onscreens): halve right-rotator interval to 45s to bound OSR blank recovery

### DIFF
--- a/changelog.d/953.onscreens.md
+++ b/changelog.d/953.onscreens.md
@@ -1,0 +1,1 @@
+Right-rotator overlay now rotates every 45s (was 90s), matching the left, to bound how long a stale/blank CEF offscreen frame stays on screen before the next rotation repaints it. [#953](https://github.com/adanalife/tripbot/pull/953)

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -5,7 +5,15 @@ import (
 	"time"
 )
 
-var rightRotatorUpdateFrequency = time.Duration(90 * time.Second)
+// Matches the left rotator's 45s cadence. Beyond pacing the message swap, the
+// interval doubles as a blank-recovery cadence: OBS renders this overlay via
+// GPU-accelerated CEF offscreen rendering (BrowserHWAccel=true), whose
+// shared-texture handoff occasionally gets a stale/blank frame stuck — and CEF
+// only pushes a fresh frame when the rendered pixels actually change. A content
+// rotation is what forces that repaint, so a shorter interval bounds how long a
+// stuck-blank overlay stays blank. This was 90s, which left the right rotator
+// visibly blank ~2x longer than the left (the asymmetry that surfaced the bug).
+var rightRotatorUpdateFrequency = time.Duration(45 * time.Second)
 
 // All right-rotator lines are platform-neutral (!location and !timewarp are both
 // in the YouTube allowlist). Weight 2 reproduces the old duplicated entries.


### PR DESCRIPTION
## What

Drops the right rotator's message-rotation interval from **90s → 45s**, matching the left rotator (`left-rotator.go:9`).

## Why

While watching prod (onscreens 3.8.0), the **right** rotator was blank while the left was fine. Investigated on the live OBS pod, read-only, via `GetSourceScreenshot` over OBS WebSocket:

- Server was healthy — `state.json` had both rotators `showing:true` with valid content.
- At the OBS source level, `right rotating` rendered a blank/transparent frame while `left rotating` had text. So the blank lives in OBS's **GPU-accelerated CEF offscreen renderer** (`BrowserHWAccel=true`), whose shared-texture handoff occasionally gets a stale/blank frame stuck.
- CEF only pushes a fresh frame when the rendered **pixels change**. The page re-sets `innerHTML` to identical content every 500ms (no pixel change → no repaint), so a stuck-blank overlay stays blank until the content **rotates** to a different message — which forces the repaint and self-heals. OBS logs confirmed no source reload; it recovered in place. A 5-min monitor showed it stable across two rotation cycles once healed.

The left rotates every **45s**, the right every **90s** — so the right stayed visibly blank up to ~2× longer. That asymmetry is the whole 'left fine, right missing' symptom.

This is a **mitigation**, not a root-cause fix: it halves worst-case blank exposure and makes the two rotators symmetric. It does not eliminate the underlying OSR stale-texture path (the deliberate `BrowserHWAccel=true` from #611). Heal remains probabilistic — a weighted-random repeat of the same message doesn't change pixels — but the exposure window is now bounded the same as the left's.

Follow-on to #916 (shipped 3.8.0), which removed the compositing layer that blanked the rotators on *every* rotation; this addresses the residual intermittent stale-frame.

## Test

- `go build ./pkg/onscreens-server/` ✓, gofmt clean.
- Single interval constant; render path unchanged.