### PR TITLE
Release v3.9.1

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,6 +9,12 @@ name: pr-title
 # Scoped to develop-targeting PRs only: release PRs to master merge-commit
 # (not squash), so their title (`Release vX.Y.Z`) never becomes a commit
 # subject and isn't a conventional type — exempting them here.
+#
+# The standing back-merge PR (backmerge/master-to-develop, opened by
+# backmerge.yml) DOES target develop but is likewise merged with a merge commit
+# (never squashed), so its `⏪ Back-merge…` title never becomes a commit subject
+# either — the step below skips it by head branch. A skipped step still reports
+# the `conventional` job as success, so the required check stays green.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -22,6 +28,7 @@ jobs:
     name: conventional
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - if: github.head_ref != 'backmerge/master-to-develop'
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Unreleased changes live as fragment files in [`changelog.d/`](changelog.d/) and 
 
 <!-- towncrier release notes start -->
 
+## [v3.9.1] — 2026-06-21
+
+### CI / Tooling
+
+- Exempt the standing back-merge PR (`backmerge/master-to-develop`) from the conventional PR-title check — it merges with a merge commit, so its title never becomes a commit subject. ([#952](https://github.com/adanalife/tripbot/pull/952))
+
 ## [v3.9.0] — 2026-06-21
 
 Minor release. Completes the YouTube→platform-gateway migration: with both chat directions routed through `gateway-youtube`, tripbot holds no YouTube token at any point in its lifecycle, and the in-process YouTube auth + Data-API client are deleted. Prod now serves the dashcam corpus from the minipc's local NVMe instead of the NAS (with an instant NFS fallback), onscreens-server reports to its own Sentry project, and a consumer-side `tripbot_gateway_up` reachability metric lands. Rounds out with a batch of release-engineering upgrades — towncrier changelog fragments, Conventional Commits enforcement on commits and PR titles, and arm64 release builds routed to a self-hosted rpi5 runner with GitHub-hosted fallback.

--- a/changelog.d/952.ci.md
+++ b/changelog.d/952.ci.md
@@ -1,0 +1,1 @@
+Exempt the standing back-merge PR (`backmerge/master-to-develop`) from the conventional PR-title check — it merges with a merge commit, so its title never becomes a commit subject.

--- a/changelog.d/952.ci.md
+++ b/changelog.d/952.ci.md
@@ -1,1 +1,0 @@
-Exempt the standing back-merge PR (`backmerge/master-to-develop`) from the conventional PR-title check — it merges with a merge commit, so its title never becomes a commit subject.

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -5,7 +5,15 @@ import (
 	"time"
 )
 
-var rightRotatorUpdateFrequency = time.Duration(90 * time.Second)
+// Matches the left rotator's 45s cadence. Beyond pacing the message swap, the
+// interval doubles as a blank-recovery cadence: OBS renders this overlay via
+// GPU-accelerated CEF offscreen rendering (BrowserHWAccel=true), whose
+// shared-texture handoff occasionally gets a stale/blank frame stuck — and CEF
+// only pushes a fresh frame when the rendered pixels actually change. A content
+// rotation is what forces that repaint, so a shorter interval bounds how long a
+// stuck-blank overlay stays blank. This was 90s, which left the right rotator
+// visibly blank ~2x longer than the left (the asymmetry that surfaced the bug).
+var rightRotatorUpdateFrequency = time.Duration(45 * time.Second)
 
 // All right-rotator lines are platform-neutral (!location and !timewarp are both
 // in the YouTube allowlist). Weight 2 reproduces the old duplicated entries.


### PR DESCRIPTION
Patch release. One CI fix since [v3.9.0](https://github.com/adanalife/tripbot/releases/tag/v3.9.0).

### CI / Tooling

- Exempt the standing back-merge PR (\`backmerge/master-to-develop\`) from the conventional PR-title check — it merges with a merge commit, so its title never becomes a commit subject. ([#952](https://github.com/adanalife/tripbot/pull/952/changes))

---

**Merge note:** merge with a **merge commit** (not squash, per the merge-strategy convention) and include **`#patch`** in the merge commit subject so auto-tag cuts `v3.9.1`. After it merges, the standing back-merge PR syncs `master` → `develop`.