### PR TITLE
ci(pending-release): don't abort the bump heuristic when changelog.d is empty

### DIFF
--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -101,9 +101,13 @@ jobs:
           #      fix/ci/cleanup/misc implies feature work -> minor.
           SUBJECTS=$(git log --no-merges --pretty=format:'%s' "origin/master..HEAD")
           BODIES=$(git log --no-merges --pretty=format:'%b' "origin/master..HEAD")
+          # `|| true`: with no fragments (e.g. right after a release build
+          # consumed them all) the grep matches nothing and exits 1, which
+          # under `set -o pipefail` + `set -e` would abort the whole job. An
+          # empty HASFEAT just means "no minor signal", not an error.
           HASFEAT=$(find changelog.d -maxdepth 1 -type f -name '*.md' 2>/dev/null \
             | sed -nE 's#.*\.([a-z]+)\.md$#\1#p' \
-            | grep -vE '^(fix|ci|cleanup|misc|summary)$' | head -1)
+            | grep -vE '^(fix|ci|cleanup|misc|summary)$' | head -1 || true)
           if echo "$SUBJECTS" | grep -qE '^[a-z]+(\(.+\))?!:' \
             || echo "$BODIES" | grep -q 'BREAKING CHANGE'; then
             BUMP="major"


### PR DESCRIPTION
## Problem

`pending-release` failed at **release-cut time** in all three repos (observed on platform-gateway #28 and tripbot-console #62). The job aborted in <1s with no output.

## Root cause

The suggested-bump heuristic scans changelog fragment types:

```sh
HASFEAT=$(find changelog.d -maxdepth 1 -type f -name "*.md" \
  | sed -nE "s#...#...#p" | grep -vE "^(...)$" | head -1)
```

Right after `task changelog:build` consumes every fragment, `find` returns nothing, so `grep -vE` matches nothing and **exits 1**. Under `set -o pipefail` + `set -e` (`bash -e`), that aborts the whole job. It only triggers when `changelog.d/` is empty *and* develop is ahead of master — i.e. exactly the post-release-build state — which is why it bit precisely when cutting a release.

It is cosmetic (never blocked a merge), but it puts a spurious red ✗ on every release PR.

## Fix

Append `|| true` to that command substitution so an empty result means "no minor signal" rather than a fatal error. Verified under `bash -euo pipefail`: empty → no abort, `fix`-only → no false minor, a feature fragment → still detects minor.

Part of a 3-repo fix (same shared workflow): tripbot, platform-gateway, tripbot-console.

---
**Sibling PRs (same fix):** tripbot adanalife/tripbot#961 · platform-gateway adanalife/platform-gateway#41 · tripbot-console adanalife/tripbot-console#63