### PR TITLE
feat(youtube): bot-less prod launch — poll gate + promo rotators

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -184,6 +184,16 @@ class EnvConfig:
     # in-process pkg/youtube send. The inbound chat poll stays in-process
     # regardless (no gateway streaming endpoint).
     youtube_api_url: str = ""
+    # Gate the youtube instance's inbound chat poll (tripbot's
+    # YOUTUBE_INBOUND_ENABLED + onscreens' rotator copy). False = bot-less
+    # YouTube: outbound rotators + background jobs run, but nothing reads chat
+    # (no command responds) and the rotators advertise promo copy pointing at
+    # Twitch instead of commands. Prod launches bot-less while the YouTube Data
+    # API quota extension is pending — prod's 2s poll floor would blow the
+    # default 10k/day quota. Flip to True the day the extension lands. Stage
+    # stays True: its 10s floor fits the default quota, so it runs the full bot
+    # for testing. Only meaningful on a youtube instance.
+    youtube_inbound_enabled: bool = True
 
     def tag_for(self, component: str) -> str:
         """Image tag for a component: its pinned release tag when versions.yaml
@@ -278,6 +288,10 @@ ENVS: dict[str, EnvConfig] = {
         # ExternalSecret to sync.
         platforms=("twitch", "youtube"),
         parked_platforms=("youtube",),
+        # prod youtube launches bot-less: inbound chat poll off (quota extension
+        # pending), so rotators serve promo copy and no command responds. Flip to
+        # True when the YouTube Data API quota lands. See youtube_inbound_enabled.
+        youtube_inbound_enabled=False,
         # prod twitch is the always-live stream; youtube boots idle until flip-on
         obs_streaming=("twitch",),
         # The live stream always wins: prod app pods outrank default-priority

--- a/cdk8s/adanalife_k8s/constructs/onscreens.py
+++ b/cdk8s/adanalife_k8s/constructs/onscreens.py
@@ -47,6 +47,12 @@ class OnscreensServer(Construct):
         # advertise Twitch-only commands (!miles, !guess). onscreens-server reads
         # ONSCREENS_SERVER_PLATFORM (defaults to twitch if unset).
         data["ONSCREENS_SERVER_PLATFORM"] = platform
+        # Bot-less YouTube: when the youtube pipeline's inbound chat is off, the
+        # rotators serve promo copy instead of command hints (no command can
+        # respond). Mirrors tripbot's YOUTUBE_INBOUND_ENABLED so both surfaces
+        # flip together. Only stamped when disabled (binary defaults to enabled).
+        if platform == "youtube" and not env.youtube_inbound_enabled:
+            data["ONSCREENS_SERVER_YOUTUBE_INBOUND_ENABLED"] = "false"
         cfg_hash = configmap.config_map(
             self,
             "config",

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -185,6 +185,12 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
     # twitch instance never carries it. Routed unconditionally when wired (no flag).
     if platform == "youtube" and env.youtube_api_url:
         data["YOUTUBE_API_URL"] = env.youtube_api_url
+    # Bot-less YouTube: gate off the inbound chat poll. Only stamped when
+    # disabled (the binary defaults to enabled) so a live, inbound-enabled
+    # youtube instance keeps a minimal ConfigMap and no needless config-hash
+    # rollout. The chatbot also swaps to promo help copy when this is false.
+    if platform == "youtube" and not env.youtube_inbound_enabled:
+        data["YOUTUBE_INBOUND_ENABLED"] = "false"
     return data
 
 

--- a/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
@@ -10,6 +10,7 @@ data:
   ENV: production
   NATS_URL: nats://nats.prod-1-platform.svc.cluster.local:4222
   ONSCREENS_SERVER_PLATFORM: youtube
+  ONSCREENS_SERVER_YOUTUBE_INBOUND_ENABLED: "false"
   OTEL_RESOURCE_ATTRIBUTES: deployment.environment=prod-1,service.namespace=tripbot,service.platform=youtube
   OTEL_SDK_DISABLED: "false"
   OTEL_TRACES_SAMPLER: parentbased_traceidratio
@@ -37,7 +38,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: "9313331745"
+        adanalife.dev/config-hash: e0054f4b89
       labels:
         app: onscreens-youtube
     spec:

--- a/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
@@ -28,6 +28,7 @@ data:
   TRIPBOT_SERVER_PORT: "8080"
   VERBOSE: "false"
   VLC_SERVER_HOST: vlc-youtube:8080
+  YOUTUBE_INBOUND_ENABLED: "false"
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -65,7 +66,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 6ad4f51ca5
+        adanalife.dev/config-hash: 54a56afcd2
       labels:
         app: tripbot-youtube
     spec:

--- a/changelog.d/962.chatbot.md
+++ b/changelog.d/962.chatbot.md
@@ -1,0 +1,1 @@
+Bot-less YouTube mode: `YOUTUBE_INBOUND_ENABLED` (default true) gates the inbound chat poll. When off, the Chatter/!help rotator serves promotional copy pointing viewers at the live Twitch channel instead of commands that can't respond.

--- a/changelog.d/962.deploy.md
+++ b/changelog.d/962.deploy.md
@@ -1,0 +1,1 @@
+Prod YouTube launches bot-less while the YouTube Data API quota extension is pending — the inbound chat poll is off (it would blow the default quota at prod's 2s floor), so the bot streams and posts but answers no commands. Stage keeps the full bot for testing.

--- a/changelog.d/962.onscreens.md
+++ b/changelog.d/962.onscreens.md
@@ -1,0 +1,1 @@
+On-screen left/right rotators serve promotional copy (watch & chat live on Twitch, interactivity coming soon) on a bot-less YouTube instance instead of advertising chat commands that no-op there.

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -270,8 +270,18 @@ func (t *Tripbot) connectToYouTube(ctx context.Context) {
 	}
 
 	t.app.ConnectYouTubeViaGateway()
-	go t.app.NewGatewayYouTubeChatPoller().Run(ctx)
-	slog.InfoContext(ctx, "youtube chat via gateway (inbound + outbound)", "gateway", c.Conf.YouTubeAPIURL)
+	if c.Conf.YouTubeInboundEnabled {
+		go t.app.NewGatewayYouTubeChatPoller().Run(ctx)
+		slog.InfoContext(ctx, "youtube chat via gateway (inbound + outbound)", "gateway", c.Conf.YouTubeAPIURL)
+	} else {
+		// Bot-less mode: outbound posting (rotators) + background jobs stay up,
+		// but the inbound poll — the expensive YouTube Data API spend — is off,
+		// so no command responds. The chatbot serves promo copy instead of
+		// command ads (see enabledHelpMessages). Flip YOUTUBE_INBOUND_ENABLED
+		// to true once the quota extension lands.
+		slog.WarnContext(ctx, "youtube inbound chat disabled (bot-less mode); outbound + jobs only",
+			"gateway", c.Conf.YouTubeAPIURL, "fix", "set YOUTUBE_INBOUND_ENABLED=true to read chat")
+	}
 
 	// nothing else to do on the main goroutine — the poller and HTTP server
 	// run until the signal handler shuts the process down.

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -30,6 +30,14 @@ type App struct {
 	// (indexCommands): Twitch runs the full registry, YouTube runs the v1
 	// allowlist. Empty is treated as Twitch. Set from c.Conf.Platform in New().
 	Platform string
+	// botless, when true, makes the rotating Chatter / !help lines advertise
+	// promo copy (follow on Twitch, interactivity coming soon) instead of
+	// command ads — for a YouTube instance running with inbound chat disabled,
+	// where no command can respond. Set in New() from
+	// c.Conf.Platform == "youtube" && !c.Conf.YouTubeInboundEnabled. The
+	// zero value (false) keeps the normal per-platform command-filtered help,
+	// so directly-constructed test Apps are unaffected unless they opt in.
+	botless bool
 	// DB is the GORM handle used by commands that need to read or write the
 	// database. nil in tests that don't exercise the DB; otherwise either the
 	// real database.GormDB() or a sqlmock-backed gorm.DB.
@@ -142,6 +150,7 @@ func (a *App) db() *gorm.DB {
 func New() *App {
 	a := &App{
 		Platform: c.Conf.Platform,
+		botless:  c.Conf.Platform == platformYouTube && !c.Conf.YouTubeInboundEnabled,
 		// DB stays nil; commands use a.db() which falls back to database.GormDB().
 		Onscreens:  realOnscreens{c: onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment)},
 		VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)},

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -347,6 +347,13 @@ func (a *App) indexCommands() {
 // never advertises a command that would silently no-op. A line that doesn't
 // start with a "!command" token is always kept.
 func (a *App) enabledHelpMessages() []string {
+	// A bot-less instance (YouTube with inbound chat disabled) can't answer any
+	// command, so advertise promo copy pointing at Twitch instead of command
+	// hints that would silently no-op. These lines carry no "!command" token, so
+	// they skip the per-platform command filtering below.
+	if a.botless {
+		return slices.Clone(c.YouTubeBotlessHelpMessages)
+	}
 	out := make([]string, 0, len(c.HelpMessages))
 	for _, msg := range c.HelpMessages {
 		fields := strings.Fields(msg)

--- a/pkg/chatbot/registry_test.go
+++ b/pkg/chatbot/registry_test.go
@@ -2,6 +2,7 @@ package chatbot
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -172,3 +173,26 @@ func TestEnabledHelpMessagesFiltersByPlatform(t *testing.T) {
 		t.Error("YouTube help messages unexpectedly empty")
 	}
 }
+
+// TestBotlessHelpMessagesAdvertiseNoCommands verifies a bot-less instance
+// (YouTube with inbound chat disabled) swaps its rotating help lines for the
+// promo set and advertises no "!command" token — typing a command into an
+// unread YouTube chat would look like a broken bot.
+func TestBotlessHelpMessagesAdvertiseNoCommands(t *testing.T) {
+	yt := &App{Platform: platformYouTube, botless: true}
+	yt.indexCommands()
+
+	if len(yt.helpMessages) != len(c.YouTubeBotlessHelpMessages) {
+		t.Fatalf("bot-less help should be the promo set (%d lines), got %d",
+			len(c.YouTubeBotlessHelpMessages), len(yt.helpMessages))
+	}
+	for _, msg := range yt.helpMessages {
+		if commandToken.MatchString(msg) {
+			t.Errorf("bot-less help line advertises a command: %q", msg)
+		}
+	}
+}
+
+// commandToken matches a chat-command token ("!" followed by a letter, e.g.
+// !location) without matching a bare "!" used as punctuation.
+var commandToken = regexp.MustCompile(`![a-zA-Z]`)

--- a/pkg/config/onscreens-server/type.go
+++ b/pkg/config/onscreens-server/type.go
@@ -34,4 +34,12 @@ type OnscreensServerConfig struct {
 	// YouTube overlay doesn't advertise Twitch-only commands. Defaults to twitch
 	// (the primary platform). Set by infra per onscreens-<platform> pod.
 	Platform string `default:"twitch" envconfig:"PLATFORM"`
+
+	// YouTubeInboundEnabled mirrors tripbot's gate of the same name for this
+	// pipeline's platform. When false on a youtube instance the bot isn't
+	// reading chat, so the rotators advertise promotional copy (watch/chat on
+	// Twitch, interactivity coming soon) instead of command hints that would
+	// no-op. Default true; ignored on twitch. Stamped per-pipeline by infra
+	// alongside tripbot's flag so both surfaces flip together.
+	YouTubeInboundEnabled bool `default:"true" envconfig:"YOUTUBE_INBOUND_ENABLED"`
 }

--- a/pkg/config/tripbot/helpers.go
+++ b/pkg/config/tripbot/helpers.go
@@ -41,6 +41,21 @@ var HelpMessages = []string{
 	"!timewarp: Magically warp to a new moment in time",
 }
 
+// YouTubeBotlessHelpMessages are the rotating Chatter / !help lines a bot-less
+// YouTube instance posts (YOUTUBE_INBOUND_ENABLED=false). With no chat reader,
+// the interactive commands can't respond, so these advertise the live Twitch
+// channel and signal that YouTube interactivity is on the way. Deliberately
+// free of any "!command" token: a command a YouTube viewer types into an unread
+// chat looks like a broken bot. Swapped in by enabledHelpMessages when the App
+// is bot-less.
+var YouTubeBotlessHelpMessages = []string{
+	"Want to chat? The interactive bot is live right now on Twitch → twitch.tv/ADanaLife_",
+	"Interactive commands are coming to YouTube soon — follow so you don't miss it!",
+	"Curious where we are or what day this was? Ask the bot live on Twitch: twitch.tv/ADanaLife_",
+	"Driving across America, 24 hours a day. Watch and chat live on Twitch → twitch.tv/ADanaLife_",
+	"This is a bot-powered slow-TV roadtrip. The full interactive experience is on Twitch: twitch.tv/ADanaLife_",
+}
+
 var GoogleMapsStyle = []string{
 	"element:geometry|color:0x242f3e",
 	"element:labels.text.fill|color:0x746855",

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -74,6 +74,16 @@ type TripbotConfig struct {
 	// gone, so with this empty the instance comes up without YouTube chat.
 	YouTubeAPIURL string `envconfig:"YOUTUBE_API_URL"`
 
+	// YouTubeInboundEnabled gates the gateway-youtube inbound chat poll on a
+	// PLATFORM=youtube instance. Default true. Set false for a "bot-less"
+	// YouTube presence: outbound posting (rotators) and the background jobs keep
+	// running, but nothing reads chat, so no command can respond. When false the
+	// chatbot also swaps its rotating Chatter/!help copy from command ads to
+	// promotional lines (see pkg/chatbot enabledHelpMessages) — advertising a
+	// command nobody can run reads as a broken bot. Flip to true the day the
+	// YouTube Data API quota extension lands. No effect on Twitch.
+	YouTubeInboundEnabled bool `default:"true" envconfig:"YOUTUBE_INBOUND_ENABLED"`
+
 	// NatsURL is the in-cluster NATS endpoint used for fire-and-forget
 	// inter-component events. Format:
 	// nats://nats.<env-platform-ns>.svc.cluster.local:4222.

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -26,6 +26,16 @@ var possibleLeftMessages = []rotatorMessage{
 	// {Text: "Use !report to report stream issues"},
 }
 
+// botlessLeftMessages replace the command-hint left rotator on a bot-less
+// YouTube instance: no commands work there, so point viewers at the live,
+// interactive Twitch stream and signal that YouTube interactivity is coming.
+var botlessLeftMessages = []rotatorMessage{
+	{Text: "Chat with the bot live on Twitch", Weight: 2},
+	{Text: "twitch.tv/ADanaLife_", Weight: 2},
+	{Text: "Interactive commands coming to YouTube soon"},
+	{Text: "Follow the journey live on Twitch"},
+}
+
 // newLeftRotator constructs the left-rotator *Onscreen, primes it with a
 // first message synchronously (so the OBS browser source has content to
 // render the moment it polls — otherwise there's a brief race where the
@@ -51,6 +61,10 @@ func leftRotatorContent() string {
 	// show a special, very rare message
 	if rand.Intn(10000) == 0 {
 		return "You found the rare message! Make a clip for a prize!"
+	}
+
+	if botless() {
+		return pickRotatorMessage(botlessLeftMessages)
 	}
 
 	// pick a weighted-random message for this platform

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -24,6 +24,15 @@ var possibleRightMessages = []rotatorMessage{
 	{Text: "Streaming 24 hours a day"},
 }
 
+// botlessRightMessages replace the command-hint right rotator on a bot-less
+// YouTube instance (see botlessLeftMessages). Kept distinct from the left set so
+// the two corners don't show the same line at once.
+var botlessRightMessages = []rotatorMessage{
+	{Text: "Watch & chat live on Twitch", Weight: 2},
+	{Text: "Streaming 24 hours a day"},
+	{Text: "Don't forget to follow :)"},
+}
+
 // newRightRotator constructs the right-rotator *Onscreen, primes it with
 // a first message synchronously (so the OBS browser source has content
 // to render the moment it polls — otherwise there's a brief race where
@@ -46,6 +55,9 @@ func rightRotatorLoop(osc *Onscreen) {
 
 // rightRotatorContent creates the content for the rightRotator
 func rightRotatorContent() string {
+	if botless() {
+		return pickRotatorMessage(botlessRightMessages)
+	}
 	// pick a weighted-random message for this platform
 	return pickRotatorMessage(possibleRightMessages)
 }

--- a/pkg/onscreens-server/rotator.go
+++ b/pkg/onscreens-server/rotator.go
@@ -33,6 +33,14 @@ type rotatorMessage struct {
 	Weight    int
 }
 
+// botless reports whether this instance should show promotional copy instead of
+// command hints — true only for a YouTube pipeline whose inbound chat is off
+// (YOUTUBE_INBOUND_ENABLED=false). In that state no command can respond, so the
+// rotators must not advertise commands. Mirrors the chatbot's botless gate.
+func botless() bool {
+	return c.Conf.Platform == platformYouTube && !c.Conf.YouTubeInboundEnabled
+}
+
 // appliesTo reports whether m should show on the given platform.
 func (m rotatorMessage) appliesTo(platform string) bool {
 	if len(m.Platforms) == 0 {

--- a/pkg/onscreens-server/rotator_test.go
+++ b/pkg/onscreens-server/rotator_test.go
@@ -1,6 +1,7 @@
 package onscreensServer
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,6 +14,44 @@ func withPlatform(t *testing.T, platform string) {
 	prev := c.Conf.Platform
 	c.Conf.Platform = platform
 	t.Cleanup(func() { c.Conf.Platform = prev })
+}
+
+// withInbound sets c.Conf.YouTubeInboundEnabled for the duration of a test and
+// restores it.
+func withInbound(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := c.Conf.YouTubeInboundEnabled
+	c.Conf.YouTubeInboundEnabled = enabled
+	t.Cleanup(func() { c.Conf.YouTubeInboundEnabled = prev })
+}
+
+// TestBotlessRotatorsAdvertiseNoCommands verifies that on a bot-less YouTube
+// instance both rotators serve the promo set and never surface a "!command"
+// token (which would no-op there and look broken).
+func TestBotlessRotatorsAdvertiseNoCommands(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	withInbound(t, false)
+	// "!" followed by a letter is a command token (e.g. !location); a bare "!"
+	// as punctuation (the rare-message line) is fine.
+	commandToken := regexp.MustCompile(`![a-zA-Z]`)
+	for i := 0; i < 4000; i++ {
+		if msg := leftRotatorContent(); commandToken.MatchString(msg) {
+			t.Fatalf("bot-less left rotator surfaced a command: %q", msg)
+		}
+		if msg := rightRotatorContent(); commandToken.MatchString(msg) {
+			t.Fatalf("bot-less right rotator surfaced a command: %q", msg)
+		}
+	}
+}
+
+// TestRotatorsServeCommandsWhenInboundEnabled confirms a YouTube instance with
+// inbound chat on keeps the normal command-hint rotators (the post-quota state).
+func TestRotatorsServeCommandsWhenInboundEnabled(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	withInbound(t, true)
+	if botless() {
+		t.Fatal("YouTube with inbound enabled should not be bot-less")
+	}
 }
 
 func TestRotatorMessageAppliesTo(t *testing.T) {


### PR DESCRIPTION
## What

PR 1 of the bot-less YouTube launch. Lets prod stream on YouTube **without the chat bot** while the YouTube Data API quota extension is pending, without looking like a broken bot.

"Bot-less" = the gateway-youtube **inbound chat poll is gated off**. Reading chat (`liveChatMessages.list`, ~43k units/day at prod's 2s floor) is the quota-blocked operation; outbound posting (~50 units/call) and all background jobs keep running. So the bot still posts rotators and drives the stream — it just doesn't answer commands. Because nothing answers commands, every command-advertising rotator is repointed to promotional copy.

## Changes

- **`feat(youtube)`** — `YOUTUBE_INBOUND_ENABLED` config (default `true`) gates the inbound poll loop in `connectToYouTube`. No effect on Twitch.
- **`feat(chatbot)`** — `YouTubeBotlessHelpMessages` promo set (Twitch CTA + "interactivity coming soon", zero `!command` tokens) swapped in via an `App.botless` gate. Zero-value-safe: bare test Apps keep the normal command-filtered help.
- **`feat(onscreens)`** — on-screen left/right rotators serve promo copy when bot-less, gated by a mirrored `YOUTUBE_INBOUND_ENABLED` onscreens-server config so both surfaces flip together.
- **`feat(deploy)`** — `youtube_inbound_enabled=False` on **prod-1 only** → stamps the flag onto the prod `tripbot-youtube` + `onscreens-youtube` ConfigMaps. **Stage stays inbound-enabled** (its 10s floor fits the default quota) so it keeps running the full bot for testing; stage ConfigMaps are untouched.

## The quota-arrival flip

When the extension lands, flip prod back to the full bot with a single value: `youtube_inbound_enabled=True` (re-synth + deploy). Both the poll loop and all rotator copy revert together.

## Notes

- Prod-youtube is still **parked** (`replicas=0`); turning the stream on (un-park + wire the gateway URL + stream key) is a separate infra/deploy step.
- New tests cover both surfaces asserting no command token (`![a-zA-Z]`) leaks into bot-less copy.
- Follow-ups (separate PRs): location/date/city onscreens overlay (PR 2), console rotator editor (PR 3).