### PR TITLE
ci: drop self-hosted rpi5 runner from release workflows

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -83,44 +83,8 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/release-development.yml'
 
-  # Route the arm64 build legs to the self-hosted rpi5 runner
-  # (arc-arm64-tripbot) when it's online, else fall back to the 2x-billed
-  # GitHub-hosted arm runner — no manual intervention when the Pi is unplugged.
-  # Probes the repo's runners via the ARC GitHub App; minRunners:1 keeps one warm
-  # runner registered so "an online runner exists" is a true health signal.
-  # tripbot/vlc/onscreens consume this; obs deliberately stays GitHub-hosted (its
-  # heavy compile isn't on the Pi yet).
-  pick-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      arm64_runner: ${{ steps.pick.outputs.arm64_runner }}
-    steps:
-      - name: Mint ARC GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.ARC_APP_ID }}
-          private-key: ${{ secrets.ARC_APP_PRIVATE_KEY }}
-      - name: Pick arm64 runner (self-hosted if online, else GitHub-hosted)
-        id: pick
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          # ARC scale-set runners route by scale-set NAME (runs-on:
-          # arc-arm64-tripbot) and report empty .labels via this API, so match on
-          # the runner name prefix, not a label.
-          online=$(gh api "repos/${{ github.repository }}/actions/runners" \
-            --jq 'any(.runners[]; .status=="online" and (.name|startswith("arc-arm64-tripbot")))')
-          if [ "$online" = "true" ]; then
-            echo "arm64_runner=arc-arm64-tripbot" >> "$GITHUB_OUTPUT"
-            echo "::notice::arm64 legs → self-hosted rpi5 runner (arc-arm64-tripbot)"
-          else
-            echo "arm64_runner=ubuntu-24.04-arm" >> "$GITHUB_OUTPUT"
-            echo "::notice::arm64 legs → GitHub-hosted (rpi5 runner offline)"
-          fi
-
   tripbot-build:
-    needs: [changes, pick-runner]
+    needs: changes
     if: needs.changes.outputs.tripbot == 'true'
     name: tripbot-build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -131,7 +95,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ${{ needs.pick-runner.outputs.arm64_runner }}
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -200,7 +164,7 @@ jobs:
             adanalife/tripbot:develop-arm64
 
   vlc-build:
-    needs: [changes, pick-runner]
+    needs: changes
     if: needs.changes.outputs.vlc == 'true'
     name: vlc-build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -211,7 +175,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ${{ needs.pick-runner.outputs.arm64_runner }}
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -363,7 +327,7 @@ jobs:
             adanalife/obs:develop-arm64
 
   onscreens-server-build:
-    needs: [changes, pick-runner]
+    needs: changes
     if: needs.changes.outputs.onscreens == 'true'
     name: onscreens-server-build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -374,7 +338,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ${{ needs.pick-runner.outputs.arm64_runner }}
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,43 +5,7 @@ on:
       - v*
 
 jobs:
-  # Route the arm64 build legs to the self-hosted rpi5 runner
-  # (arc-arm64-tripbot) when it's online, else fall back to the 2x-billed
-  # GitHub-hosted arm runner. Probes the repo's runners via the ARC GitHub App;
-  # minRunners:1 keeps one warm runner registered so "an online runner exists"
-  # is a true health signal. tripbot/vlc/onscreens consume this; obs stays
-  # GitHub-hosted (its heavy compile isn't on the Pi yet).
-  pick-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      arm64_runner: ${{ steps.pick.outputs.arm64_runner }}
-    steps:
-      - name: Mint ARC GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.ARC_APP_ID }}
-          private-key: ${{ secrets.ARC_APP_PRIVATE_KEY }}
-      - name: Pick arm64 runner (self-hosted if online, else GitHub-hosted)
-        id: pick
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          # ARC scale-set runners route by scale-set NAME (runs-on:
-          # arc-arm64-tripbot) and report empty .labels via this API, so match on
-          # the runner name prefix, not a label.
-          online=$(gh api "repos/${{ github.repository }}/actions/runners" \
-            --jq 'any(.runners[]; .status=="online" and (.name|startswith("arc-arm64-tripbot")))')
-          if [ "$online" = "true" ]; then
-            echo "arm64_runner=arc-arm64-tripbot" >> "$GITHUB_OUTPUT"
-            echo "::notice::arm64 legs → self-hosted rpi5 runner (arc-arm64-tripbot)"
-          else
-            echo "arm64_runner=ubuntu-24.04-arm" >> "$GITHUB_OUTPUT"
-            echo "::notice::arm64 legs → GitHub-hosted (rpi5 runner offline)"
-          fi
-
   tripbot-build:
-    needs: pick-runner
     name: tripbot-build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -51,7 +15,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ${{ needs.pick-runner.outputs.arm64_runner }}
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -137,7 +101,6 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   vlc-build:
-    needs: pick-runner
     name: vlc-build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -147,7 +110,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ${{ needs.pick-runner.outputs.arm64_runner }}
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -333,7 +296,6 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   onscreens-server-build:
-    needs: pick-runner
     name: onscreens-server-build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -343,7 +305,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ${{ needs.pick-runner.outputs.arm64_runner }}
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Removes the `pick-runner` job from `release.yml` and `release-development.yml` and pins all arm64 build legs (tripbot/vlc/onscreens) to the GitHub-hosted `ubuntu-24.04-arm` runner.

**Why:** the Raspberry Pi is too slow to be worth running CI on. The matrix-on-native-runners shape stays — cgo/libvlc compilation makes QEMU a non-starter for these images — only the Pi routing goes. `ubuntu-24.04-arm` was already the picker's offline fallback, so this is just the steady-state behavior with the indirection (and the ARC GitHub App token mint) removed. obs was never routed to the Pi and is unchanged.

Companion to [adanalife/tripbot-console#65](https://github.com/adanalife/tripbot-console/pull/65/changes), which removes the same Pi routing there.

`skip-changelog`: CI-only change.