### PR TITLE
ci(changelog): exempt the back-merge PR from the fragment check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,10 @@ concurrency:
 jobs:
   fragment:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    # The back-merge PR (backmerge/master-to-develop) targets develop but
+    # carries no user-facing change, so it never needs a fragment — exempt
+    # it by head branch, mirroring pr-title.yml.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && github.head_ref != 'backmerge/master-to-develop' }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Problem

The back-merge PR (`backmerge/master-to-develop`, opened by `backmerge.yml`) targets `develop`, so `changelog.yml` demands a changelog fragment from it — but a back-merge carries no user-facing change and should never need one. This failed the `fragment` check on the v3.9.1 back-merge PR (#960).

`pr-title.yml` already exempts the back-merge PR by head branch; `changelog.yml` did not.

## Fix

Extend the job `if` to also skip when `github.head_ref == backmerge/master-to-develop`, mirroring `pr-title.yml`. The `fragment` check then reports `skipping` (non-blocking) on back-merge PRs.

Follow-up to #961 (the HASFEAT pipefail fix), which merged before this commit could be added.

---
**Sibling PRs (same fix):** platform-gateway adanalife/platform-gateway#41 · tripbot-console adanalife/tripbot-console#67