### PR TITLE
feat(cdk8s): unpark prod-1 youtube app stack

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -277,22 +277,22 @@ ENVS: dict[str, EnvConfig] = {
         # The DB lives in its own namespace so a `kubectl delete ns prod-1` can't
         # take years of irreplaceable data.
         data_namespace="prod-1-data",
-        # youtube is staged here but parked at replicas=0 (parked_platforms): the
-        # full prod-youtube stack renders + Argo manages it, but it runs nothing
-        # until stage-youtube is shut down and prod-youtube is turned on, so the
-        # minipc never runs two youtube stacks at once. Turn on = drop "youtube"
-        # from parked_platforms (and, to stream, add it to obs_streaming + create
-        # the prod-account SM key k8s/obs/youtube-stream-key). The youtube tripbot
+        # youtube is LIVE (unparked) — the prod-youtube app stack (tripbot /
+        # vlc / onscreens) runs at replicas=1, streaming unlisted to burn in
+        # before the public launch. stage-youtube is scaled down first so the
+        # minipc never runs two youtube encoders at once. The youtube tripbot
         # instance pulls tripbot-youtube-creds from prod-account SM
-        # k8s/tripbot/youtube-creds regardless — that must exist for its
-        # ExternalSecret to sync.
+        # k8s/tripbot/youtube-creds — that must be seeded for its ExternalSecret
+        # to sync.
         platforms=("twitch", "youtube"),
-        parked_platforms=("youtube",),
         # prod youtube launches bot-less: inbound chat poll off (quota extension
         # pending), so rotators serve promo copy and no command responds. Flip to
         # True when the YouTube Data API quota lands. See youtube_inbound_enabled.
         youtube_inbound_enabled=False,
-        # prod twitch is the always-live stream; youtube boots idle until flip-on
+        # obs_streaming governs only the in-tripbot OBS build (prod-twitch). prod
+        # obs-youtube streaming is owned by the standalone obs repo now (its own
+        # obs_streaming + the per-platform OBS cutover in infra), so it's NOT
+        # listed here — tripbot-apps skips obs-youtube for prod.
         obs_streaming=("twitch",),
         # The live stream always wins: prod app pods outrank default-priority
         # co-tenants (stage, dashcam-cv), and the encode/decode pair carries

--- a/cdk8s/dist/prod-1-obs-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-obs-youtube.k8s.yaml
@@ -28,7 +28,7 @@ metadata:
   name: obs-youtube
   namespace: prod-1
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: obs-youtube

--- a/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-onscreens-youtube.k8s.yaml
@@ -26,7 +26,7 @@ metadata:
   name: onscreens-youtube
   namespace: prod-1
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: onscreens-youtube

--- a/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
@@ -59,7 +59,7 @@ metadata:
   name: tripbot-youtube
   namespace: prod-1
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: tripbot-youtube

--- a/cdk8s/dist/prod-1-vlc-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-vlc-youtube.k8s.yaml
@@ -30,7 +30,7 @@ metadata:
   name: vlc-youtube
   namespace: prod-1
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: vlc-youtube

--- a/changelog.d/968.deploy.md
+++ b/changelog.d/968.deploy.md
@@ -1,0 +1,1 @@
+Unpark the prod-1 YouTube app stack — tripbot/vlc/onscreens-youtube go live (unlisted, bot-less).


### PR DESCRIPTION
Phase 4 of the prod-YouTube unlisted-stream bring-up. Drops `youtube` from prod-1 `parked_platforms` so the prod YouTube app stack (`tripbot`/`vlc`/`onscreens`-youtube) runs at replicas=1 and the stream goes live **unlisted** to burn in before launch.

- `cdk8s/config.py` prod-1: `parked_platforms=()`; stays bot-less (`youtube_inbound_enabled=False`)
- re-synth: `prod-1-{tripbot,vlc,onscreens,obs}-youtube.k8s.yaml` flip `replicas: 0→1`

`obs-youtube` streaming is owned by the standalone obs repo now ([obs#6](https://github.com/adanalife/obs/pull/6) + the per-platform OBS cutover in infra), so tripbot-apps skips obs-youtube for prod — the obs-youtube manifest tripbot still renders is unused by Argo.

Part of the cross-repo bring-up: [infra#787](https://github.com/adanalife/infra/pull/787) (stream-key SM), [obs#6](https://github.com/adanalife/obs/pull/6) (obs activation), infra appset cutover (next).

**Apply order:** seed prod stream key + obs v1.0.2 release + infra appset cutover land first; scale down stage-youtube before prod obs-youtube syncs (iGPU budget = 2 encoders).