### PR TITLE
ci(pre-commit): add pre-push towncrier fragment guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ exclude: '^(assets/video/|pkg/server/static/)'
 
 # Install both the pre-commit (file-content) hooks and the commit-msg hook
 # (the Conventional Commits check below) on a plain `pre-commit install`.
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -117,3 +117,13 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+
+  - repo: local
+    hooks:
+      - id: changelog-fragment
+        name: changelog fragment (towncrier)
+        entry: scripts/check-changelog-fragment.sh
+        language: script
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true

--- a/scripts/check-changelog-fragment.sh
+++ b/scripts/check-changelog-fragment.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Pre-push guard: block a push whose branch adds no towncrier changelog fragment
+# (the same check CI's changelog gate runs), so a missing fragment is caught
+# locally instead of in CI. The authoritative gate stays CI + the skip-changelog
+# PR label; this is a fast local pre-flight.
+#
+# Auto-skipped on develop/master/release/backmerge branches (they carry no
+# fragment). Bypass for genuinely fragment-less work (CI-only tweaks, refactors,
+# dep bumps):
+#   SKIP_CHANGELOG=1 git push     (then add the skip-changelog label on the PR)
+#   git push --no-verify          (skips all pre-push hooks)
+set -euo pipefail
+
+[ -n "${SKIP_CHANGELOG:-}" ] && exit 0
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+case "$branch" in
+  develop | master | release/* | backmerge/*) exit 0 ;;
+esac
+
+base="origin/develop"
+git rev-parse --verify --quiet "$base" >/dev/null 2>&1 || exit 0
+
+if uvx towncrier check --config towncrier.toml --compare-with "$base"; then
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+
+No changelog fragment found for this branch.
+  Add one:  task changelog:add PR=<n> TYPE=<type>
+  Or, if no entry is warranted (CI-only / refactor / dep bump):
+    SKIP_CHANGELOG=1 git push   — and add the skip-changelog label on the PR.
+MSG
+exit 1


### PR DESCRIPTION
Adds a pre-push hook running `towncrier check --compare-with origin/develop` so a missing changelog fragment is caught locally instead of in CI. Auto-skips develop/master/release/backmerge branches; bypass with `SKIP_CHANGELOG=1 git push` or `git push --no-verify`. CI changelog gate + the skip-changelog label stay authoritative. Part of a 4-repo rollout (tripbot/obs/platform-gateway/tripbot-console). Codified in vault decisions/release-pr-explicit-bump-token.md context.