### PR TITLE
ci(dependabot): self-apply skip-changelog label on bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,34 @@
 
 version: 2
 updates:
+  # Bumps carry no user-facing change, so they never need a towncrier
+  # changelog fragment. Self-apply skip-changelog so the changelog
+  # workflow's existing label escape hatch exempts them — this keeps the
+  # enforcement workflow bot-agnostic (survives a future move off Dependabot
+  # without a workflow edit). Note: setting `labels` replaces Dependabot's
+  # defaults, so the otherwise-automatic dependencies/ecosystem labels are
+  # restated here.
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: daily
+    labels:
+      - dependencies
+      - go
+      - skip-changelog
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    labels:
+      - dependencies
+      - github_actions
+      - skip-changelog
   - package-ecosystem: docker
     directory: infra/docker/tripbot
     schedule:
       interval: daily
+    labels:
+      - dependencies
+      - docker
+      - skip-changelog


### PR DESCRIPTION
Dependabot bumps never carry a user-facing changelog entry, so the towncrier fragment requirement fails them until someone hand-applies the `skip-changelog` label.

This has Dependabot self-apply `skip-changelog` via `dependabot.yml`. The changelog workflow already honors that label, so enforcement stays **bot-agnostic** — a future move to Renovate only touches the bot config (rewritten anyway), not the changelog workflow. Chosen over a `github.actor` workflow check for that reason.

Setting `labels` replaces Dependabot's defaults, so the otherwise-automatic `dependencies`/ecosystem labels are restated.

Part of a set across the repos with changelog enforcement: adanalife/platform-gateway#52, adanalife/tripbot-console#72, adanalife/obs#12.