### PR TITLE
feat(vlc): label vlc-server/OBS metrics by streaming platform

### DIFF
--- a/changelog.d/983.vlc.md
+++ b/changelog.d/983.vlc.md
@@ -1,0 +1,1 @@
+Stamp a `service_platform` label (twitch/youtube) on every vlc-server and OBS metric series, so the per-platform encoder instances stay distinct instead of colliding on identical Prometheus series identities.

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -14,6 +14,7 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	"github.com/adanalife/tripbot/pkg/helpers"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/natsclient"
 	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -68,6 +69,11 @@ func main() {
 
 	// set up telemetry (no-op if OTEL_SDK_DISABLED)
 	initializeTelemetry()
+
+	// stamp the streaming platform onto the vlc-server/OBS gauges so the
+	// per-platform instances (twitch/youtube/…) stay distinct series instead
+	// of colliding on identical labels. Must run before the stats pollers.
+	instrumentation.SetPlatform(c.Conf.Platform)
 
 	// set up error logging
 	initializeErrorLogger()

--- a/pkg/instrumentation/vlc_server.go
+++ b/pkg/instrumentation/vlc_server.go
@@ -3,8 +3,31 @@ package instrumentation
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
+
+// platformAttr stamps the streaming platform (twitch/youtube) onto every
+// vlc-server and OBS metric series. Without it the per-platform vlc-server
+// instances emit byte-identical series identities — service.platform lives
+// only on the OTel resource → target_info, not on the datapoints — so the
+// twitch and youtube encoders collide onto one series. The attribute key
+// matches the resource attribute (service.platform → service_platform label)
+// so it lines up with target_info and the Stream Health dashboard's existing
+// filters. Defaults to twitch to match the config default; cmd/vlc-server
+// overrides it via SetPlatform at startup before the pollers begin.
+var platformAttr = metric.WithAttributes(attribute.String("service.platform", "twitch"))
+
+// SetPlatform stamps the streaming platform this instance feeds onto the
+// vlc-server/OBS gauges. Call once at startup (before the stats pollers run)
+// with the instance's STREAM_PLATFORM value so per-platform series stay
+// distinct as more platforms are added.
+func SetPlatform(p string) {
+	if p == "" {
+		p = "twitch"
+	}
+	platformAttr = metric.WithAttributes(attribute.String("service.platform", p))
+}
 
 var (
 	vlcInputBitRate       = mustFloat64Gauge("vlc_player_input_bitrate", "libvlc input bitrate (libvlc-native units, ~bytes/µs)")
@@ -72,14 +95,14 @@ type vlcPlayerStatsIface struct {
 
 func (v vlcPlayerStatsIface) Update(s VLCPlayerStatsSnapshot) {
 	ctx := context.Background()
-	v.inputBitRate.Record(ctx, s.InputBitRate)
-	v.demuxBitRate.Record(ctx, s.DemuxBitRate)
-	v.displayedFPS.Record(ctx, s.DisplayedFPS)
-	v.decodedVideo.Record(ctx, s.DecodedVideo)
-	v.displayedPictures.Record(ctx, s.DisplayedPictures)
-	v.lostPictures.Record(ctx, s.LostPictures)
-	v.demuxCorrupted.Record(ctx, s.DemuxCorrupted)
-	v.demuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity)
+	v.inputBitRate.Record(ctx, s.InputBitRate, platformAttr)
+	v.demuxBitRate.Record(ctx, s.DemuxBitRate, platformAttr)
+	v.displayedFPS.Record(ctx, s.DisplayedFPS, platformAttr)
+	v.decodedVideo.Record(ctx, s.DecodedVideo, platformAttr)
+	v.displayedPictures.Record(ctx, s.DisplayedPictures, platformAttr)
+	v.lostPictures.Record(ctx, s.LostPictures, platformAttr)
+	v.demuxCorrupted.Record(ctx, s.DemuxCorrupted, platformAttr)
+	v.demuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity, platformAttr)
 }
 
 // OBSStreaming exposes the streaming-active gauge.
@@ -135,7 +158,7 @@ func (o obsStreamingIface) Set(active bool) {
 	if active {
 		v = 1
 	}
-	o.g.Record(context.Background(), v)
+	o.g.Record(context.Background(), v, platformAttr)
 }
 
 type obsStatsIface struct {
@@ -157,26 +180,26 @@ type obsStatsIface struct {
 
 func (o obsStatsIface) Update(s OBSStatsSnapshot) {
 	ctx := context.Background()
-	o.activeFPS.Record(ctx, s.ActiveFPS)
-	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime)
-	o.cpuUsage.Record(ctx, s.CPUUsage)
-	o.memoryUsage.Record(ctx, s.MemoryUsage)
-	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames)
-	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames)
-	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames)
-	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames)
+	o.activeFPS.Record(ctx, s.ActiveFPS, platformAttr)
+	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime, platformAttr)
+	o.cpuUsage.Record(ctx, s.CPUUsage, platformAttr)
+	o.memoryUsage.Record(ctx, s.MemoryUsage, platformAttr)
+	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames, platformAttr)
+	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames, platformAttr)
+	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames, platformAttr)
+	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames, platformAttr)
 }
 
 func (o obsStatsIface) UpdateStream(s OBSStreamSnapshot) {
 	ctx := context.Background()
-	o.streamBytes.Record(ctx, s.OutputBytes)
-	o.streamDuration.Record(ctx, s.OutputDurationMS)
-	o.streamCongestion.Record(ctx, s.OutputCongestion)
+	o.streamBytes.Record(ctx, s.OutputBytes, platformAttr)
+	o.streamDuration.Record(ctx, s.OutputDurationMS, platformAttr)
+	o.streamCongestion.Record(ctx, s.OutputCongestion, platformAttr)
 	v := int64(0)
 	if s.Reconnecting {
 		v = 1
 	}
-	o.streamReconnecting.Record(ctx, v)
-	o.streamSkipped.Record(ctx, s.SkippedFrames)
-	o.streamTotal.Record(ctx, s.TotalFrames)
+	o.streamReconnecting.Record(ctx, v, platformAttr)
+	o.streamSkipped.Record(ctx, s.SkippedFrames, platformAttr)
+	o.streamTotal.Record(ctx, s.TotalFrames, platformAttr)
 }


### PR DESCRIPTION
## Problem

Since the YouTube launch there are two `vlc-server` instances per env (`vlc-twitch` + `vlc-youtube`), each polling its own OBS. But the `obs_*` and `vlc_player_*` gauges carried **no platform-distinguishing label** — `service.platform` lives only on the OTel *resource* (so it lands on `target_info`, not on the datapoints). Both instances therefore emit byte-identical Prometheus series identities and **collide onto a single series**.

Confirmed against prod metrics:
- `target_info` shows both `vlc-server` targets up (`service_platform` = twitch + youtube).
- `obs_streaming_active` (and siblings) have labels `{deployment_environment, job, service_name, service_namespace, service_version}` only — no `service_platform`, `instance`, or `pod`.
- Net effect: the youtube encoder is effectively unobservable, and the Stream Health dashboard's bitrate / skipped-frame panels graph a corrupted blend of two encoders (the "linearly increasing" artifact). The streams themselves are healthy (~6.2 Mbps, ~0.03 skipped frames/s).

The dashboard's `service_platform=~"$platform"` filter looked like it handled this but is a silent no-op — a regex matcher matches series that *lack* the label.

## Fix

Stamp a `service.platform` attribute onto every `vlc_player_*` and `obs_*` datapoint:
- `instrumentation.SetPlatform(p)` builds the attribute from `STREAM_PLATFORM` (defaults to `twitch`, matching config).
- Wired in at `cmd/vlc-server` startup, after telemetry init and before the stats pollers.
- Applied to all `.Record()` calls in `pkg/instrumentation/vlc_server.go`.

The attribute **key matches the OTel resource attribute** so the metric carries the same `service_platform` label as `target_info` — which means the Stream Health dashboard's existing `service_platform` filters and `$platform` template var start working with no rename. Per-platform encoders now produce distinct series, and the design scales to additional platforms.

## Companion PR
- infra#792: Stream Health dashboard — break panels out `by (… , service_platform)` so twitch/youtube draw as separate lines (forward-compatible; collapses to one line until this ships).

## Follow-up (not in this PR)
- Other per-platform tripbot metrics (chat `command`/`event` counters from `tripbot-twitch`/`tripbot-youtube`) collide the same way — separate pass; the durable broad fix is promoting the `service.platform` resource attr → metric label in the Alloy pipeline for all metrics at once.

## Deploy note
Takes effect in prod only after a vlc-server release + rollout.