### PR TITLE
fix(obs): audio-fallback follow-ups — loop the fallback bed + observable SomaFM probe

### DIFF
--- a/changelog.d/+audio-fallback-followups.fix.md
+++ b/changelog.d/+audio-fallback-followups.fix.md
@@ -1,0 +1,1 @@
+Fix two issues in the SomaFM audio-fallback watchdog found during stage testing: the fallback now loops the local Car Hum bed (it was playing once and then going silent), and the SomaFM reachability probe now logs why it fails and uses a fresh connection per check (a stale pooled connection could otherwise strand the stream on the fallback bed).

--- a/pkg/obs/audiowatchdog/audiowatchdog.go
+++ b/pkg/obs/audiowatchdog/audiowatchdog.go
@@ -106,30 +106,52 @@ func DefaultDeps(meter *VolumeMeter) Deps {
 	}
 }
 
+// somaFMProbeClient is dedicated to the reachability probe. DisableKeepAlives
+// forces a fresh connection every probe: a periodic liveness check must not
+// reuse a pooled connection, since a half-dead pooled conn to SomaFM would make
+// a perfectly healthy edge look unreachable and strand us on the fallback bed.
+// The explicit Timeout bounds the whole request as a backstop to the per-call
+// context deadline.
+var somaFMProbeClient = &http.Client{
+	Timeout:   6 * time.Second,
+	Transport: &http.Transport{DisableKeepAlives: true},
+}
+
 // defaultSomaFMReachable opens the SomaFM edge and reads a byte: success means
 // the edge is serving stream data. During an outage the connect hangs and the
-// 5s client timeout trips, so this returns false. Distinct from "the website
-// is up" — somafm.com can 200 while every ICEcast edge is dead.
+// timeout trips, so this returns false. Distinct from "the website is up" —
+// somafm.com can 200 while every ICEcast edge is dead.
+//
+// Every failure path logs why (at warn). The probe is only consulted while on
+// the fallback bed, so in steady state it's silent; the logging is what makes a
+// stuck-on-fallback state diagnosable instead of an unexplained silence (the
+// original swallowed every error — see the 2026-06-24 stage test).
 func defaultSomaFMReachable(ctx context.Context) bool {
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, 6*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(cctx, http.MethodGet, somaFMProbeURL, nil)
 	if err != nil {
+		slog.WarnContext(ctx, "somafm probe: build request failed", "err", err)
 		return false
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := somaFMProbeClient.Do(req)
 	if err != nil {
+		slog.WarnContext(ctx, "somafm probe: request failed", "err", err)
 		return false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		slog.WarnContext(ctx, "somafm probe: unexpected status", "status", resp.StatusCode)
 		return false
 	}
 	// Read a single byte — a live stream yields one immediately; a stalled
 	// edge that completed the handshake but sends nothing trips the timeout.
 	buf := make([]byte, 1)
-	n, err := io.ReadFull(resp.Body, buf)
-	return n == 1 && (err == nil || err == io.EOF)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		slog.WarnContext(ctx, "somafm probe: no stream bytes", "err", err)
+		return false
+	}
+	return true
 }
 
 // Watch evaluates the background-audio source every cfg.Interval and keeps

--- a/pkg/obs/inputs.go
+++ b/pkg/obs/inputs.go
@@ -44,20 +44,28 @@ func SetBackgroundAudioFile(ctx context.Context, inputName, file string) error {
 // URL. Used by the audio-fallback watchdog to swap the SomaFM source onto the
 // local Car Hum bed when SomaFM is unreachable. file must exist inside the OBS
 // container.
+//
+// looping=true is essential: the SomaFM source ships with looping unset (a
+// radio stream doesn't loop), so without forcing it on, the fallback FLAC would
+// play exactly once and then go silent — re-creating the dead air we're trying
+// to avoid. (Confirmed on stage 2026-06-24.)
 func SetInputLocalFileMode(ctx context.Context, inputName, file string) error {
 	return setInputSettings(ctx, inputName, map[string]any{
 		"is_local_file": true,
 		"local_file":    file,
+		"looping":       true,
 	})
 }
 
 // SetInputNetworkMode flips an ffmpeg_source back to its network stream by
-// setting is_local_file=false. The source's `input` URL is preserved across
-// the local-file detour (the overlay merge never overwrote it), so OBS reopens
-// the original stream. The inverse of SetInputLocalFileMode.
+// setting is_local_file=false (and clearing looping, which is meaningless for a
+// live stream). The source's `input` URL is preserved across the local-file
+// detour (the overlay merge never overwrote it), so OBS reopens the original
+// stream. The inverse of SetInputLocalFileMode.
 func SetInputNetworkMode(ctx context.Context, inputName string) error {
 	return setInputSettings(ctx, inputName, map[string]any{
 		"is_local_file": false,
+		"looping":       false,
 	})
 }
 


### PR DESCRIPTION
Follow-ups from running the [#993](https://github.com/adanalife/tripbot/pull/993/changes) audio-fallback watchdog on **stage** (2026-06-24), where I blocked SomaFM with a Cilium policy and watched the watchdog react.

## What the stage test showed

**The good:** the watchdog detected the *hardest* case and recovered. The block left the SomaFM source in a **silent-but-`PLAYING`** wedge (`state=OBS_MEDIA_STATE_PLAYING`, `level_db=-60`), and the **meter-silence path** caught exactly what the media-state path would have missed — it counted 3 misses and swapped, and OBS reloaded `Groove Salad Classic` to the local Car Hum FLAC. Detection + swap-to-fallback works end-to-end.

**Two bugs, fixed here:**

1. **Fallback played once then went silent.** The SomaFM source ships with `looping` unset (radio doesn't loop), and `SetInputLocalFileMode` didn't force it on — so the fallback FLAC played once and stopped, re-creating dead air. Now sets `looping: true` (and clears it on the way back).

2. **Swap-back never fired; the probe hid why.** Once on the fallback bed, the watchdog stayed there — the SomaFM reachability probe returned false even though SomaFM was fully reachable from the pod (`curl` → `200`, `firstbyte=0.31s`, valid TLS, no proxy, no HTTP/2 — all ruled out on the live pod). Root cause is still unconfirmed **because the probe swallowed its error**. This makes it observable (every failure path logs why) and switches it to a dedicated client with `DisableKeepAlives`, so a half-dead pooled connection — a plausible real cause — can't strand the stream on the fallback bed. The next stage run will surface the actual error if it persists.

## Not changed (deliberately)
- The repoint mechanism itself is validated and kept (per the decision to stay on Option A). A dedicated muted Car Hum source on the Twitch scene is captured as a future consideration in the vault TODO.

## Re-test plan
Redeploy to stage, then re-run the SomaFM block (with a corrected **allow-all + deny-SomaFM** Cilium policy — the first attempt used `egressDeny`-only, which default-denies *all* egress and briefly took out stage DNS). Expect: looping Car Hum on fallback, and either a clean swap-back or a now-logged probe error.