### PR TITLE
fix(obs): set a User-Agent on the SomaFM probe (Go's default is rejected)

### DIFF
--- a/changelog.d/+somafm-probe-user-agent.fix.md
+++ b/changelog.d/+somafm-probe-user-agent.fix.md
@@ -1,0 +1,1 @@
+Fix the SomaFM audio-fallback swap-back: the reachability probe sent Go's default `User-Agent`, which SomaFM's ICEcast edges reject (connection closed before any response), so the probe always reported unreachable and the stream could never return from the local Car Hum bed to SomaFM. The probe now sends a real User-Agent.

--- a/pkg/obs/audiowatchdog/audiowatchdog.go
+++ b/pkg/obs/audiowatchdog/audiowatchdog.go
@@ -46,6 +46,15 @@ const (
 	// hands out a healthy edge rather than pinning one. A failed probe keeps us
 	// on the safe local bed; per-edge probing is a tracked follow-up.
 	somaFMProbeURL = "https://ice.somafm.com/gsclassic-128-mp3"
+
+	// somaFMProbeUserAgent overrides Go's default User-Agent on the probe.
+	// SomaFM's ICEcast edges reject "Go-http-client/1.1" outright — the
+	// connection is closed before any response (the probe saw a bare EOF), so
+	// the probe always reported unreachable and the stream could never swap
+	// back off the fallback bed. Any non-default UA is accepted; confirmed on
+	// stage 2026-06-24. (OBS's own player sends an Lavf/ffmpeg UA, which is why
+	// playback itself was never affected.)
+	somaFMProbeUserAgent = "tripbot-audio-watchdog"
 )
 
 // Deps are the OBS + SomaFM hooks the watchdog calls. Injectable so the loop
@@ -134,6 +143,7 @@ func defaultSomaFMReachable(ctx context.Context) bool {
 		slog.WarnContext(ctx, "somafm probe: build request failed", "err", err)
 		return false
 	}
+	req.Header.Set("User-Agent", somaFMProbeUserAgent) // SomaFM rejects Go's default UA
 	resp, err := somaFMProbeClient.Do(req)
 	if err != nil {
 		slog.WarnContext(ctx, "somafm probe: request failed", "err", err)


### PR DESCRIPTION
## Root cause (the swap-back bug)

Found by deploying [#994](https://github.com/adanalife/tripbot/pull/994)'s new probe logging to stage and reading it. The audio-fallback watchdog's SomaFM reachability probe always reported **unreachable**, so once the stream fell back to the local Car Hum bed it could never swap back. #994 made the probe log its error:

```
WARN somafm probe: request failed  err="Get \"https://ice.somafm.com/gsclassic-128-mp3\": EOF"
```

A bare `EOF` — SomaFM closes the connection before any response. Proven from inside the pod that it's the **User-Agent**:

```
curl -A "Go-http-client/1.1"      → 000   (SomaFM rejects Go's default UA)
curl -A "tripbot-audio-watchdog"  → 200
curl -H "User-Agent:" (empty)     → 200
```

SomaFM's ICEcast edges reject Go's default `Go-http-client/1.1`. OBS's own ffmpeg player sends an `Lavf/` UA, which is accepted — that's why playback was never affected, only tripbot's Go probe.

## Fix
Set `User-Agent: tripbot-audio-watchdog` on the probe request. One line + the const/comment.

## Effect
With this, the probe succeeds when SomaFM is up → the watchdog swaps back off the fallback bed → the full cycle works. Together with #994 (looping fallback) this completes the fallback loop. As a bonus it also stops the per-tick `somafm probe: request failed` log spam #994 surfaced (the probe ran every tick and failed every time).

Stacked on #993 → #994; all three should ride the next develop→master release to prod.