### PR TITLE
chore: mark duplicate NATS publisher interfaces as ponytail debt

### DIFF
--- a/changelog.d/+ponytail-debt-nats.misc.md
+++ b/changelog.d/+ponytail-debt-nats.misc.md
@@ -1,0 +1,1 @@
+Mark the chatbot/eventbus NATS publisher interfaces as ponytail debt (they duplicate `natsclient.Publisher`); no functional change.

--- a/pkg/chatbot/nats.go
+++ b/pkg/chatbot/nats.go
@@ -10,6 +10,11 @@ import (
 // NATS is the publish surface chatbot uses for fire-and-forget pubsub
 // events. Tests inject a fake (recordingNATS / noopNATS); production
 // uses realNATS which delegates to the pkg/natsclient singleton.
+//
+// ponytail: NATS duplicates natsclient.Publisher (identical Publish signature),
+// and realNATS below duplicates natsclient's connPublisher adapter. Could
+// collapse onto natsclient.Publisher + natsclient.DefaultPublisher(). Kept as an
+// explicit local seam for now — deferred 2026-06-29 (ponytail-audit).
 type NATS interface {
 	// Publish sends payload on subject. Errors are logged but never
 	// returned — every chatbot publish is fire-and-forget by design.

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -30,6 +30,11 @@ import (
 // Publisher is the fire-and-forget publish surface the Emit helpers use. Tests
 // inject a fake via SetPublisher; production uses realPublisher, which delegates
 // to the pkg/natsclient singleton.
+//
+// ponytail: Publisher duplicates natsclient.Publisher (identical signature) and
+// realPublisher re-implements natsclient's connPublisher. Could collapse onto
+// natsclient.Publisher + natsclient.DefaultPublisher(). Kept as an explicit local
+// seam for now — deferred 2026-06-29 (ponytail-audit).
 type Publisher interface {
 	Publish(ctx context.Context, subject string, payload []byte)
 }


### PR DESCRIPTION
A ponytail over-engineering audit flagged that `chatbot.NATS` and `eventbus.Publisher` are each a byte-identical re-declaration of the existing `natsclient.Publisher` interface (same `Publish(ctx, subject, payload)` signature), with `realNATS`/`realPublisher` re-implementing natsclient's `connPublisher` adapter.

Rather than collapse them now, this marks both with a `ponytail:` comment so the deferral is tracked and `/ponytail-debt` can harvest it later. Comment-only — no functional change.