### PR TITLE
refactor: drop go-spew dependency

### DIFF
--- a/changelog.d/+drop-go-spew.cleanup.md
+++ b/changelog.d/+drop-go-spew.cleanup.md
@@ -1,0 +1,1 @@
+Drop the `go-spew` dependency — its only live use was a single debug dump, now done with `fmt.Printf`.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/andreykaipov/goobs v1.8.3
 	github.com/bradfitz/latlong v0.0.0-20170410180902-f3db6d0dff40
 	github.com/bwmarrin/discordgo v0.29.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dimiro1/banner v1.1.0
 	github.com/gempir/go-twitch-irc/v4 v4.4.1
 	github.com/getsentry/sentry-go v0.46.2

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/events"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
 	"github.com/hako/durafmt"
 )
@@ -179,7 +179,7 @@ func (s *Sessions) isLoggedIn(username string) bool {
 func (s *Sessions) Shutdown(ctx context.Context) {
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "logged-in users at shutdown")
-		spew.Dump(s.loggedIn)
+		fmt.Printf("%+v\n", s.loggedIn)
 	}
 	for _, user := range s.loggedIn {
 		s.logout(ctx, user)

--- a/script/make-map/make-map.go
+++ b/script/make-map/make-map.go
@@ -23,8 +23,6 @@ var skipToDate = false
 var skipDate = time.Date(2018, time.Month(9), 29, 0, 0, 0, 0, time.UTC)
 
 func main() {
-	// spew.Dump(takeout.LoadLocations())
-
 	//TODO: remove this if it's not needed
 	// err := godotenv.Load()
 	// if err != nil {


### PR DESCRIPTION
A ponytail over-engineering audit flagged `github.com/davecgh/go-spew` as a one-use dependency: its only live use was a single debug dump in `Sessions.Shutdown` (`pkg/users/session.go`).

- Replaced `spew.Dump(s.loggedIn)` with `fmt.Printf("%+v\n", s.loggedIn)` in the existing `Verbose` debug-logging block.
- Removed a dead commented-out `spew.Dump(...)` reference in `script/make-map`.
- `go mod tidy` dropped `go-spew` from `go.mod` (it remains in `go.sum` only as a transitive dependency of testify/sentry).

Tests: `task test:macos` passes; `go build ./script/...` builds.