### PR TITLE
refactor: use stdlib idioms over hand-rolled loops/comparisons

### DIFF
--- a/changelog.d/+stdlib-idioms.cleanup.md
+++ b/changelog.d/+stdlib-idioms.cleanup.md
@@ -1,0 +1,1 @@
+Replace a handful of hand-rolled loops/comparisons with their stdlib equivalents (`slices.Contains`, `slices.Sort`, `strings.EqualFold`). No behavior change.

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -475,7 +475,7 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 		vid = vid.Next(ctx)
 	}
 
-	if strings.ToLower(guess) == strings.ToLower(vid.State) {
+	if strings.EqualFold(guess, vid.State) {
 		msg = fmt.Sprintf("@%s got it! We're in %s", user.Username, vid.State)
 		// show the flag for the state
 		a.Onscreens.ShowFlag(ctx, 10*time.Second)

--- a/pkg/config/tripbot/helpers.go
+++ b/pkg/config/tripbot/helpers.go
@@ -23,7 +23,7 @@ func (c TripbotConfig) IsTesting() bool {
 // UserIsAdmin returns true if a given user runs the channel
 // it's used to restrict admin features
 func UserIsAdmin(username string) bool {
-	return strings.ToLower(username) == strings.ToLower(Conf.ChannelName)
+	return strings.EqualFold(username, Conf.ChannelName)
 }
 
 // HelpMessages are all of the different things !help can return

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -10,6 +10,7 @@ package feature
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"time"
 )
@@ -78,10 +79,8 @@ func sortFlags(fs []Flag) {
 // against a username-targeted flag falls through to roles/default).
 func evaluate(f Flag, ctx EvalContext) bool {
 	if ctx.Username != "" {
-		for _, u := range f.EnabledForUsernames {
-			if u == ctx.Username {
-				return true
-			}
+		if slices.Contains(f.EnabledForUsernames, ctx.Username) {
+			return true
 		}
 	}
 	for _, want := range f.EnabledForRoles {

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -152,12 +153,7 @@ func (cl *API) SetChatters(logins []string, count int) {
 
 // UserIsSubscriber returns true if the user subscribes to the channel
 func (cl *API) UserIsSubscriber(username string) bool {
-	for _, sub := range cl.subscribers {
-		if username == sub {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(cl.subscribers, username)
 }
 
 // UserIsFollower returns true if the user follows the channel.

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -3,7 +3,7 @@ package users
 import (
 	"context"
 	"log/slog"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -200,7 +200,7 @@ func (s *Sessions) sortedUsernameList() []string {
 	for username := range s.loggedIn {
 		usernames = append(usernames, username)
 	}
-	sort.Sort(sort.StringSlice(usernames))
+	slices.Sort(usernames)
 	return usernames
 }
 


### PR DESCRIPTION
From a ponytail over-engineering audit: replace a handful of hand-rolled loops and comparisons with their stdlib equivalents. No behavior change.

Swaps:
- `twitch.UserIsSubscriber` — `slices.Contains` over a manual `for` loop
- `feature.evaluate` — `slices.Contains` for the username allowlist membership check
- `users.sortedUsernameList` — `slices.Sort` over `sort.Sort(sort.StringSlice(...))`
- `config/tripbot.UserIsAdmin` — `strings.EqualFold` over double `strings.ToLower`
- `chatbot` `!guess` correct-answer check — `strings.EqualFold` over double `strings.ToLower`
- `helpers.SplitOnRegex` — body collapsed to `regexp.MustCompile(delimiter).Split(text, -1)` (signature, doc, and existing test unchanged)