### PR TITLE
feat(onscreens): stop both rotators advertising the same command at once

### DIFF
--- a/changelog.d/+rotator-dedup.onscreens.md
+++ b/changelog.d/+rotator-dedup.onscreens.md
@@ -1,0 +1,1 @@
+The two overlay corners no longer advertise the same command at the same time — when one rotator shows e.g. `!location`, the other skips any line mentioning that command (relaxing only if the exclusion would leave it blank). Internally the left/right rotators are now one parameterized `rotator` type instead of two near-identical copies.

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -1,8 +1,6 @@
 package onscreensServer
 
 import (
-	"log/slog"
-	"math/rand"
 	"time"
 )
 
@@ -33,7 +31,7 @@ var possibleLeftMessages = []rotatorMessage{
 // two corners never echo each other. Teases the guess/miles features without
 // printing a "!command" token a YouTube viewer would type into an unread chat.
 // On a bot-less stream these are mixed with the live location line (see
-// botlessLeftPool) — the info the !location command would return.
+// leftLiveLine) — the info the !location command would return.
 var botlessLeftMessages = []rotatorMessage{
 	{Text: "Chat live with the bot on Twitch", Weight: 2},
 	{Text: "twitch.tv/ADanaLife_", Weight: 2},
@@ -48,46 +46,26 @@ var botlessLeftMessages = []rotatorMessage{
 // data against the current promo weights.
 const liveDataWeight = 6
 
-// botlessLeftPool is the bot-less left-rotator pool: the static promo lines plus
-// the live location line ("📍 City, State") when tripbot has pushed a fresh one.
-func botlessLeftPool(now time.Time) []rotatorMessage {
+// leftLiveLine is the bot-less left-rotator live-data line: the current location
+// ("📍 City, State") when tripbot has pushed a fresh one. Paired with
+// rightLiveLine's date so the two corners show "where" and "when" rather than
+// duplicating one field.
+func leftLiveLine(now time.Time) (rotatorMessage, bool) {
 	if loc, _, ok := liveLocation.snapshot(now); ok && loc != "" {
-		return append([]rotatorMessage{{Text: "📍 " + loc, Weight: liveDataWeight}}, botlessLeftMessages...)
+		return rotatorMessage{Text: "📍 " + loc, Weight: liveDataWeight}, true
 	}
-	return botlessLeftMessages
+	return rotatorMessage{}, false
 }
 
-// newLeftRotator constructs the left-rotator *Onscreen, primes it with a
-// first message synchronously (so the OBS browser source has content to
-// render the moment it polls — otherwise there's a brief race where the
-// rotator is empty until the goroutine schedules), and kicks off the
-// background loop that rotates the message every leftRotatorUpdateFrequency.
-func newLeftRotator() *Onscreen {
-	slog.Info("creating onscreen", "kind", "left-rotator")
-	osc := newOnscreen()
-	osc.Show(leftRotatorContent())
-	go leftRotatorLoop(osc)
-	return osc
-}
-
-func leftRotatorLoop(osc *Onscreen) {
-	for { // forever
-		time.Sleep(time.Duration(leftRotatorUpdateFrequency))
-		osc.Show(leftRotatorContent())
+// newLeftRotator configures the left corner. The caller pairs it with the right
+// rotator and calls start().
+func newLeftRotator() *rotator {
+	return &rotator{
+		kind:            "left-rotator",
+		freq:            leftRotatorUpdateFrequency,
+		messages:        possibleLeftMessages,
+		botlessMessages: botlessLeftMessages,
+		liveLine:        leftLiveLine,
+		rareMessage:     "You found the rare message! Make a clip for a prize!",
 	}
-}
-
-// leftRotatorContent creates the content for the leftRotator
-func leftRotatorContent() string {
-	// show a special, very rare message
-	if rand.Intn(10000) == 0 {
-		return "You found the rare message! Make a clip for a prize!"
-	}
-
-	if botless() {
-		return pickRotatorMessage(botlessLeftPool(time.Now()))
-	}
-
-	// pick a weighted-random message for this platform
-	return pickRotatorMessage(possibleLeftMessages)
 }

--- a/pkg/onscreens-server/live-data_test.go
+++ b/pkg/onscreens-server/live-data_test.go
@@ -31,32 +31,54 @@ func TestLocationStoreFreshness(t *testing.T) {
 }
 
 func TestBotlessPoolsIncludeFreshLocationData(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	withInbound(t, false) // bot-less, so pool() returns the promo set
 	now := time.Now()
 	liveLocation.set("Moab, Utah", "Thursday June 14, 2018", now)
 	t.Cleanup(func() { liveLocation.set("", "", time.Time{}) })
 
-	if got := botlessLeftPool(now); !poolHasText(got, "📍 Moab, Utah") {
+	if got := newLeftRotator().pool(now); !poolHasText(got, "📍 Moab, Utah") {
 		t.Errorf("bot-less left pool missing the location line: %+v", got)
 	}
-	if got := botlessRightPool(now); !poolHasText(got, "📅 Thursday June 14, 2018") {
+	if got := newRightRotator().pool(now); !poolHasText(got, "📅 Thursday June 14, 2018") {
 		t.Errorf("bot-less right pool missing the date line: %+v", got)
 	}
 }
 
 func TestBotlessPoolsOmitStaleData(t *testing.T) {
+	withPlatform(t, platformYouTube)
+	withInbound(t, false)
 	now := time.Now()
 	liveLocation.set("Moab, Utah", "Thursday June 14, 2018", now.Add(-locationDataTTL-time.Minute))
 	t.Cleanup(func() { liveLocation.set("", "", time.Time{}) })
 
 	// Stale data → pools fall back to the static promo sets only.
-	left := botlessLeftPool(now)
+	left := newLeftRotator().pool(now)
 	if poolHasText(left, "📍 Moab, Utah") {
 		t.Error("stale location should not appear in the left pool")
 	}
 	if len(left) != len(botlessLeftMessages) {
 		t.Errorf("left pool = %d entries, want the %d static promo lines", len(left), len(botlessLeftMessages))
 	}
-	if poolHasText(botlessRightPool(now), "📅 Thursday June 14, 2018") {
+	if poolHasText(newRightRotator().pool(now), "📅 Thursday June 14, 2018") {
 		t.Error("stale date should not appear in the right pool")
+	}
+}
+
+// TestLiveLineFreshness covers the live-data line builders directly: fresh data
+// yields a weighted line, stale/empty data yields ok=false.
+func TestLiveLineFreshness(t *testing.T) {
+	now := time.Now()
+	liveLocation.set("Moab, Utah", "Thursday June 14, 2018", now)
+	t.Cleanup(func() { liveLocation.set("", "", time.Time{}) })
+
+	if line, ok := leftLiveLine(now); !ok || line.Text != "📍 Moab, Utah" {
+		t.Errorf("leftLiveLine(fresh) = (%q, %v), want the location line + ok", line.Text, ok)
+	}
+	if line, ok := rightLiveLine(now); !ok || line.Text != "📅 Thursday June 14, 2018" {
+		t.Errorf("rightLiveLine(fresh) = (%q, %v), want the date line + ok", line.Text, ok)
+	}
+	if _, ok := leftLiveLine(now.Add(locationDataTTL + time.Minute)); ok {
+		t.Error("leftLiveLine(stale) should not be ok")
 	}
 }

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -1,7 +1,6 @@
 package onscreensServer
 
 import (
-	"log/slog"
 	"time"
 )
 
@@ -30,7 +29,7 @@ var possibleRightMessages = []rotatorMessage{
 // YouTube's "subscribe" (the left corner owns the Twitch CTA), so the two
 // corners advertise different actions instead of both saying "follow on
 // Twitch". On a bot-less stream these are mixed with the live date line (see
-// botlessRightPool) — the info the !date command would return.
+// rightLiveLine) — the info the !date command would return.
 var botlessRightMessages = []rotatorMessage{
 	{Text: "Driving across America, 24 hours a day"},
 	{Text: "Subscribe to ride along"},
@@ -38,42 +37,25 @@ var botlessRightMessages = []rotatorMessage{
 	{Text: "Real dashcam footage, streaming nonstop"},
 }
 
-// botlessRightPool is the bot-less right-rotator pool: the static promo lines
-// plus the live date line ("📅 Monday January 2, 2006") when tripbot has pushed
-// a fresh one. Paired with botlessLeftPool's location so the two corners show
-// "where" and "when" rather than duplicating one field.
-func botlessRightPool(now time.Time) []rotatorMessage {
+// rightLiveLine is the bot-less right-rotator live-data line: the current date
+// ("📅 Monday January 2, 2006") when tripbot has pushed a fresh one. Paired with
+// leftLiveLine's location so the two corners show "when" and "where" rather than
+// duplicating one field.
+func rightLiveLine(now time.Time) (rotatorMessage, bool) {
 	if _, date, ok := liveLocation.snapshot(now); ok && date != "" {
-		return append([]rotatorMessage{{Text: "📅 " + date, Weight: liveDataWeight}}, botlessRightMessages...)
+		return rotatorMessage{Text: "📅 " + date, Weight: liveDataWeight}, true
 	}
-	return botlessRightMessages
+	return rotatorMessage{}, false
 }
 
-// newRightRotator constructs the right-rotator *Onscreen, primes it with
-// a first message synchronously (so the OBS browser source has content
-// to render the moment it polls — otherwise there's a brief race where
-// the rotator is empty until the goroutine schedules), and kicks off the
-// background loop that rotates the message every rightRotatorUpdateFrequency.
-func newRightRotator() *Onscreen {
-	slog.Info("creating onscreen", "kind", "right-rotator")
-	osc := newOnscreen()
-	osc.Show(rightRotatorContent())
-	go rightRotatorLoop(osc)
-	return osc
-}
-
-func rightRotatorLoop(osc *Onscreen) {
-	for { // forever
-		time.Sleep(time.Duration(rightRotatorUpdateFrequency))
-		osc.Show(rightRotatorContent())
+// newRightRotator configures the right corner. The caller pairs it with the left
+// rotator and calls start().
+func newRightRotator() *rotator {
+	return &rotator{
+		kind:            "right-rotator",
+		freq:            rightRotatorUpdateFrequency,
+		messages:        possibleRightMessages,
+		botlessMessages: botlessRightMessages,
+		liveLine:        rightLiveLine,
 	}
-}
-
-// rightRotatorContent creates the content for the rightRotator
-func rightRotatorContent() string {
-	if botless() {
-		return pickRotatorMessage(botlessRightPool(time.Now()))
-	}
-	// pick a weighted-random message for this platform
-	return pickRotatorMessage(possibleRightMessages)
 }

--- a/pkg/onscreens-server/rotator.go
+++ b/pkg/onscreens-server/rotator.go
@@ -1,7 +1,11 @@
 package onscreensServer
 
 import (
+	"log/slog"
 	"math/rand"
+	"regexp"
+	"slices"
+	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/onscreens-server"
 )
@@ -14,6 +18,9 @@ const (
 	platformTwitch  = "twitch"
 	platformYouTube = "youtube"
 )
+
+// rareOdds is the 1-in-N chance the left rotator shows its easter-egg line.
+const rareOdds = 10000
 
 // rotatorMessage is one line a rotator can display.
 //
@@ -33,6 +40,92 @@ type rotatorMessage struct {
 	Weight    int
 }
 
+// rotator drives one corner overlay (left or right). Both corners are the same
+// machine — a weighted-random pool swapped on a fixed cadence — differing only
+// in their message data, cadence, optional live-data line, and easter egg. The
+// per-corner specifics are wired in newLeftRotator / newRightRotator.
+//
+// sibling is the other corner. When set, a rotator avoids picking a line that
+// advertises a command the sibling is currently showing, so the two corners
+// don't both say "!location" at once (which reads as broken).
+type rotator struct {
+	kind            string                                     // for logs: "left-rotator" / "right-rotator"
+	freq            time.Duration                              // how often the visible line swaps
+	messages        []rotatorMessage                           // bot-enabled pool (command hints)
+	botlessMessages []rotatorMessage                           // bot-less promo pool (no commands)
+	liveLine        func(now time.Time) (rotatorMessage, bool) // bot-less live-data line (location/date); nil = none
+	rareMessage     string                                     // 1-in-rareOdds easter egg; "" = none
+
+	osc     *Onscreen // render target; nil until start()
+	sibling *rotator  // the other corner, for command de-duplication
+}
+
+// startRotators builds both corner rotators, pairs them as siblings (so neither
+// advertises a command the other is currently showing), starts their background
+// loops, and returns their *Onscreen render targets. Left is started first, so
+// it primes with no sibling content yet (right.osc is still nil — siblingCommands
+// no-ops); right then primes against left's first line.
+func startRotators() (left, right *Onscreen) {
+	l := newLeftRotator()
+	r := newRightRotator()
+	l.sibling, r.sibling = r, l
+	return l.start(), r.start()
+}
+
+// start creates the rotator's *Onscreen, primes it with a first message
+// synchronously (so the OBS browser source has content to render the moment it
+// polls — otherwise there's a brief race where the rotator is empty until the
+// goroutine schedules), kicks off the background rotation loop, and returns the
+// onscreen.
+func (r *rotator) start() *Onscreen {
+	slog.Info("creating onscreen", "kind", r.kind)
+	r.osc = newOnscreen()
+	r.osc.Show(r.content())
+	go r.loop()
+	return r.osc
+}
+
+func (r *rotator) loop() {
+	for { // forever
+		time.Sleep(r.freq)
+		r.osc.Show(r.content())
+	}
+}
+
+// content picks the next line to display: the rare easter egg on a lucky roll,
+// otherwise a weighted-random pick from this corner's pool that doesn't collide
+// with whatever command the sibling corner is currently showing.
+func (r *rotator) content() string {
+	if r.rareMessage != "" && rand.Intn(rareOdds) == 0 {
+		return r.rareMessage
+	}
+	return pickRotatorMessage(r.pool(time.Now()), r.siblingCommands())
+}
+
+// pool returns the message set for the current instance state: the bot-less
+// promo pool (with the live location/date line prepended when fresh) on a
+// bot-less YouTube instance, otherwise the normal command-hint pool.
+func (r *rotator) pool(now time.Time) []rotatorMessage {
+	if !botless() {
+		return r.messages
+	}
+	if r.liveLine != nil {
+		if line, ok := r.liveLine(now); ok {
+			return append([]rotatorMessage{line}, r.botlessMessages...)
+		}
+	}
+	return r.botlessMessages
+}
+
+// siblingCommands is the set of !command tokens the other corner is currently
+// showing, used to keep both corners from advertising the same command at once.
+func (r *rotator) siblingCommands() map[string]bool {
+	if r.sibling == nil || r.sibling.osc == nil {
+		return nil
+	}
+	return commandsIn(r.sibling.osc.Content)
+}
+
 // botless reports whether this instance should show promotional copy instead of
 // command hints — true only for a YouTube pipeline whose inbound chat is off
 // (YOUTUBE_INBOUND_ENABLED=false). In that state no command can respond, so the
@@ -43,15 +136,7 @@ func botless() bool {
 
 // appliesTo reports whether m should show on the given platform.
 func (m rotatorMessage) appliesTo(platform string) bool {
-	if len(m.Platforms) == 0 {
-		return true
-	}
-	for _, p := range m.Platforms {
-		if p == platform {
-			return true
-		}
-	}
-	return false
+	return len(m.Platforms) == 0 || slices.Contains(m.Platforms, platform)
 }
 
 func (m rotatorMessage) weight() int {
@@ -61,25 +146,67 @@ func (m rotatorMessage) weight() int {
 	return m.Weight
 }
 
-// pickRotatorMessage returns a weighted-random message among those applicable
-// to this instance's platform. Returns "" when none apply (the rotator shows
-// nothing rather than panicking).
-func pickRotatorMessage(msgs []rotatorMessage) string {
+// commandTokenRE matches a "!command" token: a bang followed by word chars (so a
+// bare "!" used as punctuation, e.g. in the rare-message line, isn't a command).
+var commandTokenRE = regexp.MustCompile(`!(\w+)`)
+
+// commandsIn returns the set of !command tokens mentioned in text (without the
+// leading bang). Empty/nil when text advertises no commands.
+func commandsIn(text string) map[string]bool {
+	matches := commandTokenRE.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	cmds := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		cmds[m[1]] = true
+	}
+	return cmds
+}
+
+// sharesCommand reports whether m advertises any command in exclude.
+func (m rotatorMessage) sharesCommand(exclude map[string]bool) bool {
+	if len(exclude) == 0 {
+		return false
+	}
+	for cmd := range commandsIn(m.Text) {
+		if exclude[cmd] {
+			return true
+		}
+	}
+	return false
+}
+
+// pickRotatorMessage returns a weighted-random message among those applicable to
+// this instance's platform and not advertising a command in exclude (the
+// sibling corner's current commands). Returns "" when no message applies at all.
+// If exclude rules out every otherwise-eligible message, the exclusion is
+// relaxed rather than showing nothing — better a brief duplicate than a blank
+// corner.
+func pickRotatorMessage(msgs []rotatorMessage, exclude map[string]bool) string {
 	platform := c.Conf.Platform
+
+	eligible := func(m rotatorMessage) bool {
+		return m.appliesTo(platform) && !m.sharesCommand(exclude)
+	}
 
 	total := 0
 	for _, m := range msgs {
-		if m.appliesTo(platform) {
+		if eligible(m) {
 			total += m.weight()
 		}
 	}
 	if total == 0 {
+		if len(exclude) > 0 {
+			// Every candidate collided with the sibling; relax and retry once.
+			return pickRotatorMessage(msgs, nil)
+		}
 		return ""
 	}
 
 	n := rand.Intn(total)
 	for _, m := range msgs {
-		if !m.appliesTo(platform) {
+		if !eligible(m) {
 			continue
 		}
 		if n -= m.weight(); n < 0 {

--- a/pkg/onscreens-server/rotator_test.go
+++ b/pkg/onscreens-server/rotator_test.go
@@ -35,10 +35,10 @@ func TestBotlessRotatorsAdvertiseNoCommands(t *testing.T) {
 	// as punctuation (the rare-message line) is fine.
 	commandToken := regexp.MustCompile(`![a-zA-Z]`)
 	for i := 0; i < 4000; i++ {
-		if msg := leftRotatorContent(); commandToken.MatchString(msg) {
+		if msg := newLeftRotator().content(); commandToken.MatchString(msg) {
 			t.Fatalf("bot-less left rotator surfaced a command: %q", msg)
 		}
-		if msg := rightRotatorContent(); commandToken.MatchString(msg) {
+		if msg := newRightRotator().content(); commandToken.MatchString(msg) {
 			t.Fatalf("bot-less right rotator surfaced a command: %q", msg)
 		}
 	}
@@ -74,7 +74,7 @@ func TestRotatorMessageAppliesTo(t *testing.T) {
 func TestLeftRotatorOmitsTwitchOnlyOnYouTube(t *testing.T) {
 	withPlatform(t, platformYouTube)
 	for i := 0; i < 2000; i++ {
-		msg := pickRotatorMessage(possibleLeftMessages)
+		msg := pickRotatorMessage(possibleLeftMessages, nil)
 		if strings.Contains(msg, "!miles") || strings.Contains(msg, "!guess") {
 			t.Fatalf("YouTube left rotator surfaced a Twitch-only line: %q", msg)
 		}
@@ -87,7 +87,7 @@ func TestLeftRotatorSurfacesTwitchOnlyOnTwitch(t *testing.T) {
 	withPlatform(t, platformTwitch)
 	var sawMiles, sawGuess bool
 	for i := 0; i < 5000 && !(sawMiles && sawGuess); i++ {
-		switch pickRotatorMessage(possibleLeftMessages) {
+		switch pickRotatorMessage(possibleLeftMessages, nil) {
 		case "Earn miles for every minute you watch (`!miles`)":
 			sawMiles = true
 		case "Try and `!guess` what state we're in":
@@ -105,7 +105,7 @@ func TestPickRotatorMessageEmptyWhenNoneApply(t *testing.T) {
 		{Text: "a", Platforms: []string{platformTwitch}},
 		{Text: "b", Platforms: []string{platformTwitch}},
 	}
-	if got := pickRotatorMessage(twitchOnly); got != "" {
+	if got := pickRotatorMessage(twitchOnly, nil); got != "" {
 		t.Errorf("expected empty string when no message applies, got %q", got)
 	}
 }
@@ -121,12 +121,85 @@ func TestPickRotatorMessageRespectsWeight(t *testing.T) {
 	var common int
 	const n = 10000
 	for i := 0; i < n; i++ {
-		if pickRotatorMessage(msgs) == "common" {
+		if pickRotatorMessage(msgs, nil) == "common" {
 			common++
 		}
 	}
 	// Expect ~90%; allow generous slack to stay non-flaky.
 	if common < n*3/4 {
 		t.Errorf("weighted draw not biased: common=%d/%d", common, n)
+	}
+}
+
+func TestCommandsIn(t *testing.T) {
+	cmds := commandsIn("Where are we? (`!location`) and try `!timewarp`")
+	if !cmds["location"] || !cmds["timewarp"] {
+		t.Errorf("expected location+timewarp, got %v", cmds)
+	}
+	// A bare "!" as punctuation is not a command token.
+	if got := commandsIn("You found the rare message! Make a clip for a prize!"); got != nil {
+		t.Errorf("expected no commands in punctuation-only text, got %v", got)
+	}
+	if got := commandsIn("twitch.tv/ADanaLife_"); got != nil {
+		t.Errorf("expected no commands, got %v", got)
+	}
+}
+
+// TestPickExcludesSiblingCommand is the headline of the dedup feature: when the
+// sibling corner is already showing !location, this corner must never pick a
+// line advertising !location — the two corners shouldn't echo the same command.
+func TestPickExcludesSiblingCommand(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	exclude := map[string]bool{"location": true}
+	for i := 0; i < 4000; i++ {
+		if got := pickRotatorMessage(possibleRightMessages, exclude); got == "Try running `!location`" {
+			t.Fatalf("right rotator surfaced !location while sibling shows it: %q", got)
+		}
+	}
+}
+
+// TestPickRelaxesWhenExclusionEmptiesPool verifies the fallback: if excluding
+// the sibling's commands would rule out every eligible line, the rotator shows a
+// (briefly duplicate) line rather than going blank.
+func TestPickRelaxesWhenExclusionEmptiesPool(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	msgs := []rotatorMessage{{Text: "Try running `!location`"}}
+	if got := pickRotatorMessage(msgs, map[string]bool{"location": true}); got != "Try running `!location`" {
+		t.Errorf("expected exclusion to relax to the only line, got %q", got)
+	}
+}
+
+// TestStartRotatorsPairsSiblings confirms the two corners are wired to each
+// other so siblingCommands can see across.
+func TestStartRotatorsPairsSiblings(t *testing.T) {
+	l := newLeftRotator()
+	r := newRightRotator()
+	l.sibling, r.sibling = r, l
+	if l.sibling != r || r.sibling != l {
+		t.Fatal("rotators not paired as siblings")
+	}
+	// With no started onscreen on the sibling, siblingCommands is a safe no-op.
+	if got := l.siblingCommands(); got != nil {
+		t.Errorf("expected nil sibling commands before sibling starts, got %v", got)
+	}
+}
+
+// TestContentAvoidsSiblingCommandEndToEnd exercises the whole feature path:
+// content() → siblingCommands() reads the sibling's live Content → the matching
+// command is excluded from the pick. With the left corner pinned to its
+// !location line, the right corner must never echo !location.
+func TestContentAvoidsSiblingCommandEndToEnd(t *testing.T) {
+	withPlatform(t, platformTwitch)
+	l := newLeftRotator()
+	r := newRightRotator()
+	l.sibling, r.sibling = r, l
+	// Pin the left corner to a line advertising !location.
+	l.osc = newOnscreen()
+	l.osc.Show("Where are we? (`!location`)")
+
+	for i := 0; i < 4000; i++ {
+		if got := r.content(); got == "Try running `!location`" {
+			t.Fatalf("right corner echoed !location while left shows it: %q", got)
+		}
 	}
 }

--- a/pkg/onscreens-server/server.go
+++ b/pkg/onscreens-server/server.go
@@ -61,14 +61,15 @@ func New(cfg Config) *Server {
 	if version == "" {
 		version = "dev"
 	}
+	leftRotator, rightRotator := startRotators()
 	return &Server{
 		Version:      version,
 		Flag:         newFlagOnscreen(),
 		GPS:          newGPSOnscreen(),
 		Leaderboard:  newLeaderboardOnscreen(),
-		LeftRotator:  newLeftRotator(),
+		LeftRotator:  leftRotator,
 		MiddleText:   newMiddleText(),
-		RightRotator: newRightRotator(),
+		RightRotator: rightRotator,
 		Timewarp:     newTimewarp(),
 	}
 }


### PR DESCRIPTION
## What

The two overlay corners (left/right rotators) rotate on independent 45s timers, so they could both land on the same command hint — e.g. both showing \`!location\` at once, which reads as broken on stream.

Now each rotator excludes any candidate line that mentions a command its **sibling corner is currently showing**. The exclusion relaxes (shows the line anyway) only if honoring it would leave the corner blank — better a brief duplicate than an empty overlay.

## How

Came out of a ponytail over-engineering audit that flagged \`left-rotator.go\` and \`right-rotator.go\` as near-identical copies. They're now one parameterized \`rotator\` type; the per-corner **message data, cadence, live-data line, and easter egg** are the only differences (wired in \`newLeftRotator\`/\`newRightRotator\`). The collapse is what made the sibling-awareness easy to add — both corners share one pick path that takes an \`exclude\` set.

- \`commandsIn(text)\` extracts \`!command\` tokens (a bare \`!\` as punctuation isn't a command, so the rare-message line is unaffected).
- \`startRotators()\` pairs the two as siblings and starts them; left primes first (right's onscreen still nil → no-op), right primes against left's first line.
- Also folds in the audit's \`appliesTo\` → \`slices.Contains\` simplification for this file.

## Tests

\`pkg/onscreens-server\` suite passes. Added coverage: token extraction, sibling-command exclusion at the pick level and end-to-end through \`content()\`, the relax-when-empty fallback, and sibling pairing. Existing bot-less / platform-scoping tests updated to the new API.