### PR TITLE
fix(onscreens): add heartbeat pixel so dropped CEF frames self-heal

### DIFF
--- a/changelog.d/1006.onscreens.md
+++ b/changelog.d/1006.onscreens.md
@@ -1,0 +1,1 @@
+Fixed the occasionally-blank rotator corner: a near-invisible heartbeat pixel on every onscreen page forces CEF to deliver a continuous frame stream to OBS, so a dropped frame after the hourly browser-source refresh self-heals in ~500ms instead of staying blank until the next rotation (up to 45s — indefinitely for middle-text).

--- a/pkg/onscreens-server/templates/onscreen.html.tmpl
+++ b/pkg/onscreens-server/templates/onscreen.html.tmpl
@@ -133,6 +133,26 @@
 </style>
 </head>
 <body>
+<!-- Heartbeat: OBS renders this page via CEF offscreen rendering
+     (BrowserHWAccel), which only delivers a new frame to OBS when pixels
+     change — and occasionally drops one (post-reload, the page can get stuck
+     compositing its blank initial paint until the next content change; the
+     rotators' 45s cadence was the only recovery). Repainting this near-invisible
+     pixel twice a second forces a continuous frame stream, so a dropped frame
+     self-heals in ~500ms. background-color (not opacity/transform) on purpose:
+     it's a main-thread paint property, so it can't be optimized into a
+     compositor-only animation that OSR might fail to deliver. -->
+<div id="heartbeat" style="position:fixed;left:0;bottom:0;width:1px;height:1px;"></div>
+<script>
+(function () {
+  var hb = document.getElementById('heartbeat');
+  var on = false;
+  setInterval(function () {
+    on = !on;
+    hb.style.background = on ? 'rgba(0,0,0,0.02)' : 'rgba(0,0,0,0.01)';
+  }, 500);
+})();
+</script>
 {{if eq .Name "timewarp"}}
 <div id="warp">
   <div class="cover"><div class="streaks" id="tw-streaks"></div></div>


### PR DESCRIPTION
The occasionally-blank rotator corner (still happening after the 90s→45s cadence fix) isn't the server rotating to a blank string — every server-side blank path is sealed (`pickRotatorMessage` relaxes sibling exclusion instead of returning empty, and nothing ever hides the rotator onscreens). It's a dropped frame in OBS's HW-accelerated CEF offscreen rendering: CEF only delivers a frame to OBS when pixels change, and after the hourly browser-source refresh a source can get stuck compositing its blank initial paint (`#root` starts hidden until the first `state.json` tick). The 500ms poll rewrites identical innerHTML — no pixel change, no frame — so the next rotation (≤45s) was the only recovery. Per-source CEF instances are why it's always one corner at a time.

This adds a near-invisible 1px heartbeat to every onscreen page: a `background-color` toggle every 500ms (a main-thread paint property, deliberately not opacity/transform, so it can't be promoted to a compositor-only animation that OSR might fail to deliver). Any dropped frame now self-heals in ~500ms. Also covers middle-text, which had no rotation to rescue it and could previously stay blank until the next hourly refresh.