### PR TITLE
feat(db): rollup schema — user_rollups, watermarks, scoreboard snapshots

### DIFF
--- a/changelog.d/1007.chatbot.md
+++ b/changelog.d/1007.chatbot.md
@@ -1,0 +1,1 @@
+Rollup schema: `user_rollups` + `rollup_watermarks` + `scoreboard_snapshots` tables — derived-state substrate for the events rollup reconciler (worker in a follow-up PR)

--- a/db/migrate/025_create_user_rollups.down.sql
+++ b/db/migrate/025_create_user_rollups.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE rollup_watermarks;
+DROP TABLE user_rollups;

--- a/db/migrate/025_create_user_rollups.up.sql
+++ b/db/migrate/025_create_user_rollups.up.sql
@@ -1,0 +1,28 @@
+/* Derived per-(platform, username) aggregates, recomputed from the append-only
+   events table by the rollup reconciler. events_miles is events-derived only
+   (no subscriber bonus, no manual corrections) — users.miles stays the display
+   number; this column is for audit and cross-platform aggregation.
+   Keyed on (platform, username), not users.id: events rows key on it and it's
+   the join key future identity linking will use. Bots are included here;
+   readers filter is_bot via a users join. */
+CREATE TABLE user_rollups (
+  id            SERIAL PRIMARY KEY,
+  platform      TEXT NOT NULL,
+  username      VARCHAR(64) NOT NULL,
+  events_miles  REAL NOT NULL DEFAULT 0.0,
+  session_count INTEGER NOT NULL DEFAULT 0,
+  first_seen    TIMESTAMP WITH TIME ZONE,
+  last_seen     TIMESTAMP WITH TIME ZONE,
+  date_updated  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (platform, username)
+);
+
+/* Reconciler progress, keyed on events.id (never date_created — historical
+   rows carry zero-value dates). One row per rollup job. */
+CREATE TABLE rollup_watermarks (
+  name          TEXT PRIMARY KEY,
+  last_event_id INTEGER NOT NULL DEFAULT 0,
+  date_updated  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO rollup_watermarks (name) VALUES ('user_rollups');

--- a/db/migrate/026_create_scoreboard_snapshots.down.sql
+++ b/db/migrate/026_create_scoreboard_snapshots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE scoreboard_snapshots;

--- a/db/migrate/026_create_scoreboard_snapshots.up.sql
+++ b/db/migrate/026_create_scoreboard_snapshots.up.sql
@@ -1,0 +1,14 @@
+/* Immutable month-end snapshots of the monthly scoreboards (miles_YYYY_MM,
+   guess_state_YYYY_MM), written once per board by the rollup reconciler after
+   rollover. Monthly boards themselves stay mutable-in-place and roll over
+   silently; this table is what lets a future !lastmonth render history. */
+CREATE TABLE scoreboard_snapshots (
+  id              SERIAL PRIMARY KEY,
+  scoreboard_name VARCHAR(64) NOT NULL,
+  platform        TEXT NOT NULL,
+  rank            INTEGER NOT NULL,
+  username        VARCHAR(64) NOT NULL,
+  value           REAL NOT NULL,
+  date_created    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (scoreboard_name, platform, rank)
+);


### PR DESCRIPTION
## Summary

Schema-only PR: the derived-state tables for the events rollup reconciler (worker lands in a follow-up PR stacked on this one).

- **Migration 025** — `user_rollups` (per-`(platform, username)` aggregates: events-derived miles, session count, first/last seen) + `rollup_watermarks` (reconciler progress, keyed on `events.id` — never `date_created`, which carries zero-value dates on historical rows).
- **Migration 026** — `scoreboard_snapshots`: immutable month-end top-50 snapshots of the monthly boards, so history survives the silent month rollover.

Design notes baked into the SQL comments: `users.miles` stays the display number (it includes the subscriber bonus + manual corrections, which aren't reconstructible from events); `user_rollups.events_miles` is audit/aggregation substrate. Bots are included in the write path; readers filter `is_bot` via a users join, matching `cmd/backfill-miles` semantics.

## Testing

- `migrate up` / `down` / `up` round-trip locally (verified in the follow-up PR's harness).
- No code changes; nothing reads these tables yet.