### PR TITLE
feat(cdk8s): flip ExternalSecrets to SSM Parameter Store

### DIFF
--- a/cdk8s/adanalife_k8s/charts.py
+++ b/cdk8s/adanalife_k8s/charts.py
@@ -59,7 +59,7 @@ class IdentityChart(Chart):
     isolated from the per-component app churn so the DB-creds ExternalSecret isn't
     re-applied on every app sync.
 
-    Depends on infra's ESO SecretStore (the `aws-secretsmanager` store these
+    Depends on infra's ESO SecretStore (the `aws-parameterstore` store these
     ExternalSecrets reference) + the shared observability Secrets being present
     first — same data→supporting→apps ordering as before, now spanning two repos.
     """

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -262,7 +262,7 @@ class Tripbot(Construct):
                 namespace=ns,
                 labels=labels,
                 creation_policy="Owner",
-                extract="k8s/tripbot/youtube-creds",
+                extract="/k8s/tripbot/youtube-creds",
             )
             env_from.append(
                 k8s.EnvFromSource(
@@ -507,7 +507,7 @@ def _emit_db_external_secret(scope, ns, labels):
             {
                 "refreshInterval": "1h",
                 "secretStoreRef": {
-                    "name": "aws-secretsmanager",
+                    "name": "aws-parameterstore",
                     "kind": "SecretStore",
                 },
                 "target": {
@@ -525,21 +525,21 @@ def _emit_db_external_secret(scope, ns, labels):
                     {
                         "secretKey": "user",
                         "remoteRef": {
-                            "key": "k8s/postgres/credentials",
+                            "key": "/k8s/postgres/credentials",
                             "property": "user",
                         },
                     },
                     {
                         "secretKey": "password",
                         "remoteRef": {
-                            "key": "k8s/postgres/credentials",
+                            "key": "/k8s/postgres/credentials",
                             "property": "password",
                         },
                     },
                     {
                         "secretKey": "db",
                         "remoteRef": {
-                            "key": "k8s/postgres/credentials",
+                            "key": "/k8s/postgres/credentials",
                             "property": "db",
                         },
                     },
@@ -555,12 +555,12 @@ def _emit_app_external_secrets(scope, ns, labels):
         (
             "twitch-external-secret",
             "tripbot-twitch-creds",
-            "k8s/tripbot/twitch-creds",
+            "/k8s/tripbot/twitch-creds",
         ),
         (
             "google-maps-external-secret",
             "tripbot-google-maps-api-key",
-            "k8s/tripbot/google-maps-api-key",
+            "/k8s/tripbot/google-maps-api-key",
         ),
     ]:
         eso.external_secret(
@@ -577,13 +577,13 @@ def _emit_app_external_secrets(scope, ns, labels):
         (
             "discord-alerts-external-secret",
             "tripbot-discord-alerts-webhook",
-            "k8s/tripbot/discord-alerts-webhook",
+            "/k8s/tripbot/discord-alerts-webhook",
             "DISCORD_ALERTS_WEBHOOK",
         ),
         (
             "discord-bot-token-external-secret",
             "tripbot-discord-bot-token",
-            "k8s/tripbot/discord-bot-token",
+            "/k8s/tripbot/discord-bot-token",
             "DISCORD_BOT_TOKEN",
         ),
     ]:

--- a/cdk8s/adanalife_k8s/eso.py
+++ b/cdk8s/adanalife_k8s/eso.py
@@ -33,7 +33,7 @@ import imports.io.external_secrets as esx
 # The store every app ExternalSecret references — namespaced, identical in
 # every env (isolation is structural: a namespaced store is unreachable
 # cross-namespace; the backing eso-aws-credentials decides the AWS account).
-DEFAULT_STORE = ("aws-secretsmanager", "SecretStore")
+DEFAULT_STORE = ("aws-parameterstore", "SecretStore")
 
 _STORE_KIND = {
     "SecretStore": esx.ExternalSecretSpecSecretStoreRefKind.SECRET_STORE,

--- a/cdk8s/dist/development-tripbot-identity.k8s.yaml
+++ b/cdk8s/dist/development-tripbot-identity.k8s.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: aws-secretsmanager
+    name: aws-parameterstore
     kind: SecretStore
   target:
     name: tripbot-database-creds
@@ -22,15 +22,15 @@ spec:
   data:
     - secretKey: user
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: password
     - secretKey: db
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: db
 ---
 apiVersion: external-secrets.io/v1
@@ -44,11 +44,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/twitch-creds
+        key: /k8s/tripbot/twitch-creds
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-twitch-creds
@@ -64,11 +64,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/google-maps-api-key
+        key: /k8s/tripbot/google-maps-api-key
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-google-maps-api-key
@@ -84,12 +84,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-alerts-webhook
+        key: /k8s/tripbot/discord-alerts-webhook
       secretKey: DISCORD_ALERTS_WEBHOOK
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-alerts-webhook
@@ -105,12 +105,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-bot-token
+        key: /k8s/tripbot/discord-bot-token
       secretKey: DISCORD_BOT_TOKEN
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-bot-token

--- a/cdk8s/dist/local-tripbot-identity.k8s.yaml
+++ b/cdk8s/dist/local-tripbot-identity.k8s.yaml
@@ -20,11 +20,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/twitch-creds
+        key: /k8s/tripbot/twitch-creds
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-twitch-creds
@@ -40,11 +40,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/google-maps-api-key
+        key: /k8s/tripbot/google-maps-api-key
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-google-maps-api-key
@@ -60,12 +60,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-alerts-webhook
+        key: /k8s/tripbot/discord-alerts-webhook
       secretKey: DISCORD_ALERTS_WEBHOOK
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-alerts-webhook
@@ -81,12 +81,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-bot-token
+        key: /k8s/tripbot/discord-bot-token
       secretKey: DISCORD_BOT_TOKEN
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-bot-token

--- a/cdk8s/dist/prod-1-tripbot-identity.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-identity.k8s.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: aws-secretsmanager
+    name: aws-parameterstore
     kind: SecretStore
   target:
     name: tripbot-database-creds
@@ -22,15 +22,15 @@ spec:
   data:
     - secretKey: user
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: password
     - secretKey: db
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: db
 ---
 apiVersion: external-secrets.io/v1
@@ -44,11 +44,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/twitch-creds
+        key: /k8s/tripbot/twitch-creds
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-twitch-creds
@@ -64,11 +64,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/google-maps-api-key
+        key: /k8s/tripbot/google-maps-api-key
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-google-maps-api-key
@@ -84,12 +84,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-alerts-webhook
+        key: /k8s/tripbot/discord-alerts-webhook
       secretKey: DISCORD_ALERTS_WEBHOOK
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-alerts-webhook
@@ -105,12 +105,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-bot-token
+        key: /k8s/tripbot/discord-bot-token
       secretKey: DISCORD_BOT_TOKEN
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-bot-token

--- a/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
@@ -42,11 +42,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/youtube-creds
+        key: /k8s/tripbot/youtube-creds
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-youtube-creds

--- a/cdk8s/dist/stage-1-tripbot-identity.k8s.yaml
+++ b/cdk8s/dist/stage-1-tripbot-identity.k8s.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: aws-secretsmanager
+    name: aws-parameterstore
     kind: SecretStore
   target:
     name: tripbot-database-creds
@@ -22,15 +22,15 @@ spec:
   data:
     - secretKey: user
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: password
     - secretKey: db
       remoteRef:
-        key: k8s/postgres/credentials
+        key: /k8s/postgres/credentials
         property: db
 ---
 apiVersion: external-secrets.io/v1
@@ -44,11 +44,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/twitch-creds
+        key: /k8s/tripbot/twitch-creds
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-twitch-creds
@@ -64,11 +64,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/google-maps-api-key
+        key: /k8s/tripbot/google-maps-api-key
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-google-maps-api-key
@@ -84,12 +84,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-alerts-webhook
+        key: /k8s/tripbot/discord-alerts-webhook
       secretKey: DISCORD_ALERTS_WEBHOOK
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-alerts-webhook
@@ -105,12 +105,12 @@ metadata:
 spec:
   data:
     - remoteRef:
-        key: k8s/tripbot/discord-bot-token
+        key: /k8s/tripbot/discord-bot-token
       secretKey: DISCORD_BOT_TOKEN
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-discord-bot-token

--- a/cdk8s/dist/stage-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/stage-1-tripbot-youtube.k8s.yaml
@@ -42,11 +42,11 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: k8s/tripbot/youtube-creds
+        key: /k8s/tripbot/youtube-creds
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: aws-secretsmanager
+    name: aws-parameterstore
   target:
     creationPolicy: Owner
     name: tripbot-youtube-creds

--- a/changelog.d/+eso-parameterstore.deploy.md
+++ b/changelog.d/+eso-parameterstore.deploy.md
@@ -1,0 +1,1 @@
+Identity/DB/observability Secrets now sync from SSM Parameter Store (the free `aws-parameterstore` ESO store) instead of AWS Secrets Manager.


### PR DESCRIPTION
Flips every ExternalSecret in cdk8s (identity secrets, postgres creds, youtube creds) to the `aws-parameterstore` SecretStore with `/`-prefixed keys. Part of the Secrets Manager → SSM Parameter Store cost migration; the store lands via [infra#809](https://github.com/adanalife/infra/pull/809/changes).

**Merge gate:** infra#808 applied + values seeded, and infra#809 merged + stores applied, BEFORE this merges (stage autosyncs develop). Existing Secrets persist either way; only refreshes would fail if merged early.

dist re-synthed; 35/35 cdk8s tests pass.