### PR TITLE
feat(rollups): events rollup reconciler + month-end scoreboard snapshots

### DIFF
--- a/changelog.d/1007.chatbot.md
+++ b/changelog.d/1007.chatbot.md
@@ -1,0 +1,1 @@
+Rollup schema: `user_rollups` + `rollup_watermarks` + `scoreboard_snapshots` tables — derived-state substrate for the events rollup reconciler (worker in a follow-up PR)

--- a/changelog.d/1009.chatbot.md
+++ b/changelog.d/1009.chatbot.md
@@ -1,0 +1,1 @@
+Events rollup reconciler: `user_rollups` aggregates recomputed from the events table on an id watermark, plus once-only month-end scoreboard snapshots — derived state for `!leaderboard` async, `!lastmonth`, and cross-platform stats

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -28,6 +28,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/obs/audiowatchdog"
 	"github.com/adanalife/tripbot/pkg/obs/watchdog"
 	onscreensClient "github.com/adanalife/tripbot/pkg/onscreens-client"
+	"github.com/adanalife/tripbot/pkg/rollups"
 	"github.com/adanalife/tripbot/pkg/server"
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	mytwitch "github.com/adanalife/tripbot/pkg/twitch"
@@ -812,6 +813,11 @@ func (t *Tripbot) scheduleBackgroundJobs() {
 	}
 	t.addJob(61*time.Second, "users.UpdateSession", t.sessions.UpdateSession)
 	t.addJob(62*time.Second, "users.UpdateLeaderboard", t.sessions.UpdateLeaderboard)
+	// Derived-state reconciler over the events table (all platforms' events,
+	// but only one instance should run it — the twitch gate above covers that).
+	// Singleton mode + the reconciler's own row lock make overlap harmless.
+	t.addJob(5*time.Minute, "rollups.Reconcile", rollups.Reconcile,
+		gocron.WithSingletonMode(gocron.LimitModeReschedule))
 	t.addJob(5*time.Minute, "chatbot.ShowRotatingLeaderboard", t.app.ShowRotatingLeaderboard)
 	t.addJob(5*time.Minute, "users.PrintCurrentSession", t.sessions.PrintCurrentSession)
 	t.addJob(5*time.Minute, "twitch.GetSubscribers", t.refreshSubscribers)

--- a/db/migrate/025_create_user_rollups.down.sql
+++ b/db/migrate/025_create_user_rollups.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE rollup_watermarks;
+DROP TABLE user_rollups;

--- a/db/migrate/025_create_user_rollups.up.sql
+++ b/db/migrate/025_create_user_rollups.up.sql
@@ -1,0 +1,28 @@
+/* Derived per-(platform, username) aggregates, recomputed from the append-only
+   events table by the rollup reconciler. events_miles is events-derived only
+   (no subscriber bonus, no manual corrections) — users.miles stays the display
+   number; this column is for audit and cross-platform aggregation.
+   Keyed on (platform, username), not users.id: events rows key on it and it's
+   the join key future identity linking will use. Bots are included here;
+   readers filter is_bot via a users join. */
+CREATE TABLE user_rollups (
+  id            SERIAL PRIMARY KEY,
+  platform      TEXT NOT NULL,
+  username      VARCHAR(64) NOT NULL,
+  events_miles  REAL NOT NULL DEFAULT 0.0,
+  session_count INTEGER NOT NULL DEFAULT 0,
+  first_seen    TIMESTAMP WITH TIME ZONE,
+  last_seen     TIMESTAMP WITH TIME ZONE,
+  date_updated  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (platform, username)
+);
+
+/* Reconciler progress, keyed on events.id (never date_created — historical
+   rows carry zero-value dates). One row per rollup job. */
+CREATE TABLE rollup_watermarks (
+  name          TEXT PRIMARY KEY,
+  last_event_id INTEGER NOT NULL DEFAULT 0,
+  date_updated  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO rollup_watermarks (name) VALUES ('user_rollups');

--- a/db/migrate/026_create_scoreboard_snapshots.down.sql
+++ b/db/migrate/026_create_scoreboard_snapshots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE scoreboard_snapshots;

--- a/db/migrate/026_create_scoreboard_snapshots.up.sql
+++ b/db/migrate/026_create_scoreboard_snapshots.up.sql
@@ -1,0 +1,14 @@
+/* Immutable month-end snapshots of the monthly scoreboards (miles_YYYY_MM,
+   guess_state_YYYY_MM), written once per board by the rollup reconciler after
+   rollover. Monthly boards themselves stay mutable-in-place and roll over
+   silently; this table is what lets a future !lastmonth render history. */
+CREATE TABLE scoreboard_snapshots (
+  id              SERIAL PRIMARY KEY,
+  scoreboard_name VARCHAR(64) NOT NULL,
+  platform        TEXT NOT NULL,
+  rank            INTEGER NOT NULL,
+  username        VARCHAR(64) NOT NULL,
+  value           REAL NOT NULL,
+  date_created    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (scoreboard_name, platform, rank)
+);

--- a/pkg/rollups/rollups.go
+++ b/pkg/rollups/rollups.go
@@ -1,0 +1,164 @@
+// Package rollups maintains derived summary tables from the append-only
+// events table. The events table stays the source of truth (never mutated
+// here); everything this package writes is rebuildable derived state:
+//
+//	DELETE FROM user_rollups;
+//	UPDATE rollup_watermarks SET last_event_id = 0 WHERE name = 'user_rollups';
+//
+// user_rollups.events_miles is events-derived only — it excludes the live
+// subscriber bonus and historical manual corrections, so it will read lower
+// than users.miles. users.miles remains the display number; this column is
+// for audit, reconciliation, and cross-platform aggregation.
+package rollups
+
+import (
+	"context"
+	"log/slog"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/adanalife/tripbot/pkg/scoreboards"
+	"gorm.io/gorm"
+)
+
+const watermarkName = "user_rollups"
+
+// reconcileSQL fully recomputes aggregates for every (platform, username)
+// that has new events since the watermark. The pairing CTE is the same
+// algorithm as cmd/backfill-miles: the N-th login pairs with the N-th logout
+// (robust to historical rows with NULL session_id), sessions over 24h are
+// dropped as missed logouts, and miles = 0.1 per 3 minutes.
+//
+// Full recompute (not incremental addition) is what makes the tick idempotent
+// and self-healing: re-running with any watermark produces the same rows.
+// The aggregate subqueries deliberately aren't bounded by the captured max id
+// — seeing rows newer than the watermark just makes the result more current,
+// and those users get recomputed again next tick anyway.
+//
+// first_seen/last_seen exclude the pre-2000 sentinel: historical events rows
+// carry zero-value (0001-01-01) date_created from an old insert bug.
+const reconcileSQL = `
+WITH dirty AS (
+    SELECT DISTINCT platform, username FROM events
+    WHERE id > ? AND id <= ?
+),
+login_rn AS (
+    SELECT e.platform, e.username, e.date_created AS login_time,
+           ROW_NUMBER() OVER (PARTITION BY e.platform, e.username ORDER BY e.date_created) AS rn
+    FROM events e JOIN dirty d ON d.platform = e.platform AND d.username = e.username
+    WHERE e.event = 'login'
+),
+logout_rn AS (
+    SELECT e.platform, e.username, e.date_created AS logout_time,
+           ROW_NUMBER() OVER (PARTITION BY e.platform, e.username ORDER BY e.date_created) AS rn
+    FROM events e JOIN dirty d ON d.platform = e.platform AND d.username = e.username
+    WHERE e.event = 'logout'
+),
+sessions AS (
+    SELECT l.platform, l.username,
+           EXTRACT(EPOCH FROM (lo.logout_time - l.login_time)) / 60.0 AS minutes
+    FROM login_rn l
+    JOIN logout_rn lo ON lo.platform = l.platform AND lo.username = l.username AND lo.rn = l.rn
+    WHERE lo.logout_time > l.login_time
+      AND EXTRACT(EPOCH FROM (lo.logout_time - l.login_time)) / 3600.0 < 24
+),
+miles AS (
+    SELECT platform, username, SUM(0.1 * minutes / 3.0)::real AS events_miles
+    FROM sessions GROUP BY platform, username
+),
+agg AS (
+    SELECT d.platform, d.username,
+           COALESCE(m.events_miles, 0) AS events_miles,
+           (SELECT COUNT(*) FROM events e WHERE e.platform = d.platform
+              AND e.username = d.username AND e.event = 'login') AS session_count,
+           (SELECT MIN(e.date_created) FROM events e WHERE e.platform = d.platform
+              AND e.username = d.username AND e.date_created > '2000-01-01') AS first_seen,
+           (SELECT MAX(e.date_created) FROM events e WHERE e.platform = d.platform
+              AND e.username = d.username AND e.date_created > '2000-01-01') AS last_seen
+    FROM dirty d
+    LEFT JOIN miles m ON m.platform = d.platform AND m.username = d.username
+)
+INSERT INTO user_rollups (platform, username, events_miles, session_count, first_seen, last_seen, date_updated)
+SELECT platform, username, events_miles, session_count, first_seen, last_seen, now()
+FROM agg
+ON CONFLICT (platform, username) DO UPDATE SET
+    events_miles  = EXCLUDED.events_miles,
+    session_count = EXCLUDED.session_count,
+    first_seen    = EXCLUDED.first_seen,
+    last_seen     = EXCLUDED.last_seen,
+    date_updated  = now()
+`
+
+// snapshotSQL freezes a finished monthly scoreboard into scoreboard_snapshots,
+// top 50 per platform. Single idempotent statement: inserts nothing if the
+// board doesn't exist yet, and the NOT EXISTS guard makes the write once-only
+// per board. Bots excluded, matching the live leaderboard reads.
+const snapshotSQL = `
+INSERT INTO scoreboard_snapshots (scoreboard_name, platform, rank, username, value)
+SELECT ?, ranked.platform, ranked.rank, ranked.username, ranked.value
+FROM (
+    SELECT u.platform, u.username, s.value,
+           ROW_NUMBER() OVER (PARTITION BY u.platform ORDER BY s.value DESC) AS rank
+    FROM scores s
+    JOIN scoreboards b ON b.id = s.scoreboard_id
+    JOIN users u ON u.id = s.user_id
+    WHERE b.name = ? AND u.is_bot = false
+) ranked
+WHERE ranked.rank <= 50
+  AND NOT EXISTS (SELECT 1 FROM scoreboard_snapshots ss WHERE ss.scoreboard_name = ?)
+`
+
+// Reconcile is the rollup tick, registered as a background job on the twitch
+// instance (it scans every platform's events regardless of which instance
+// runs it). One transaction per tick: snapshot any just-finished monthly
+// boards, then recompute aggregates for users with events past the watermark
+// and advance it. The watermark keys on events.id — never date_created, which
+// is zero-valued on historical rows.
+func Reconcile(ctx context.Context) {
+	if c.Conf.ReadOnly {
+		return
+	}
+
+	err := database.GormDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Month-end snapshots run before the new-events check so a quiet
+		// month still gets frozen on the first tick after rollover.
+		for _, board := range []string{scoreboards.PreviousMilesScoreboard(), scoreboards.PreviousGuessScoreboard()} {
+			res := tx.Exec(snapshotSQL, board, board, board)
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected > 0 {
+				slog.InfoContext(ctx, "froze monthly scoreboard snapshot",
+					"scoreboard", board, "count", res.RowsAffected)
+			}
+		}
+
+		// FOR UPDATE serializes overlapping ticks (belt-and-suspenders on
+		// top of the job's singleton mode).
+		var wm int64
+		if err := tx.Raw(`SELECT last_event_id FROM rollup_watermarks WHERE name = ? FOR UPDATE`,
+			watermarkName).Scan(&wm).Error; err != nil {
+			return err
+		}
+		var maxID int64
+		if err := tx.Raw(`SELECT COALESCE(MAX(id), 0) FROM events`).Scan(&maxID).Error; err != nil {
+			return err
+		}
+		if maxID <= wm {
+			return nil
+		}
+
+		res := tx.Exec(reconcileSQL, wm, maxID)
+		if res.Error != nil {
+			return res.Error
+		}
+		slog.DebugContext(ctx, "reconciled user rollups",
+			"count", res.RowsAffected, "watermark", maxID)
+
+		return tx.Exec(`UPDATE rollup_watermarks SET last_event_id = ?, date_updated = now() WHERE name = ?`,
+			maxID, watermarkName).Error
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "rollup reconcile failed", "err", err)
+	}
+}

--- a/pkg/rollups/rollups_test.go
+++ b/pkg/rollups/rollups_test.go
@@ -1,0 +1,123 @@
+package rollups
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/database"
+	"github.com/adanalife/tripbot/pkg/scoreboards"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// installMockDB mirrors pkg/chatbot's helper: a sqlmock-backed *gorm.DB
+// installed as the process-wide singleton so Reconcile routes to the mock.
+func installMockDB(t *testing.T) sqlmock.Sqlmock {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	database.SetGormDB(gdb)
+	t.Cleanup(func() {
+		database.SetGormDB(nil)
+		_ = sqlDB.Close()
+	})
+	return mock
+}
+
+// expectSnapshots registers the two idempotent month-end snapshot inserts that
+// open every tick. Strict args pin the board-name parameter in all three
+// positions (insert value, board lookup, once-only guard).
+func expectSnapshots(mock sqlmock.Sqlmock) {
+	for _, board := range []string{scoreboards.PreviousMilesScoreboard(), scoreboards.PreviousGuessScoreboard()} {
+		mock.ExpectExec(`INSERT INTO scoreboard_snapshots`).
+			WithArgs(board, board, board).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+}
+
+func TestReconcile_NoNewEventsIsANoOp(t *testing.T) {
+	mock := installMockDB(t)
+
+	mock.ExpectBegin()
+	expectSnapshots(mock)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT last_event_id FROM rollup_watermarks WHERE name = $1 FOR UPDATE`)).
+		WithArgs(watermarkName).
+		WillReturnRows(sqlmock.NewRows([]string{"last_event_id"}).AddRow(100))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(id), 0) FROM events`)).
+		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(100))
+	mock.ExpectCommit()
+
+	Reconcile(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestReconcile_RecomputesDirtyUsersAndAdvancesWatermark(t *testing.T) {
+	mock := installMockDB(t)
+
+	mock.ExpectBegin()
+	expectSnapshots(mock)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT last_event_id FROM rollup_watermarks WHERE name = $1 FOR UPDATE`)).
+		WithArgs(watermarkName).
+		WillReturnRows(sqlmock.NewRows([]string{"last_event_id"}).AddRow(100))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COALESCE(MAX(id), 0) FROM events`)).
+		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(150))
+	// Strict args pin the watermark window: recompute exactly (100, 150].
+	mock.ExpectExec(`INSERT INTO user_rollups`).
+		WithArgs(int64(100), int64(150)).
+		WillReturnResult(sqlmock.NewResult(0, 3))
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE rollup_watermarks SET last_event_id = $1, date_updated = now() WHERE name = $2`)).
+		WithArgs(int64(150), watermarkName).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	Reconcile(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestReconcile_SnapshotErrorRollsBack(t *testing.T) {
+	mock := installMockDB(t)
+
+	mock.ExpectBegin()
+	board := scoreboards.PreviousMilesScoreboard()
+	mock.ExpectExec(`INSERT INTO scoreboard_snapshots`).
+		WithArgs(board, board, board).
+		WillReturnError(context.DeadlineExceeded)
+	mock.ExpectRollback()
+
+	Reconcile(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestReconcile_ReadOnlySkipsEverything(t *testing.T) {
+	mock := installMockDB(t)
+
+	orig := c.Conf.ReadOnly
+	c.Conf.ReadOnly = true
+	t.Cleanup(func() { c.Conf.ReadOnly = orig })
+
+	Reconcile(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("ReadOnly Reconcile touched the DB: %v", err)
+	}
+}

--- a/pkg/scoreboards/miles.go
+++ b/pkg/scoreboards/miles.go
@@ -18,3 +18,21 @@ func CurrentGuessScoreboard() string {
 	// uses YYYY_MM format
 	return "guess_state_" + time.Now().Format("2006_01")
 }
+
+// previousMonth returns a time inside the previous calendar month. Anchored to
+// the first of the current month minus a day so month-length differences can't
+// skip a month (time.AddDate(0, -1, 0) on the 31st normalizes forward).
+func previousMonth() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1)
+}
+
+// PreviousMilesScoreboard names last month's miles scoreboard.
+func PreviousMilesScoreboard() string {
+	return "miles_" + previousMonth().Format("2006_01")
+}
+
+// PreviousGuessScoreboard names last month's guess scoreboard.
+func PreviousGuessScoreboard() string {
+	return "guess_state_" + previousMonth().Format("2006_01")
+}


### PR DESCRIPTION
## Summary

The worker half of the rollup schema in #1007 (stacked on that branch — merge #1007 first; GitHub will retarget this to develop).

- **`pkg/rollups`** — `Reconcile(ctx)`: one transaction per tick. Freezes any just-finished monthly scoreboard into `scoreboard_snapshots` (top 50 per platform, once-only via existence guard), then fully recomputes `user_rollups` aggregates for every `(platform, username)` with events past the watermark, and advances the watermark.
- **Algorithm parity with `cmd/backfill-miles`** — same ROW_NUMBER login/logout pairing, 24h session cap, `0.1 mi / 3 min`. Full per-user recompute makes every tick idempotent and self-healing; the whole derived state is rebuildable (`DELETE FROM user_rollups` + watermark reset).
- **Watermark keys on `events.id`** — never `date_created`, which is zero-valued (`0001-01-01`) on historical rows.
- **Registration** — `rollups.Reconcile` every 5 min on the twitch instance only (it scans all platforms' events; the gate just picks one runner). gocron singleton mode + `FOR UPDATE` on the watermark row serialize any overlap.
- **`users.miles` stays the display number** — `events_miles` excludes the live subscriber bonus and manual corrections, so it reads lower by design; it's for audit/reconciliation and cross-platform aggregation.
- New `scoreboards.PreviousMilesScoreboard()` / `PreviousGuessScoreboard()` helpers (anchored to first-of-month so 31st-day normalization can't skip a month).

## Testing

- sqlmock tests with strict `WithArgs`: no-op tick, recompute window `(wm, max]` + watermark advance, snapshot-error rollback, ReadOnly short-circuit.
- `go build ./cmd/tripbot ./pkg/rollups ./pkg/scoreboards` + `go test` green.
- Parity check vs `cmd/backfill-miles` on a historical dump planned before merge.