### PR TITLE
refactor(users): rebuild lifetime leaderboard from the DB each tick

### DIFF
--- a/changelog.d/1010.chatbot.md
+++ b/changelog.d/1010.chatbot.md
@@ -1,0 +1,1 @@
+Lifetime leaderboard is rebuilt from the users table every tick (was: in-memory from logged-in users only, drifting from the DB after boot); live session miles still overlay for logged-in viewers

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -4,103 +4,72 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strconv"
+	"sort"
 	"strings"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
 	"github.com/adanalife/tripbot/pkg/database"
-	"github.com/logrusorgru/aurora/v3"
 )
 
 var initLeaderboardSize = 25
 var maxLeaderboardSize = 50
 
-// InitLeaderboard creates the initial leaderboard
-func (s *Sessions) InitLeaderboard(ctx context.Context) {
+// fetchLeaderboard reads the top users by stored lifetime miles, scoped to
+// this instance's platform, excluding bots and the channel owner.
+func fetchLeaderboard(ctx context.Context, limit int) ([]User, error) {
 	var users []User
-
 	result := database.GormDB().WithContext(ctx).
 		Where("platform = ? AND miles != 0 AND is_bot = false AND username != ?", c.Conf.Platform, strings.ToLower(c.Conf.ChannelName)).
 		Order("miles DESC").
-		Limit(initLeaderboardSize).
+		Limit(limit).
 		Find(&users)
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "error fetching leaderboard", "err", result.Error)
-	}
-
-	for _, user := range users {
-		miles := fmt.Sprintf("%.1f", user.Miles)
-		pair := []string{user.Username, miles}
-		s.lifetimeLeaderboard = append(s.lifetimeLeaderboard, pair)
-	}
+	return users, result.Error
 }
 
-// UpdateLeaderboard rebuilds the lifetime-miles leaderboard from the
-// session's logged-in users. The work is in-memory (no DB hits), so ctx
-// only carries the cron-tick span for log correlation.
+// InitLeaderboard creates the initial leaderboard
+func (s *Sessions) InitLeaderboard(ctx context.Context) {
+	users, err := fetchLeaderboard(ctx, initLeaderboardSize)
+	if err != nil {
+		slog.ErrorContext(ctx, "error fetching leaderboard", "err", err)
+	}
+	s.lifetimeLeaderboard = toPairs(users)
+}
+
+// UpdateLeaderboard rebuilds the lifetime-miles leaderboard from the users
+// table, overlaying in-progress session miles for anyone currently logged in
+// so lurkers' numbers keep ticking between logouts. Replaces the cached slice
+// wholesale; before this it was rebuilt in-memory from logged-in users only,
+// which drifted from the DB after boot.
 func (s *Sessions) UpdateLeaderboard(ctx context.Context) {
-	for _, user := range s.loggedIn {
-		// skip adding this user if they're a bot or the channel owner
-		if user.IsBot || c.UserIsAdmin(user.Username) {
+	users, err := fetchLeaderboard(ctx, maxLeaderboardSize)
+	if err != nil {
+		slog.ErrorContext(ctx, "error fetching leaderboard", "err", err)
+		return
+	}
+	for i, user := range users {
+		if live, ok := s.loggedIn[user.Username]; ok {
+			users[i].Miles = s.CurrentMiles(ctx, *live)
+		}
+	}
+	// ponytail: a logged-in user whose stored miles sit just below the top-50
+	// cutoff won't appear until logout — same class of miss as the old
+	// in-memory rebuild.
+	sort.SliceStable(users, func(i, j int) bool { return users[i].Miles > users[j].Miles })
+	s.lifetimeLeaderboard = toPairs(users)
+}
+
+// toPairs formats users as the [username, miles] string pairs the leaderboard
+// consumers render, skipping admin accounts (the DB query already excludes
+// bots and the channel owner).
+func toPairs(users []User) [][]string {
+	pairs := make([][]string, 0, len(users))
+	for _, user := range users {
+		if c.UserIsAdmin(user.Username) {
 			continue
 		}
-		s.insertIntoLeaderboard(ctx, *user)
+		pairs = append(pairs, []string{user.Username, fmt.Sprintf("%.1f", user.Miles)})
 	}
-	// truncate the leaderboard if it gets too big
-	if len(s.lifetimeLeaderboard) > maxLeaderboardSize {
-		s.lifetimeLeaderboard = s.lifetimeLeaderboard[:maxLeaderboardSize]
-	}
-}
-
-// convert the string to a float32
-func strToFloat32(ctx context.Context, str string) float32 {
-	value, err := strconv.ParseFloat(str, 32)
-	if err != nil {
-		slog.ErrorContext(ctx, "error parsing float", "err", err)
-		return 0.0
-	}
-	return float32(value)
-}
-
-func (s *Sessions) insertIntoLeaderboard(ctx context.Context, user User) {
-	// first we remove this user from the board
-	s.removeFromLeaderboard(user.Username)
-
-	// get the current miles as a float
-	miles := s.CurrentMiles(ctx, user)
-
-	for i, pair := range s.lifetimeLeaderboard {
-		val := strToFloat32(ctx, pair[1])
-		// see if our miles are higher
-		if miles >= val {
-			milesStr := fmt.Sprintf("%.1f", miles)
-			newPair := []string{user.Username, milesStr}
-
-			// insert into the leaderboard
-			// https://github.com/golang/go/wiki/SliceTricks#insert
-			s.lifetimeLeaderboard = append(s.lifetimeLeaderboard[:i], append([][]string{newPair}, s.lifetimeLeaderboard[i:]...)...)
-			return
-		}
-	}
-}
-
-// removeFromLeaderboard searches the leaderboard for a username and removes it
-func (s *Sessions) removeFromLeaderboard(username string) {
-	for i, pair := range s.lifetimeLeaderboard {
-		if pair[0] == username {
-			// delete from the leaderboard
-			// https://github.com/golang/go/wiki/SliceTricks#delete
-			s.lifetimeLeaderboard = append(s.lifetimeLeaderboard[:i], s.lifetimeLeaderboard[i+1:]...)
-			return
-		}
-	}
-}
-
-// this was used for development
-func (s *Sessions) printLeaderboard() {
-	for i, pair := range s.lifetimeLeaderboard {
-		fmt.Printf("%d: %s - %s\n", i+1, pair[1], aurora.Magenta(pair[0]))
-	}
+	return pairs
 }
 
 // LifetimeLeaderboard returns the cached lifetime-miles leaderboard (a slice of

--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -2,109 +2,117 @@ package users
 
 import (
 	"context"
+	"database/sql/driver"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
-func TestStrToFloat32Valid(t *testing.T) {
-	tests := []struct {
-		in   string
-		want float32
-	}{
-		{"0", 0},
-		{"1.5", 1.5},
-		{"42.0", 42.0},
-		{"-3.25", -3.25},
+// installMockDB mirrors pkg/chatbot's helper: a sqlmock-backed *gorm.DB
+// installed as the process-wide singleton so fetchLeaderboard routes to it.
+func installMockDB(t *testing.T) sqlmock.Sqlmock {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
-			got := strToFloat32(context.Background(), tt.in)
-			if got != tt.want {
-				t.Fatalf("got %v, want %v", got, tt.want)
-			}
-		})
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
 	}
+	database.SetGormDB(gdb)
+	t.Cleanup(func() {
+		database.SetGormDB(nil)
+		_ = sqlDB.Close()
+	})
+	return mock
 }
 
-func TestRemoveFromLeaderboard(t *testing.T) {
+func leaderboardRows(rows ...[]driver.Value) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"username", "miles", "platform", "is_bot"})
+	for _, row := range rows {
+		r.AddRow(row...)
+	}
+	return r
+}
+
+// TestUpdateLeaderboard_ReadsFromDB pins the platform-scoping contract with
+// strict args: the fetch must filter by this instance's platform and exclude
+// the channel owner (loose regexes have silently absorbed missing platform
+// filters before).
+func TestUpdateLeaderboard_ReadsFromDB(t *testing.T) {
+	mock := installMockDB(t)
+	mock.ExpectQuery(`SELECT \* FROM "users" WHERE platform = \$1 AND miles != 0 AND is_bot = false AND username != \$2 ORDER BY miles DESC LIMIT \$3`).
+		WithArgs(c.Conf.Platform, strings.ToLower(c.Conf.ChannelName), maxLeaderboardSize).
+		WillReturnRows(leaderboardRows(
+			[]driver.Value{"alice", float32(100), "twitch", false},
+			[]driver.Value{"bob", float32(50), "twitch", false},
+		))
+
 	s := New(noopChatterSource{})
-	s.lifetimeLeaderboard = [][]string{
-		{"alice", "100"}, {"bob", "75"}, {"carol", "50"},
-	}
+	s.UpdateLeaderboard(context.Background())
 
-	s.removeFromLeaderboard("bob")
-
-	if len(s.lifetimeLeaderboard) != 2 {
-		t.Fatalf("expected 2 entries after remove, got %d", len(s.lifetimeLeaderboard))
+	want := [][]string{{"alice", "100.0"}, {"bob", "50.0"}}
+	got := s.LifetimeLeaderboard()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d entries, got %d: %v", len(want), len(got), got)
 	}
-	for _, pair := range s.lifetimeLeaderboard {
-		if pair[0] == "bob" {
-			t.Fatal("bob still present after remove")
+	for i := range want {
+		if got[i][0] != want[i][0] || got[i][1] != want[i][1] {
+			t.Fatalf("row %d: got %v, want %v", i, got[i], want[i])
 		}
 	}
-}
-
-func TestRemoveFromLeaderboardMissing(t *testing.T) {
-	s := New(noopChatterSource{})
-	s.lifetimeLeaderboard = [][]string{
-		{"alice", "100"}, {"bob", "75"},
-	}
-
-	s.removeFromLeaderboard("nobody")
-
-	if len(s.lifetimeLeaderboard) != 2 {
-		t.Fatalf("expected unchanged length after missing remove, got %d", len(s.lifetimeLeaderboard))
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
 	}
 }
 
-func TestRemoveFromLeaderboardEmpty(t *testing.T) {
+// A logged-in user's in-progress session miles overlay their stored miles and
+// can reorder the board between logouts.
+func TestUpdateLeaderboard_OverlaysLiveSessionMiles(t *testing.T) {
+	mock := installMockDB(t)
+	mock.ExpectQuery(`SELECT \* FROM "users"`).
+		WithArgs(c.Conf.Platform, strings.ToLower(c.Conf.ChannelName), maxLeaderboardSize).
+		WillReturnRows(leaderboardRows(
+			[]driver.Value{"alice", float32(100), "twitch", false},
+			[]driver.Value{"bob", float32(99), "twitch", false},
+		))
+
 	s := New(noopChatterSource{})
+	// bob has been logged in for ~10 hours: 0.1mi/3min = ~20 miles in
+	// progress, enough to pass alice before his logout writes it back.
+	s.loggedIn["bob"] = &User{Username: "bob", Miles: 99, LoggedIn: time.Now().Add(-10 * time.Hour)}
+	s.UpdateLeaderboard(context.Background())
 
-	s.removeFromLeaderboard("alice")
-
-	if len(s.lifetimeLeaderboard) != 0 {
-		t.Fatalf("expected empty leaderboard, got %v", s.lifetimeLeaderboard)
+	got := s.LifetimeLeaderboard()
+	if len(got) != 2 || got[0][0] != "bob" {
+		t.Fatalf("expected bob first after live-miles overlay, got %v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
 	}
 }
 
-// insertIntoLeaderboard pulls miles from User.CurrentMiles. The user isn't in
-// the default session, so CurrentMiles returns User.Miles directly (no session
-// bonus) — making the math deterministic.
-func TestInsertIntoLeaderboardOrdersByMilesDesc(t *testing.T) {
+// A failed fetch must leave the previous board in place rather than blanking
+// what the rotators display.
+func TestUpdateLeaderboard_KeepsCacheOnError(t *testing.T) {
+	mock := installMockDB(t)
+	mock.ExpectQuery(`SELECT \* FROM "users"`).
+		WillReturnError(context.DeadlineExceeded)
+
 	s := New(noopChatterSource{})
-	s.lifetimeLeaderboard = [][]string{
-		{"existing-1", "100"},
-		{"existing-2", "50"},
-		{"existing-3", "10"},
-	}
+	s.lifetimeLeaderboard = [][]string{{"alice", "100.0"}}
+	s.UpdateLeaderboard(context.Background())
 
-	u := User{Username: "newcomer", Miles: 75}
-	s.insertIntoLeaderboard(context.Background(), u)
-
-	if len(s.lifetimeLeaderboard) != 4 {
-		t.Fatalf("expected 4 entries after insert, got %d: %v",
-			len(s.lifetimeLeaderboard), s.lifetimeLeaderboard)
-	}
-	if s.lifetimeLeaderboard[1][0] != "newcomer" {
-		t.Fatalf("expected newcomer at index 1 (between 100 and 50), got order %v", s.lifetimeLeaderboard)
-	}
-}
-
-func TestInsertIntoLeaderboardReplacesExistingUser(t *testing.T) {
-	s := New(noopChatterSource{})
-	s.lifetimeLeaderboard = [][]string{
-		{"alice", "100"},
-		{"bob", "50"},
-	}
-
-	// Bob's miles increased to 200 — should jump above alice and replace his old row.
-	u := User{Username: "bob", Miles: 200}
-	s.insertIntoLeaderboard(context.Background(), u)
-
-	if len(s.lifetimeLeaderboard) != 2 {
-		t.Fatalf("expected length unchanged after replace, got %d: %v",
-			len(s.lifetimeLeaderboard), s.lifetimeLeaderboard)
-	}
-	if s.lifetimeLeaderboard[0][0] != "bob" {
-		t.Fatalf("expected bob to be #1 with 200 miles, got %v", s.lifetimeLeaderboard)
+	if len(s.LifetimeLeaderboard()) != 1 {
+		t.Fatalf("expected cache preserved on error, got %v", s.LifetimeLeaderboard())
 	}
 }


### PR DESCRIPTION
## Summary

Independent piece of the rollup/identity work (no schema dependency; pairs conceptually with #1007/#1009).

The lifetime-miles leaderboard was an in-memory cache rebuilt every 62s from **currently-logged-in users only** — after boot it drifted from the users table (an offline user's entry stayed frozen at whatever `InitLeaderboard` saw). Now every tick fetches the top rows from the users table (platform-scoped, bots + channel owner excluded) and overlays in-progress session miles for logged-in users, so lurkers' numbers keep ticking between logouts exactly like before.

- `users.miles` remains the display number (per the rollup design: events-derived miles are audit-only).
- Deletes the hand-rolled insert/remove/parse helpers; consumers (`LifetimeLeaderboard()` → chatbot rotators, Discord commands) unchanged.
- Known edge (commented): a logged-in user whose stored miles sit just below the top-50 cutoff won't appear until logout — same class of miss as the old rebuild.

## Testing

- New sqlmock tests with strict `WithArgs` pinning the platform + channel-name filters, the live-miles overlay reorder, and cache-preserved-on-error.
- `go test ./pkg/users ./pkg/chatbot ./pkg/discord` green.