### PR TITLE
chore(taskfile): auth-bootstrap reads twitch creds from SSM

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,9 +69,9 @@ tasks:
     cmds:
       - |
         secret=$(aws-vault exec adanalife-stage -- \
-          aws secretsmanager get-secret-value \
-          --secret-id k8s/tripbot/twitch-creds \
-          --query SecretString --output text)
+          aws ssm get-parameter --with-decryption \
+          --name /k8s/tripbot/twitch-creds \
+          --query Parameter.Value --output text)
         export TWITCH_CLIENT_ID=$(echo "$secret" | jq -r .TWITCH_CLIENT_ID)
         export TWITCH_CLIENT_SECRET=$(echo "$secret" | jq -r .TWITCH_CLIENT_SECRET)
         printf '\a'
@@ -86,9 +86,9 @@ tasks:
     cmds:
       - |
         secret=$(aws-vault exec adanalife-stage -- \
-          aws secretsmanager get-secret-value \
-          --secret-id k8s/tripbot/twitch-creds \
-          --query SecretString --output text)
+          aws ssm get-parameter --with-decryption \
+          --name /k8s/tripbot/twitch-creds \
+          --query Parameter.Value --output text)
         export TWITCH_CLIENT_ID=$(echo "$secret" | jq -r .TWITCH_CLIENT_ID)
         export TWITCH_CLIENT_SECRET=$(echo "$secret" | jq -r .TWITCH_CLIENT_SECRET)
         printf '\a'

--- a/changelog.d/+taskfile-ssm.deploy.md
+++ b/changelog.d/+taskfile-ssm.deploy.md
@@ -1,0 +1,1 @@
+The auth:bootstrap tasks read Twitch app credentials from SSM Parameter Store instead of the retired AWS Secrets Manager.


### PR DESCRIPTION
The two `auth:bootstrap` tasks were the last Secrets Manager readers anywhere — they now `aws ssm get-parameter` the same value at `/k8s/tripbot/twitch-creds`. Pairs with [infra#814](https://github.com/adanalife/infra/pull/814/changes), which deletes the SM containers.