### PR TITLE
feat(cdk8s): wire prod tripbot-twitch to gateway-twitch (dormant)

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -277,6 +277,11 @@ ENVS: dict[str, EnvConfig] = {
         # prod gateway holds a YouTube token as of 2026-06-22, so this is safe to
         # ship; without a gateway token, sends would fail.
         youtube_api_url="http://gateway-youtube.prod-1.svc.cluster.local:8080",
+        # Wire prod tripbot-twitch to gateway-twitch (in-namespace). This only
+        # sets TWITCH_API_URL — routing stays two-layer-gated, so the gateway is
+        # dormant until the chatbot.twitch_gateway feature flag is flipped on via
+        # the console (no restart). See vault/platform-gateway/cutover-runbook.
+        twitch_api_url="http://gateway-twitch.prod-1.svc.cluster.local:8080",
         # The live stream always wins: prod app pods outrank default-priority
         # co-tenants (stage, dashcam-cv), and vlc's decode side carries a real CPU
         # request so contention can't starve it (20-core node). OBS's matching

--- a/cdk8s/dist/prod-1-tripbot-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-twitch.k8s.yaml
@@ -25,6 +25,7 @@ data:
   READ_ONLY: "false"
   SENTRY_ENVIRONMENT: prod-1
   TRIPBOT_SERVER_PORT: "8080"
+  TWITCH_API_URL: http://gateway-twitch.prod-1.svc.cluster.local:8080
   VERBOSE: "false"
   VLC_SERVER_HOST: vlc-twitch:8080
 ---
@@ -44,7 +45,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 8f844f58f3
+        adanalife.dev/config-hash: 38bd887a79
       labels:
         app: tripbot-twitch
     spec:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -144,8 +144,9 @@ def test_stage_omits_replicas_prod_keeps_one():
 
 
 def test_stage_twitch_routes_through_gateway():
-    """Stage tripbot-twitch carries TWITCH_API_URL (Phase 3 gateway); the youtube
-    instance and prod tripbot do not."""
+    """Both stage and prod tripbot-twitch carry TWITCH_API_URL (Phase 3 gateway);
+    the youtube instances do not. On prod the gateway stays dormant until the
+    chatbot.twitch_gateway flag is flipped — TWITCH_API_URL only wires it."""
 
     def _cm_data(stem):
         return _by_kind(_objects(stem), "ConfigMap")[0]["data"]
@@ -154,8 +155,12 @@ def test_stage_twitch_routes_through_gateway():
         _cm_data("stage-1-tripbot-twitch").get("TWITCH_API_URL")
         == "http://gateway-twitch.stage-1.svc.cluster.local:8080"
     )
+    assert (
+        _cm_data("prod-1-tripbot-twitch").get("TWITCH_API_URL")
+        == "http://gateway-twitch.prod-1.svc.cluster.local:8080"
+    )
     assert "TWITCH_API_URL" not in _cm_data("stage-1-tripbot-youtube")
-    assert "TWITCH_API_URL" not in _cm_data("prod-1-tripbot-twitch")
+    assert "TWITCH_API_URL" not in _cm_data("prod-1-tripbot-youtube")
 
 
 def test_stage_youtube_routes_sends_through_gateway():

--- a/changelog.d/+wire-prod-twitch-gateway.gateway.md
+++ b/changelog.d/+wire-prod-twitch-gateway.gateway.md
@@ -1,0 +1,1 @@
+Prod tripbot-twitch is now wired to gateway-twitch (TWITCH_API_URL set). Routing stays gated behind the chatbot.twitch_gateway feature flag, so the gateway is dormant until the flag is flipped on via the console — no restart.


### PR DESCRIPTION
Sets `TWITCH_API_URL` on the **prod-1** `tripbot-twitch` instance, pointing at the in-namespace `gateway-twitch` Service — mirroring the stage-1 wiring already in place.

This is **step 2 of the Twitch gateway cutover runbook**: the flag-off wiring restart. Routing stays two-layer-gated, so **this change alone cuts nothing over** — the gateway becomes *wired but dormant*:

1. ✅ `TWITCH_API_URL` set (this PR) — deploy-time wiring.
2. ⏳ `chatbot.twitch_gateway` flag — runtime, console-toggleable, per-call read, **no restart**. Currently `false` on prod.

Only when the flag is flipped does prod tripbot route Helix through the gateway.

### Readiness (verified live on prod-1)
- `gateway-twitch` v1.1.4, **2/2 Running**, readiness on `/health` passing.
- Deploying this rolls `tripbot-twitch` once (ConfigMap hash bump) **with the flag off** — safe re: the EventSub-channelID startup ordering rule.

### Changes
- `config.py`: add `twitch_api_url` to the `prod-1` EnvConfig.
- `test_cdk8s.py`: flip the assertion — prod now carries `TWITCH_API_URL`.
- `dist/prod-1-tripbot-twitch.k8s.yaml`: re-synthed (golden).

Full sequence + revert path: `vault/platform-gateway/cutover-runbook.md`.