### PR TITLE
ci(release): always require bump token in the release PR title

### DIFF
--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -13,8 +13,8 @@ name: pending-release
 # body, which is what auto-tag.yml reads. Do NOT rely on the "default patch":
 # every release window still contains the previous release's `Bump prod ... #none`
 # commits, and a bare title lets that stray #none skip tagging entirely (an
-# explicit #patch outranks #none; a missing token does not). This bit v3.4.1
-# and again v3.10.1.
+# explicit #patch outranks #none; a missing token does not). This has silently
+# skipped tagging on more than one past release.
 #
 # The pending changelog shown in the PR body is rendered with `towncrier build
 # --draft` from the fragments currently on develop.
@@ -149,7 +149,7 @@ jobs:
           RANGE="${LATEST_TAG:-origin/master}...develop"
           {
             echo "> **Draft / staging view — not meant to merge as-is.** Rebuilt automatically on every push to \`develop\`."
-            echo "> To cut a release: (1) on \`develop\`, run \`task changelog:build VERSION=X.Y.Z\` to collate the \`changelog.d/\` fragments into \`CHANGELOG.md\` (add a \`summary\` fragment first if you want a lead paragraph), commit, and push; (2) rename this PR to \`Release vX.Y.Z #patch\` (or \`#minor\` / \`#major\`) — the bump token in the title is **required, always**, not optional; (3) mark it **Ready for review** and **merge it with a merge commit**. The title becomes the merge-commit body, and \`auto-tag.yml\` reads the token from it. ⚠️ Do not omit the token trusting the \`patch\` default: every release window carries the prior release's \`Bump prod ... #none\` commits, and a bare title lets that \`#none\` skip tagging (it skipped v3.10.1). An explicit \`#patch\` outranks \`#none\`. Once promoted out of draft, this workflow stops editing the PR."
+            echo "> To cut a release: (1) on \`develop\`, run \`task changelog:build VERSION=X.Y.Z\` to collate the \`changelog.d/\` fragments into \`CHANGELOG.md\` (add a \`summary\` fragment first if you want a lead paragraph), commit, and push; (2) rename this PR to \`Release vX.Y.Z #patch\` (or \`#minor\` / \`#major\`) — the bump token in the title is **required, always**, not optional; (3) mark it **Ready for review** and **merge it with a merge commit**. The title becomes the merge-commit body, and \`auto-tag.yml\` reads the token from it. ⚠️ Do not omit the token trusting the \`patch\` default: every release window carries the prior release's \`Bump prod ... #none\` commits, and a bare title lets that \`#none\` skip tagging entirely. An explicit \`#patch\` outranks \`#none\`. Once promoted out of draft, this workflow stops editing the PR."
             echo
             echo "$BUMP_LINE"
             echo

--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -8,9 +8,13 @@ name: pending-release
 # This is a staging VIEW, not a release tool: it never merges anything. To cut
 # a release: on develop run `task changelog:build VERSION=X.Y.Z` to collate the
 # changelog.d/ fragments into CHANGELOG.md and commit; then rename this PR to
-# "Release vX.Y.Z", mark it ready, and merge it with the bump token (#minor /
-# #major; default patch) in the MERGE COMMIT message — auto-tag.yml reads the
-# token from commits landing on master.
+# "Release vX.Y.Z #patch" (or #minor / #major) and merge it. The bump token in
+# the title is ALWAYS required — it lands in the develop->master merge-commit
+# body, which is what auto-tag.yml reads. Do NOT rely on the "default patch":
+# every release window still contains the previous release's `Bump prod ... #none`
+# commits, and a bare title lets that stray #none skip tagging entirely (an
+# explicit #patch outranks #none; a missing token does not). This bit v3.4.1
+# and again v3.10.1.
 #
 # The pending changelog shown in the PR body is rendered with `towncrier build
 # --draft` from the fragments currently on develop.
@@ -145,7 +149,7 @@ jobs:
           RANGE="${LATEST_TAG:-origin/master}...develop"
           {
             echo "> **Draft / staging view — not meant to merge as-is.** Rebuilt automatically on every push to \`develop\`."
-            echo "> To cut a release: (1) on \`develop\`, run \`task changelog:build VERSION=X.Y.Z\` to collate the \`changelog.d/\` fragments into \`CHANGELOG.md\` (add a \`summary\` fragment first if you want a lead paragraph), commit, and push; (2) rename this PR to \`Release vX.Y.Z\`, mark it **Ready for review**; (3) **merge it with a merge commit** whose message carries the bump token (\`#minor\` / \`#major\`; default \`patch\`). \`auto-tag.yml\` reads the token off the commit landing on \`master\`. Once promoted out of draft, this workflow stops editing the PR."
+            echo "> To cut a release: (1) on \`develop\`, run \`task changelog:build VERSION=X.Y.Z\` to collate the \`changelog.d/\` fragments into \`CHANGELOG.md\` (add a \`summary\` fragment first if you want a lead paragraph), commit, and push; (2) rename this PR to \`Release vX.Y.Z #patch\` (or \`#minor\` / \`#major\`) — the bump token in the title is **required, always**, not optional; (3) mark it **Ready for review** and **merge it with a merge commit**. The title becomes the merge-commit body, and \`auto-tag.yml\` reads the token from it. ⚠️ Do not omit the token trusting the \`patch\` default: every release window carries the prior release's \`Bump prod ... #none\` commits, and a bare title lets that \`#none\` skip tagging (it skipped v3.10.1). An explicit \`#patch\` outranks \`#none\`. Once promoted out of draft, this workflow stops editing the PR."
             echo
             echo "$BUMP_LINE"
             echo


### PR DESCRIPTION
Codifies the fix for the v3.10.1 tagging miss.

**What happened:** #1014 (`Release v3.10.1`) merged develop→master, but `auto-tag` skipped tagging — the merge commit had no bump token, so `github-tag-action` scanned the `v3.10.0..HEAD` window and hit the leftover `Bump prod … #none` commits from the 3.10.0 release. `#none` = skip. No tag → no image → no `Bump prod … to 3.10.1` PRs.

**The rule:** every release window carries the *previous* release's `Bump prod … #none` commits, so the `patch` default is never safe. An explicit `#patch`/`#minor`/`#major` in the release PR title lands in the merge-commit body and **outranks** `#none` in the action's match order.

**Changes** (`pending-release.yml`): header comment + PR-body checklist now require `Release vX.Y.Z #patch` (or `#minor`/`#major`) in the title, always — with the why inline so future-me doesn't re-learn it.

Labeled skip-changelog (CI/process only, no user-facing change).