### PR TITLE
perf(db): index events(username, event, date_created) for the rollup reconciler

### DIFF
--- a/changelog.d/1028.fix.md
+++ b/changelog.d/1028.fix.md
@@ -1,0 +1,1 @@
+Index `events (username, event, date_created)` so the rollup reconciler does per-user index scans instead of full-scanning the events table every tick

--- a/db/migrate/028_events_pairing_index.down.sql
+++ b/db/migrate/028_events_pairing_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS events_username_event_date;

--- a/db/migrate/028_events_pairing_index.up.sql
+++ b/db/migrate/028_events_pairing_index.up.sql
@@ -1,0 +1,15 @@
+/* The rollup reconciler's pairing CTEs filter events by (username, event) and
+   order by date_created; its first_seen/last_seen/session_count subqueries
+   filter by (username, event) too. The existing events_username_date index
+   (username, date_created) doesn't cover the event predicate, so the planner
+   falls back to a full events scan on every tick — a ~280ms fixed floor per
+   reconcile regardless of how few users are dirty (observed in prod 2026-07-04).
+   This index turns those into per-user index scans. Platform stays a residual
+   filter (near-constant, not selective enough to lead).
+
+   CONCURRENTLY so building it doesn't lock login/logout writes on the live
+   events table. golang-migrate runs migrations without a transaction wrapper,
+   so CONCURRENTLY is allowed — but this file must stay a SINGLE statement
+   (a multi-statement file would be sent in one implicit transaction). */
+CREATE INDEX CONCURRENTLY IF NOT EXISTS events_username_event_date
+  ON events (username, event, date_created);


### PR DESCRIPTION
## Summary

Follow-up to the rollup reconciler (#1009), which shipped to prod 2026-07-04. Prod logs showed every reconcile tick hitting a **~280ms fixed floor** regardless of dirty-set size:

| dirty users | tick duration |
|---|---|
| 17,240 (first-tick backfill) | 3362ms |
| 2 | 555ms |
| 1 | 283ms |

A 1-user recompute shouldn't cost 283ms — the tell is a per-tick cost independent of row count. Root cause: the pairing CTEs (`login_rn`/`logout_rn`) and the `session_count`/`first_seen`/`last_seen` subqueries filter `events` by `(username, event)`, but the only covering index is `events_username_date (username, date_created)` — no `event` column — so the planner full-scans `events` each tick. That floor also grows with the table.

This is the index the rollup plan explicitly deferred ("add one if the reconcile shows pain"). Adds `events (username, event, date_created)`, which turns the pairing + aggregate subqueries into per-user index scans. Platform stays a residual filter (near-constant, not selective enough to lead).

- Built `CONCURRENTLY` so it doesn't lock login/logout writes on the live `events` table.
- Single-statement up file (golang-migrate runs migrations without a transaction wrapper, but a multi-statement file would be sent in one implicit transaction, which `CONCURRENTLY` can't join).

## Testing

- Migration is additive (index only); `migrate up` on next deploy builds it concurrently.
- Verify after deploy: the `SLOW SQL >= 200ms` warnings at `rollups.go:151` should disappear for small dirty sets, and `EXPLAIN` on the reconcile query should show index scans on `events_username_event_date` instead of a seq scan.