### PR TITLE
chore(cdk8s): add cdk8s:verify task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -218,6 +218,16 @@ tasks:
       - mise exec -- uv run cdk8s synth
       - git diff --exit-code -- dist/ || { echo "dist/ is stale — run task cdk8s:synth and commit"; exit 1; }
 
+  cdk8s:verify:
+    desc: The cdk8s edit loop in one step — synth, show what changed in dist/, run the synth-time checks
+    dir: cdk8s
+    deps: [cdk8s:imports]
+    cmds:
+      - mise exec -- uv run cdk8s synth
+      - git status --short -- dist/
+      - git diff --stat -- dist/
+      - mise exec -- uv run pytest -q
+
   cdk8s:stage:diff:
     desc: kubectl diff the synthed stage-1 app manifests against the live cluster (read-only)
     dir: cdk8s

--- a/changelog.d/1037.misc.md
+++ b/changelog.d/1037.misc.md
@@ -1,0 +1,1 @@
+- Added `task cdk8s:verify` — the synth → diff dist/ → synth-time-checks loop as one command


### PR DESCRIPTION
Adds `task cdk8s:verify` — synth, show what changed in `dist/`, run the synth-time checks, in one step. Transcript analysis found this exact loop hand-typed as 3-4 separate commands in 40 sessions.

**Siblings (one initiative, four repos):** [tripbot#1037](https://github.com/adanalife/tripbot/pull/1037), [tripbot-console#98](https://github.com/adanalife/tripbot-console/pull/98), [platform-gateway#72](https://github.com/adanalife/platform-gateway/pull/72), [infra#816](https://github.com/adanalife/infra/pull/816)