### PR TITLE
chore: make code comments timeless

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,6 +1,5 @@
 # Copy to .env.development and fill in real values.
 # .env.development is gitignored; this template is checked in.
-# vault/tripbot/credentials.md walks through where each value comes from.
 
 # --- environment ---
 ENV=development

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -2,15 +2,12 @@ name: backmerge
 
 # After anything lands on master (a release merge, a bump-prs pin edit), open or
 # refresh ONE standing PR that merges master back into develop, so develop never
-# drifts from master. Skipping this back-merge is what caused the v3.6.0
-# phantom-divergence cleanup; this automates it (see merge-strategy-by-target-
-# branch + the cutting-a-release notes).
+# drifts from master and release PRs never hit phantom-divergence conflicts.
 #
 # ⚠️ The PR it opens MUST be merged with a MERGE COMMIT, never squashed/rebased.
 # Squash copies the file contents without making master's commits ancestors of
 # develop, so the divergence stays in place and the next release PR conflicts on
-# CHANGELOG.md (exactly what happened when the manual v3.6.0 back-merge was
-# squash-merged). The PR body repeats this warning.
+# CHANGELOG.md. The PR body repeats this warning.
 #
 # Mechanics mirror bump-prs.yml: a well-known branch (backmerge/master-to-develop)
 # is recreated from develop with master merged in and force-pushed, so there is

--- a/.github/workflows/bump-prs.yml
+++ b/.github/workflows/bump-prs.yml
@@ -2,10 +2,9 @@ name: bump-prs
 
 # Dependabot-style prod version-bump PRs, one per component, so each deploy is
 # its own merge gesture (OBS/VLC restarts interrupt the stream — those PRs sit
-# until a quiet moment; tripbot/onscreens merge freely). Relocated from
-# infra/.github/workflows/bump-prs.yml once the manifests moved into this repo:
-# it now edits THIS repo's cdk8s/versions.yaml and the PRs target `master`
-# (the prod-tracking branch — prod-1 pins float to master, stage rides develop).
+# until a quiet moment; tripbot/onscreens merge freely). Each PR edits
+# cdk8s/versions.yaml and targets `master` (the prod-tracking branch —
+# prod-1 pins float to master, stage rides develop).
 #
 # Bump PRs are deploy gestures, not releases: both the commit message and the PR
 # title carry `#none` so auto-tag.yml skips the version bump when they land on
@@ -21,9 +20,8 @@ name: bump-prs
 #   - opens the PR if missing, refreshes title/body if it exists;
 #   - if prod is already on the dispatched version, closes any stale PR.
 #
-# Unlike infra's bump-prs (which leans on a separate auto-synth workflow to push
-# dist/ back), this repo's cdk8s gate is verify-only, so the bump job re-synths
-# and commits dist/ itself (hence the python/node toolchain below).
+# This repo's cdk8s gate is verify-only, so the bump job re-synths and commits
+# dist/ itself (hence the python/node toolchain below).
 #
 # Everything authenticates as the adanalife-automation GitHub App (token minted
 # per run; credentials fanned out by terraform/platform): GITHUB_TOKEN-created

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 name: codeql-analysis
 
-# No schedule trigger: every PR and every push to develop/master already gets
-# analyzed, so a weekly cron re-scanning the same HEAD was duplicate work.
+# No schedule trigger: pull_request + push events already analyze every commit
+# that lands on develop/master, so a cron re-scan would be redundant.
 on:
   pull_request:
   push:
@@ -21,39 +21,18 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,7 +4,7 @@ name: pr-title
 # pre-commit hook only guards local commits; because develop PRs squash-merge,
 # the PR *title* becomes the commit subject written to history, so it is
 # validated here. Mark this check "required" in branch protection to block
-# non-conforming titles. See vault/decisions/conventional-commits.md.
+# non-conforming titles.
 #
 # Scoped to develop-targeting PRs only: release PRs to master merge-commit
 # (not squash), so their title (`Release vX.Y.Z`) never becomes a commit

--- a/bin/current-file.sh
+++ b/bin/current-file.sh
@@ -8,7 +8,6 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   PIDFILE="run/OBS.pid"
 fi
 
-#TODO: check for presence of file here
 if [ ! -f "$PIDFILE" ]; then
   echo "Pidfile not found. Is OBS(OS X)/VLC(linux) running??"
   exit 2

--- a/bin/devenv
+++ b/bin/devenv
@@ -12,13 +12,6 @@
 export COMPOSE_DOCKER_CLI_BUILD=1
 export DOCKER_BUILDKIT=1
 
-# check if docker is running, if not start it
-#TODO: figure out if this is something we want to finish
-#if [ $(uname) == 'Darwin' ]; then
-#  #TODO: check if docker is running first
-#  open -a Docker
-#fi
-
 OVERLAY="${ENV:-development}"
 
 # Warn loudly if ENV is something other than the two overlays we

--- a/bin/prodenv
+++ b/bin/prodenv
@@ -5,13 +5,6 @@
 export COMPOSE_DOCKER_CLI_BUILD=1
 export DOCKER_BUILDKIT=1
 
-# check if docker is running, if not start it
-#TODO: figure out if this is something we want to finish
-#if [ $(uname) == 'Darwin' ]; then
-#  #TODO: check if docker is running first
-#  open -a Docker
-#fi
-
 # pre-populate the bash_history
 echo "supervisorctl status" >> .bash_history.remote
 echo "vim /var/log/syslog" >> .bash_history.remote

--- a/bin/release-smoke-local
+++ b/bin/release-smoke-local
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Smoke-check tripbot + vlc-server health endpoints via kubectl
 # port-forward against the currently-active kube context. Used by
-# `task release:smoke:local`. See vault/tripbot/release-checklist.md.
+# `task release:smoke:local`.
 set -euo pipefail
 
 TRIPBOT_PORT=18080

--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -157,11 +157,10 @@ class EnvConfig:
         platform is parked (rendered but off), else the env-wide `replicas`."""
         return 0 if platform in self.parked_platforms else self.replicas
 
-    # The platform-gateway gateway-twitch URL the chatbot routes its command-time
-    # Helix calls through (Phase 3). Empty keeps tripbot's in-process pkg/twitch
-    # path; set per env to flip App.Twitch to the HTTP client. Stage points at
-    # its in-namespace gateway-twitch Service; prod stays in-process until the
-    # gateway's prod release is cut + proven.
+    # The platform-gateway gateway-twitch URL a twitch instance routes its
+    # Helix calls through — the gateway is tripbot's sole Helix caller. Empty
+    # leaves the gateway unwired (local/CI only): the Twitch audience/follower/
+    # broadcaster-send features are disabled.
     twitch_api_url: str = ""
     # Like twitch_api_url, but for a youtube instance's outbound chat sends:
     # gateway-youtube's URL routes them through the platform-gateway
@@ -243,10 +242,9 @@ ENVS: dict[str, EnvConfig] = {
         binary_env="production",
         deployment_env="prod-1",
         gpu=True,
-        # vlc doesn't need the iGPU (stream-copy + software decode); dropping its
-        # claim frees an iGPU slot and eases co-tenant contention (the 2026-06-11
-        # prod-stutter incident). OBS keeps the iGPU for VAAPI encode (sized in the
-        # obs repo now). Proven on stage first, then prod on the live twitch stream.
+        # vlc doesn't need the iGPU (stream-copy + software decode); leaving its
+        # claim off frees an iGPU slot and eases co-tenant contention. OBS keeps
+        # the iGPU for VAAPI encode (sized in the obs repo).
         vlc_gpu=False,
         dashcam_mode="nfs",
         dashcam_source="local",  # serve the corpus off the minipc's local NVMe copy
@@ -304,10 +302,8 @@ ENVS: dict[str, EnvConfig] = {
         binary_env="staging",
         deployment_env="stage-1",
         gpu=True,
-        # vlc's iGPU claim proven unnecessary 2026-06-13 (stream-copy + trivial
-        # software decode). Re-asserting vlc_gpu=False here — it was lost when the
-        # app workloads moved from infra into this repo (the cdk8s-into-repo
-        # cutover dropped the flag, so stage vlc silently reclaimed the iGPU).
+        # vlc doesn't need the iGPU (stream-copy + trivial software decode);
+        # vlc_gpu=False keeps stage vlc from claiming it.
         vlc_gpu=False,
         dashcam_mode="nfs",
         tailscale=True,
@@ -324,29 +320,24 @@ ENVS: dict[str, EnvConfig] = {
         # in stage-1-data, so a `kubectl delete ns stage-1` can't take the DB. prod
         # follows on its next wipe (set prod-1's data_namespace to prod-1-data).
         data_namespace="stage-1-data",
-        # The YouTube platform stack burns in on stage first (tripbot-youtube
-        # binds chat once a broadcast is live; vlc-youtube self-sustains). prod
-        # follows once the stage burn-in + dual-iGPU-encode validation pass.
+        # New platform stacks burn in on stage first (tripbot-youtube binds
+        # chat once a broadcast is live; vlc-youtube self-sustains).
         #
-        # twitch is back ON (2026-06-19) to test the platform-gateway end to
-        # end: stage tripbot-twitch routes its Helix calls through gateway-twitch
-        # (twitch_api_url below). The 2026-06-11 prod-stutter that forced twitch
-        # OFF here was the stage twitch *VLC decode + OBS render* contending for
-        # the shared iGPU — so only tripbot-twitch (no GPU) is meant to run;
-        # vlc/onscreens-twitch stay scaled to 0 (manual_replicas below + stage
-        # selfHeal off, so a hand/console scale sticks). Budget is still two live
-        # streams total: prod-twitch + stage-youtube.
+        # Stage twitch is meant to run tripbot-twitch ONLY: stage twitch VLC
+        # decode + OBS render contending for the shared iGPU is what stutters
+        # the prod stream, so vlc/onscreens-twitch stay scaled to 0
+        # (manual_replicas below + stage selfHeal off, so a hand/console scale
+        # sticks). Budget is two live streams total: prod-twitch + stage-youtube.
         platforms=("youtube", "twitch"),
         # Stage components are scaled up/down by hand (only tripbot-twitch runs
-        # for the gateway test); omit replicas so Argo doesn't reset them.
+        # on the twitch side); omit replicas so Argo doesn't reset them.
         manual_replicas=True,
-        # Route stage tripbot's command-time Helix calls through the in-namespace
-        # gateway-twitch gateway (Phase 3). prod stays in-process until its gateway
-        # release is cut.
+        # Route stage tripbot-twitch's Helix calls through the in-namespace
+        # gateway-twitch.
         twitch_api_url="http://gateway-twitch.stage-1.svc.cluster.local:8080",
         # Route stage tripbot-youtube's outbound chat sends through the
         # in-namespace gateway-youtube (unconditionally — no flag). The inbound
-        # poll stays in-process. prod has no youtube instance yet.
+        # poll stays in-process.
         youtube_api_url="http://gateway-youtube.stage-1.svc.cluster.local:8080",
         # Guardrail from the same incident: cap what stage can request in
         # aggregate, so "accidentally scaled up too many stage deployments"

--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -160,8 +160,7 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
     # OBS WebSocket control addr (port 4455) — distinct from OBS_SERVER_HOST's
     # :8080 Flask health server. Read directly by tripbot's pkg/obs (watchdog +
     # stream start/stop); must be per-platform so the YouTube stack dials
-    # obs-youtube, not obs-twitch. Was previously unset, leaving pkg/obs on its
-    # stale "obs:4455" default after OBS went per-platform.
+    # obs-youtube, not obs-twitch.
     data["OBS_WEBSOCKET_ADDR"] = f"{app_name('obs', platform)}:4455"
     # tripbot's Run() branches on STREAM_PLATFORM (chat transport, command
     # allowlist, Twitch-only boot steps). twitch is the binary's default, so —
@@ -176,7 +175,7 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
     if env.nats_url:
         data["NATS_URL"] = env.nats_url
     # Route the twitch instance's command-time Helix calls through the
-    # platform-gateway gateway-twitch (Phase 3) where the env opts in. Only the
+    # platform-gateway gateway-twitch where the env wires it. Only the
     # twitch platform talks Helix, so the youtube instance never carries it.
     if platform == "twitch" and env.twitch_api_url:
         data["TWITCH_API_URL"] = env.twitch_api_url

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -227,9 +227,9 @@ def test_stage_obs_feeders_colocate_with_obs():
     """vlc + onscreens feed OBS continuously (RTSP / browser-source) and must reach
     it on localhost, not across the LAN. They anchor to their platform's OBS pod
     via podAffinity instead of pulling toward the Pi on their own — keeping the
-    rpi5 toleration so they can follow OBS onto the Pi, but NOT the board
-    node-affinity that previously split the pipeline when OBS spilled to the MS-01
-    (the 2026-06-19 stage obs-youtube stutter)."""
+    rpi5 toleration so they can follow OBS onto the Pi, but NOT an independent
+    board node-affinity, which splits the pipeline across nodes (and stutters
+    the stream) whenever OBS spills to the MS-01."""
     for stem in ("stage-1-vlc-youtube", "stage-1-onscreens-youtube"):
         spec = _pod_spec(stem)
         assert _colocates_with_obs(spec, "obs-youtube"), stem
@@ -237,5 +237,5 @@ def test_stage_obs_feeders_colocate_with_obs():
         assert any(
             t.get("key") == "dana.lol/rpi5" for t in spec.get("tolerations", [])
         ), stem
-        # ... but no longer carries an independent rpi5 board pull.
+        # ... but carries no independent rpi5 board pull.
         assert not _prefers_rpi5(spec), stem

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -81,7 +81,7 @@ var version = "dev"
 
 // Tripbot holds the bot process's runtime dependencies and wiring. The boot
 // sequence (Run) and graceful shutdown are methods on it, so startup ordering
-// is explicit and the deps that used to be package-level globals are fields.
+// is explicit and the deps are fields rather than package-level globals.
 type Tripbot struct {
 	version string
 
@@ -140,7 +140,7 @@ type Tripbot struct {
 	flagClient feature.FlagClient
 
 	// gateway is the HTTP client for the platform-gateway — the single Helix
-	// caller since the cutover. Non-nil on a Twitch instance (TWITCH_API_URL is
+	// caller. Non-nil on a Twitch instance (TWITCH_API_URL is
 	// set); nil on a non-Twitch instance, which never reaches the Twitch Helix
 	// paths (all gated behind platformIsTwitch). The shared client the
 	// non-chatbot Helix callers (the OBS watchdog's live-check, the chat-send
@@ -580,10 +580,9 @@ func (t *Tripbot) startCron() {
 // Non-fatal: when the row is missing (e.g. auth-bootstrap hasn't run yet
 // against a freshly-restored DB) or the DB is briefly unreachable, the bot
 // comes up with limited functionality and polls in the background until the
-// token lands — rather than crashlooping. A crashing pod after a wipe also
-// raced the DB restore's migrate init (see the 2026-05-20 convergence-wipe
-// notes); staying up avoids that. The pod stays Ready throughout (readiness
-// no longer gates on Twitch) so the auth-links landing page + /auth/init are
+// token lands — rather than crashlooping (a crashlooping pod can also race a
+// concurrent DB restore's migrate init). The pod stays Ready throughout
+// (readiness doesn't gate on Twitch) so the auth-links landing page + /auth/init are
 // reachable to re-auth; "not in chat" is surfaced via the
 // tripbot_twitch_connected gauge instead.
 func (t *Tripbot) loadTwitchToken(ctx context.Context) {
@@ -715,8 +714,6 @@ func (t *Tripbot) gracefulShutdown() {
 	<-ctrlC
 
 	slog.Warn("caught CTRL-C, shutting down")
-	// anything below this probably won't be executed
-	// try and use !shutdown instead
 	//TODO: print different message if CurrentlyPlaying is ""
 	slog.Info("last played video", "file", t.player.Current().File())
 	if t.discordSession != nil {

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -210,7 +210,6 @@ func gracefulShutdown() {
 	<-ctrlC
 
 	slog.Warn("caught CTRL-C, shutting down")
-	// anything below this probably won't be executed
 	if srv != nil {
 		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		srv.Shutdown(drainCtx)

--- a/db/migrate/015_create_frame_embeddings.up.sql
+++ b/db/migrate/015_create_frame_embeddings.up.sql
@@ -1,6 +1,6 @@
--- Visual-search frame embeddings for the dashcam corpus (see tripbot/cv/ and
--- vault/tripbot/dashcam-cv-plan.md). Requires the pgvector extension, which the
--- postgres image provides (pgvector/pgvector:pg16).
+-- Visual-search frame embeddings for the dashcam corpus (see tripbot/cv/).
+-- Requires the pgvector extension, which the postgres image provides
+-- (pgvector/pgvector:pg16).
 CREATE EXTENSION IF NOT EXISTS vector;
 
 CREATE TABLE frame_embeddings (

--- a/db/migrate/016_drop_moments_viewings.up.sql
+++ b/db/migrate/016_drop_moments_viewings.up.sql
@@ -2,6 +2,6 @@
 -- 2020 GPS/geocoding design, never wired up. Verified zero references in Go,
 -- templates, scripts, or SQL (pkg/moments was removed in tripbot#542). An old
 -- idea we'd redesign from scratch if revived, so the dead schema shouldn't
--- linger. See vault/tripbot/dashcam-cv-plan.md.
+-- linger.
 DROP TABLE IF EXISTS viewings;
 DROP TABLE IF EXISTS moments;

--- a/infra/docker/docker-compose.development.yml
+++ b/infra/docker/docker-compose.development.yml
@@ -7,8 +7,6 @@ services:
       DISABLE_WEBHOOKS: "true"
     env_file:
       - ./.env.development
-    #TODO: add apt update, apt install -y postgresql vim
-    #TODO: add dir in this repo with scripts intended to be run in docker
     # command: -c "go run cmd/tripbot/tripbot.go 2>&1"
 
   vlc:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -41,10 +41,9 @@ services:
       - ./assets/video:/opt/data/Dashcam/_all:ro
     restart: unless-stopped
 
-  # onscreens-server used to be a second binary inside the vlc container; it now
-  # runs as its own service (mirrors the k8s split). Binds :8080 via the image's
-  # ONSCREENS_SERVER_BIND_ADDRESS env. tripbot reaches it at
-  # onscreens-server:8080.
+  # onscreens-server runs as its own service (mirrors the k8s split). Binds
+  # :8080 via the image's ONSCREENS_SERVER_BIND_ADDRESS env. tripbot reaches
+  # it at onscreens-server:8080.
   onscreens-server:
     image: adanalife/onscreens-server
     hostname: onscreens-server

--- a/infra/docker/vlc/Dockerfile
+++ b/infra/docker/vlc/Dockerfile
@@ -38,8 +38,7 @@ ENV GOPATH="/go"
 
 EXPOSE 8080
 
-# Static configs baked into the image; the entrypoint no longer regenerates
-# these via heredocs at boot.
+# Static configs baked into the image.
 COPY infra/docker/vlc/config/syslog.conf /etc/supervisor/conf.d/syslog.conf
 COPY infra/docker/vlc/config/vlc.conf /etc/supervisor/conf.d/vlc.conf
 

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -435,7 +435,6 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	}
 }
 
-// TODO: refactor to use golang '...' syntax
 func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !guess", "username", user.Username)
 	var msg string
@@ -508,7 +507,6 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 // TODO: maybe there could be a !cancel command or something
-// TODO: use fancy golang ... syntax?
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
 	slog.InfoContext(ctx, "ran !report", "username", user.Username)
 	message := strings.Join(params, " ")

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,4 +1,3 @@
-// TODO: this would be better as just 'db'
 package database
 
 import (

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -1,7 +1,5 @@
 package errors
 
-//TODO: RunningOnDarwinError
-
 type NoFootageForStateError struct {
 	Msg string
 }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -69,8 +69,8 @@ func ParseLatLng(ocrStr string) (float64, float64, error) {
 		return lat, lon, errors.New("failed to convert lat or lon to float")
 	}
 
-	//TODO: this is lazy
-	// I hardcoded the minus sign instead of handling other hemispheres
+	// western hemisphere assumed: the minus sign is hardcoded rather than
+	// parsed (the continental-US bounds check below rejects anything else)
 	lon = -lon
 
 	// error on impossible coords
@@ -133,7 +133,6 @@ func sunriseSunset(utcDate time.Time, lat, long float64) (time.Time, time.Time) 
 	return ActualDate(rise, lat, long), ActualDate(set, lat, long)
 }
 
-// TODO: text the admin if it errors opening browser?
 func OpenInBrowser(url string) {
 	slog.Info("opening url in browser", "url", url)
 	err := open.Run(url)

--- a/pkg/helpers/states.go
+++ b/pkg/helpers/states.go
@@ -12,8 +12,8 @@ func StateAbbrevToState(abbrev string) string {
 
 func StateToStateAbbrev(state string) string {
 	// Case-insensitive lookup so names like "district of columbia" still
-	// resolve. strings.Title was previously used but mis-capitalised the
-	// internal "of"/"and" words in multi-word names.
+	// resolve (title-casing the input would mis-capitalise the internal
+	// "of"/"and" words in multi-word names).
 	want := strings.ToLower(state)
 	for abbrev, name := range stateAbbrevs {
 		if strings.ToLower(name) == want {

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -84,7 +84,7 @@ var CarSoundSelections = carSoundSelectionsIface{counter: carSoundSelections}
 var TwitchAudience = twitchAudienceIface{subscribers: twitchSubscribers, followers: twitchFollowers}
 
 // TwitchConnection exposes the chat-connection gauge. Set(true) on IRC
-// connect, Set(false) on disconnect. Readiness no longer gates on the Twitch
+// connect, Set(false) on disconnect. Readiness doesn't gate on the Twitch
 // connection (the pod stays in the Service so the re-auth page is reachable),
 // so this gauge — alongside the admin-panel status row — is what surfaces
 // "up but not in chat" to dashboards and alerts.

--- a/pkg/onscreens-server/flag.go
+++ b/pkg/onscreens-server/flag.go
@@ -7,8 +7,7 @@ import "log/slog"
 // The state-driven flag swap is currently disabled — see
 // onscreens-client.ShowFlag (no-op) and the placeholder served by the
 // /onscreens/asset/flag handler. Bringing it back means re-implementing
-// the per-state image picker (was flagSourceFile + updateFlagFile,
-// removed in the disk-write cleanup).
+// a per-state image picker.
 func newFlagOnscreen() *Onscreen {
 	slog.Info("creating onscreen", "kind", "flag")
 	return newOnscreen()

--- a/pkg/onscreens-server/handlers.go
+++ b/pkg/onscreens-server/handlers.go
@@ -7,10 +7,9 @@ import (
 )
 
 // Onscreens overlay commands (middle / leaderboard / timewarp / gps / flag)
-// no longer have HTTP handlers — they arrive over NATS and are dispatched by
-// the subscribers in nats.go. The HTTP server here serves only the
-// browser-source feeds (state.json / render / asset), health, version,
-// metrics, and admin.
+// arrive over NATS and are dispatched by the subscribers in nats.go. The
+// HTTP server here serves only the browser-source feeds (state.json /
+// render / asset), health, version, metrics, and admin.
 
 // healthHandler is the liveness probe target.
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/onscreens-server/onscreens.go
+++ b/pkg/onscreens-server/onscreens.go
@@ -4,8 +4,6 @@ import (
 	"time"
 )
 
-//TODO: these live in the background package and could/should
-// be moved into this package
 //TODO: we don't always need SleepInterval/Expires... some
 // of these run forever (maybe refactor into ShowFor()?)
 

--- a/pkg/onscreens-server/rotator.go
+++ b/pkg/onscreens-server/rotator.go
@@ -27,9 +27,8 @@ const rareOdds = 10000
 //   - Platforms scopes the line to specific streaming platforms; empty means
 //     "all platforms". This is what keeps a YouTube overlay from advertising
 //     Twitch-only commands (!miles, !guess).
-//   - Weight biases weighted-random selection (<1 is treated as 1). It replaces
-//     the old "list the same line twice" trick for making a message more
-//     frequent.
+//   - Weight biases weighted-random selection (<1 is treated as 1), making a
+//     message proportionally more frequent without listing it twice.
 //
 // The hardcoded slices are the current source of truth; this struct is also the
 // seam for a future admin-console-editable source (swap the slice for a loaded

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -16,13 +16,10 @@ import (
 	"github.com/hako/durafmt"
 )
 
-//TODO: consider moving this whole thing elsewhere (to background perhaps?)
-
 // Sessions tracks the users currently logged in to one platform's chat plus
-// the derived lifetime-miles leaderboard. It owns what used to be the
-// package-level LoggedIn map and LifetimeMilesLeaderboard slice, so a single
-// process holds exactly one Sessions and a per-platform bot instance gets its
-// own (the prerequisite for running, e.g., a YouTube bot beside the Twitch
+// the derived lifetime-miles leaderboard. The state lives on the struct, not
+// in package-level globals, so a per-platform bot instance gets its own
+// (the prerequisite for running, e.g., a YouTube bot beside the Twitch
 // one). Its view of who is in chat comes from an injected ChatterSource.
 type Sessions struct {
 	source ChatterSource

--- a/pkg/video/setup_test.go
+++ b/pkg/video/setup_test.go
@@ -45,8 +45,7 @@ func installMockDB(t *testing.T) sqlmock.Sqlmock {
 }
 
 // recordingOnscreens is an interface fake satisfying the Player's onscreens
-// dependency, capturing each GPS overlay call by method name. Replaces the
-// old httptest-backed rig now that Player takes an interface.
+// dependency, capturing each GPS overlay call by method name.
 type recordingOnscreens struct {
 	calls []string
 }

--- a/pkg/video/type.go
+++ b/pkg/video/type.go
@@ -50,8 +50,8 @@ func (v Video) Location() (float64, float64, error) {
 	return v.Lat, v.Lng, err
 }
 
-// TODO: add color, include location/state/lat/lng?
-// TODO: where else does this get used tho?
+// String returns the slug, which callers (e.g. make-map's image filenames)
+// rely on as a stable identity — don't enrich it with display fields.
 // ex: 2018_0514_224801_013_a_opt
 func (v Video) String() string {
 	return v.Slug
@@ -62,7 +62,8 @@ func (v Video) String() string {
 // an example dashstr: 2018_0514_224801_013
 // ex: 2018_0514_224801_013
 func (v Video) DashStr() string {
-	//TODO: this never should have happened, but it did and it crashed the bot
+	// slugs shorter than 20 chars are malformed; return "" rather than
+	// panic on the slice below
 	if len(v.Slug) < 20 {
 		return ""
 	}

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -42,10 +42,9 @@ func NewPlayer(onscreens onscreens, vlc *vlcClient.Client) *Player {
 
 // GetCurrentlyPlaying will use lsof to figure out
 // which dashcam video is currently playing (seriously).
-// ctx is forward-compat plumbing — vlc-client and onscreens-client don't
-// take ctx yet, so it's not propagated into their HTTP calls. Once they do,
-// trace spans for cron.video.GetCurrentlyPlaying ticks will nest the
-// underlying VLC poll and GPS-image toggles as children.
+// ctx carries the cron tick's trace span; it isn't propagated into the
+// vlc-client / onscreens-client HTTP calls (those clients don't take a ctx,
+// so the underlying VLC poll and GPS-image toggles don't nest as children).
 // TODO: consider making this return a video struct
 func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 	var err error
@@ -93,7 +92,7 @@ func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 
 		// show the no-GPS image
 		if p.CurrentlyPlaying.Flagged {
-			//TODO: kinda cludgy that we hardcode 60s here
+			// the duration is ignored — the server owns the GPS overlay's duration
 			p.onscreens.ShowGPSImage(ctx, 60*time.Second)
 		} else {
 			p.onscreens.HideGPSImage(ctx)

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -35,8 +35,6 @@ type Client struct {
 // caller's trace. nats + env drive command publishing; pass
 // natsclient.DefaultPublisher() in production, or a nil publisher to disable
 // publishing (tests).
-//
-// TODO: eventually support HTTPS
 func New(host string, nats natsclient.Publisher, env string) *Client {
 	return &Client{
 		serverURL:  "http://" + host,
@@ -92,10 +90,8 @@ func (c *Client) Back(ctx context.Context, n int) error {
 	return nil
 }
 
-// TODO: move this to a common location
-//
-// Transport-layer errors log at Debug, not Error: CurrentlyPlaying (the sole
-// remaining caller) logs its own operation-specific failure at Error with the
+// Transport-layer errors log at Debug, not Error: CurrentlyPlaying (its
+// only caller) logs its own operation-specific failure at Error with the
 // same underlying err. Logging here too would double-count every VLC outage in
 // Loki and Sentry.
 func (c *Client) get(ctx context.Context, url string) (string, error) {

--- a/pkg/vlc-server/handlers.go
+++ b/pkg/vlc-server/handlers.go
@@ -139,7 +139,6 @@ func (s *Server) faviconHandler(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, "assets/favicon.ico")
 }
 
-// TODO: use more StatusExpectationFailed instead of http.StatusUnprocessableEntity
 func (s *Server) catchAllHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":

--- a/pkg/vlc-server/nats.go
+++ b/pkg/vlc-server/nats.go
@@ -13,14 +13,11 @@ import (
 
 // StartNATSSubscribers attaches the server's NATS subscriptions to the
 // package-singleton *nats.Conn (initialized by main via natsclient.Connect).
-// No-op when the conn is nil (NATS_URL unset) — with the HTTP command path
-// peeled off, the server simply receives no commands in that case.
+// No-op when the conn is nil (NATS_URL unset) — NATS is the sole command
+// transport, so the server simply receives no commands in that case.
 //
-// NATS is the sole transport for the vlc command surface: each handler drives
-// the same playback method the old HTTP handler called. (The observe-only
-// mirror this burned in against, and the HTTP command path, have since been
-// peeled off.) The publish-only client no longer calls HTTP, so there's no
-// double-execution despite vlc commands not being idempotent.
+// Because there is no parallel command path, non-idempotent vlc commands
+// can't double-execute.
 //
 // Subscribers are registered explicitly (not via a vlc.> wildcard) so each
 // gets its own subscribe log line and the dispatch stays readable.

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -100,7 +100,6 @@ func (s *Server) Start(ctx context.Context) {
 	// (shallow); /health/ready consults libvlc player state via Health()
 	// so K8s readiness probes pull the pod out of rotation if the player
 	// stalls (without restarting the process).
-	//TODO: handle HEAD requests here too
 	hp := r.PathPrefix("/health").Methods("GET", "HEAD").Subrouter()
 	hp.Handle("/", tagged("/health/", s.livenessHandler))
 	hp.Handle("/live", tagged("/health/live", s.livenessHandler))
@@ -110,13 +109,13 @@ func (s *Server) Start(ctx context.Context) {
 	// version endpoint — returns build metadata as JSON
 	r.Handle("/version", tagged("/version", s.versionHandler)).Methods("GET", "HEAD")
 
-	// vlc endpoints — the play / random / skip / back commands moved to NATS
-	// (see nats.go); only the currently-playing read remains on HTTP.
+	// vlc endpoints — the play / random / skip / back commands ride NATS
+	// (see nats.go); only the currently-playing read is served over HTTP.
 	vlc := r.PathPrefix("/vlc").Methods("GET").Subrouter()
 	vlc.Handle("/current", tagged("/vlc/current", s.vlcCurrentHandler))
 
-	// onscreen endpoints now live in cmd/onscreens-server (separate binary,
-	// separate port). vlc-server no longer serves /onscreens/* — clients
+	// Onscreen endpoints are served by cmd/onscreens-server (separate binary,
+	// separate port), so nothing under /onscreens/* is routed here — clients
 	// (chatbot, OBS browser sources) hit ONSCREENS_SERVER_HOST directly.
 
 	// next-frame cover layer. OBS loads /next-frame.html as a browser
@@ -149,7 +148,6 @@ func (s *Server) Start(ctx context.Context) {
 	// negroni.New + explicit middleware so we can swap negroni's stdlib
 	// logger for an slog-based one — see pkg/httpmw.SlogLogger. The static
 	// middleware from negroni.Classic is dropped (no public/ directory).
-	//TODO: consider adding HTMLPanicFormatter
 	app := negroni.New(
 		httpmw.NewRecovery(func(any) { instrumentation.HTTPPanics.Inc(c.Conf.ServerType) }),
 		httpmw.NewSlogLogger(),

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -31,9 +31,7 @@ var vlcStaticFlags = []string{
 
 // vlcCmdFlags is built lazily in startVLC() from vlcStaticFlags +
 // per-host tuning values pulled from config (VLC_FILE_CACHING,
-// VLC_CANVAS_WIDTH, VLC_CANVAS_HEIGHT). Defaults match what was
-// previously hardcoded here, so this is a no-op refactor unless an
-// env var is explicitly set.
+// VLC_CANVAS_WIDTH, VLC_CANVAS_HEIGHT).
 var vlcCmdFlags []string
 
 // mediaOptions returns the per-Media options driven by VLC_OUTPUT.
@@ -68,7 +66,7 @@ func mediaOptions() []string {
 
 // linuxSpecificFlags returns the Linux-only VLC flags, sourced from
 // config (VLC_VOUT, VLC_AVCODEC_HW). Defaults: --vout dummy (headless;
-// the container no longer ships an X server) and --avcodec-hw
+// the container has no X server) and --avcodec-hw
 // vdpau_avcodec (can be none, vdpau_avcodec, or cuda). On a Linux dev
 // host where you want a preview window, set VLC_VOUT=x11 and
 // VLC_OUTPUT=window (or both).
@@ -186,8 +184,6 @@ func (s *Server) Health() error {
 // s.http may be nil if Shutdown is called before Start populated it; in
 // that case there's nothing to drain and we skip straight to libvlc
 // cleanup.
-//
-// TODO: are there more things to close gracefully?
 func (s *Server) Shutdown(ctx context.Context) {
 	if s.http != nil {
 		slog.InfoContext(ctx, "shutting down VLC web server")
@@ -230,8 +226,7 @@ func (s *Server) currentlyPlaying() string {
 
 func startVLC() error {
 	// build the base flag set from the static list + config-driven tuning
-	// values. Defaults in pkg/config/vlc-server reproduce what used to be
-	// hardcoded here, so unset env vars yield identical behavior.
+	// values (defaults live in pkg/config/vlc-server)
 	canvasW := strconv.Itoa(c.Conf.VlcCanvasWidth)
 	canvasH := strconv.Itoa(c.Conf.VlcCanvasHeight)
 	vlcCmdFlags = append([]string{}, vlcStaticFlags...)

--- a/script/make-map/make-map.go
+++ b/script/make-map/make-map.go
@@ -23,12 +23,6 @@ var skipToDate = false
 var skipDate = time.Date(2018, time.Month(9), 29, 0, 0, 0, 0, time.UTC)
 
 func main() {
-	//TODO: remove this if it's not needed
-	// err := godotenv.Load()
-	// if err != nil {
-	// 	log.Fatal("Error loading .env file")
-	// }
-
 	client, err := maps.NewClient(maps.WithAPIKey(c.Conf.GoogleMapsAPIKey))
 	if err != nil {
 		log.Fatalf("client error: %s", err)


### PR DESCRIPTION
Comment-only sweep of the whole repo (no executable line changes — the diff is comments, docstrings, and blank lines).

What it enforces: a comment describes the code **as it stands**, never the change that produced it. Categories cleaned:

- **Diff-narration → present tense.** Past-tense change justifications ("no longer", "now uses", "was previously", "replaces the old…", "no-op refactor") rewritten as standing descriptions, or dropped where git history is the right home (`backmerge.yml`'s v3.6.0 war stories, `bump-prs.yml`'s relocated-from-infra preamble, VLC flag-refactor notes).
- **Stale comments the code outgrew** (the actively-misleading class): `config.py` said prod Helix stays in-process "until the gateway's prod release is cut" — prod has routed through gateway-twitch since the cutover, and the in-process fallback no longer exists; also "prod has no youtube instance yet" (it's live) and the empty-`twitch_api_url` semantics.
- **Plan/session jargon**: "(Phase 3)" labels, dated incident shorthand rewritten as the timeless constraint (e.g. the rpi5 podAffinity test docstring now states *why* a board pull is wrong instead of citing a dated stutter).
- **Private doc references** removed from migrations, `pr-title.yml`, `bin/release-smoke-local`, `.env.development.example`.
- **Obsolete TODO markers** deleted where the adjacent code shows they're done or moot (HEAD handling that exists, a pidfile check that exists, a package move that already happened, HTTPS for a cluster-internal client, etc.), plus dead commented-out blocks (`bin/{dev,prod}env` Docker-autostart, make-map's godotenv stub) and CodeQL template boilerplate.
- **Live TODOs stay** — the real work items are being routed into the project tracker separately; their in-code markers remain as breadcrumbs.

Review tip: every hunk should read sensibly with zero diff context. If any rewrite reads as opinion rather than fact, flag it — happy to revert line-by-line.