### PR TITLE
feat(chatbot): seed the chatbot.find feature flag (disabled)

### DIFF
--- a/changelog.d/+seed-find-flag.chatbot.md
+++ b/changelog.d/+seed-find-flag.chatbot.md
@@ -1,0 +1,1 @@
+Seed the `chatbot.find` feature flag (disabled) so the console can toggle `!find` on.

--- a/db/migrate/032_seed_chatbot_find_flag.down.sql
+++ b/db/migrate/032_seed_chatbot_find_flag.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM feature_flags WHERE key = 'chatbot.find';

--- a/db/migrate/032_seed_chatbot_find_flag.up.sql
+++ b/db/migrate/032_seed_chatbot_find_flag.up.sql
@@ -1,0 +1,28 @@
+/* Seeds chatbot.find — the dormant-ship gate for the !find visual-search
+   command (#879). Without this row the console toggle errors ("flag not
+   found"), so !find can never be turned on.
+
+   One row per platform (per the 019 guidance): !find is a playback command
+   allowlisted on both the twitch and youtube instances, so each platform
+   toggles independently.
+
+   Defaults off: enable per env from the console once the video-pipeline embed
+   responder is live there; flipping it back off reverts without a bot
+   restart. */
+INSERT INTO feature_flags (key, platform, description, enabled, target_removal_date)
+VALUES
+    (
+        'chatbot.find',
+        'twitch',
+        'Enables the !find visual-search command: embeds the chat query via the video-pipeline embed responder and jumps the stream to the closest corpus moment. Requires the responder deployed in the env; toggling takes effect without a bot restart.',
+        FALSE,
+        DATE '2027-01-06'
+    ),
+    (
+        'chatbot.find',
+        'youtube',
+        'Enables the !find visual-search command: embeds the chat query via the video-pipeline embed responder and jumps the stream to the closest corpus moment. Requires the responder deployed in the env; toggling takes effect without a bot restart.',
+        FALSE,
+        DATE '2027-01-06'
+    )
+ON CONFLICT (key, platform) DO NOTHING;


### PR DESCRIPTION
Follow-up to [#879](https://github.com/adanalife/tripbot/pull/879/changes): `!find` ships dormant behind `chatbot.find`, but the flags API/console toggle errors on a key with no `feature_flags` row — the same trap `chatbot.twitch_gateway` hit and solved in migration 021. Seeds one **disabled** row per platform (twitch + youtube — `!find` is allowlisted on both).

Enable per env from the console once that env's embed responder is live (prod-1's is already running; stage's is up for the smoke test).