### PR TITLE
feat(chatbot): persist viewer-count and video-play history to postgres

### DIFF
--- a/changelog.d/+viewer-analytics.chatbot.md
+++ b/changelog.d/+viewer-analytics.chatbot.md
@@ -1,0 +1,1 @@
+Persist the viewer-count and video-play signals into new append-only `video_plays` + `viewer_samples` tables (migration 033), so footage-performance history accrues durably instead of vanishing with each fire-and-forget NATS emission

--- a/db/migrate/033_create_viewer_analytics.down.sql
+++ b/db/migrate/033_create_viewer_analytics.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE viewer_samples;
+DROP TABLE video_plays;

--- a/db/migrate/033_create_viewer_analytics.up.sql
+++ b/db/migrate/033_create_viewer_analytics.up.sql
@@ -1,0 +1,27 @@
+/* Append-only raw signals for footage-performance analytics, mirroring the
+   eventbus emissions into durable storage (NATS core is fire-and-forget).
+   video_plays: one row per clip switch — the permanent timeline of what was
+   on screen when. viewer_samples: one row per ~61s viewer-count tick.
+   state/flagged/lat/lng are denormalized at play time because videos rows
+   mutate afterwards (coord backfills, state interpolation); the play row
+   records what was true on screen. */
+CREATE TABLE video_plays (
+  id           SERIAL PRIMARY KEY,
+  platform     TEXT NOT NULL,
+  video_id     INTEGER,
+  state        TEXT NOT NULL DEFAULT '',
+  flagged      BOOLEAN NOT NULL DEFAULT false,
+  lat          DOUBLE PRECISION NOT NULL DEFAULT 0,
+  lng          DOUBLE PRECISION NOT NULL DEFAULT 0,
+  started_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX video_plays_platform_started_at ON video_plays (platform, started_at);
+
+CREATE TABLE viewer_samples (
+  id           SERIAL PRIMARY KEY,
+  platform     TEXT NOT NULL,
+  count        INTEGER NOT NULL,
+  video_id     INTEGER,
+  sampled_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX viewer_samples_platform_sampled_at ON viewer_samples (platform, sampled_at);

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/events"
 	"github.com/adanalife/tripbot/pkg/scoreboards"
+	"github.com/adanalife/tripbot/pkg/viewstats"
 	"github.com/google/uuid"
 	"github.com/hako/durafmt"
 )
@@ -49,6 +50,10 @@ func (s *Sessions) UpdateSession(ctx context.Context) {
 	// Publish the authoritative chatter total so the admin panel's live console
 	// updates the "in chat" number (and flashes it on a change) without a reload.
 	eventbus.EmitViewerCount(ctx, c.Conf.Environment, c.Conf.Platform, s.source.ChatterCount())
+
+	// Persist the same total as a viewer_samples row — the durable half of the
+	// emission above, tagged with the clip currently on screen.
+	viewstats.RecordSample(ctx, s.source.ChatterCount())
 
 	// log out the people who aren't present
 	for username, user := range s.loggedIn {

--- a/pkg/video/setup_test.go
+++ b/pkg/video/setup_test.go
@@ -90,3 +90,12 @@ func expectLoadHit(mock sqlmock.Sqlmock, id int, slug string, flagged bool) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "slug", "flagged"}).
 			AddRow(id, slug, flagged))
 }
+
+// expectPlayInsert queues the video_plays INSERT a clip transition writes
+// (viewstats.RecordPlay). State/lat/lng are zero because expectLoadHit stages
+// only id/slug/flagged.
+func expectPlayInsert(mock sqlmock.Sqlmock, videoID int, flagged bool) {
+	mock.ExpectQuery(`INSERT INTO "video_plays"`).
+		WithArgs(sqlmock.AnyArg(), videoID, "", flagged, 0.0, 0.0, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+}

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -12,6 +12,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/eventbus"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
+	"github.com/adanalife/tripbot/pkg/viewstats"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
 )
 
@@ -89,6 +90,13 @@ func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 		eventbus.EmitVideoChanged(ctx, c.Conf.Environment, c.Conf.Platform,
 			p.CurrentlyPlaying.File(), p.CurrentlyPlaying.State, p.CurrentlyPlaying.Flagged,
 			p.CurrentlyPlaying.Lat, p.CurrentlyPlaying.Lng)
+
+		// Persist the switch as a video_plays row — the durable half of the
+		// emission above (NATS core is fire-and-forget). The first tick after a
+		// restart records a fresh play for the clip already on screen, since its
+		// true start time wasn't observed.
+		viewstats.RecordPlay(ctx, p.CurrentlyPlaying.ID, p.CurrentlyPlaying.State,
+			p.CurrentlyPlaying.Flagged, p.CurrentlyPlaying.Lat, p.CurrentlyPlaying.Lng)
 
 		// show the no-GPS image
 		if p.CurrentlyPlaying.Flagged {

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -51,6 +51,7 @@ func TestPlayer_GetCurrentlyPlaying_FirstCall_FlaggedShowsGPS(t *testing.T) {
 
 	// DB returns a flagged video for the slug derived from vlcCurrent.
 	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
+	expectPlayInsert(mock, 1, true)
 
 	p.GetCurrentlyPlaying(context.Background())
 
@@ -77,6 +78,7 @@ func TestPlayer_GetCurrentlyPlaying_FirstCall_NotFlaggedHidesGPS(t *testing.T) {
 	p := NewPlayer(rec, vlc)
 
 	expectLoadHit(mock, 7, "2019_0615_183000_001", false)
+	expectPlayInsert(mock, 7, false)
 
 	p.GetCurrentlyPlaying(context.Background())
 
@@ -99,9 +101,11 @@ func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	// Only one DB hit expected — the second GetCurrentlyPlaying call sees
-	// curVid == preVid and short-circuits before reaching LoadOrCreate.
+	// Only one DB hit + play insert expected — the second GetCurrentlyPlaying
+	// call sees curVid == preVid and short-circuits before reaching
+	// LoadOrCreate.
 	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
+	expectPlayInsert(mock, 1, false)
 
 	p.GetCurrentlyPlaying(context.Background())
 	timeStartedAfterFirst := p.timeStarted
@@ -130,10 +134,13 @@ func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	// First vid: flagged → ShowGPSImage.
+	// First vid: flagged → ShowGPSImage. Each transition loads the video then
+	// records its play, so the expectations interleave.
 	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
+	expectPlayInsert(mock, 1, true)
 	// Second vid: not flagged → HideGPSImage.
 	expectLoadHit(mock, 2, "2019_0615_183000_001", false)
+	expectPlayInsert(mock, 2, false)
 
 	p.GetCurrentlyPlaying(context.Background())
 	firstStart := p.timeStarted
@@ -181,6 +188,7 @@ func TestPlayer_CurrentProgress_TracksTimeSinceStart(t *testing.T) {
 	p := NewPlayer(rec, vlc)
 
 	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
+	expectPlayInsert(mock, 1, false)
 
 	p.GetCurrentlyPlaying(context.Background())
 	time.Sleep(10 * time.Millisecond)

--- a/pkg/viewstats/viewstats.go
+++ b/pkg/viewstats/viewstats.go
@@ -1,0 +1,99 @@
+// Package viewstats persists the raw footage-performance signals into
+// append-only Postgres tables: one video_plays row per clip switch and one
+// viewer_samples row per viewer-count tick. It mirrors the eventbus
+// video.changed / viewers.count emissions — which are fire-and-forget over
+// NATS — so the history accrues durably. Writes are best-effort: a failed
+// insert logs and drops the row rather than disturbing the player/session
+// cron ticks that call in.
+package viewstats
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/database"
+)
+
+// VideoPlay is one video_plays row: a clip landed on screen at StartedAt.
+// State/Flagged/Lat/Lng are denormalized at play time because videos rows
+// mutate afterwards (coord backfills, state interpolation) — the play row
+// records what was true on screen. VideoID is nil when the clip had no DB row
+// (a failed LoadOrCreate); the row still marks that a switch happened.
+type VideoPlay struct {
+	ID       int `gorm:"primaryKey"`
+	Platform string
+	VideoID  *int
+	State    string
+	Flagged  bool
+	Lat      float64
+	Lng      float64
+	// autoCreateTime makes GORM stamp the column on insert instead of writing
+	// the zero value over its DEFAULT CURRENT_TIMESTAMP. See pkg/events for
+	// the full story.
+	StartedAt time.Time `gorm:"autoCreateTime"`
+}
+
+// ViewerSample is one viewer_samples row: Count chatters were in this
+// platform's chat at SampledAt. VideoID is the clip on screen at sample time,
+// denormalized so per-clip queries don't need interval pairing; nil before the
+// first play of the process or when that play had no DB row.
+type ViewerSample struct {
+	ID       int `gorm:"primaryKey"`
+	Platform string
+	Count    int
+	VideoID  *int
+	// autoCreateTime: see VideoPlay.StartedAt.
+	SampledAt time.Time `gorm:"autoCreateTime"`
+}
+
+// currentVideoID remembers the most recent play's video id so RecordSample can
+// denormalize it without the sessions package knowing the player. 0 means no
+// play recorded yet this process.
+var currentVideoID atomic.Int64
+
+// RecordPlay writes a video_plays row for a clip switch. Pass videoID 0 when
+// the clip has no DB row; the row is written with a NULL video_id.
+func RecordPlay(ctx context.Context, videoID int, state string, flagged bool, lat, lng float64) {
+	currentVideoID.Store(int64(videoID))
+	if c.Conf.ReadOnly {
+		return
+	}
+	var vid *int
+	if videoID != 0 {
+		vid = &videoID
+	}
+	play := VideoPlay{
+		Platform: c.Conf.Platform,
+		VideoID:  vid,
+		State:    state,
+		Flagged:  flagged,
+		Lat:      lat,
+		Lng:      lng,
+	}
+	if err := database.GormDB().WithContext(ctx).Create(&play).Error; err != nil {
+		slog.ErrorContext(ctx, "error recording video play", "err", err, "video_id", videoID)
+	}
+}
+
+// RecordSample writes a viewer_samples row for one viewer-count tick, tagged
+// with the currently-playing clip as of the last RecordPlay.
+func RecordSample(ctx context.Context, count int) {
+	if c.Conf.ReadOnly {
+		return
+	}
+	var vid *int
+	if id := int(currentVideoID.Load()); id != 0 {
+		vid = &id
+	}
+	sample := ViewerSample{
+		Platform: c.Conf.Platform,
+		Count:    count,
+		VideoID:  vid,
+	}
+	if err := database.GormDB().WithContext(ctx).Create(&sample).Error; err != nil {
+		slog.ErrorContext(ctx, "error recording viewer sample", "err", err, "count", count)
+	}
+}

--- a/pkg/viewstats/viewstats_test.go
+++ b/pkg/viewstats/viewstats_test.go
@@ -1,0 +1,82 @@
+package viewstats
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// installMockDB stands up a sqlmock-backed *gorm.DB as the process-wide
+// singleton. Mirrors the pattern from pkg/chatbot/mockdb_test.go.
+func installMockDB(t *testing.T) sqlmock.Sqlmock {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	database.SetGormDB(gdb)
+	t.Cleanup(func() {
+		database.SetGormDB(nil)
+		_ = sqlDB.Close()
+	})
+	return mock
+}
+
+// notZeroTime matches any non-zero timestamp arg — the guard that
+// autoCreateTime actually stamped the column instead of writing 0001-01-01
+// over its DEFAULT (the pkg/events regression).
+type notZeroTime struct{}
+
+func (notZeroTime) Match(v driver.Value) bool {
+	tm, ok := v.(time.Time)
+	return ok && !tm.IsZero()
+}
+
+func TestRecordPlayAndSample(t *testing.T) {
+	mock := installMockDB(t)
+	ctx := context.Background()
+
+	// A sample before any play carries a NULL video_id.
+	mock.ExpectQuery(`INSERT INTO "viewer_samples" .*RETURNING "id"`).
+		WithArgs(sqlmock.AnyArg(), 3, nil, notZeroTime{}).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	RecordSample(ctx, 3)
+
+	mock.ExpectQuery(`INSERT INTO "video_plays" .*RETURNING "id"`).
+		WithArgs(sqlmock.AnyArg(), 42, "Utah", false, 38.5, -109.5, notZeroTime{}).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	RecordPlay(ctx, 42, "Utah", false, 38.5, -109.5)
+
+	// After the play, samples are tagged with its video id.
+	mock.ExpectQuery(`INSERT INTO "viewer_samples" .*RETURNING "id"`).
+		WithArgs(sqlmock.AnyArg(), 5, 42, notZeroTime{}).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(2))
+	RecordSample(ctx, 5)
+
+	// A play with no DB row (videoID 0) writes NULL and resets the sample tag.
+	mock.ExpectQuery(`INSERT INTO "video_plays" .*RETURNING "id"`).
+		WithArgs(sqlmock.AnyArg(), nil, "", true, 0.0, 0.0, notZeroTime{}).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(2))
+	RecordPlay(ctx, 0, "", true, 0, 0)
+
+	mock.ExpectQuery(`INSERT INTO "viewer_samples" .*RETURNING "id"`).
+		WithArgs(sqlmock.AnyArg(), 5, nil, notZeroTime{}).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(3))
+	RecordSample(ctx, 5)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Item from the viewer-analytics design: the `viewers.count` and `video.changed` signals were emitted over NATS only — fire-and-forget, with the JetStream `lastplayed` cache holding just the latest value — so no footage-performance history was accruing. Every week without these tables is a week of unanswerable "what footage performs" questions.

- **Migration 033**: two append-only tables.
  - `video_plays` — one row per clip switch (`platform, video_id, state, flagged, lat, lng, started_at`). State/coords are denormalized at play time because `videos` rows mutate afterwards (coord backfills, state interpolation); the play row records what was on screen.
  - `viewer_samples` — one row per ~61s viewer tick (`platform, count, video_id, sampled_at`), tagged with the currently-playing clip so per-clip queries don't need interval pairing.
- **`pkg/viewstats`**: the two GORM models + `RecordPlay`/`RecordSample`. Writes are best-effort (log-and-drop) so a DB hiccup never disturbs the player/session cron ticks. Respects `READ_ONLY`.
- Call sites sit directly beside the existing eventbus emissions in `pkg/video` (clip transition) and `pkg/users` (`UpdateSession`).

## Volume

~1k `video_plays` + ~1.4k `viewer_samples` rows/day per platform — negligible.

## Deliberately not in this PR

The `video_performance` rollup/view and the console "top videos" report — the methodology (churn from `events` login/logout pairing, aggregated by state/region) is a query-time concern that can be designed once data exists. This PR is the time-sensitive half: start accruing.

https://claude.ai/code/session_0189msYRBLWw6grQ3iiggdhR