### PR TITLE
fix(natsclient): retry failed initial connect instead of going permanently deaf

### DIFF
--- a/changelog.d/+nats-initial-connect-retry.fix.md
+++ b/changelog.d/+nats-initial-connect-retry.fix.md
@@ -1,0 +1,1 @@
+NATS connections now retry a failed initial connect forever instead of leaving the process permanently deaf. A boot race (node reboot bringing apps and NATS up together) previously killed timewarps, overlays, and `!guess` scoring integrity until a manual restart; now subscriptions replay and JetStream streams declare automatically when the connection lands.

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-co-op/gocron/v2"
+	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -336,16 +337,19 @@ func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 // when NATS_URL is empty the connection is skipped and publishes no-op silently.
 //
 // EnsureStreams declares the JetStream streams the standalone tripbot-console
-// consumes (chat + video history), so they exist before the publishers emit. It
-// no-ops when JetStream is unavailable (NATS off or a server without JetStream)
-// — publishes then fall back to live-only core subjects, so a stream-declare
+// consumes (chat + video history), so they exist before the publishers emit.
+// It runs in the on-connect callback so it executes against a live server
+// even when the first dial loses the boot race and the client connects late.
+// It no-ops when JetStream is unavailable (a server without JetStream) —
+// publishes then fall back to live-only core subjects, so a stream-declare
 // failure must not be fatal.
 func (t *Tripbot) startNATS(ctx context.Context) {
-	natsclient.Connect(c.Conf.NatsURL, "tripbot")
-	if err := eventbus.EnsureStreams(ctx, natsclient.JetStream(), c.Conf.Environment); err != nil {
-		slog.WarnContext(ctx, "jetstream stream setup failed; console will run without durable history",
-			"err", err)
-	}
+	natsclient.Connect(c.Conf.NatsURL, "tripbot", func(*nats.Conn) {
+		if err := eventbus.EnsureStreams(ctx, natsclient.JetStream(), c.Conf.Environment); err != nil {
+			slog.WarnContext(ctx, "jetstream stream setup failed; console will run without durable history",
+				"err", err)
+		}
+	})
 }
 
 // authStatusInterval is how often the instance publishes its auth.status

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	vlcServer "github.com/adanalife/tripbot/pkg/vlc-server"
 	"github.com/getsentry/sentry-go"
+	"github.com/nats-io/nats.go"
 )
 
 // version is overridable at build time via -ldflags "-X main.version=...".
@@ -54,15 +55,20 @@ func main() {
 
 	// Connect to NATS so Server.Start can attach the command subscribers.
 	// Optional — when NATS_URL is empty the conn is nil and the subscriber
-	// registration is skipped; HTTP remains the sole transport.
-	natsclient.Connect(c.Conf.NatsURL, "vlc-server")
-
-	// Declare the lastplayed last-value-cache stream before the first play —
-	// a core publish to a subject no stream covers is silently uncaptured.
-	// Best-effort: resume-on-restart degrades to PlayRandom without it.
-	if err := vlcServer.EnsureLastPlayedStream(shutdownCtx, natsclient.JetStream(), c.Conf.Environment); err != nil {
-		slog.Warn("lastplayed stream setup failed; resume-on-restart disabled", "err", err)
-	}
+	// registration is skipped; HTTP remains the sole transport. A failed dial
+	// retries in the background (boot race) with subscriptions replayed on
+	// connect, so the subscribers below bind either way.
+	//
+	// The lastplayed last-value-cache stream is declared in the on-connect
+	// callback — a core publish to a subject no stream covers is silently
+	// uncaptured, and declaring on connect works even when the client wins
+	// the boot race and connects late. Best-effort: resume-on-restart
+	// degrades to PlayRandom without it.
+	natsclient.Connect(c.Conf.NatsURL, "vlc-server", func(*nats.Conn) {
+		if err := vlcServer.EnsureLastPlayedStream(shutdownCtx, natsclient.JetStream(), c.Conf.Environment); err != nil {
+			slog.Warn("lastplayed stream setup failed; resume-on-restart disabled", "err", err)
+		}
+	})
 
 	// await graceful shutdown signal
 	listenForShutdown()

--- a/pkg/natsclient/natsclient.go
+++ b/pkg/natsclient/natsclient.go
@@ -10,6 +10,7 @@ package natsclient
 import (
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -20,11 +21,27 @@ var (
 	conn *nats.Conn
 )
 
+// reconnectWait is the delay between connect attempts, both for the initial
+// connect (RetryOnFailedConnect) and for reconnects after a drop.
+const reconnectWait = 2 * time.Second
+
 // Connect dials the configured NATS endpoint and stashes the result as
 // the package singleton. When url is empty the function returns nil and
 // every downstream call no-ops — lets local dev / tests skip NATS.
 // Idempotent: a successful prior Connect short-circuits on re-entry.
-func Connect(url string, name string) *nats.Conn {
+//
+// The connection retries forever: RetryOnFailedConnect covers the boot race
+// where this process starts before NATS is reachable (a node reboot brings
+// apps and NATS up together), so a failed first dial no longer leaves the
+// process permanently deaf. The returned conn is usable immediately —
+// subscriptions made while disconnected are queued client-side and replayed
+// on connect; publishes buffer up to the client's reconnect buffer and are
+// otherwise dropped, matching the fire-and-forget contract.
+//
+// onConnect callbacks run once, when the connection is first established
+// (immediately or after retries) — the place for JetStream stream declares
+// and anything else that needs a live server.
+func Connect(url string, name string, onConnect ...func(*nats.Conn)) *nats.Conn {
 	mu.Lock()
 	defer mu.Unlock()
 	if conn != nil {
@@ -37,13 +54,28 @@ func Connect(url string, name string) *nats.Conn {
 	c, err := nats.Connect(url,
 		nats.Name(name),
 		nats.MaxReconnects(-1),
+		nats.RetryOnFailedConnect(true),
+		nats.ReconnectWait(reconnectWait),
+		nats.ConnectHandler(func(nc *nats.Conn) {
+			slog.Info("nats connected", "url", nc.ConnectedUrl(), "name", name)
+			for _, f := range onConnect {
+				f(nc)
+			}
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			slog.Info("nats reconnected", "url", nc.ConnectedUrl(), "name", name)
+		}),
 	)
 	if err != nil {
-		slog.Error("nats connect failed; pubsub publishes will no-op", "err", err, "url", url)
+		// Only non-retryable errors land here (bad URL/options) — dial
+		// failures return a conn that keeps retrying in the background.
+		slog.Error("nats config invalid; pubsub publishes will no-op", "err", err, "url", url)
 		return nil
 	}
 	conn = c
-	slog.Info("nats connected", "url", url, "name", name)
+	if !c.IsConnected() {
+		slog.Warn("nats unreachable; retrying in background", "url", url, "name", name)
+	}
 	return conn
 }
 

--- a/pkg/natsclient/natsclient_test.go
+++ b/pkg/natsclient/natsclient_test.go
@@ -1,0 +1,39 @@
+package natsclient
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestConnectRetriesUnreachableServer pins the boot-race behavior: a dial
+// failure must return a live, retrying conn (subscriptions queue and replay
+// on connect) rather than nil — nil left the process permanently deaf.
+func TestConnectRetriesUnreachableServer(t *testing.T) {
+	t.Cleanup(func() { SetConn(nil) })
+	SetConn(nil)
+
+	// A port nothing listens on: dial fails, retry loop takes over.
+	conn := Connect("nats://127.0.0.1:1", "natsclient-test")
+	if conn == nil {
+		t.Fatal("Connect returned nil for an unreachable server; want a retrying conn")
+	}
+	if conn.IsConnected() {
+		t.Fatal("conn unexpectedly connected to a dead port")
+	}
+	// Subscriptions on a not-yet-connected conn must queue, not error.
+	if _, err := conn.Subscribe("test.subject", func(*nats.Msg) {}); err != nil {
+		t.Fatalf("Subscribe on retrying conn errored: %v", err)
+	}
+	conn.Close()
+}
+
+// TestConnectEmptyURLStaysNil pins the local-dev contract: no URL, no conn.
+func TestConnectEmptyURLStaysNil(t *testing.T) {
+	t.Cleanup(func() { SetConn(nil) })
+	SetConn(nil)
+
+	if conn := Connect("", "natsclient-test"); conn != nil {
+		t.Fatal("Connect with empty URL returned a conn; want nil no-op mode")
+	}
+}


### PR DESCRIPTION
If NATS wasn't reachable at process start, `natsclient.Connect` logged `nats connect failed; pubsub publishes will no-op` and the process ran forever with pub/sub dead behind a healthy-looking pod. Hit live twice on 2026-07-06 (both minipc reboots): vlc/onscreens raced cluster DNS, which killed timewarps + overlays on both platforms — and since the timewarp jump is the only `!guess` dedup, left the guess scoreboard open to `!guess ny` spam.

**The fix** (three small pieces):
- `nats.RetryOnFailedConnect(true)` + `ReconnectWait(2s)` (+ existing `MaxReconnects(-1)`): a failed dial now returns a live conn that redials forever. Subscriptions made while disconnected queue client-side and replay on connect — the vlc/onscreens/tripbot subscriber layers heal with no changes.
- JetStream stream declares (tripbot's `EnsureStreams`, vlc's `EnsureLastPlayedStream`) move into a new variadic `onConnect` callback on `Connect`, which nats.go fires exactly once on first establishment — immediate or late — so declares always run against a live server.
- Logs tell the truth: `nats connected` now logs when the connection actually lands (`ConnectHandler`), `nats unreachable; retrying in background` on a lost boot race, `nats reconnected` on later reconnects. `Connect` only returns nil for an empty URL (no-op mode) or invalid config.

Regression tests pin the two contracts: unreachable server → non-nil retrying conn that accepts subscriptions; empty URL → nil.

onscreens-server needs no change (variadic signature, no stream declare). gateway (platform-gateway) and console (tripbot-console) have the same pattern and get their own PRs.

Context doc: the guess-integrity dependency is written up in the vault (timewarp-flow).