### PR TITLE
feat(cdk8s): expose stage vlc-twitch RTSP on NodePort 30855

### DIFF
--- a/cdk8s/adanalife_k8s/config.py
+++ b/cdk8s/adanalife_k8s/config.py
@@ -286,8 +286,11 @@ ENVS: dict[str, EnvConfig] = {
         priority_class="prod-stream",
         vlc_cpu_request="1",
         # Stable LAN endpoint for pulling the dashcam RTSP feed off-cluster
-        # (e.g. OBS on a desktop) without kubectl: rtsp://<minipc-ip>:30854/dashcam
-        # (TCP transport). Distinct from any future stage NodePort (same node).
+        # (e.g. OBS on a desktop) without kubectl: rtsp://<minipc-ip>:30854/dashcam.
+        # UDP transport only — the libvlc RTSP sout answers SETUP with 461
+        # Unsupported for TCP interleave, so a kubectl port-forward (TCP-only)
+        # can't carry the media; the NodePort is the sole off-cluster path.
+        # Stage uses a distinct port (the two envs co-tenant the one node).
         vlc_rtsp_node_port=30854,
     ),
     "stage-1": EnvConfig(
@@ -305,6 +308,11 @@ ENVS: dict[str, EnvConfig] = {
         # vlc doesn't need the iGPU (stream-copy + trivial software decode);
         # vlc_gpu=False keeps stage vlc from claiming it.
         vlc_gpu=False,
+        # LAN endpoint to watch the stage dashcam feed off-cluster (find/guess
+        # testing) without kubectl: rtsp://<minipc-ip>:30855/dashcam over UDP
+        # (see the prod note above re: why UDP + why port-forward can't work).
+        # 30855 is distinct from prod's 30854 — same node can't reuse a NodePort.
+        vlc_rtsp_node_port=30855,
         dashcam_mode="nfs",
         tailscale=True,
         # Prefer the ephemeral arm64 rpi5 worker for stage's stateless app pods

--- a/cdk8s/dist/stage-1-vlc-twitch.k8s.yaml
+++ b/cdk8s/dist/stage-1-vlc-twitch.k8s.yaml
@@ -137,6 +137,24 @@ spec:
     app: vlc-twitch
   type: ClusterIP
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: vlc-twitch
+    app.kubernetes.io/part-of: tripbot
+  name: vlc-twitch-rtsp
+  namespace: stage-1
+spec:
+  ports:
+    - name: rtsp
+      nodePort: 30855
+      port: 8554
+      targetPort: rtsp
+  selector:
+    app: vlc-twitch
+  type: NodePort
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/changelog.d/+find-sub-only-ack.chatbot.md
+++ b/changelog.d/+find-sub-only-ack.chatbot.md
@@ -1,0 +1,1 @@
+`!find` is now subscriber-only and replies with 👀 the moment it's invoked, so a slow search reads as "working" rather than dead. Twitch-only for now (removed from the YouTube command allowlist).

--- a/changelog.d/+nats-initial-connect-retry.fix.md
+++ b/changelog.d/+nats-initial-connect-retry.fix.md
@@ -1,0 +1,1 @@
+NATS connections now retry a failed initial connect forever instead of leaving the process permanently deaf. A boot race (node reboot bringing apps and NATS up together) previously killed timewarps, overlays, and `!guess` scoring integrity until a manual restart; now subscriptions replay and JetStream streams declare automatically when the connection lands.

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gempir/go-twitch-irc/v4"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-co-op/gocron/v2"
+	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -336,16 +337,19 @@ func (t *Tripbot) startFeatureFlags(ctx context.Context) {
 // when NATS_URL is empty the connection is skipped and publishes no-op silently.
 //
 // EnsureStreams declares the JetStream streams the standalone tripbot-console
-// consumes (chat + video history), so they exist before the publishers emit. It
-// no-ops when JetStream is unavailable (NATS off or a server without JetStream)
-// — publishes then fall back to live-only core subjects, so a stream-declare
+// consumes (chat + video history), so they exist before the publishers emit.
+// It runs in the on-connect callback so it executes against a live server
+// even when the first dial loses the boot race and the client connects late.
+// It no-ops when JetStream is unavailable (a server without JetStream) —
+// publishes then fall back to live-only core subjects, so a stream-declare
 // failure must not be fatal.
 func (t *Tripbot) startNATS(ctx context.Context) {
-	natsclient.Connect(c.Conf.NatsURL, "tripbot")
-	if err := eventbus.EnsureStreams(ctx, natsclient.JetStream(), c.Conf.Environment); err != nil {
-		slog.WarnContext(ctx, "jetstream stream setup failed; console will run without durable history",
-			"err", err)
-	}
+	natsclient.Connect(c.Conf.NatsURL, "tripbot", func(*nats.Conn) {
+		if err := eventbus.EnsureStreams(ctx, natsclient.JetStream(), c.Conf.Environment); err != nil {
+			slog.WarnContext(ctx, "jetstream stream setup failed; console will run without durable history",
+				"err", err)
+		}
+	})
 }
 
 // authStatusInterval is how often the instance publishes its auth.status

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/telemetry"
 	vlcServer "github.com/adanalife/tripbot/pkg/vlc-server"
 	"github.com/getsentry/sentry-go"
+	"github.com/nats-io/nats.go"
 )
 
 // version is overridable at build time via -ldflags "-X main.version=...".
@@ -54,15 +55,20 @@ func main() {
 
 	// Connect to NATS so Server.Start can attach the command subscribers.
 	// Optional — when NATS_URL is empty the conn is nil and the subscriber
-	// registration is skipped; HTTP remains the sole transport.
-	natsclient.Connect(c.Conf.NatsURL, "vlc-server")
-
-	// Declare the lastplayed last-value-cache stream before the first play —
-	// a core publish to a subject no stream covers is silently uncaptured.
-	// Best-effort: resume-on-restart degrades to PlayRandom without it.
-	if err := vlcServer.EnsureLastPlayedStream(shutdownCtx, natsclient.JetStream(), c.Conf.Environment); err != nil {
-		slog.Warn("lastplayed stream setup failed; resume-on-restart disabled", "err", err)
-	}
+	// registration is skipped; HTTP remains the sole transport. A failed dial
+	// retries in the background (boot race) with subscriptions replayed on
+	// connect, so the subscribers below bind either way.
+	//
+	// The lastplayed last-value-cache stream is declared in the on-connect
+	// callback — a core publish to a subject no stream covers is silently
+	// uncaptured, and declaring on connect works even when the client wins
+	// the boot race and connects late. Best-effort: resume-on-restart
+	// degrades to PlayRandom without it.
+	natsclient.Connect(c.Conf.NatsURL, "vlc-server", func(*nats.Conn) {
+		if err := vlcServer.EnsureLastPlayedStream(shutdownCtx, natsclient.JetStream(), c.Conf.Environment); err != nil {
+			slog.Warn("lastplayed stream setup failed; resume-on-restart disabled", "err", err)
+		}
+	})
 
 	// await graceful shutdown signal
 	listenForShutdown()

--- a/pkg/chatbot/find.go
+++ b/pkg/chatbot/find.go
@@ -242,6 +242,11 @@ func (a *App) findCmd(ctx context.Context, user *users.User, params []string) {
 	}
 	query := strings.Join(params, " ")
 
+	// Acknowledge immediately — the embed + pgvector search can take several
+	// seconds, and without a reply the command looks dead. Remove once the
+	// search is consistently fast.
+	a.Chat.Say(fmt.Sprintf("@%s 👀", user.Username))
+
 	hits, err := a.Search.Find(ctx, query)
 	if err != nil {
 		slog.ErrorContext(ctx, "find search failed", "err", err, "query", query)

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -58,10 +58,10 @@ func (a *App) buildRegistry() []Command {
 			RequiresFollow: true,
 		},
 		{
-			Trigger:        "!find",
-			Aliases:        []string{"!search"},
-			Handler:        a.findCmd,
-			RequiresFollow: true,
+			Trigger:            "!find",
+			Aliases:            []string{"!search"},
+			Handler:            a.findCmd,
+			RequiresSubscriber: true,
 		},
 		{
 			Trigger:        "!skip",
@@ -296,7 +296,8 @@ var youtubeCommands = map[string]bool{
 	"!weather": true, "!time": true, "!date": true, "!sunset": true,
 	"!state": true, "!location": true,
 	// playback control (drives this platform's vlc pipeline)
-	"!timewarp": true, "!goto": true, "!find": true, "!skip": true, "!back": true,
+	// !find is Twitch-only for now — subscriber-gated + still slow, revisit for YouTube later
+	"!timewarp": true, "!goto": true, "!skip": true, "!back": true,
 	// socials / static links
 	"!socialmedia": true, "!discord": true, "!twitter": true, "!instagram": true,
 	"!facebook": true, "!youtube": true, "!tiktok": true, "!bluesky": true,

--- a/pkg/natsclient/natsclient.go
+++ b/pkg/natsclient/natsclient.go
@@ -10,6 +10,7 @@ package natsclient
 import (
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -20,11 +21,27 @@ var (
 	conn *nats.Conn
 )
 
+// reconnectWait is the delay between connect attempts, both for the initial
+// connect (RetryOnFailedConnect) and for reconnects after a drop.
+const reconnectWait = 2 * time.Second
+
 // Connect dials the configured NATS endpoint and stashes the result as
 // the package singleton. When url is empty the function returns nil and
 // every downstream call no-ops — lets local dev / tests skip NATS.
 // Idempotent: a successful prior Connect short-circuits on re-entry.
-func Connect(url string, name string) *nats.Conn {
+//
+// The connection retries forever: RetryOnFailedConnect covers the boot race
+// where this process starts before NATS is reachable (a node reboot brings
+// apps and NATS up together), so a failed first dial no longer leaves the
+// process permanently deaf. The returned conn is usable immediately —
+// subscriptions made while disconnected are queued client-side and replayed
+// on connect; publishes buffer up to the client's reconnect buffer and are
+// otherwise dropped, matching the fire-and-forget contract.
+//
+// onConnect callbacks run once, when the connection is first established
+// (immediately or after retries) — the place for JetStream stream declares
+// and anything else that needs a live server.
+func Connect(url string, name string, onConnect ...func(*nats.Conn)) *nats.Conn {
 	mu.Lock()
 	defer mu.Unlock()
 	if conn != nil {
@@ -37,13 +54,28 @@ func Connect(url string, name string) *nats.Conn {
 	c, err := nats.Connect(url,
 		nats.Name(name),
 		nats.MaxReconnects(-1),
+		nats.RetryOnFailedConnect(true),
+		nats.ReconnectWait(reconnectWait),
+		nats.ConnectHandler(func(nc *nats.Conn) {
+			slog.Info("nats connected", "url", nc.ConnectedUrl(), "name", name)
+			for _, f := range onConnect {
+				f(nc)
+			}
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			slog.Info("nats reconnected", "url", nc.ConnectedUrl(), "name", name)
+		}),
 	)
 	if err != nil {
-		slog.Error("nats connect failed; pubsub publishes will no-op", "err", err, "url", url)
+		// Only non-retryable errors land here (bad URL/options) — dial
+		// failures return a conn that keeps retrying in the background.
+		slog.Error("nats config invalid; pubsub publishes will no-op", "err", err, "url", url)
 		return nil
 	}
 	conn = c
-	slog.Info("nats connected", "url", url, "name", name)
+	if !c.IsConnected() {
+		slog.Warn("nats unreachable; retrying in background", "url", url, "name", name)
+	}
 	return conn
 }
 

--- a/pkg/natsclient/natsclient_test.go
+++ b/pkg/natsclient/natsclient_test.go
@@ -1,0 +1,39 @@
+package natsclient
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestConnectRetriesUnreachableServer pins the boot-race behavior: a dial
+// failure must return a live, retrying conn (subscriptions queue and replay
+// on connect) rather than nil — nil left the process permanently deaf.
+func TestConnectRetriesUnreachableServer(t *testing.T) {
+	t.Cleanup(func() { SetConn(nil) })
+	SetConn(nil)
+
+	// A port nothing listens on: dial fails, retry loop takes over.
+	conn := Connect("nats://127.0.0.1:1", "natsclient-test")
+	if conn == nil {
+		t.Fatal("Connect returned nil for an unreachable server; want a retrying conn")
+	}
+	if conn.IsConnected() {
+		t.Fatal("conn unexpectedly connected to a dead port")
+	}
+	// Subscriptions on a not-yet-connected conn must queue, not error.
+	if _, err := conn.Subscribe("test.subject", func(*nats.Msg) {}); err != nil {
+		t.Fatalf("Subscribe on retrying conn errored: %v", err)
+	}
+	conn.Close()
+}
+
+// TestConnectEmptyURLStaysNil pins the local-dev contract: no URL, no conn.
+func TestConnectEmptyURLStaysNil(t *testing.T) {
+	t.Cleanup(func() { SetConn(nil) })
+	SetConn(nil)
+
+	if conn := Connect("", "natsclient-test"); conn != nil {
+		t.Fatal("Connect with empty URL returned a conn; want nil no-op mode")
+	}
+}


### PR DESCRIPTION
Gives stage the same off-cluster RTSP access prod has had since [tripbot#896](https://github.com/adanalife/tripbot/pull/896/changes), so the stage dashcam feed can be watched in VLC/OBS on the LAN while testing `!find` / `!guess`:

```
rtsp://minipc.whereisdana.today:30855/dashcam        # UDP, no --rtsp-tcp
```

**Why a NodePort and not port-forward:** verified today that the libvlc RTSP sout answers `SETUP` with **461 Unsupported transport** for TCP interleave — it only speaks RTP-over-UDP. `kubectl port-forward` is TCP-only, so it physically can't carry the media (the handshake succeeds, the decoder inits from the SDP, then no RTP arrives → "no data received in 10s"). The NodePort lets UDP RTP flow pod→LAN directly; confirmed prod's 30854 delivers video packets to a LAN Mac over plain UDP.

30855 is distinct from prod's 30854 (the two envs co-tenant the one minipc node, and a NodePort can't be claimed twice). Also fixes the prod config comment, which incorrectly said "(TCP transport)".

Applied live to stage ahead of merge (stage selfHeal is off, so it sticks); this records it in IaC.