### PR TITLE
feat(find): jump to a random nearby moment instead of the closest

### DIFF
--- a/changelog.d/1062.chatbot.md
+++ b/changelog.d/1062.chatbot.md
@@ -1,0 +1,1 @@
+`!find` now jumps to a random nearby match instead of always the closest, so repeating a search (e.g. `!find bridge`) tours different spots.

--- a/pkg/chatbot/find.go
+++ b/pkg/chatbot/find.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -26,9 +27,19 @@ const (
 	// findEmbedTimeout bounds the NATS request to the embed responder. A cold
 	// responder embeds a query in well under a second; the headroom is slack.
 	findEmbedTimeout = 10 * time.Second
-	// findResultLimit is how many candidate frames the pgvector search returns;
-	// the command jumps to the closest.
-	findResultLimit = 5
+	// findCandidatePool is how many nearest frames the pgvector search returns.
+	// !find jumps to a random distinct moment among them (below the ceiling)
+	// rather than always the single closest, so repeated !find <thing> tours
+	// different matches. Wider than findRandomizeTopN because the nearest frames
+	// cluster into a handful of moments once deduped.
+	findCandidatePool = 40
+	// findMomentBucketSec groups frames from the same clip within this many
+	// seconds into one "moment", so near-identical adjacent frames don't crowd
+	// the randomization down to a single spot on stream.
+	findMomentBucketSec = 60.0
+	// findRandomizeTopN caps how many distinct moments the pick randomizes over,
+	// keeping the jump reasonably close while still varied.
+	findRandomizeTopN = 10
 	// findMaxDistance is the cosine-distance ceiling for "close enough to jump".
 	// pgvector's <=> is (1 - cosine_similarity). Above this we treat the query
 	// as a miss rather than yanking the stream to a bad match. Calibrated on the
@@ -117,7 +128,7 @@ func (realSearch) Find(ctx context.Context, query string) ([]SearchHit, error) {
 	if err != nil {
 		return nil, err
 	}
-	return searchFrameEmbeddings(ctx, database.GormDB(), resp.Vector, resp.Model, resp.States, resp.Months, findResultLimit)
+	return searchFrameEmbeddings(ctx, database.GormDB(), resp.Vector, resp.Model, resp.States, resp.Months, findCandidatePool)
 }
 
 // requestEmbedding asks the video-pipeline responder to embed query, returning
@@ -206,6 +217,41 @@ func vectorLiteral(v []float32) string {
 	return b.String()
 }
 
+// findRandIntn is the randomness seam for moment selection; tests override it
+// to force a deterministic pick.
+var findRandIntn = rand.Intn
+
+// pickFindHit chooses which matching frame to jump to. Rather than always the
+// single closest frame (which makes !find deterministic — !find bridge would
+// land the same bridge every time), it collapses the nearest frames into
+// distinct moments — adjacent frames of one clip embed near-identically — and
+// picks one at random from the closest few, so repeated !find <thing> tours
+// different matches with no stored state. hits must be ordered nearest-first;
+// the caller guarantees hits[0] is under findMaxDistance, so at least one
+// moment always qualifies.
+func pickFindHit(hits []SearchHit) SearchHit {
+	seen := make(map[string]bool)
+	moments := make([]SearchHit, 0, findRandomizeTopN)
+	for _, h := range hits {
+		if h.Distance > findMaxDistance {
+			continue
+		}
+		key := fmt.Sprintf("%s:%d", h.Slug, int(h.TsSec/findMomentBucketSec))
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		moments = append(moments, h)
+		if len(moments) == findRandomizeTopN {
+			break
+		}
+	}
+	if len(moments) == 0 {
+		return hits[0]
+	}
+	return moments[findRandIntn(len(moments))]
+}
+
 // findCmd implements !find: visual search over the dashcam corpus, jumping the
 // stream to the closest matching moment. Shares the playback-jump rate-limiter
 // with !timewarp / !goto so the playhead can't be yanked too often.
@@ -258,7 +304,7 @@ func (a *App) findCmd(ctx context.Context, user *users.User, params []string) {
 		return
 	}
 
-	hit := hits[0]
+	hit := pickFindHit(hits)
 	// Land ahead of the matched frame so the moment doesn't slip past on stream.
 	if err := a.VLC.PlayFileAtTimestamp(ctx, hit.Slug+".MP4", hit.TsSec-findJumpLeadInSec); err != nil {
 		slog.ErrorContext(ctx, "find jump failed", "err", err, "slug", hit.Slug)

--- a/pkg/chatbot/find_test.go
+++ b/pkg/chatbot/find_test.go
@@ -44,6 +44,7 @@ func newFindTestApp(t *testing.T, search Search) (*App, *recordingVLC, *recordin
 
 func TestFindCmd_JumpsToClosestHit(t *testing.T) {
 	skipIfDarwin(t)
+	pinFindRandIntn(t, 0) // force the closest moment so the jump is assertable
 	search := &recordingSearch{Hits: []SearchHit{
 		{Slug: "2018_0514_224801_013", TsSec: 163.5, State: "Nevada", Distance: 0.21},
 		{Slug: "2018_0601_000000_001", TsSec: 12, State: "Utah", Distance: 0.55},
@@ -210,6 +211,47 @@ func TestSearchFrameEmbeddings_WithStateAndMonthFilters(t *testing.T) {
 func TestSearchFrameEmbeddings_EmptyVector(t *testing.T) {
 	if _, err := searchFrameEmbeddings(context.Background(), nil, nil, "model-x", nil, nil, 5); err == nil {
 		t.Error("expected an error for an empty query vector")
+	}
+}
+
+// pinFindRandIntn forces pickFindHit's random choice to a fixed index for the
+// duration of a test, then restores the real source.
+func pinFindRandIntn(t *testing.T, idx int) {
+	t.Helper()
+	orig := findRandIntn
+	findRandIntn = func(int) int { return idx }
+	t.Cleanup(func() { findRandIntn = orig })
+}
+
+func TestPickFindHit_CollapsesAdjacentFramesIntoOneMoment(t *testing.T) {
+	// Three near-identical adjacent frames of one clip plus one distinct moment:
+	// dedup should leave exactly two moments to randomize over.
+	hits := []SearchHit{
+		{Slug: "clipA", TsSec: 100.0, Distance: 0.20},
+		{Slug: "clipA", TsSec: 101.5, Distance: 0.21},
+		{Slug: "clipA", TsSec: 103.0, Distance: 0.22},
+		{Slug: "clipB", TsSec: 5.0, Distance: 0.30},
+	}
+	pinFindRandIntn(t, 1) // second distinct moment
+	if got := pickFindHit(hits); got.Slug != "clipB" {
+		t.Errorf("index 1 should be the second distinct moment clipB, got %+v", got)
+	}
+	pinFindRandIntn(t, 0) // first distinct moment = closest frame of clipA
+	if got := pickFindHit(hits); got.Slug != "clipA" || got.TsSec != 100.0 {
+		t.Errorf("index 0 should be clipA@100 (closest), got %+v", got)
+	}
+}
+
+func TestPickFindHit_SkipsHitsOverCeiling(t *testing.T) {
+	// The nearer hit is over the ceiling; only clipB qualifies. Pinning index 0
+	// must return clipB — if the over-ceiling hit were included it'd sort first.
+	hits := []SearchHit{
+		{Slug: "clipA", TsSec: 1, Distance: findMaxDistance + 0.01},
+		{Slug: "clipB", TsSec: 1, Distance: 0.20},
+	}
+	pinFindRandIntn(t, 0)
+	if got := pickFindHit(hits); got.Slug != "clipB" {
+		t.Errorf("expected the over-ceiling clipA to be skipped, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
`!find` was deterministic — the same query always jumped to the single closest frame, so `!find bridge` landed the same bridge every time. Now `pickFindHit` widens the candidate pool to 40, collapses near-identical adjacent frames into distinct moments (60s buckets per clip), and picks one at random from the closest ~10 — so repeated `!find <thing>` tours different matches, with no stored state. The distance ceiling still gates quality.

Tunables: `findRandomizeTopN` (variety width), `findMomentBucketSec` (dedup window).

Tests cover `pickFindHit` dedup + ceiling-skip; the existing closest-jump test pins the random seam.

## Test plan
- [ ] `!find <thing>` twice lands different moments
- [ ] a real match still jumps somewhere sensible