### PR TITLE
feat(chatbot): comp specific users as subscribers

### DIFF
--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -99,6 +99,9 @@ _ENV_CONFIG: dict[str, dict[str, str]] = {
         "CHANNEL_NAME": "adanalife_",
         "BOT_USERNAME": "tripbot4000",
         "GOOGLE_APPS_PROJECT_ID": "tripbot-prod",
+        # Comped as a subscriber for sub-only commands (e.g. !find) without
+        # an actual sub. Comma-separated for more than one.
+        "COMPED_SUBSCRIBERS": "reapermoss",
     },
     "stage-1": {
         "CHANNEL_NAME": "adanalife_staging",

--- a/cdk8s/dist/prod-1-tripbot-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-twitch.k8s.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   BOT_USERNAME: tripbot4000
   CHANNEL_NAME: adanalife_
+  COMPED_SUBSCRIBERS: reapermoss
   DATABASE_HOST: postgres.prod-1-data.svc.cluster.local
   ENV: production
   EXTERNAL_URL: https://tripbot-twitch.prod.whereisdana.today
@@ -45,7 +46,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 38bd887a79
+        adanalife.dev/config-hash: 7885a57f35
       labels:
         app: tripbot-twitch
     spec:

--- a/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   BOT_USERNAME: tripbot4000
   CHANNEL_NAME: adanalife_
+  COMPED_SUBSCRIBERS: reapermoss
   DATABASE_HOST: postgres.prod-1-data.svc.cluster.local
   ENV: production
   EXTERNAL_URL: https://tripbot-youtube.prod.whereisdana.today
@@ -67,7 +68,7 @@ spec:
   template:
     metadata:
       annotations:
-        adanalife.dev/config-hash: 73a0f8b3e9
+        adanalife.dev/config-hash: 13902e838a
       labels:
         app: tripbot-youtube
     spec:

--- a/changelog.d/1063.chatbot.md
+++ b/changelog.d/1063.chatbot.md
@@ -1,0 +1,1 @@
+Specific users can be comped as subscribers (`COMPED_SUBSCRIBERS`) to run subscriber-only commands like `!find` without an actual sub.

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -78,7 +78,9 @@ type sessionUser struct {
 func (su sessionUser) HasCommandAvailable(ctx context.Context) bool {
 	return su.s.HasCommandAvailable(ctx, su.u)
 }
-func (su sessionUser) IsSubscriber() bool { return su.s.IsSubscriber(*su.u) }
+func (su sessionUser) IsSubscriber() bool {
+	return c.UserIsCompedSubscriber(su.u.Username) || su.s.IsSubscriber(*su.u)
+}
 
 func (a *App) dispatch(ctx context.Context, cmd *Command, user *users.User, params []string) {
 	incChatCommandCounter(cmd.Trigger)

--- a/pkg/config/tripbot/helpers.go
+++ b/pkg/config/tripbot/helpers.go
@@ -22,6 +22,18 @@ func UserIsAdmin(username string) bool {
 	return strings.EqualFold(username, Conf.ChannelName)
 }
 
+// UserIsCompedSubscriber reports whether username is on the comped-subscriber
+// allowlist — treated as a subscriber for subscriber-only commands without an
+// actual sub.
+func UserIsCompedSubscriber(username string) bool {
+	for _, u := range Conf.CompedSubscribers {
+		if strings.EqualFold(u, username) {
+			return true
+		}
+	}
+	return false
+}
+
 // HelpMessages are all of the different things !help can return
 var HelpMessages = []string{
 	"!commands: List more commands you can use",

--- a/pkg/config/tripbot/type.go
+++ b/pkg/config/tripbot/type.go
@@ -16,6 +16,10 @@ type TripbotConfig struct {
 	ChannelName string `required:"true" envconfig:"CHANNEL_NAME"`
 	// BotUsername is the username of the bot
 	BotUsername string `required:"true" envconfig:"BOT_USERNAME"`
+	// CompedSubscribers are usernames treated as subscribers for
+	// subscriber-only commands without an actual sub (comped friends/VIPs).
+	// Comma-separated, case-insensitive. Empty by default.
+	CompedSubscribers []string `envconfig:"COMPED_SUBSCRIBERS"`
 	// ExternalURL is the where the bot's HTTP server can be reached
 	ExternalURL string `required:"true" envconfig:"EXTERNAL_URL"`
 	// GoogleMapsAPIKey is the API key with which we access Google Maps.


### PR DESCRIPTION
Adds a `COMPED_SUBSCRIBERS` allowlist so named users are treated as subscribers for subscriber-only commands (e.g. `!find`) without an actual sub. Applied at the `IsSubscriber()` seam, so it covers every sub-gated command, not just `!find`.

cdk8s wires it into the prod tripbot ConfigMap (`reapermoss`); the config-hash bump rolls the pods on deploy.

## Notes
- Comma-separated, case-insensitive; empty by default (no behavior change in envs that don't set it).
- Ships live once a tripbot release cuts and prod rolls onto it.