### PR TITLE
feat(cdk8s): freeze prod-1 app manifests to their pinned release version

### DIFF
--- a/.github/workflows/bump-prs.yml
+++ b/.github/workflows/bump-prs.yml
@@ -133,6 +133,19 @@ jobs:
           uv sync
           mise exec -- uv run cdk8s import
           mise exec -- uv run cdk8s synth
+          # cdk8s synth regenerated ALL prod-1 app manifests from master (which is
+          # the just-released tag — bump-prs fires from release.yml). This bump
+          # deploys ONE component, so freeze every OTHER prod component back to its
+          # own pinned release: without it, a chart/config change this release made
+          # to a component we're NOT bumping would leak into this PR. Only the
+          # bumped component's manifests change — carrying its image tag AND any
+          # config delta (new env var, mount, arg) this release introduced, so the
+          # deploy is visible as one diff. DISTNAME maps the pin key to the dist
+          # filename stem (onscreens-server -> onscreens; tripbot/vlc unchanged).
+          DISTNAME="${COMPONENT%-server}"
+          git ls-files -- 'dist/prod-1-*-twitch.k8s.yaml' 'dist/prod-1-*-youtube.k8s.yaml' \
+            | { grep -v "prod-1-${DISTNAME}-" || true; } \
+            | xargs -r git checkout --
 
       - name: Commit and push the bump branch
         if: env.CURRENT != env.VERSION
@@ -183,7 +196,7 @@ jobs:
           - What changed: [v$CURRENT...v$VERSION](https://github.com/adanalife/tripbot/compare/v$CURRENT...v$VERSION) · [release notes](https://github.com/adanalife/tripbot/releases/tag/v$VERSION)
           - $DEPLOY
           - Rollback: \`git revert\` the bump commit (same deploy path as above).
-          - The pin edit + the re-synthed \`dist/\` ride in the same commit on \`$BRANCH\`.
+          - The pin edit + the re-synthed \`dist/\` ride in the same commit on \`$BRANCH\`. The \`dist/\` diff shows the **full deploy** for this version — the image tag **and** any manifest/config change (env var, mount, arg) this release introduced for \`$COMPONENT\`, since prod is frozen to its pinned version between bumps.
 
           This PR updates in place when newer releases ship (force-push to \`$BRANCH\`).
           EOF

--- a/.github/workflows/cdk8s-synth.yml
+++ b/.github/workflows/cdk8s-synth.yml
@@ -55,5 +55,17 @@ jobs:
         working-directory: cdk8s
         run: mise exec -- uv run cdk8s synth
 
+      - name: Freeze version-pinned prod-1 manifests
+        working-directory: cdk8s
+        # prod-1 app manifests are pinned to their release version and regenerated
+        # only by bump-prs, so a chart change on develop doesn't reach prod's
+        # committed dist until its version is bumped (that's what couples the
+        # config delta to the bump). Discard this HEAD re-synth of the pinned app
+        # files before the sync check; identity + one-shot jobs stay live. Mirrors
+        # the freeze in `task cdk8s:synth`.
+        run: |
+          git ls-files -- 'dist/prod-1-*-twitch.k8s.yaml' 'dist/prod-1-*-youtube.k8s.yaml' \
+            | xargs -r git checkout --
+
       - name: Verify dist/ is committed in sync
         run: git diff --exit-code -- cdk8s/dist/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,6 +167,15 @@ tasks:
     deps: [cdk8s:imports]
     cmds:
       - mise exec -- uv run cdk8s synth
+      # prod-1 app manifests are pinned to their release version: frozen here and
+      # regenerated only by the bump-prs workflow, so a chart change on develop
+      # doesn't reach prod's committed dist until that component's version is
+      # bumped — which is what puts the config delta in the same diff as the bump.
+      # Discard this HEAD re-synth of the pinned app files; identity + one-shot
+      # jobs (no -twitch/-youtube suffix) stay live and re-synth normally.
+      - |
+        pinned=$(git ls-files -- 'dist/prod-1-*-twitch.k8s.yaml' 'dist/prod-1-*-youtube.k8s.yaml')
+        [ -n "$pinned" ] && git checkout -- $pinned || true
 
   cdk8s:test:
     desc: Run the cdk8s synth-time checks on the committed dist/
@@ -178,17 +187,15 @@ tasks:
   cdk8s:check:
     desc: Golden-file gate — re-synth and fail if cdk8s/dist/ is stale (run cdk8s:synth and commit)
     dir: cdk8s
-    deps: [cdk8s:imports]
     cmds:
-      - mise exec -- uv run cdk8s synth
+      - task: cdk8s:synth
       - git diff --exit-code -- dist/ || { echo "dist/ is stale — run task cdk8s:synth and commit"; exit 1; }
 
   cdk8s:verify:
     desc: The cdk8s edit loop in one step — synth, show what changed in dist/, run the synth-time checks
     dir: cdk8s
-    deps: [cdk8s:imports]
     cmds:
-      - mise exec -- uv run cdk8s synth
+      - task: cdk8s:synth
       - git status --short -- dist/
       - git diff --stat -- dist/
       - mise exec -- uv run pytest -q
@@ -196,9 +203,8 @@ tasks:
   cdk8s:stage:diff:
     desc: kubectl diff the synthed stage-1 app manifests against the live cluster (read-only)
     dir: cdk8s
-    deps: [cdk8s:imports]
     cmds:
-      - mise exec -- uv run cdk8s synth
+      - task: cdk8s:synth
       - for: { var: f, split: "\n" }
         cmd: kubectl diff -f "{{.f}}" || true
         vars:
@@ -206,13 +212,30 @@ tasks:
             sh: ls dist/stage-1-*.k8s.yaml | grep -v -- '-job-'
 
   cdk8s:prod:diff:
-    desc: kubectl diff the synthed prod-1 app manifests against the live cluster (read-only)
+    desc: kubectl diff the committed (release-pinned) prod-1 app manifests against the live cluster (read-only)
     dir: cdk8s
-    deps: [cdk8s:imports]
     cmds:
-      - mise exec -- uv run cdk8s synth
+      - task: cdk8s:synth
       - for: { var: f, split: "\n" }
         cmd: kubectl diff -f "{{.f}}" || true
         vars:
           f:
             sh: ls dist/prod-1-*.k8s.yaml | grep -v -- '-job-'
+
+  cdk8s:prod:bump:
+    desc: 'Regenerate one prod-1 component''s pinned manifests after a hand pin edit in versions.yaml (COMPONENT=vlc|tripbot|onscreens-server) — local mirror of the bump-prs workflow'
+    dir: cdk8s
+    deps: [cdk8s:imports]
+    requires:
+      vars: [COMPONENT]
+    cmds:
+      # Full synth regenerates ALL prod app files from HEAD; freeze every OTHER
+      # component back to its own pinned release so only COMPONENT's manifests
+      # change (its tag + any config delta this release introduced). Same logic as
+      # bump-prs.yml. DISTNAME strips the -server suffix (onscreens-server ->
+      # onscreens); tripbot/vlc are unchanged.
+      - mise exec -- uv run cdk8s synth
+      - |
+        distname="{{.COMPONENT}}"; distname="${distname%-server}"
+        others=$(git ls-files -- 'dist/prod-1-*-twitch.k8s.yaml' 'dist/prod-1-*-youtube.k8s.yaml' | grep -v "prod-1-${distname}-" || true)
+        [ -n "$others" ] && git checkout -- $others || true

--- a/cdk8s/versions.yaml
+++ b/cdk8s/versions.yaml
@@ -5,8 +5,18 @@
 # Tags are the un-suffixed multi-arch manifest tags from the tripbot release
 # workflow — no `v` prefix (3.1.0, not v3.1.0).
 #
-# Edited by the bump-prs workflow (one PR per component); hand-edits are fine
-# too — run `task cdk8s:synth` after changing a pin.
+# A pinned env's app manifests are FROZEN to their release version: `task
+# cdk8s:synth` (and the CI gate) discard the HEAD re-synth of prod's app files,
+# so a chart/config change on develop does NOT reach prod's committed dist until
+# that component's version is bumped. The bump is where the pinned manifests
+# regenerate — so a bump PR's dist diff shows the image tag AND every config
+# change (env var, mount, arg) that release introduced for the component, as one
+# deploy. (Identity Secrets + one-shot Jobs are not frozen — they re-synth live.)
+#
+# Edited by the bump-prs workflow (one PR per component). Hand-edits: change the
+# pin, then `task cdk8s:prod:bump COMPONENT=<name>` regenerates just that
+# component's prod dist (the local mirror of bump-prs) — plain `task cdk8s:synth`
+# won't, since it freezes prod.
 #
 # The comment line between pins is load-bearing: git can't auto-merge edits on
 # adjacent lines, so without a separator each merged bump PR conflicts the

--- a/changelog.d/1065.deploy.md
+++ b/changelog.d/1065.deploy.md
@@ -1,0 +1,1 @@
+prod-1 app manifests are now frozen to their pinned release version — a component's version-bump PR carries its config changes (env vars, mounts, args) in the same `dist/` diff as the image-tag bump, instead of leaking to prod at release-merge time.


### PR DESCRIPTION
## What

prod-1's app manifests floated on develop's chart with only the **image tag** pinned. So when a release added a config change (new env var, mount, arg), it reached prod's committed `dist/` at **release-merge time** — decoupled from, and invisible in, the per-component version-bump PR (which showed only a `1+ 1-` tag flip). It also meant new config could deploy to prod *ahead* of the image that needs it.

This **freezes** prod's pinned app manifests to their release version. They regenerate only at the bump, so a bump PR's `dist/` diff now shows the image tag **and** every config change that release introduced for that component — as one deploy.

## How

- **`task cdk8s:synth`** (and routed `check`/`verify`/`stage:diff`/`prod:diff`): after synth, discard the HEAD re-synth of prod's app files (`prod-1-<comp>-<platform>`). Identity Secrets + one-shot Jobs are *not* frozen — they re-synth live.
- **`cdk8s-synth` CI gate**: same freeze before the in-sync check.
- **`bump-prs`**: freeze every *other* prod component, so only the bumped component's manifests (tag + config delta) change in its PR.
- **`task cdk8s:prod:bump COMPONENT=<name>`**: local mirror of the bump flow for hand pin edits (plain `cdk8s:synth` now freezes prod).

Mechanism relies on `main.py`-direct not cleaning the outdir (only the `cdk8s synth` CLI does), so the freeze is a post-synth `git checkout` of the pinned files — no `main.py` change.

## Testing

Validated in a worktree: golden gate clean, 35 synth tests pass, both freeze incantations verified under `bash`:
- a chart change flows to stage/dev/local but **not** frozen prod;
- bumping only vlc gives `prod-1-vlc` the config delta + new tag while `prod-1-tripbot` stays frozen (even when the release also changed tripbot's chart);
- `cdk8s:prod:bump COMPONENT=vlc` regenerates only vlc's prod files.

This is the groundwork that also makes a later release-please migration cleaner (prod's deploy is now a single version-pinned unit per component).