### PR TITLE
ci(backmerge): don't re-fire on bump-prs pin merges

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,8 +1,15 @@
 name: backmerge
 
-# After anything lands on master (a release merge, a bump-prs pin edit), open or
-# refresh ONE standing PR that merges master back into develop, so develop never
-# drifts from master and release PRs never hit phantom-divergence conflicts.
+# After a release lands on master, open or refresh ONE standing PR that merges
+# master back into develop, so develop never drifts from master and release PRs
+# never hit phantom-divergence conflicts.
+#
+# Bump-prs merges are excluded (paths-ignore below): each release fans out up to
+# three bump PRs, and every one is a separate master push that would otherwise
+# re-arm this workflow — spawning a fresh back-merge PR after the prior was merged
+# (the "3 back-merge PRs per version" churn). Bump PRs only touch the prod pin +
+# its synthed dist, which develop doesn't consume; the next release's back-merge
+# sweeps those commits into develop anyway, so skipping them here loses nothing.
 #
 # ⚠️ The PR it opens MUST be merged with a MERGE COMMIT, never squashed/rebased.
 # Squash copies the file contents without making master's commits ancestors of
@@ -23,6 +30,9 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'cdk8s/versions.yaml'
+      - 'cdk8s/dist/prod-1-*'
   workflow_dispatch:
 
 permissions:

--- a/changelog.d/1066.ci.md
+++ b/changelog.d/1066.ci.md
@@ -1,0 +1,1 @@
+The master→develop back-merge PR now opens once per release instead of once per bump PR (it no longer re-fires on the per-component prod pin bumps).


### PR DESCRIPTION
## Problem

Each release fans out up to three `bump-prs` PRs (one per prod component). Every one is a separate push to `master`, and `backmerge` triggers on every `master` push — so after you merged the standing back-merge PR, the next bump merge re-armed it and opened a **fresh** one. A single version produced **three** back-merge PRs instead of one:

- v3.11.0 → [#1044](https://github.com/adanalife/tripbot/pull/1044), [#1047](https://github.com/adanalife/tripbot/pull/1047), [#1048](https://github.com/adanalife/tripbot/pull/1048)
- v3.12.0 → [#1056](https://github.com/adanalife/tripbot/pull/1056), [#1059](https://github.com/adanalife/tripbot/pull/1059), [#1061](https://github.com/adanalife/tripbot/pull/1061)

## Fix

`paths-ignore` the bump-pr footprint (`cdk8s/versions.yaml` + `cdk8s/dist/prod-1-*`) on the push trigger. A bump merge touches only those files, so it no longer re-fires backmerge; a release merge (code + CHANGELOG) still does. Result: **one back-merge PR per version**, on the release merge.

Nothing is lost — develop doesn't consume prod pins, and the next release's back-merge still sweeps those commits into develop.

## Scope

Only tripbot needs this — it's the sole develop→master repo with both `backmerge` **and** a separate `bump-prs` workflow. console/obs/platform-gateway have backmerge but bump their prod pin in the release PR itself (one master push → one back-merge); website has no backmerge; infra is master-only.