### PR TITLE
feat(chatbot): add !refreshoverlays admin command to hard-reload OBS browser sources

### DIFF
--- a/changelog.d/1072.chatbot.md
+++ b/changelog.d/1072.chatbot.md
@@ -1,0 +1,1 @@
+Add an admin-only `!refreshoverlays` command that hard-reloads OBS browser sources (respawning their CEF render process) to recover crashed/frozen onscreen overlays without restarting OBS.

--- a/pkg/chatbot/carsound.go
+++ b/pkg/chatbot/carsound.go
@@ -15,6 +15,7 @@ import (
 // fake; production uses the realOBS adapter wired in New().
 type OBS interface {
 	SetBackgroundAudioFile(ctx context.Context, inputName, file string) error
+	RefreshBrowserSources(ctx context.Context) (int, error)
 }
 
 // realOBS delegates to pkg/obs, which dials the OBS WebSocket per call using
@@ -23,6 +24,10 @@ type realOBS struct{}
 
 func (realOBS) SetBackgroundAudioFile(ctx context.Context, inputName, file string) error {
 	return obs.SetBackgroundAudioFile(ctx, inputName, file)
+}
+
+func (realOBS) RefreshBrowserSources(ctx context.Context) (int, error) {
+	return obs.RefreshBrowserSources(ctx)
 }
 
 // carHumInputName is the OBS source name of the background-audio ffmpeg_source

--- a/pkg/chatbot/carsound_test.go
+++ b/pkg/chatbot/carsound_test.go
@@ -15,17 +15,24 @@ import (
 type noopOBS struct{}
 
 func (noopOBS) SetBackgroundAudioFile(context.Context, string, string) error { return nil }
+func (noopOBS) RefreshBrowserSources(context.Context) (int, error)           { return 0, nil }
 
 // recordingOBS captures SetBackgroundAudioFile calls so tests can assert on the
 // input name + file path, and can be primed to return an error.
 type recordingOBS struct {
-	Calls []string // "<inputName>|<file>" per call
-	err   error
+	Calls      []string // "<inputName>|<file>" per call
+	Refreshed  int      // count returned from RefreshBrowserSources
+	refreshErr error
+	err        error
 }
 
 func (r *recordingOBS) SetBackgroundAudioFile(_ context.Context, inputName, file string) error {
 	r.Calls = append(r.Calls, inputName+"|"+file)
 	return r.err
+}
+
+func (r *recordingOBS) RefreshBrowserSources(context.Context) (int, error) {
+	return r.Refreshed, r.refreshErr
 }
 
 func TestCarSoundCmd_NoArgReportsCurrent_NoSwitch(t *testing.T) {

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -627,6 +627,24 @@ func (a *App) giveMilesCmd(ctx context.Context, user *users.User, params []strin
 	a.Chat.Say(fmt.Sprintf("@%s now has %.2fmi", target, newTotal))
 }
 
+// refreshOverlaysCmd hard-reloads every OBS browser source (the onscreen
+// corners, the next-frame cover, etc.) by respawning each source's CEF render
+// process. Admin-only. This is the manual recovery for a crashed/frozen overlay
+// — the hourly soft refresh can't revive a crashed CEF webpage.
+func (a *App) refreshOverlaysCmd(ctx context.Context, user *users.User, _ []string) {
+	slog.InfoContext(ctx, "ran !refreshoverlays", "username", user.Username)
+	if !c.UserIsAdmin(user.Username) {
+		return
+	}
+	n, err := a.OBS.RefreshBrowserSources(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "overlay refresh failed", "err", err)
+		a.Chat.Say("Couldn't refresh the overlays right now, try again in a bit")
+		return
+	}
+	a.Chat.Say(fmt.Sprintf("Refreshed %d overlay(s).", n))
+}
+
 func (a *App) shutdownCmd(ctx context.Context, user *users.User, _ []string) {
 	slog.InfoContext(ctx, "ran !shutdown", "username", user.Username)
 	if !c.UserIsAdmin(user.Username) {

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -2,6 +2,7 @@ package chatbot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -893,6 +894,45 @@ func TestMiddleCmd_NonAdminIsSilent(t *testing.T) {
 
 	if out() != "" {
 		t.Errorf("expected silence for non-admin, got %q", out())
+	}
+}
+
+// --- refreshOverlaysCmd ---
+
+func TestRefreshOverlaysCmd_NonAdminIsSilent(t *testing.T) {
+	app := newTestApp(video.Video{})
+	obs := &recordingOBS{Refreshed: 5}
+	app.OBS = obs
+	out := captureSay(t, app)
+
+	app.refreshOverlaysCmd(context.Background(), newTestUser("viewer1"), nil)
+
+	if out() != "" {
+		t.Errorf("expected silence for non-admin, got %q", out())
+	}
+}
+
+func TestRefreshOverlaysCmd_AdminReportsCount(t *testing.T) {
+	app := newTestApp(video.Video{})
+	app.OBS = &recordingOBS{Refreshed: 3}
+	out := captureSay(t, app)
+
+	app.refreshOverlaysCmd(context.Background(), newTestUser(adminUser), nil)
+
+	if !strings.Contains(out(), "Refreshed 3 overlay") {
+		t.Errorf("expected refreshed-count report, got %q", out())
+	}
+}
+
+func TestRefreshOverlaysCmd_ErrorIsReported(t *testing.T) {
+	app := newTestApp(video.Video{})
+	app.OBS = &recordingOBS{refreshErr: errors.New("obs unreachable")}
+	out := captureSay(t, app)
+
+	app.refreshOverlaysCmd(context.Background(), newTestUser(adminUser), nil)
+
+	if !strings.Contains(out(), "Couldn't refresh") {
+		t.Errorf("expected failure message, got %q", out())
 	}
 }
 

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -78,6 +78,11 @@ func (a *App) buildRegistry() []Command {
 			Handler: a.shutdownCmd,
 		},
 		{
+			Trigger: "!refreshoverlays",
+			Aliases: []string{"!refreshoverlay"},
+			Handler: a.refreshOverlaysCmd,
+		},
+		{
 			Trigger: "!socialmedia",
 			Aliases: []string{"!social", "!socials"},
 			Handler: func(_ context.Context, _ *users.User, _ []string) {

--- a/pkg/obs/inputs.go
+++ b/pkg/obs/inputs.go
@@ -2,10 +2,97 @@ package obs
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"time"
 
+	goobs "github.com/andreykaipov/goobs"
 	"github.com/andreykaipov/goobs/api/requests/inputs"
 )
+
+// browserSourceKind is the OBS input kind for a CEF browser_source.
+const browserSourceKind = "browser_source"
+
+// blankURL is the transient page a browser source is pointed at to force
+// obs-browser to tear down and recreate its CEF render process.
+const blankURL = "about:blank"
+
+// browserReloadGap is how long a source sits on blankURL before its real url is
+// restored — long enough for obs-browser to actually drop the old render
+// process rather than coalescing the two settings writes into a no-op.
+const browserReloadGap = 600 * time.Millisecond
+
+// RefreshBrowserSources hard-reloads every browser_source in OBS by swapping its
+// url to about:blank and back, forcing obs-browser to recreate the CEF render
+// process. Returns the number of sources reloaded.
+//
+// This is the recovery the hourly soft refresh can't do: a browser source whose
+// webpage has crashed (CEF "Webpage has crashed unexpectedly") is NOT revived by
+// PressInputPropertiesButton("refreshnocache") — only re-setting the url
+// respawns the render process. Reloads all sources on one connection; a
+// per-source failure is logged and skipped so one bad source doesn't strand the
+// rest.
+func RefreshBrowserSources(ctx context.Context) (int, error) {
+	client, err := dial(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err := client.Disconnect(); err != nil {
+			slog.WarnContext(ctx, "obs disconnect", "err", err)
+		}
+	}()
+
+	list, err := client.Inputs.GetInputList(inputs.NewGetInputListParams())
+	if err != nil {
+		return 0, fmt.Errorf("obs get input list: %w", err)
+	}
+
+	var reloaded int
+	for _, in := range list.Inputs {
+		if in.InputKind != browserSourceKind {
+			continue
+		}
+		name := in.InputName
+		settings, err := client.Inputs.GetInputSettings(inputs.NewGetInputSettingsParams().WithInputName(name))
+		if err != nil {
+			slog.WarnContext(ctx, "obs get input settings", "err", err, "input", name)
+			continue
+		}
+		// A browser source backed by a local file (not a url) has nothing to
+		// reload this way; skip it rather than clobbering its settings.
+		url, ok := settings.InputSettings["url"].(string)
+		if !ok || url == "" {
+			continue
+		}
+		if err := setBrowserURL(client, name, blankURL); err != nil {
+			slog.WarnContext(ctx, "obs blank browser url", "err", err, "input", name)
+			continue
+		}
+		time.Sleep(browserReloadGap)
+		if err := setBrowserURL(client, name, url); err != nil {
+			// Left on about:blank — log loudly; the source is blank until the next
+			// refresh restores it.
+			slog.ErrorContext(ctx, "obs restore browser url", "err", err, "input", name, "url", url)
+			continue
+		}
+		reloaded++
+	}
+	slog.InfoContext(ctx, "hard-refreshed obs browser sources", "count", reloaded)
+	return reloaded, nil
+}
+
+// setBrowserURL merges a new url onto a browser source over an existing
+// connection (overlay=true leaves the source's other settings intact).
+func setBrowserURL(client *goobs.Client, name, url string) error {
+	_, err := client.Inputs.SetInputSettings(
+		inputs.NewSetInputSettingsParams().
+			WithInputName(name).
+			WithInputSettings(map[string]any{"url": url}).
+			WithOverlay(true),
+	)
+	return err
+}
 
 // SetBackgroundAudioFile repoints an ffmpeg_source input at a different local
 // media file over the OBS WebSocket — used by the !carsound command to swap the


### PR DESCRIPTION
## What

Adds an admin-only `!refreshoverlays` chat command (alias `!refreshoverlay`) that hard-reloads every OBS `browser_source` — the onscreen corners, the next-frame cover, etc.

## Why

Today the only automated recovery is the hourly `browser-refresh` job, which uses a soft `PressInputPropertiesButton("refreshnocache")`. That **cannot revive a crashed CEF webpage** (`Webpage has crashed unexpectedly`). On 2026-07-07 the prod Twitch OBS pod hit exactly this: the `Next-frame preview` source crashed (Reason 5) right after an hourly refresh, taking the two rotator corners down with it — blank corners + a black seam-cover — and the hourly soft-refresh couldn't recover it. Manual recovery meant a source-level `url` swap over obs-websocket.

This command bakes that manual recovery in: `RefreshBrowserSources` swaps each browser source's `url` to `about:blank` and back, which respawns the CEF render process.

## Changes

- `pkg/obs`: `RefreshBrowserSources(ctx) (int, error)` — enumerate browser sources on one connection, hard-reload each via url-swap, log-and-skip per-source failures.
- `pkg/chatbot`: `!refreshoverlays` admin command (gated on `UserIsAdmin`), wired through the existing injectable `OBS` seam; tests for the admin gate, count report, and error path.

## Verification

- `go test ./pkg/chatbot/ ./pkg/obs/` green; `go build ./cmd/tripbot/` clean; gofmt clean.
- The underlying url-swap reload was validated live on prod obs-twitch during the incident — recovered all three dead sources (confirmed via `GetSourceScreenshot`) without an OBS restart.

## Follow-up (not in this PR)

Console button: the eventbus is one-directional (tripbot→console observations only), so a console button needs a new console→tripbot command channel — the same missing seam as the unbuilt force-reauth button. Scoped separately.