### PR TITLE
feat(contract): declare onscreens command subjects + envelopes as commands.json

### DIFF
--- a/changelog.d/1074.onscreens.md
+++ b/changelog.d/1074.onscreens.md
@@ -1,0 +1,1 @@
+Add `commands.json` to `pkg/contract` — the NATS onscreens-command subject + envelope registry (JSON Schema), so the admin console can publish overlay commands without hand-building subject strings. Companion to `eventbus.json`.

--- a/pkg/contract/commands.go
+++ b/pkg/contract/commands.go
@@ -6,7 +6,7 @@ import (
 )
 
 // This file declares the onscreens *command* registry — the NATS subjects that
-// drive the on-screen overlays (timewarp, middle text, leaderboard, GPS, flag)
+// drive the on-screen overlays (timewarp, middle text, leaderboard, GPS)
 // plus the passive location feed, with each payload as a JSON Schema (draft
 // 2020-12). It is emitted as the sibling commands.json by
 // `go generate ./pkg/contract`, exactly like eventbus.json.
@@ -99,7 +99,6 @@ func commandsContract() orderedObject {
 			{"timewarp_hide", commandSubject("timewarp", "hide", "Command", commandFields)},
 			{"gps_show", commandSubject("gps", "show", "Command", commandFields)},
 			{"gps_hide", commandSubject("gps", "hide", "Command", commandFields)},
-			{"flag_hide", commandSubject("flag", "hide", "Command", commandFields)},
 			{"location_update", commandSubject("location", "update", "LocationData", locationUpdateFields)},
 		}},
 	}

--- a/pkg/contract/commands.go
+++ b/pkg/contract/commands.go
@@ -1,0 +1,122 @@
+package contract
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// This file declares the onscreens *command* registry — the NATS subjects that
+// drive the on-screen overlays (timewarp, middle text, leaderboard, GPS, flag)
+// plus the passive location feed, with each payload as a JSON Schema (draft
+// 2020-12). It is emitted as the sibling commands.json by
+// `go generate ./pkg/contract`, exactly like eventbus.json.
+//
+// The distinction from eventbus.json: eventbus is *observations* tripbot
+// publishes and the console consumes (facts about what happened). This is
+// *commands* — imperatives that onscreens-server subscribes to and acts on.
+// tripbot already publishes them (pkg/onscreens-client); this contract lets the
+// admin console publish the same subjects to drive the overlays from a button,
+// without hand-rebuilding the subject strings or payload shapes (the exact
+// hazard the eventbus contract was created for).
+//
+// Source of truth: pkg/onscreens-events (the shared wire-format package, imported
+// by both the tripbot publisher and the onscreens-server subscriber).
+// commands_schema_test.go reflects over those structs — flattening the embedded
+// Envelope — to assert the declared field names + required-ness match, so a
+// struct change that isn't mirrored here fails CI. Reflection stays in the test
+// so pkg/contract never imports pkg/onscreens-events (package-boundary discipline).
+
+const commandsComment = "Generated from pkg/onscreens-events via `go generate ./pkg/contract` — do not hand-edit. The NATS onscreens-command subject + envelope registry that tripbot and the admin console publish and onscreens-server consumes; payload schemas are JSON Schema (draft 2020-12)."
+
+// commandSubjectPattern documents the onscreens command subject convention. It
+// differs from the eventbus pattern by a trailing {platform} leaf — each
+// onscreens-server (onscreens-twitch / onscreens-youtube) subscribes only to its
+// own platform, so a Twitch-triggered overlay never renders on YouTube.
+const commandSubjectPattern = "tripbot.{env}.onscreens.{overlay}.{verb}.{platform}"
+
+// Declared onscreens command envelope field lists. Each mirrors the json tags of
+// the matching pkg/onscreens-events struct in promoted-field order (the embedded
+// Envelope's emitted_at comes first). commands_schema_test.go asserts the match.
+var (
+	middleShowFields = []field{
+		{"emitted_at", dateType(), true},
+		{"msg", strType(), true},
+	}
+	timewarpShowFields = []field{
+		{"emitted_at", dateType(), true},
+		{"username", strType(), true},
+	}
+	leaderboardShowFields = []field{
+		{"emitted_at", dateType(), true},
+		{"title", strType(), true},
+		{"rows", arrayType(arrayType(strType())), true},
+	}
+	locationUpdateFields = []field{
+		{"emitted_at", dateType(), true},
+		{"location", strType(), true},
+		{"date", strType(), true},
+	}
+	// commandFields is the bare envelope shared by every hide plus gps.show —
+	// the pkg/onscreens-events Command type (no data beyond the envelope).
+	commandFields = []field{
+		{"emitted_at", dateType(), true},
+	}
+)
+
+// commandEnvelopeFields maps each declared schema title to its field list so the
+// reflection test can cross-check against the real pkg/onscreens-events structs.
+var commandEnvelopeFields = map[string][]field{
+	"MiddleShow":      middleShowFields,
+	"TimewarpShow":    timewarpShowFields,
+	"LeaderboardShow": leaderboardShowFields,
+	"LocationData":    locationUpdateFields,
+	"Command":         commandFields,
+}
+
+// commandSubject renders one subject entry: the subject template, the transport
+// (core NATS for every onscreens command — fire-and-forget, nothing replayed),
+// and the payload schema.
+func commandSubject(overlay, verb, schemaTitle string, fields []field) orderedObject {
+	return orderedObject{
+		{"subject", "tripbot.{env}.onscreens." + overlay + "." + verb + ".{platform}"},
+		{"transport", "core"},
+		{"schema", objectSchema(schemaTitle, fields)},
+	}
+}
+
+// commandsContract builds the full onscreens command registry in stable on-disk
+// order, grouped by overlay (show before hide), then the passive location feed.
+func commandsContract() orderedObject {
+	return orderedObject{
+		{"_comment", commandsComment},
+		{"subject_pattern", commandSubjectPattern},
+		{"subjects", orderedObject{
+			{"middle_show", commandSubject("middle", "show", "MiddleShow", middleShowFields)},
+			{"middle_hide", commandSubject("middle", "hide", "Command", commandFields)},
+			{"leaderboard_show", commandSubject("leaderboard", "show", "LeaderboardShow", leaderboardShowFields)},
+			{"leaderboard_hide", commandSubject("leaderboard", "hide", "Command", commandFields)},
+			{"timewarp_show", commandSubject("timewarp", "show", "TimewarpShow", timewarpShowFields)},
+			{"timewarp_hide", commandSubject("timewarp", "hide", "Command", commandFields)},
+			{"gps_show", commandSubject("gps", "show", "Command", commandFields)},
+			{"gps_hide", commandSubject("gps", "hide", "Command", commandFields)},
+			{"flag_hide", commandSubject("flag", "hide", "Command", commandFields)},
+			{"location_update", commandSubject("location", "update", "LocationData", locationUpdateFields)},
+		}},
+	}
+}
+
+// MarshalCommands renders commands.json: the registry as 2-space-indented JSON
+// with stable key order + trailing newline (the bytes the generator writes and
+// the golden test compares against).
+func MarshalCommands() ([]byte, error) {
+	compact, err := commandsContract().MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	if err := json.Indent(&out, compact, "", "  "); err != nil {
+		return nil, err
+	}
+	out.WriteByte('\n')
+	return out.Bytes(), nil
+}

--- a/pkg/contract/commands.json
+++ b/pkg/contract/commands.json
@@ -160,23 +160,6 @@
         ]
       }
     },
-    "flag_hide": {
-      "subject": "tripbot.{env}.onscreens.flag.hide.{platform}",
-      "transport": "core",
-      "schema": {
-        "type": "object",
-        "title": "Command",
-        "properties": {
-          "emitted_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "required": [
-          "emitted_at"
-        ]
-      }
-    },
     "location_update": {
       "subject": "tripbot.{env}.onscreens.location.update.{platform}",
       "transport": "core",

--- a/pkg/contract/commands.json
+++ b/pkg/contract/commands.json
@@ -1,0 +1,206 @@
+{
+  "_comment": "Generated from pkg/onscreens-events via `go generate ./pkg/contract` — do not hand-edit. The NATS onscreens-command subject + envelope registry that tripbot and the admin console publish and onscreens-server consumes; payload schemas are JSON Schema (draft 2020-12).",
+  "subject_pattern": "tripbot.{env}.onscreens.{overlay}.{verb}.{platform}",
+  "subjects": {
+    "middle_show": {
+      "subject": "tripbot.{env}.onscreens.middle.show.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "MiddleShow",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "msg": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "emitted_at",
+          "msg"
+        ]
+      }
+    },
+    "middle_hide": {
+      "subject": "tripbot.{env}.onscreens.middle.hide.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "Command",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "emitted_at"
+        ]
+      }
+    },
+    "leaderboard_show": {
+      "subject": "tripbot.{env}.onscreens.leaderboard.show.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "LeaderboardShow",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "emitted_at",
+          "title",
+          "rows"
+        ]
+      }
+    },
+    "leaderboard_hide": {
+      "subject": "tripbot.{env}.onscreens.leaderboard.hide.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "Command",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "emitted_at"
+        ]
+      }
+    },
+    "timewarp_show": {
+      "subject": "tripbot.{env}.onscreens.timewarp.show.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "TimewarpShow",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "emitted_at",
+          "username"
+        ]
+      }
+    },
+    "timewarp_hide": {
+      "subject": "tripbot.{env}.onscreens.timewarp.hide.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "Command",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "emitted_at"
+        ]
+      }
+    },
+    "gps_show": {
+      "subject": "tripbot.{env}.onscreens.gps.show.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "Command",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "emitted_at"
+        ]
+      }
+    },
+    "gps_hide": {
+      "subject": "tripbot.{env}.onscreens.gps.hide.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "Command",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "emitted_at"
+        ]
+      }
+    },
+    "flag_hide": {
+      "subject": "tripbot.{env}.onscreens.flag.hide.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "Command",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "emitted_at"
+        ]
+      }
+    },
+    "location_update": {
+      "subject": "tripbot.{env}.onscreens.location.update.{platform}",
+      "transport": "core",
+      "schema": {
+        "type": "object",
+        "title": "LocationData",
+        "properties": {
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "emitted_at",
+          "location",
+          "date"
+        ]
+      }
+    }
+  }
+}

--- a/pkg/contract/commands_golden_test.go
+++ b/pkg/contract/commands_golden_test.go
@@ -1,0 +1,26 @@
+package contract
+
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed commands.json
+var committedCommands []byte
+
+// TestCommandsMatchesCommitted is the anti-drift guard for the onscreens command
+// registry: it regenerates commands.json from the in-code declaration and
+// asserts the result is byte-identical to the committed file. If the registry
+// changes without regenerating, this fails CI.
+func TestCommandsMatchesCommitted(t *testing.T) {
+	got, err := MarshalCommands()
+	if err != nil {
+		t.Fatalf("MarshalCommands: %v", err)
+	}
+	if string(got) != string(committedCommands) {
+		t.Errorf("commands.json is out of date with the pkg/contract command registry.\n"+
+			"Run `go generate ./pkg/contract` and commit the result.\n\n"+
+			"--- committed commands.json ---\n%s\n--- generated ---\n%s",
+			committedCommands, got)
+	}
+}

--- a/pkg/contract/commands_schema_test.go
+++ b/pkg/contract/commands_schema_test.go
@@ -1,0 +1,93 @@
+package contract
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	oe "github.com/adanalife/tripbot/pkg/onscreens-events"
+)
+
+// TestCommandsSchemaMatchesStructs reflects over the real pkg/onscreens-events
+// command envelope structs and asserts the declared field lists (name +
+// required) match field-for-field, in promoted order. Unlike the eventbus
+// structs these embed a shared Envelope, so the walk flattens anonymous struct
+// fields — the embedded Envelope's emitted_at is promoted to the front, exactly
+// as it lands on the wire. A rename, added/removed field, or changed omitempty
+// that isn't mirrored in commands.go fails here, so commands.json (and the
+// Python types generated from it) can't silently drift from the wire format.
+//
+// Reflection lives in this test, not in commands.go, so pkg/contract never
+// imports pkg/onscreens-events (package-boundary discipline).
+func TestCommandsSchemaMatchesStructs(t *testing.T) {
+	structs := map[string]reflect.Type{
+		"MiddleShow":      reflect.TypeOf(oe.MiddleShow{}),
+		"TimewarpShow":    reflect.TypeOf(oe.TimewarpShow{}),
+		"LeaderboardShow": reflect.TypeOf(oe.LeaderboardShow{}),
+		"LocationData":    reflect.TypeOf(oe.LocationData{}),
+		"Command":         reflect.TypeOf(oe.Command{}),
+	}
+
+	type nameReq struct {
+		name     string
+		required bool
+	}
+
+	for title, typ := range structs {
+		declared, ok := commandEnvelopeFields[title]
+		if !ok {
+			t.Errorf("%s: no declared field list in commandEnvelopeFields", title)
+			continue
+		}
+
+		fromStruct := flattenJSONFields(typ)
+		if len(fromStruct) != len(declared) {
+			t.Errorf("%s: struct has %d json fields, declared schema has %d",
+				title, len(fromStruct), len(declared))
+			continue
+		}
+		for i := range fromStruct {
+			if fromStruct[i].name != declared[i].Name {
+				t.Errorf("%s field %d: struct json name %q != declared %q",
+					title, i, fromStruct[i].name, declared[i].Name)
+			}
+			if fromStruct[i].required != declared[i].Required {
+				t.Errorf("%s field %q: struct required=%v != declared required=%v",
+					title, fromStruct[i].name, fromStruct[i].required, declared[i].Required)
+			}
+		}
+	}
+}
+
+type jsonField struct {
+	name     string
+	required bool
+}
+
+// flattenJSONFields walks a struct's json-tagged fields in promotion order,
+// recursing into anonymous embedded structs (so the embedded Envelope's
+// emitted_at appears where Go promotes it — at the front). Mirrors how
+// encoding/json flattens the embedded envelope onto the wire.
+func flattenJSONFields(typ reflect.Type) []jsonField {
+	var out []jsonField
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.Anonymous && f.Type.Kind() == reflect.Struct && f.Tag.Get("json") == "" {
+			out = append(out, flattenJSONFields(f.Type)...)
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		parts := strings.Split(tag, ",")
+		required := true
+		for _, p := range parts[1:] {
+			if p == "omitempty" {
+				required = false
+			}
+		}
+		out = append(out, jsonField{name: parts[0], required: required})
+	}
+	return out
+}

--- a/pkg/contract/internal/gen/main.go
+++ b/pkg/contract/internal/gen/main.go
@@ -46,4 +46,17 @@ func main() {
 		log.Fatalf("write %s: %v", ebOut, err)
 	}
 	log.Printf("wrote %s", ebOut)
+
+	// The onscreens command registry (subjects onscreens-server subscribes to +
+	// their envelope schemas) is emitted alongside — a sibling commands.json the
+	// console syncs to publish overlay commands without hand-building subjects.
+	cmdData, err := contract.MarshalCommands()
+	if err != nil {
+		log.Fatalf("marshal commands: %v", err)
+	}
+	cmdOut := filepath.Join(filepath.Dir(self), "..", "..", "commands.json")
+	if err := os.WriteFile(cmdOut, cmdData, 0o644); err != nil {
+		log.Fatalf("write %s: %v", cmdOut, err)
+	}
+	log.Printf("wrote %s", cmdOut)
 }


### PR DESCRIPTION
## What

Adds a **command** registry to `pkg/contract` (`commands.go` → generated `commands.json`), mirroring the existing eventbus registry. It declares every onscreens overlay-command NATS subject — `middle`/`leaderboard`/`timewarp`/`gps`/`flag` show+hide, plus the `location` feed — with each payload as a JSON Schema (draft 2020-12).

## Why

`eventbus.json` covers **observations** (tripbot→console, "what happened"). This covers **commands** (imperatives published to onscreens-server, "make this happen"). Foundation for the admin console driving overlays from a button (timewarp button, middle-text field, …) without hand-rebuilding subject strings or payload shapes — the exact drift hazard the eventbus contract was created to kill.

Subject taxonomy differs from eventbus by a trailing `{platform}` leaf: `tripbot.{env}.onscreens.{overlay}.{verb}.{platform}`, so a Twitch-triggered overlay never renders on YouTube.

## Drift guard

`commands_schema_test.go` reflects over the real `pkg/onscreens-events` structs and asserts declared field names + required-ness match field-for-field — **flattening the embedded `Envelope`** (these structs embed it, unlike the eventbus structs, so `emitted_at` is promoted to the front, exactly as it lands on the wire). `commands_golden_test.go` asserts `commands.json` is byte-identical to the regenerated output. A wire-format change that isn't mirrored here fails CI.

## Follow-up

The console (tripbot-console) syncs this via `task contract:sync` and generates a Python command-publisher from it — separate PR, linked when up.

## Verification

`go generate ./pkg/contract` clean (no diff to contract.json/eventbus.json); `go test ./pkg/contract/` green; gofmt clean.