### PR TITLE
feat(obs): console-published obs.refresh command to hard-reload OBS browser sources

### DIFF
--- a/changelog.d/1075.console.md
+++ b/changelog.d/1075.console.md
@@ -1,0 +1,1 @@
+tripbot now subscribes to an `obs.refresh` NATS command (`tripbot.<env>.obs.refresh.<platform>`), letting the admin console hard-reload a crashed/frozen OBS overlay from a button — the console-driven counterpart to the `!refreshoverlays` chat command.

--- a/cmd/tripbot/obsrefresh.go
+++ b/cmd/tripbot/obsrefresh.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/natsclient"
+	"github.com/adanalife/tripbot/pkg/obs"
+	obsEvents "github.com/adanalife/tripbot/pkg/obs-events"
+	"github.com/nats-io/nats.go"
+)
+
+// startOBSRefreshSubscriber wires the "hard-reload the OBS browser sources"
+// command. The standalone console publishes obsEvents on
+// tripbot.<env>.obs.refresh.<platform>; tripbot owns the OBS WebSocket, so it's
+// the thing that actually reloads. It's the console-button counterpart to the
+// !refreshoverlays chat command — the recovery for a crashed/frozen overlay a
+// soft refresh can't revive.
+//
+// Per-platform: each tripbot instance subscribes to its own platform's leaf, so
+// a Twitch-triggered refresh only touches obs-twitch. Unlike chat.send this runs
+// for both platforms (each owns its own OBS), so it's wired before the YouTube
+// early-return in run(). No-op when NATS is unconfigured. Must run after
+// startNATS (conn).
+func (t *Tripbot) startOBSRefreshSubscriber(ctx context.Context) {
+	conn := natsclient.Conn()
+	if conn == nil {
+		slog.InfoContext(ctx, "obs.refresh subscriber skipped (NATS_URL unset)")
+		return
+	}
+	subject := obsEvents.RefreshSubject(c.Conf.Environment, c.Conf.Platform)
+	if _, err := conn.Subscribe(subject, func(m *nats.Msg) {
+		var ev obsEvents.Refresh
+		if err := json.Unmarshal(m.Data, &ev); err != nil {
+			slog.ErrorContext(ctx, "obs.refresh: decode", "err", err, "subject", m.Subject)
+			return
+		}
+		n, err := obs.RefreshBrowserSources(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "obs.refresh: reload failed", "err", err, "subject", m.Subject)
+			return
+		}
+		slog.InfoContext(ctx, "obs.refresh: reloaded browser sources", "count", n)
+	}); err != nil {
+		slog.ErrorContext(ctx, "obs.refresh subscribe failed", "err", err, "subject", subject)
+		return
+	}
+	slog.InfoContext(ctx, "nats subscribed", "subject", subject)
+}

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -252,8 +252,9 @@ func (t *Tripbot) Run() {
 		t.startEventSub(shutdownCtx)
 	}
 	t.startNATS(shutdownCtx)
-	t.player.EmitCurrentVideo(shutdownCtx) // after startNATS: publishes the current video.changed for the standalone console
-	t.startAuthStatusEmitter(shutdownCtx)  // after startNATS: publishes auth.status snapshots for the standalone console
+	t.player.EmitCurrentVideo(shutdownCtx)   // after startNATS: publishes the current video.changed for the standalone console
+	t.startAuthStatusEmitter(shutdownCtx)    // after startNATS: publishes auth.status snapshots for the standalone console
+	t.startOBSRefreshSubscriber(shutdownCtx) // after startNATS: per-platform (each instance owns its OBS), so before the YouTube early-return
 	if !platformIsTwitch() {
 		t.connectToYouTube(shutdownCtx)
 		return

--- a/pkg/obs-events/events.go
+++ b/pkg/obs-events/events.go
@@ -1,0 +1,33 @@
+// Package obsEvents holds the wire format for OBS *command* events published
+// over NATS — operator-initiated imperatives that drive tripbot's OBS WebSocket
+// connection. The first is obs.refresh (tripbot.<env>.obs.refresh.<platform>):
+// "hard-reload every browser source on this platform's OBS". tripbot owns the
+// OBS WebSocket, so it's the subscriber; the standalone tripbot-console is the
+// publisher (a settings-page button), the same command split as pkg/chat-events.
+//
+// Like pkg/chat-events, pkg/vlc-events and pkg/onscreens-events it is
+// stdlib-only and side-effect-free: no init(), no pkg/config import, env is
+// always a parameter rather than read from config — so it links safely into any
+// binary.
+package obsEvents
+
+import "time"
+
+// Envelope is embedded in every obs command event. EmittedAt is an RFC3339Nano
+// UTC timestamp, useful for latency/debugging. Snake_case JSON so a future
+// protobuf schema maps 1-1.
+type Envelope struct {
+	EmittedAt string `json:"emitted_at"`
+}
+
+// NewEnvelope returns an Envelope stamped with the current UTC time.
+func NewEnvelope() Envelope {
+	return Envelope{EmittedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+}
+
+// Refresh is the payload for the obs.refresh subject: hard-reload every OBS
+// browser source. It carries no fields beyond the envelope — the subject (with
+// its platform leaf) is the whole command. Fire-and-forget; no reply.
+type Refresh struct {
+	Envelope
+}

--- a/pkg/obs-events/events_test.go
+++ b/pkg/obs-events/events_test.go
@@ -1,0 +1,18 @@
+package obsEvents
+
+import "testing"
+
+func TestRefreshSubject(t *testing.T) {
+	cases := []struct {
+		env, platform, want string
+	}{
+		{"staging", PlatformTwitch, "tripbot.staging.obs.refresh.twitch"},
+		{"prod", PlatformYouTube, "tripbot.prod.obs.refresh.youtube"},
+		{"development", PlatformTwitch, "tripbot.development.obs.refresh.twitch"},
+	}
+	for _, c := range cases {
+		if got := RefreshSubject(c.env, c.platform); got != c.want {
+			t.Errorf("RefreshSubject(%q, %q) = %q, want %q", c.env, c.platform, got, c.want)
+		}
+	}
+}

--- a/pkg/obs-events/subjects.go
+++ b/pkg/obs-events/subjects.go
@@ -1,0 +1,25 @@
+package obsEvents
+
+import "fmt"
+
+// domain is the fixed segment between <env> and the verb in every obs command
+// subject: tripbot.<env>.obs.<verb>.
+const domain = "obs"
+
+// Platform values for the per-platform subject leaf. Each per-platform tripbot
+// (tripbot-twitch / tripbot-youtube) owns its own OBS WebSocket connection, so
+// an obs command is scoped to one platform and only that instance handles it.
+const (
+	PlatformTwitch  = "twitch"
+	PlatformYouTube = "youtube"
+)
+
+// RefreshSubject builds tripbot.<env>.obs.refresh.<platform> — the operator
+// "hard-reload every OBS browser source on <platform>'s OBS" command. The
+// per-platform tripbot instance subscribes to its own leaf and calls
+// pkg/obs.RefreshBrowserSources. It's the console-published counterpart to the
+// !refreshoverlays chat command: the recovery for a crashed/frozen overlay a
+// soft refresh can't revive.
+func RefreshSubject(env, platform string) string {
+	return fmt.Sprintf("tripbot.%s.%s.refresh.%s", env, domain, platform)
+}


### PR DESCRIPTION
The through-tripbot seam for the console **overlay hard-refresh button** — the first console→tripbot command channel for actions that need tripbot's OBS WebSocket.

**Stacked on #1072** (base `obs-refresh`), which adds `pkg/obs.RefreshBrowserSources`. Retarget to `develop` once #1072 merges.

- New `pkg/obs-events` — the OBS command wire format (subject + envelope), sibling to `pkg/chat-events` / `pkg/vlc-events` / `pkg/onscreens-events`. Subject: `tripbot.<env>.obs.refresh.<platform>`.
- `cmd/tripbot` subscriber (mirrors `startChatSendSubscriber`) that calls `obs.RefreshBrowserSources` on the message. Wired **before** the YouTube early-return so each per-platform instance (tripbot-twitch / tripbot-youtube) subscribes to its own leaf and reloads its own OBS.

Console-side publisher + button: **adanalife/tripbot-console#109**. The button is inert until this ships.

Tests: `task test:macos` green (incl. the new `pkg/obs-events` subject test).