### PR TITLE
feat(chatbot): anonymize YouTube viewer in !report sinks

### DIFF
--- a/changelog.d/1079.chatbot.md
+++ b/changelog.d/1079.chatbot.md
@@ -1,0 +1,1 @@
+The `!report` command no longer attaches a YouTube viewer's display name to its downstream alerts (Sentry, Discord), matching YouTube's no-persisted-identity model; the report text still comes through. Twitch reports are unchanged.

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -498,18 +498,34 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 }
 
 // TODO: maybe there could be a !cancel command or something
+// reportReporter is the label a !report is attributed to in its downstream
+// sinks (the Sentry error event and the Discord alert). YouTube viewers are
+// anonymized because v1 punts YouTube identity entirely (see the youtubeCommands
+// allowlist) — until real YouTube user support lands there is no persisted
+// identity to stand behind, so the name is kept out of those durable/external
+// sinks. Twitch reports keep the username. Note the transient 14-day Loki chat
+// line still carries the name for every message; this only governs the report's
+// longer-lived sinks.
+func reportReporter(platform, username string) string {
+	if platform == platformYouTube {
+		return "a youtube viewer"
+	}
+	return username
+}
+
 func (a *App) reportCmd(ctx context.Context, user *users.User, params []string) {
-	slog.InfoContext(ctx, "ran !report", "username", user.Username)
+	reporter := reportReporter(a.platform(), user.Username)
+	slog.InfoContext(ctx, "ran !report", "username", reporter)
 	message := strings.Join(params, " ")
 	// Always log to slog (→ stderr + Sentry via the slog→Sentry handler)
 	// as the durable audit trail.
-	slog.ErrorContext(ctx, "!report", "err", fmt.Errorf("viewer report from %s: %s", user.Username, message))
+	slog.ErrorContext(ctx, "!report", "err", fmt.Errorf("viewer report from %s: %s", reporter, message))
 	// Fire-and-forget to Discord for real-time notification. Skipped
 	// silently when DISCORD_ALERTS_WEBHOOK is unset (e.g. local dev) —
 	// the slog/Sentry path still fires so nothing is lost.
 	if webhook := c.Conf.DiscordAlertsWebhook; webhook != "" {
 		if isDiscordWebhookURL(webhook) {
-			go postReportToDiscord(webhook, user.Username, message)
+			go postReportToDiscord(webhook, reporter, message)
 		} else {
 			// A misconfigured secret (e.g. the SM placeholder string) would
 			// otherwise log a "unsupported protocol scheme" ERROR on every

--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -202,6 +202,15 @@ func TestReportCmd_AcksViaIRC(t *testing.T) {
 	}
 }
 
+func TestReportReporter_AnonymizesYouTube(t *testing.T) {
+	if got := reportReporter(platformYouTube, "someviewer"); got != "a youtube viewer" {
+		t.Errorf("youtube reporter = %q, want it anonymized (no viewer name in report sinks)", got)
+	}
+	if got := reportReporter(platformTwitch, "someviewer"); got != "someviewer" {
+		t.Errorf("twitch reporter = %q, want the username preserved", got)
+	}
+}
+
 func TestIsDiscordWebhookURL(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Part of the YouTube API ToS compliance work. An audit of what a YouTube chat message touches turned up that `!report` (which is in the YouTube command allowlist) fans the viewer's display name + text out to **Sentry** (via the slog→Sentry handler) and **Discord** (webhook) — two external sinks with their own retention, beyond the disclosed 14-day Loki logs.

YouTube is a v1 rollout that persists no viewer identity, so this keeps the YouTube display name out of those durable/external sinks. The report **text** still flows through so the operator sees reports; only the name is dropped, replaced with "a youtube viewer". Twitch reports are unchanged. The transient 14-day Loki chat line still carries the name for every message (that's disclosed in the privacy policy).

Restore the real name here when real YouTube user support lands.

- `pkg/chatbot/commands.go` — `reportReporter(platform, username)` helper; `reportCmd` uses it for the slog/Sentry error and the Discord post.
- `pkg/chatbot/commands_test.go` — `TestReportReporter_AnonymizesYouTube`.

Pairs with website privacy-policy PRs #247 (merged) and #249.