### PR TITLE
fix(chatbot): drop the 500ms timewarp overlay lead-in for a snappier warp

### DIFF
--- a/changelog.d/1086.chatbot.md
+++ b/changelog.d/1086.chatbot.md
@@ -1,0 +1,1 @@
+Removed the 500ms lead-in before the timewarp overlay, making `!timewarp`, `!guess`, and `!find` warps noticeably snappier (the cut-masking cover delay is unchanged).

--- a/pkg/chatbot/playback.go
+++ b/pkg/chatbot/playback.go
@@ -27,12 +27,6 @@ const timewarpCreditFlagKey = "chatbot.timewarp_credit"
 // plus it's also used to reset peoples lastLocation time
 var lastTimewarpTime time.Time
 
-// timewarpOverlayLeadIn is how long we wait after the "Here we go...!" chat
-// message before bringing up the warp overlay. Lets the audience register the
-// chat beat before the cover slams in, so the takeover feels intentional
-// rather than instantaneous.
-var timewarpOverlayLeadIn = 500 * time.Millisecond
-
 // timewarpCoverDelay is how long we wait after triggering the full-screen warp
 // overlay before actually jumping the playhead. The overlay is driven by a
 // browser source that polls for state, so it needs a beat to bring the opaque
@@ -41,14 +35,11 @@ var timewarpOverlayLeadIn = 500 * time.Millisecond
 var timewarpCoverDelay = 800 * time.Millisecond
 
 // showTimewarpOverlay brings up the full-screen warp overlay that masks a
-// playhead jump: it waits a beat so the preceding chat message lands, resolves
-// the (feature-flagged) username credit, triggers the overlay, then waits for
-// the browser source to render the opaque cover before the caller hard-cuts.
+// playhead jump: it resolves the (feature-flagged) username credit, triggers
+// the overlay, then waits for the browser source to render the opaque cover
+// before the caller hard-cuts.
 // Shared by !timewarp/!guess (random jump) and !find (targeted jump).
 func (a *App) showTimewarpOverlay(ctx context.Context, username string) {
-	// give the chat message a beat to land before the visual takeover
-	time.Sleep(timewarpOverlayLeadIn)
-
 	// The on-overlay username credit is feature-flagged (per platform); the
 	// warp always runs, only the credit line is gated. An empty credit means
 	// the overlay shows no @-line.


### PR DESCRIPTION
## What

Removes `timewarpOverlayLeadIn` (the 500ms pause before the warp overlay comes up) from `showTimewarpOverlay`, so it's gone for every warp path — `!timewarp`, `!guess`, and `!find`.

## Why

The lead-in only existed to separate the overlay from the "Here we go...!" chat line. Two problems:

- Twitch's chat/stream latency is measured in *seconds*, so 500ms never actually won that sequencing race.
- Admin triggers skip the "Here we go...!" line entirely, so for those it was pure dead time.

## What's preserved

The `timewarpCoverDelay` (800ms between overlay-show and the playhead jump) is untouched — that's the one that actually masks the hard cut behind the opaque cover. This change only removes the pre-overlay pause, dropping trigger-to-jump from ~1300ms to ~800ms.

Pairs with the console-side timewarp button fix ([tripbot-console#111](https://github.com/adanalife/tripbot-console/pull/111)), which already omitted this lead-in.