### PR TITLE
fix(geo): return an error on empty geocoder results instead of panicking

### DIFF
--- a/changelog.d/1091.fix.md
+++ b/changelog.d/1091.fix.md
@@ -1,0 +1,1 @@
+Reverse geocoding no longer panics the video-save path when the geocoder returns zero addresses (bad GPS coords, ZERO_RESULTS) — `geo.City`/`geo.State` now return a descriptive error instead.

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -56,6 +56,11 @@ func (c *Client) City(lat, lon float64) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// The SDK can return a nil error with zero addresses (e.g. ZERO_RESULTS
+	// for coords outside any mapped area); indexing would panic.
+	if len(addresses) == 0 {
+		return "", fmt.Errorf("reverse geocode returned no addresses for %f,%f", lat, lon)
+	}
 	address := addresses[0]
 	if address.City == "" {
 		return fmt.Sprintf("Somewhere in %s", address.State), nil
@@ -72,6 +77,9 @@ func (c *Client) State(lat, lon float64) (string, error) {
 	addresses, err := geocoder.GeocodingReverse(geocoder.Location{Latitude: lat, Longitude: lon})
 	if err != nil {
 		return "", err
+	}
+	if len(addresses) == 0 {
+		return "", fmt.Errorf("reverse geocode returned no addresses for %f,%f", lat, lon)
 	}
 	return addresses[0].State, nil
 }


### PR DESCRIPTION
## Summary
- `geo.City` and `geo.State` indexed `addresses[0]` unconditionally after the reverse-geocode call. The SDK can return a nil error with zero addresses (bad GPS coords, ZERO_RESULTS), which panicked the video-save path. Both functions now return a descriptive error instead.
- All callers already handle the returned error: `pkg/video/db.go` logs it and saves the video with an empty state, `pkg/locationfeed` skips the city, and the `!location` chat command tolerates an empty address — so the behavior change is strictly "error instead of panic".

## Test plan
- [x] task test:macos