### PR TITLE
fix(events): honor READ_ONLY without VERBOSE

### DIFF
--- a/changelog.d/1092.fix.md
+++ b/changelog.d/1092.fix.md
@@ -1,0 +1,1 @@
+Events writers honor `READ_ONLY` even when `VERBOSE` is off — read-only mode skipped DB writes only when both were set.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -33,8 +33,10 @@ type Event struct {
 }
 
 func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
-	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping login event: read-only mode", "username", user)
+	if c.Conf.ReadOnly {
+		if c.Conf.Verbose {
+			slog.InfoContext(ctx, "skipping login event: read-only mode", "username", user)
+		}
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Platform: c.Conf.Platform, Event: "login", SessionID: sessionID}).Error; err != nil {
@@ -48,8 +50,10 @@ func Login(ctx context.Context, user string, sessionID uuid.UUID) error {
 // unreconstructable bonus (sub-grants + 5% bonus); pass nil to write NULL
 // when it's zero.
 func Logout(ctx context.Context, user string, sessionID uuid.UUID, extraMiles *float64) error {
-	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping logout event: read-only mode", "username", user)
+	if c.Conf.ReadOnly {
+		if c.Conf.Verbose {
+			slog.InfoContext(ctx, "skipping logout event: read-only mode", "username", user)
+		}
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Platform: c.Conf.Platform, Event: "logout", SessionID: sessionID, ExtraMilesEarned: extraMiles}).Error; err != nil {
@@ -64,8 +68,10 @@ func Logout(ctx context.Context, user string, sessionID uuid.UUID, extraMiles *f
 // Unsubscribe it bounds a viewer's subscribed interval, which is what the 5%
 // miles bonus keys off. No session_id: this isn't a login/logout.
 func Subscribe(ctx context.Context, user string) error {
-	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping subscribe event: read-only mode", "username", user)
+	if c.Conf.ReadOnly {
+		if c.Conf.Verbose {
+			slog.InfoContext(ctx, "skipping subscribe event: read-only mode", "username", user)
+		}
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Platform: c.Conf.Platform, Event: "subscribe"}).Error; err != nil {
@@ -79,8 +85,10 @@ func Subscribe(ctx context.Context, user string) error {
 // channel.subscription.end — real lapse/cancel, never a guessed expiry).
 // Closes the interval Subscribe opened.
 func Unsubscribe(ctx context.Context, user string) error {
-	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping unsubscribe event: read-only mode", "username", user)
+	if c.Conf.ReadOnly {
+		if c.Conf.Verbose {
+			slog.InfoContext(ctx, "skipping unsubscribe event: read-only mode", "username", user)
+		}
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Platform: c.Conf.Platform, Event: "unsubscribe"}).Error; err != nil {
@@ -95,8 +103,10 @@ func Unsubscribe(ctx context.Context, user string) error {
 // user_rollups.extra_miles alongside the session bonuses. This is the audit
 // trail for out-of-band miles changes the login/logout pairing can't see.
 func Correction(ctx context.Context, user string, delta float64) error {
-	if c.Conf.ReadOnly && c.Conf.Verbose {
-		slog.InfoContext(ctx, "skipping correction event: read-only mode", "username", user)
+	if c.Conf.ReadOnly {
+		if c.Conf.Verbose {
+			slog.InfoContext(ctx, "skipping correction event: read-only mode", "username", user)
+		}
 		return &terrors.ReadOnlyError{Msg: "read-only mode"}
 	}
 	if err := database.GormDB().WithContext(ctx).Create(&Event{Username: user, Platform: c.Conf.Platform, Event: "correction", ExtraMilesEarned: &delta}).Error; err != nil {


### PR DESCRIPTION
## Summary
- Every writer in `pkg/events` (Login/Logout/Subscribe/Unsubscribe/Correction) guarded its DB write with `ReadOnly && Verbose`, so read-only mode with `VERBOSE=false` silently wrote to the database anyway.
- Guard on `ReadOnly` alone, matching `pkg/rollups` and `pkg/viewstats`; the skip log line stays behind `Verbose`.

## Test plan
- [x] task test:macos