### PR TITLE
fix(twitch): guard the audience cache with a mutex

### DIFF
--- a/changelog.d/1093.fix.md
+++ b/changelog.d/1093.fix.md
@@ -1,0 +1,1 @@
+Guard the Twitch audience cache (subscribers, chatters, chatter count) with a mutex so the refresh crons and readers no longer race.

--- a/pkg/twitch/client.go
+++ b/pkg/twitch/client.go
@@ -46,6 +46,12 @@ type API struct {
 
 	// channelID is the twitch-internal user ID for the channel.
 	channelID string
+
+	// audienceMu guards subscribers, currentChatters, and chatterCount, which
+	// are written by the gateway refresh crons and read from command dispatch
+	// and the session-update cron. RWMutex because reads (UserIsSubscriber,
+	// Chatters, ChatterCount) outnumber writes.
+	audienceMu sync.RWMutex
 	// subscribers is the usernames of the current subscribers.
 	subscribers []string
 	// currentChatters holds the most recent chatter list, cached from the gateway.

--- a/pkg/twitch/twitch.go
+++ b/pkg/twitch/twitch.go
@@ -16,7 +16,9 @@ func (cl *API) SetSubscribers(logins []string) {
 	for i, login := range logins {
 		subs[i] = strings.ToLower(login)
 	}
+	cl.audienceMu.Lock()
 	cl.subscribers = subs
+	cl.audienceMu.Unlock()
 	instrumentation.TwitchAudience.SetSubscribers(int64(len(subs)))
 }
 
@@ -29,11 +31,15 @@ func (cl *API) SetChatters(logins []string, count int) {
 	for i, login := range logins {
 		chatters[i] = helix.ChatChatter{UserLogin: login}
 	}
+	cl.audienceMu.Lock()
 	cl.currentChatters = chatters
 	cl.chatterCount = count
+	cl.audienceMu.Unlock()
 }
 
 // UserIsSubscriber returns true if the user subscribes to the channel.
 func (cl *API) UserIsSubscriber(username string) bool {
+	cl.audienceMu.RLock()
+	defer cl.audienceMu.RUnlock()
 	return slices.Contains(cl.subscribers, username)
 }

--- a/pkg/twitch/viewers.go
+++ b/pkg/twitch/viewers.go
@@ -17,12 +17,16 @@ func (cl *API) SetChannelID(id string) {
 // ChatterCount returns the number of chatters as reported by Twitch, cached
 // from the gateway via SetChatters.
 func (cl *API) ChatterCount() int {
+	cl.audienceMu.RLock()
+	defer cl.audienceMu.RUnlock()
 	return cl.chatterCount
 }
 
 // Chatters returns a set of current chatter logins, cached from the gateway via
 // SetChatters.
 func (cl *API) Chatters() map[string]struct{} {
+	cl.audienceMu.RLock()
+	defer cl.audienceMu.RUnlock()
 	chatters := make(map[string]struct{})
 	for _, chatter := range cl.currentChatters {
 		chatters[chatter.UserLogin] = struct{}{}


### PR DESCRIPTION
## Summary
- The `API` struct's audience cache (`subscribers`, `currentChatters`, `chatterCount`) is written by the gateway subscriber/chatter refresh crons and read from command dispatch and the session-update cron — concurrent goroutines with no lock, unlike the token fields which `tokenMu` guards.
- Adds a sibling `audienceMu sync.RWMutex` and takes it at every read/write site (`SetSubscribers`, `SetChatters`, `UserIsSubscriber`, `Chatters`, `ChatterCount`). The lock is never held across gateway/Helix calls.

## Test plan
- [x] task test:macos