### PR TITLE
fix(users): guard Sessions state with a mutex

### DIFF
--- a/changelog.d/1095.fix.md
+++ b/changelog.d/1095.fix.md
@@ -1,0 +1,1 @@
+Fix a data race on viewer session state between the session cron and the IRC handlers.

--- a/pkg/users/leaderboard.go
+++ b/pkg/users/leaderboard.go
@@ -32,7 +32,10 @@ func (s *Sessions) InitLeaderboard(ctx context.Context) {
 	if err != nil {
 		slog.ErrorContext(ctx, "error fetching leaderboard", "err", err)
 	}
-	s.lifetimeLeaderboard = toPairs(users)
+	pairs := toPairs(users)
+	s.mu.Lock()
+	s.lifetimeLeaderboard = pairs
+	s.mu.Unlock()
 }
 
 // UpdateLeaderboard rebuilds the lifetime-miles leaderboard from the users
@@ -47,15 +50,27 @@ func (s *Sessions) UpdateLeaderboard(ctx context.Context) {
 		return
 	}
 	for i, user := range users {
-		if live, ok := s.loggedIn[user.Username]; ok {
-			users[i].Miles = s.CurrentMiles(ctx, *live)
+		// copy the live user under the lock; CurrentMiles locks internally,
+		// so it must run after the release
+		s.mu.Lock()
+		live, ok := s.loggedIn[user.Username]
+		var liveCopy User
+		if ok {
+			liveCopy = *live
+		}
+		s.mu.Unlock()
+		if ok {
+			users[i].Miles = s.CurrentMiles(ctx, liveCopy)
 		}
 	}
 	// ponytail: a logged-in user whose stored miles sit just below the top-50
 	// cutoff won't appear until logout — same class of miss as the old
 	// in-memory rebuild.
 	sort.SliceStable(users, func(i, j int) bool { return users[i].Miles > users[j].Miles })
-	s.lifetimeLeaderboard = toPairs(users)
+	pairs := toPairs(users)
+	s.mu.Lock()
+	s.lifetimeLeaderboard = pairs
+	s.mu.Unlock()
 }
 
 // toPairs formats users as the [username, miles] string pairs the leaderboard
@@ -74,5 +89,10 @@ func toPairs(users []User) [][]string {
 
 // LifetimeLeaderboard returns the cached lifetime-miles leaderboard (a slice of
 // [username, miles] pairs), hydrated by InitLeaderboard and rebuilt by
-// UpdateLeaderboard.
-func (s *Sessions) LifetimeLeaderboard() [][]string { return s.lifetimeLeaderboard }
+// UpdateLeaderboard. The rebuilds swap the slice wholesale, so the returned
+// snapshot is safe to read without further locking.
+func (s *Sessions) LifetimeLeaderboard() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lifetimeLeaderboard
+}

--- a/pkg/users/session.go
+++ b/pkg/users/session.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
@@ -22,8 +24,14 @@ import (
 // in package-level globals, so a per-platform bot instance gets its own
 // (the prerequisite for running, e.g., a YouTube bot beside the Twitch
 // one). Its view of who is in chat comes from an injected ChatterSource.
+//
+// Sessions is accessed from multiple goroutines: the UpdateSession /
+// UpdateLeaderboard crons, the inbound IRC handlers, and command dispatch.
+// mu guards loggedIn and lifetimeLeaderboard; it is held only for map/slice
+// access, never across DB or chatter-source calls.
 type Sessions struct {
 	source ChatterSource
+	mu     sync.Mutex
 	// loggedIn maps username -> User for everyone currently in chat.
 	loggedIn map[string]*User
 	// lifetimeLeaderboard is the cached [username, miles] leaderboard,
@@ -55,8 +63,9 @@ func (s *Sessions) UpdateSession(ctx context.Context) {
 	// emission above, tagged with the clip currently on screen.
 	viewstats.RecordSample(ctx, s.source.ChatterCount())
 
-	// log out the people who aren't present
-	for username, user := range s.loggedIn {
+	// log out the people who aren't present, working from a snapshot so the
+	// lock isn't held across the DB work logout does
+	for username, user := range s.sessionSnapshot() {
 		if _, ok := currentChatters[username]; ok {
 			// they're logged in and a current chatter, do nothing
 			continue
@@ -75,8 +84,8 @@ func (s *Sessions) UpdateSession(ctx context.Context) {
 // LoginIfNecessary checks the list of currently-logged in users and will
 // run login() if this user isn't currently logged in
 func (s *Sessions) LoginIfNecessary(ctx context.Context, username string) *User {
-	if s.isLoggedIn(username) {
-		return s.loggedIn[username]
+	if user, ok := s.get(username); ok {
+		return user
 	}
 	// they weren't logged in, so note in the DB
 	return s.login(ctx, username)
@@ -84,9 +93,28 @@ func (s *Sessions) LoginIfNecessary(ctx context.Context, username string) *User 
 
 // LogoutIfNecessary will log out the user if it finds them in the session
 func (s *Sessions) LogoutIfNecessary(ctx context.Context, username string) {
-	if s.isLoggedIn(username) {
-		s.logout(ctx, s.loggedIn[username])
+	if user, ok := s.get(username); ok {
+		s.logout(ctx, user)
 	}
+}
+
+// get returns the logged-in *User for username, if present. It takes mu;
+// callers must not already hold it.
+func (s *Sessions) get(username string) (*User, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	user, ok := s.loggedIn[username]
+	return user, ok
+}
+
+// sessionSnapshot returns a copy of the loggedIn map, so callers can iterate
+// (and do slow DB work per entry) without holding mu.
+func (s *Sessions) sessionSnapshot() map[string]*User {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot := make(map[string]*User, len(s.loggedIn))
+	maps.Copy(snapshot, s.loggedIn)
+	return snapshot
 }
 
 // login will record the users presence in the DB
@@ -123,7 +151,9 @@ func (s *Sessions) login(ctx context.Context, username string) *User {
 	}
 
 	// add them to the session
+	s.mu.Lock()
 	s.loggedIn[username] = &user
+	s.mu.Unlock()
 
 	if err := events.Login(ctx, username, user.sessionID); err != nil {
 		slog.ErrorContext(ctx, "error creating login event", "err", err)
@@ -176,22 +206,25 @@ func (s *Sessions) logout(ctx context.Context, u *User) {
 	}
 
 	// remove them from the session
+	s.mu.Lock()
 	delete(s.loggedIn, u.Username)
+	s.mu.Unlock()
 }
 
 // isLoggedIn checks if the user is currently logged in
 func (s *Sessions) isLoggedIn(username string) bool {
-	_, ok := s.loggedIn[username]
+	_, ok := s.get(username)
 	return ok
 }
 
 // Shutdown loops through all of the logged-in users and logs them out
 func (s *Sessions) Shutdown(ctx context.Context) {
+	snapshot := s.sessionSnapshot()
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "logged-in users at shutdown")
-		fmt.Printf("%+v\n", s.loggedIn)
+		fmt.Printf("%+v\n", snapshot)
 	}
-	for _, user := range s.loggedIn {
+	for _, user := range snapshot {
 		s.logout(ctx, user)
 	}
 }
@@ -199,6 +232,8 @@ func (s *Sessions) Shutdown(ctx context.Context) {
 // GiveEveryoneMiles gives all logged-in users miles
 func (s *Sessions) GiveEveryoneMiles(gift float32) {
 	slog.Info("giving all logged-in users gift miles", "gift", gift)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, user := range s.loggedIn {
 		user.Miles += gift
 		// track the grant separately so logout can record it as extra_miles_earned
@@ -212,16 +247,27 @@ func (s *Sessions) GiveEveryoneMiles(gift float32) {
 // The delta is deliberately NOT added to sessionExtraMiles — the caller logs a
 // separate correction event carrying it, and doing both would double-count.
 func (s *Sessions) CorrectMiles(ctx context.Context, username string, delta float32) float32 {
-	if u, ok := s.loggedIn[username]; ok {
-		u.Miles += delta
-		u.save(ctx)
-		return u.Miles
+	s.mu.Lock()
+	live, ok := s.loggedIn[username]
+	var updated User
+	if ok {
+		live.Miles += delta
+		updated = *live
+	}
+	s.mu.Unlock()
+	if ok {
+		updated.save(ctx)
+		return updated.Miles
 	}
 	u := FindOrCreate(ctx, username)
 	u.Miles += delta
 	u.save(ctx)
 	return u.Miles
 }
+
+// The snapshot helpers below (sortedUsernameList, colorizeUsernames, humans,
+// countHumans, bots, countBots) read loggedIn directly and assume the caller
+// holds mu.
 
 // sortedUsernameList creates a list of only usernames, and sort it
 func (s *Sessions) sortedUsernameList() []string {
@@ -283,16 +329,23 @@ func (s *Sessions) countBots() int {
 // PrintCurrentSession simply prints info about the current session.
 // ctx links the snapshot log line to the parent cron-tick span.
 func (s *Sessions) PrintCurrentSession(ctx context.Context) {
-	usernames := s.sortedUsernameList()
-	coloredUsernames := s.colorizeUsernames(usernames)
+	s.mu.Lock()
+	coloredUsernames := s.colorizeUsernames(s.sortedUsernameList())
+	humanCount := s.countHumans()
+	botCount := s.countBots()
+	s.mu.Unlock()
 
 	slog.InfoContext(ctx, "session snapshot",
 		"chatters", s.source.ChatterCount(),
-		"humans", s.countHumans(),
-		"bots", s.countBots(),
+		"humans", humanCount,
+		"bots", botCount,
 		"logged_in", strings.Join(coloredUsernames, ", "),
 	)
 }
 
 // LoggedInCount returns the number of users currently in chat.
-func (s *Sessions) LoggedInCount() int { return len(s.loggedIn) }
+func (s *Sessions) LoggedInCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.loggedIn)
+}

--- a/pkg/users/session_test.go
+++ b/pkg/users/session_test.go
@@ -1,0 +1,47 @@
+package users
+
+import (
+	"context"
+	"database/sql/driver"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSessions_ConcurrentAccess hammers the session map and the leaderboard
+// cache from multiple goroutines, mirroring production: the UpdateLeaderboard
+// cron rebuilds the board while command dispatch reads it and the IRC-side
+// calls poke the login map. Under -race this fails if Sessions loses its
+// locking.
+func TestSessions_ConcurrentAccess(t *testing.T) {
+	const iterations = 50
+
+	mock := installMockDB(t)
+	for range iterations {
+		mock.ExpectQuery(`SELECT \* FROM "users"`).
+			WillReturnRows(leaderboardRows([]driver.Value{"alice", float32(100), "twitch", false}))
+	}
+
+	s := New(noopChatterSource{})
+	s.loggedIn["alice"] = &User{Username: "alice", Miles: 100, LoggedIn: time.Now()}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for _, fn := range []func(){
+		func() { s.UpdateLeaderboard(ctx) },
+		func() { _ = s.LifetimeLeaderboard() },
+		func() { s.GiveEveryoneMiles(0.1) },
+		func() { _ = s.isLoggedIn("alice") },
+		func() { _ = s.LoggedInCount() },
+		func() { s.LogoutIfNecessary(ctx, "ghost") },
+	} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				fn()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -53,12 +53,12 @@ var guessCooldown = 3 * time.Minute
 // per-user data stay explicitly separate.
 
 func (s *Sessions) loggedInDur(u User) time.Duration {
-	// exit early if they're not logged in
-	if !s.isLoggedIn(u.Username) {
+	// lookup the user in the session so the LoggedIn value is current
+	live, ok := s.get(u.Username)
+	if !ok {
 		return 0 * time.Second
 	}
-	// lookup the user in the session so the LoggedIn value is current
-	return time.Now().Sub(s.loggedIn[u.Username].LoggedIn)
+	return time.Now().Sub(live.LoggedIn)
 }
 
 func (s *Sessions) sessionMiles(ctx context.Context, u User) float32 {
@@ -129,9 +129,11 @@ func (s *Sessions) SetBot(ctx context.Context, username string, isBot bool) erro
 	}
 	user.IsBot = isBot
 	user.save(ctx)
+	s.mu.Lock()
 	if loggedIn, ok := s.loggedIn[username]; ok {
 		loggedIn.IsBot = isBot
 	}
+	s.mu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `Sessions` had no synchronization, but its `loggedIn` map is written by the `users.UpdateSession` cron and by the IRC handlers (`LoginIfNecessary`/`LogoutIfNecessary`) while chat commands read it concurrently, and `lifetimeLeaderboard` is swapped by the `UpdateLeaderboard` cron while command dispatch reads it. An unsynchronized concurrent map write is a runtime crash, not just a race-detector warning.
- Adds a `sync.Mutex` to `Sessions` covering both fields. The lock is held only for map/slice access, never across DB or chatter-source calls: `UpdateSession` and `Shutdown` iterate a snapshot of the map, and `UpdateLeaderboard` copies each live user under the lock before computing miles.
- Adds a concurrent-access test that hammers the map and leaderboard from six goroutines; verified it fails under `-race` without the mutex and passes with it.

## Test plan
- [x] task test:macos
- [x] go test -race ./pkg/users/ (new TestSessions_ConcurrentAccess fails on the unfixed code, passes with the fix)
- [x] go vet ./pkg/users/