### PR TITLE
fix(chatbot): bound the weather fetch with a 5s timeout

### DIFF
--- a/changelog.d/1096.fix.md
+++ b/changelog.d/1096.fix.md
@@ -1,0 +1,1 @@
+The `!weather` Open-Meteo fetch is now bounded by a 5s timeout, so a hung response can't stall the chat handler indefinitely.

--- a/pkg/chatbot/weather.go
+++ b/pkg/chatbot/weather.go
@@ -28,10 +28,17 @@ type Weather interface {
 // weather here when this was filmed" for the 2018 dashcam corpus.
 const openMeteoArchiveURL = "https://archive-api.open-meteo.com/v1/archive"
 
+// weatherHTTPTimeout bounds the archive fetch so a hung Open-Meteo response
+// can't stall the chat handler.
+const weatherHTTPTimeout = 5 * time.Second
+
 // realWeather queries the Open-Meteo archive over HTTP.
 type realWeather struct{}
 
 func (realWeather) Historical(ctx context.Context, when time.Time, lat, lng float64) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, weatherHTTPTimeout)
+	defer cancel()
+
 	date := when.Format("2006-01-02")
 	u := fmt.Sprintf(
 		"%s?latitude=%.4f&longitude=%.4f&start_date=%s&end_date=%s&hourly=temperature_2m,weather_code&temperature_unit=fahrenheit&timezone=auto",


### PR DESCRIPTION
## Summary
- `realWeather.Historical` ran its Open-Meteo archive request with no deadline, so a hung response could stall the chat handler indefinitely. The request context is now wrapped in a 5s `context.WithTimeout`, matching the pattern `fetchSomaFMCurrent` already uses for the SomaFM fetch.

## Test plan
- [x] task test:macos