### PR TITLE
fix(vlc-server): return early when the current media can't be read

### DIFF
--- a/changelog.d/1097.fix.md
+++ b/changelog.d/1097.fix.md
@@ -1,0 +1,1 @@
+vlc-server: `currentlyPlaying` no longer panics when the player has no current media — it returns an empty result early instead.

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -212,12 +212,18 @@ func (s *Server) currentlyPlaying() string {
 	cur, err := s.Player.Media()
 	if err != nil {
 		slog.Error("error fetching currently-playing media", "err", err)
+		return ""
+	}
+	if cur == nil {
+		// no media loaded in the player
+		return ""
 	}
 
 	// get media path
 	path, err := cur.Location()
 	if err != nil {
-		slog.Error("error fetching currently-playing media", "err", err)
+		slog.Error("error fetching currently-playing media location", "err", err)
+		return ""
 	}
 
 	// strip the path off and just return the filename


### PR DESCRIPTION
## Summary
- `currentlyPlaying` logged a `Player.Media()` error but kept going, so a nil media panicked on `cur.Location()`. `Media()` can also return nil media with no error when nothing is loaded. Both cases now return `""` early (all callers already tolerate an empty result), and the two error branches log distinct messages so the failing call is identifiable.

## Test plan
- [x] task test:macos
- [x] task vlc-server:vet:macos