### PR TITLE
chore: drop deprecated no-op rand.Seed bootstrapping

### DIFF
--- a/changelog.d/1098.cleanup.md
+++ b/changelog.d/1098.cleanup.md
@@ -1,0 +1,1 @@
+Drop deprecated no-op `rand.Seed` bootstrapping from the tripbot and vlc-server binaries (Go 1.20+ auto-seeds the global source)

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
@@ -219,7 +218,6 @@ func platformIsTwitch() bool {
 // instances.
 func (t *Tripbot) Run() {
 	slog.Info("tripbot starting", "version", t.version, "platform", c.Conf.Platform)
-	createRandomSeed()
 	// shutdownCtx is canceled on SIGINT/SIGTERM; the HTTP server uses it
 	// to trigger a graceful shutdown so in-flight requests aren't cut.
 	// listenForShutdown's gracefulShutdown goroutine handles the rest of
@@ -512,12 +510,6 @@ func (t *Tripbot) startEventSub(ctx context.Context) {
 			slog.ErrorContext(ctx, "eventsub run terminated", "err", err)
 		}
 	}()
-}
-
-// createRandomSeed ensures that random numbers will be random
-func createRandomSeed() {
-	// create a brand new random seed
-	rand.Seed(time.Now().UnixNano())
 }
 
 // listenForShutdown creates a background job that listens for a graceful shutdown request

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"log/slog"
-	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
@@ -39,9 +38,6 @@ func main() {
 	if helpers.RunningOnDarwin() {
 		log.Fatal("This doesn't yet work on darwin")
 	}
-
-	// create a brand new random seed
-	rand.Seed(time.Now().UnixNano())
 
 	// write the current pid to a pidfile
 	helpers.WritePidFile(c.Conf.VLCPidFile)


### PR DESCRIPTION
## Summary
- Delete `createRandomSeed` in `cmd/tripbot` and the equivalent inline `rand.Seed(time.Now().UnixNano())` call in `cmd/vlc-server`. Go 1.20+ auto-seeds the global `math/rand` source, so these were deprecated no-ops. The unused `math/rand` imports go with them; both call sites seeded only the global source, so nothing load-bearing changes.

## Test plan
- [x] task test:macos