### PR TITLE
fix(errors): flush Sentry before exiting in fatal helpers

### DIFF
--- a/changelog.d/1099.fix.md
+++ b/changelog.d/1099.fix.md
@@ -1,0 +1,1 @@
+Flush Sentry before exiting in the fatal-error helpers so the fatal event isn't lost with the process

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -116,5 +116,8 @@ func FatalContext(ctx context.Context, e error, msg string) {
 		e = errors.New(msg)
 	}
 	slog.ErrorContext(ctx, msg, "err", e)
+	// The slog-sentry handler enqueues on an async transport; without a
+	// flush the fatal event would die with the process before it's sent.
+	sentry.Flush(2 * time.Second)
 	os.Exit(1)
 }


### PR DESCRIPTION
## Summary
- `FatalContext` (and `Fatal`, which delegates to it) called `os.Exit(1)` immediately after `slog.ErrorContext`. The slog-sentry handler enqueues on an async transport, so the fatal error — the one you most want in Sentry — could die with the process before being sent.
- Add `sentry.Flush(2 * time.Second)` before the exit.

## Test plan
- [x] `go vet ./pkg/errors/`
- [x] `task test:macos`
- [ ] Optional: trigger a fatal in staging and confirm the event reaches Sentry