### PR TITLE
fix(backfill-miles): escape string values in generated SQL

### DIFF
--- a/changelog.d/1100.fix.md
+++ b/changelog.d/1100.fix.md
@@ -1,0 +1,1 @@
+backfill-miles: `--output-sql` escapes single quotes in platform and username, so a `'` in a username no longer breaks the generated SQL.

--- a/cmd/backfill-miles/backfill-miles.go
+++ b/cmd/backfill-miles/backfill-miles.go
@@ -36,6 +36,7 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"strings"
 
 	_ "github.com/lib/pq"
 )
@@ -78,6 +79,11 @@ const updateMilesSQL = `UPDATE users SET miles = $1 WHERE id = $2`
 // the same user IDs as the source. Matches by platform + username and only
 // raises miles.
 const upsertMilesSQLFmt = "UPDATE users SET miles = GREATEST(miles, %.4f) WHERE platform = '%s' AND username = '%s';\n"
+
+// sqlQuote escapes single quotes for inlined SQL string literals.
+func sqlQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
 
 type row struct {
 	id       int
@@ -153,7 +159,7 @@ func main() {
 			if r.computed <= r.stored || r.delta < *minDelta {
 				continue
 			}
-			fmt.Printf(upsertMilesSQLFmt, r.computed, r.platform, r.username)
+			fmt.Printf(upsertMilesSQLFmt, r.computed, sqlQuote(r.platform), sqlQuote(r.username))
 		}
 		return
 	}


### PR DESCRIPTION
## Summary
- `--output-sql` interpolated `platform` and `username` raw into the generated `UPDATE` statements, so a single quote in a username produced broken SQL when piped into `psql`. Both values are now escaped (`'` doubled to `''`) via a local `sqlQuote` helper, matching the one backfill-coords already has.

## Test plan
- [x] `mise exec -- go build ./cmd/backfill-miles` and `go vet ./cmd/backfill-miles`
- [x] `task test:macos` (full suite green)
- [ ] Next real `--output-sql` run against the historical dump should confirm quoted usernames render as valid SQL