### PR TITLE
fix(video): bound Video.Next walk and propagate lookup errors

### DIFF
--- a/changelog.d/1101.fix.md
+++ b/changelog.d/1101.fix.md
@@ -1,0 +1,1 @@
+Chat commands that fall back to the next unflagged video (`!location`, `!weather`, `!time`, and friends) no longer hang forever when the video chain is broken or every candidate is flagged — they now reply that GPS coords couldn't be found.

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -24,6 +24,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/feature"
 	"github.com/adanalife/tripbot/pkg/helpers"
 	"github.com/adanalife/tripbot/pkg/users"
+	"github.com/adanalife/tripbot/pkg/video"
 	"github.com/getsentry/sentry-go"
 	"github.com/hako/durafmt"
 	"gorm.io/gorm"
@@ -257,7 +258,13 @@ func (a *App) sunsetCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.Video.Current()
 	if vid.Flagged {
 		a.Chat.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next(ctx)
+		next, err := vid.Next(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding next unflagged video", "err", err)
+			a.Chat.Say("I couldn't figure out current GPS coords, sorry!")
+			return
+		}
+		vid = next
 	}
 	lat, lng, _ := vid.Location()
 	a.Chat.Say(helpers.SunsetStr(vid.DateFilmed, lat, lng))
@@ -276,7 +283,13 @@ func (a *App) weatherCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.Video.Current()
 	if vid.Flagged {
 		a.Chat.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next(ctx)
+		next, err := vid.Next(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding next unflagged video", "err", err)
+			a.Chat.Say("I couldn't figure out current GPS coords, sorry!")
+			return
+		}
+		vid = next
 	}
 	lat, lng, _ := vid.Location()
 	desc, err := a.Weather.Historical(ctx, vid.DateFilmed, lat, lng)
@@ -295,7 +308,13 @@ func (a *App) locationCmd(ctx context.Context, user *users.User, _ []string) {
 		a.Chat.Say("I couldn't figure out current GPS coords, using next closest...")
 		//TODO: write something like vid.FindClosest() that
 		// chooses whether or not to use Next() vs Prev()
-		vid = vid.Next(ctx)
+		next, err := vid.Next(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding next unflagged video", "err", err)
+			a.Chat.Say("I couldn't figure out current GPS coords, sorry!")
+			return
+		}
+		vid = next
 	}
 	// extract the coordinates
 	lat, lng, err := vid.Location()
@@ -398,7 +417,11 @@ func (a *App) timeCmd(ctx context.Context, user *users.User, _ []string) {
 	var lat, lng float64
 	vid := a.Video.Current()
 	if vid.Flagged {
-		lat, lng, err = vid.Next(ctx).Location()
+		var next video.Video
+		next, err = vid.Next(ctx)
+		if err == nil {
+			lat, lng, err = next.Location()
+		}
 	} else {
 		lat, lng, err = vid.Location()
 	}
@@ -417,7 +440,11 @@ func (a *App) dateCmd(ctx context.Context, user *users.User, _ []string) {
 	var lat, lng float64
 	vid := a.Video.Current()
 	if vid.Flagged {
-		lat, lng, err = vid.Next(ctx).Location()
+		var next video.Video
+		next, err = vid.Next(ctx)
+		if err == nil {
+			lat, lng, err = next.Location()
+		}
 	} else {
 		lat, lng, err = vid.Location()
 	}
@@ -468,7 +495,13 @@ func (a *App) guessCmd(ctx context.Context, user *users.User, params []string) {
 	vid := a.Video.Current()
 	if vid.Flagged {
 		a.Chat.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next(ctx)
+		next, err := vid.Next(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding next unflagged video", "err", err)
+			a.Chat.Say("I couldn't figure out current GPS coords, sorry!")
+			return
+		}
+		vid = next
 	}
 
 	if strings.EqualFold(guess, vid.State) {
@@ -489,7 +522,13 @@ func (a *App) stateCmd(ctx context.Context, user *users.User, _ []string) {
 	vid := a.Video.Current()
 	if vid.Flagged {
 		a.Chat.Say("I couldn't figure out current GPS coords, using next closest...")
-		vid = vid.Next(ctx)
+		next, err := vid.Next(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding next unflagged video", "err", err)
+			a.Chat.Say("I couldn't figure out current GPS coords, sorry!")
+			return
+		}
+		vid = next
 	}
 	msg := fmt.Sprintf("We're in %s", vid.State)
 	// record that they know the location now

--- a/pkg/video/db.go
+++ b/pkg/video/db.go
@@ -136,19 +136,30 @@ func (v Video) save(ctx context.Context) error {
 	return database.GormDB().WithContext(ctx).Create(&insert).Error
 }
 
-// Next() finds the next unflagged video
+// Next() finds the next unflagged video by walking the next_vid chain.
+// The walk is bounded by the playlist length, so a broken chain or a
+// cycle of flagged videos returns an error instead of spinning forever.
 // TODO: should this be NextUnflagged?
-// TODO: handle errors in here?
-func (v Video) Next(ctx context.Context) Video {
+func (v Video) Next(ctx context.Context) (Video, error) {
+	var count int64
+	if err := database.GormDB().WithContext(ctx).Model(&Video{}).Count(&count).Error; err != nil {
+		return Video{}, err
+	}
+
 	vid := v
-	for { // ever
-		vid, _ = loadById(ctx, vid.NextVid.Int64)
+	for i := int64(0); i < count; i++ {
+		nextID := vid.NextVid.Int64
+		var err error
+		vid, err = loadById(ctx, nextID)
+		if err != nil {
+			return Video{}, fmt.Errorf("broken next_vid chain at id %d: %w", nextID, err)
+		}
 		// use the first unflagged video we find
 		if !vid.Flagged {
-			break
+			return vid, nil
 		}
 	}
-	return vid
+	return Video{}, errors.New("no unflagged video found in next_vid chain")
 }
 
 func (v Video) SetNextVid(ctx context.Context, nextVid Video) error {

--- a/pkg/video/db_test.go
+++ b/pkg/video/db_test.go
@@ -1,0 +1,76 @@
+package video
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// expectVideoCount queues the playlist-length COUNT that bounds Next()'s walk.
+func expectVideoCount(mock sqlmock.Sqlmock, count int64) {
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "videos"`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
+// expectLoadByIdHit queues a successful loadById() returning the given
+// id/flagged/next_vid row.
+func expectLoadByIdHit(mock sqlmock.Sqlmock, id int64, flagged bool, nextVid int64) {
+	mock.ExpectQuery(`SELECT \* FROM "videos" WHERE "videos"\."id" = `).
+		WithArgs(id, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "flagged", "next_vid"}).
+			AddRow(id, flagged, nextVid))
+}
+
+func TestVideoNext_ReturnsFirstUnflagged(t *testing.T) {
+	mock := installMockDB(t)
+	expectVideoCount(mock, 3)
+	expectLoadByIdHit(mock, 2, true, 3)  // flagged, keep walking
+	expectLoadByIdHit(mock, 3, false, 4) // unflagged, done
+
+	v := Video{NextVid: sql.NullInt64{Int64: 2, Valid: true}}
+	got, err := v.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next() error = %v, want nil", err)
+	}
+	if got.ID != 3 || got.Flagged {
+		t.Errorf("Next() = id %d flagged %v, want id 3 unflagged", got.ID, got.Flagged)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestVideoNext_BrokenChainReturnsError(t *testing.T) {
+	mock := installMockDB(t)
+	expectVideoCount(mock, 3)
+	// loadById miss: next_vid points at a row that doesn't exist
+	mock.ExpectQuery(`SELECT \* FROM "videos" WHERE "videos"\."id" = `).
+		WithArgs(int64(42), 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	v := Video{NextVid: sql.NullInt64{Int64: 42, Valid: true}}
+	if _, err := v.Next(context.Background()); err == nil {
+		t.Fatal("Next() with broken next_vid chain returned nil error, want error")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestVideoNext_AllFlaggedCycleReturnsError(t *testing.T) {
+	mock := installMockDB(t)
+	// two flagged videos pointing at each other; the walk stops at count=2
+	expectVideoCount(mock, 2)
+	expectLoadByIdHit(mock, 1, true, 2)
+	expectLoadByIdHit(mock, 2, true, 1)
+
+	v := Video{NextVid: sql.NullInt64{Int64: 1, Valid: true}}
+	if _, err := v.Next(context.Background()); err == nil {
+		t.Fatal("Next() over an all-flagged cycle returned nil error, want error")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Summary
- `Video.Next` looped unbounded and swallowed the `loadById` error: a broken `next_vid` chain produced a garbage zero `Video` and a cycle of flagged videos spun forever, hanging whatever chat command hit it.
- `Next` now returns `(Video, error)`: the walk is capped at the playlist length (one cheap `COUNT`), a missing row returns a broken-chain error, and exhausting the cap returns a no-unflagged-video error.
- All seven callers (`!sunset`, `!weather`, `!location`, `!time`, `!date`, `!guess`, `!state`) handle the error the way their neighboring error paths do: log it and send the existing "I couldn't figure out current GPS coords, sorry!" reply instead of hanging.

## Test plan
- [x] New sqlmock tests in `pkg/video/db_test.go`: first-unflagged walk, broken chain returns error, all-flagged cycle returns error (bounded by count).
- [x] `task test:macos` — full suite green.
- [ ] Optional: run `!location` on stage against a flagged clip to see the fallback reply live.