### PR TITLE
fix(instrumentation): stop racing on the platform attribute

### DIFF
--- a/changelog.d/1103.fix.md
+++ b/changelog.d/1103.fix.md
@@ -1,0 +1,1 @@
+The streaming-platform metric attribute is now injected when the vlc-server/OBS stats publishers are constructed, removing a mutable package global that pollers read while it could be reassigned.

--- a/cmd/vlc-server/vlc-server.go
+++ b/cmd/vlc-server/vlc-server.go
@@ -14,7 +14,6 @@ import (
 
 	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	"github.com/adanalife/tripbot/pkg/helpers"
-	"github.com/adanalife/tripbot/pkg/instrumentation"
 	"github.com/adanalife/tripbot/pkg/natsclient"
 	"github.com/adanalife/tripbot/pkg/obs"
 	"github.com/adanalife/tripbot/pkg/telemetry"
@@ -76,11 +75,6 @@ func main() {
 	// set up telemetry (no-op if OTEL_SDK_DISABLED)
 	initializeTelemetry()
 
-	// stamp the streaming platform onto the vlc-server/OBS gauges so the
-	// per-platform instances (twitch/youtube/…) stay distinct series instead
-	// of colliding on identical labels. Must run before the stats pollers.
-	instrumentation.SetPlatform(c.Conf.Platform)
-
 	// set up error logging
 	initializeErrorLogger()
 
@@ -115,8 +109,10 @@ func main() {
 	// No-op publishes when NATS is off.
 	srv.StartLastPlayedTicker(shutdownCtx, 5*time.Second)
 
-	// poll the OBS WebSocket for streaming state + render/output stats.
-	go obs.PollStreamingActive(context.Background(), 30*time.Second)
+	// poll the OBS WebSocket for streaming state + render/output stats,
+	// stamping the series with this instance's streaming platform so the
+	// per-platform instances (twitch/youtube/…) stay distinct.
+	go obs.PollStreamingActive(context.Background(), c.Conf.Platform, 30*time.Second)
 
 	// Self-heal watchdog: probes the local RTSP listener; after 3
 	// consecutive DESCRIBE failures (90s of sustained badness with the

--- a/pkg/instrumentation/vlc_server.go
+++ b/pkg/instrumentation/vlc_server.go
@@ -14,19 +14,12 @@ import (
 // twitch and youtube encoders collide onto one series. The attribute key
 // matches the resource attribute (service.platform → service_platform label)
 // so it lines up with target_info and the Stream Health dashboard's existing
-// filters. Defaults to twitch to match the config default; cmd/vlc-server
-// overrides it via SetPlatform at startup before the pollers begin.
-var platformAttr = metric.WithAttributes(attribute.String("service.platform", "twitch"))
-
-// SetPlatform stamps the streaming platform this instance feeds onto the
-// vlc-server/OBS gauges. Call once at startup (before the stats pollers run)
-// with the instance's STREAM_PLATFORM value so per-platform series stay
-// distinct as more platforms are added.
-func SetPlatform(p string) {
-	if p == "" {
-		p = "twitch"
+// filters. Defaults to twitch to match the config default.
+func platformAttr(platform string) metric.MeasurementOption {
+	if platform == "" {
+		platform = "twitch"
 	}
-	platformAttr = metric.WithAttributes(attribute.String("service.platform", p))
+	return metric.WithAttributes(attribute.String("service.platform", platform))
 }
 
 var (
@@ -74,50 +67,32 @@ type VLCPlayerStatsSnapshot struct {
 	Progress           float64 // 0..1 fraction of the current clip played
 }
 
-// VLCPlayerStats exposes the libvlc playback stats. Call Update on every
+// VLCPlayerStats publishes the libvlc playback stats, stamping every series
+// with the streaming platform it was constructed with. Call Update on every
 // poll tick with a fresh snapshot.
-var VLCPlayerStats = vlcPlayerStatsIface{
-	inputBitRate:       vlcInputBitRate,
-	demuxBitRate:       vlcDemuxBitRate,
-	displayedFPS:       vlcDisplayedFPS,
-	decodedVideo:       vlcDecodedVideo,
-	displayedPictures:  vlcDisplayedPictures,
-	lostPictures:       vlcLostPictures,
-	demuxCorrupted:     vlcDemuxCorrupted,
-	demuxDiscontinuity: vlcDemuxDiscontinuity,
-	timeRemaining:      vlcTimeRemaining,
-	progress:           vlcProgress,
+type VLCPlayerStats struct {
+	platform metric.MeasurementOption
 }
 
-type vlcPlayerStatsIface struct {
-	inputBitRate       metric.Float64Gauge
-	demuxBitRate       metric.Float64Gauge
-	displayedFPS       metric.Float64Gauge
-	decodedVideo       metric.Float64Gauge
-	displayedPictures  metric.Float64Gauge
-	lostPictures       metric.Float64Gauge
-	demuxCorrupted     metric.Float64Gauge
-	demuxDiscontinuity metric.Float64Gauge
-	timeRemaining      metric.Float64Gauge
-	progress           metric.Float64Gauge
+// NewVLCPlayerStats builds a publisher for the given streaming platform
+// (the instance's STREAM_PLATFORM value).
+func NewVLCPlayerStats(platform string) VLCPlayerStats {
+	return VLCPlayerStats{platform: platformAttr(platform)}
 }
 
-func (v vlcPlayerStatsIface) Update(s VLCPlayerStatsSnapshot) {
+func (v VLCPlayerStats) Update(s VLCPlayerStatsSnapshot) {
 	ctx := context.Background()
-	v.inputBitRate.Record(ctx, s.InputBitRate, platformAttr)
-	v.demuxBitRate.Record(ctx, s.DemuxBitRate, platformAttr)
-	v.displayedFPS.Record(ctx, s.DisplayedFPS, platformAttr)
-	v.decodedVideo.Record(ctx, s.DecodedVideo, platformAttr)
-	v.displayedPictures.Record(ctx, s.DisplayedPictures, platformAttr)
-	v.lostPictures.Record(ctx, s.LostPictures, platformAttr)
-	v.demuxCorrupted.Record(ctx, s.DemuxCorrupted, platformAttr)
-	v.demuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity, platformAttr)
-	v.timeRemaining.Record(ctx, s.TimeRemaining, platformAttr)
-	v.progress.Record(ctx, s.Progress, platformAttr)
+	vlcInputBitRate.Record(ctx, s.InputBitRate, v.platform)
+	vlcDemuxBitRate.Record(ctx, s.DemuxBitRate, v.platform)
+	vlcDisplayedFPS.Record(ctx, s.DisplayedFPS, v.platform)
+	vlcDecodedVideo.Record(ctx, s.DecodedVideo, v.platform)
+	vlcDisplayedPictures.Record(ctx, s.DisplayedPictures, v.platform)
+	vlcLostPictures.Record(ctx, s.LostPictures, v.platform)
+	vlcDemuxCorrupted.Record(ctx, s.DemuxCorrupted, v.platform)
+	vlcDemuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity, v.platform)
+	vlcTimeRemaining.Record(ctx, s.TimeRemaining, v.platform)
+	vlcProgress.Record(ctx, s.Progress, v.platform)
 }
-
-// OBSStreaming exposes the streaming-active gauge.
-var OBSStreaming = obsStreamingIface{g: obsStreamingGauge}
 
 // OBSStatsSnapshot bundles OBS performance + stream-output stats so the
 // poller can publish in a single call without coupling instrumentation to
@@ -144,73 +119,50 @@ type OBSStreamSnapshot struct {
 	TotalFrames      float64
 }
 
-// OBSStats exposes the OBS performance + stream-output gauges.
-var OBSStats = obsStatsIface{
-	activeFPS:           obsActiveFPS,
-	averageFrameRender:  obsAverageFrameRenderMS,
-	cpuUsage:            obsCPUUsage,
-	memoryUsage:         obsMemoryUsage,
-	renderSkippedFrames: obsRenderSkippedFrames,
-	renderTotalFrames:   obsRenderTotalFrames,
-	outputSkippedFrames: obsOutputSkippedFrames,
-	outputTotalFrames:   obsOutputTotalFrames,
-	streamBytes:         obsStreamOutputBytes,
-	streamDuration:      obsStreamOutputDurationMS,
-	streamCongestion:    obsStreamCongestion,
-	streamReconnecting:  obsStreamReconnecting,
-	streamSkipped:       obsStreamSkippedFrames,
-	streamTotal:         obsStreamTotalFrames,
+// OBSStats publishes the OBS streaming-active, performance, and
+// stream-output gauges, stamping every series with the streaming platform
+// it was constructed with.
+type OBSStats struct {
+	platform metric.MeasurementOption
 }
 
-type obsStreamingIface struct{ g metric.Int64Gauge }
+// NewOBSStats builds a publisher for the given streaming platform
+// (the instance's STREAM_PLATFORM value).
+func NewOBSStats(platform string) OBSStats {
+	return OBSStats{platform: platformAttr(platform)}
+}
 
-func (o obsStreamingIface) Set(active bool) {
+// SetStreaming records whether OBS is actively streaming.
+func (o OBSStats) SetStreaming(active bool) {
 	v := int64(0)
 	if active {
 		v = 1
 	}
-	o.g.Record(context.Background(), v, platformAttr)
+	obsStreamingGauge.Record(context.Background(), v, o.platform)
 }
 
-type obsStatsIface struct {
-	activeFPS           metric.Float64Gauge
-	averageFrameRender  metric.Float64Gauge
-	cpuUsage            metric.Float64Gauge
-	memoryUsage         metric.Float64Gauge
-	renderSkippedFrames metric.Float64Gauge
-	renderTotalFrames   metric.Float64Gauge
-	outputSkippedFrames metric.Float64Gauge
-	outputTotalFrames   metric.Float64Gauge
-	streamBytes         metric.Float64Gauge
-	streamDuration      metric.Float64Gauge
-	streamCongestion    metric.Float64Gauge
-	streamReconnecting  metric.Int64Gauge
-	streamSkipped       metric.Float64Gauge
-	streamTotal         metric.Float64Gauge
-}
-
-func (o obsStatsIface) Update(s OBSStatsSnapshot) {
+func (o OBSStats) Update(s OBSStatsSnapshot) {
 	ctx := context.Background()
-	o.activeFPS.Record(ctx, s.ActiveFPS, platformAttr)
-	o.averageFrameRender.Record(ctx, s.AverageFrameRenderTime, platformAttr)
-	o.cpuUsage.Record(ctx, s.CPUUsage, platformAttr)
-	o.memoryUsage.Record(ctx, s.MemoryUsage, platformAttr)
-	o.renderSkippedFrames.Record(ctx, s.RenderSkippedFrames, platformAttr)
-	o.renderTotalFrames.Record(ctx, s.RenderTotalFrames, platformAttr)
-	o.outputSkippedFrames.Record(ctx, s.OutputSkippedFrames, platformAttr)
-	o.outputTotalFrames.Record(ctx, s.OutputTotalFrames, platformAttr)
+	obsActiveFPS.Record(ctx, s.ActiveFPS, o.platform)
+	obsAverageFrameRenderMS.Record(ctx, s.AverageFrameRenderTime, o.platform)
+	obsCPUUsage.Record(ctx, s.CPUUsage, o.platform)
+	obsMemoryUsage.Record(ctx, s.MemoryUsage, o.platform)
+	obsRenderSkippedFrames.Record(ctx, s.RenderSkippedFrames, o.platform)
+	obsRenderTotalFrames.Record(ctx, s.RenderTotalFrames, o.platform)
+	obsOutputSkippedFrames.Record(ctx, s.OutputSkippedFrames, o.platform)
+	obsOutputTotalFrames.Record(ctx, s.OutputTotalFrames, o.platform)
 }
 
-func (o obsStatsIface) UpdateStream(s OBSStreamSnapshot) {
+func (o OBSStats) UpdateStream(s OBSStreamSnapshot) {
 	ctx := context.Background()
-	o.streamBytes.Record(ctx, s.OutputBytes, platformAttr)
-	o.streamDuration.Record(ctx, s.OutputDurationMS, platformAttr)
-	o.streamCongestion.Record(ctx, s.OutputCongestion, platformAttr)
+	obsStreamOutputBytes.Record(ctx, s.OutputBytes, o.platform)
+	obsStreamOutputDurationMS.Record(ctx, s.OutputDurationMS, o.platform)
+	obsStreamCongestion.Record(ctx, s.OutputCongestion, o.platform)
 	v := int64(0)
 	if s.Reconnecting {
 		v = 1
 	}
-	o.streamReconnecting.Record(ctx, v, platformAttr)
-	o.streamSkipped.Record(ctx, s.SkippedFrames, platformAttr)
-	o.streamTotal.Record(ctx, s.TotalFrames, platformAttr)
+	obsStreamReconnecting.Record(ctx, v, o.platform)
+	obsStreamSkippedFrames.Record(ctx, s.SkippedFrames, o.platform)
+	obsStreamTotalFrames.Record(ctx, s.TotalFrames, o.platform)
 }

--- a/pkg/obs/streaming.go
+++ b/pkg/obs/streaming.go
@@ -12,9 +12,10 @@ import (
 )
 
 // PollStreamingActive connects to the OBS WebSocket and updates the
-// obs_streaming_active gauge every interval. Intended to be run as a
-// long-lived goroutine. Reconnects automatically on connection loss.
-func PollStreamingActive(ctx context.Context, interval time.Duration) {
+// obs_streaming_active gauge every interval, stamping the series with the
+// given streaming platform. Intended to be run as a long-lived goroutine.
+// Reconnects automatically on connection loss.
+func PollStreamingActive(ctx context.Context, platform string, interval time.Duration) {
 	addr := os.Getenv("OBS_WEBSOCKET_ADDR")
 	if addr == "" {
 		addr = defaultOBSWebsocketAddr
@@ -24,11 +25,12 @@ func PollStreamingActive(ctx context.Context, interval time.Duration) {
 		passwd = "adanalife"
 	}
 
+	obsStats := instrumentation.NewOBSStats(platform)
 	for {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		poll(ctx, addr, passwd, interval)
+		poll(ctx, obsStats, addr, passwd, interval)
 		// poll returned — connection lost. Wait before reconnecting.
 		select {
 		case <-ctx.Done():
@@ -40,11 +42,11 @@ func PollStreamingActive(ctx context.Context, interval time.Duration) {
 
 // poll connects once and loops until the context is cancelled or the
 // connection drops.
-func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
+func poll(ctx context.Context, obsStats instrumentation.OBSStats, addr, passwd string, interval time.Duration) {
 	client, err := goobs.New(addr, goobs.WithPassword(passwd))
 	if err != nil {
 		slog.ErrorContext(ctx, "obs websocket connect failed", "addr", addr, "err", err)
-		instrumentation.OBSStreaming.Set(false)
+		obsStats.SetStreaming(false)
 		return
 	}
 	defer func() {
@@ -66,14 +68,14 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 			resp, err := client.Stream.GetStreamStatus()
 			if err != nil {
 				// Transient: OBS pod restart, network blip, websocket drop.
-				// The outer loop reconnects after 10s and OBSStreaming
+				// The outer loop reconnects after 10s and obs_streaming_active
 				// is the alertable signal — keep this off Sentry.
 				slog.WarnContext(ctx, "obs GetStreamStatus error", "err", err)
-				instrumentation.OBSStreaming.Set(false)
+				obsStats.SetStreaming(false)
 				return // trigger reconnect
 			}
-			instrumentation.OBSStreaming.Set(resp.OutputActive)
-			instrumentation.OBSStats.UpdateStream(instrumentation.OBSStreamSnapshot{
+			obsStats.SetStreaming(resp.OutputActive)
+			obsStats.UpdateStream(instrumentation.OBSStreamSnapshot{
 				OutputBytes:      resp.OutputBytes,
 				OutputDurationMS: resp.OutputDuration,
 				OutputCongestion: resp.OutputCongestion,
@@ -89,7 +91,7 @@ func poll(ctx context.Context, addr, passwd string, interval time.Duration) {
 				slog.WarnContext(ctx, "obs GetStats error", "err", err)
 				continue
 			}
-			instrumentation.OBSStats.Update(instrumentation.OBSStatsSnapshot{
+			obsStats.Update(instrumentation.OBSStatsSnapshot{
 				ActiveFPS:              stats.ActiveFps,
 				AverageFrameRenderTime: stats.AverageFrameRenderTime,
 				CPUUsage:               stats.CpuUsage,

--- a/pkg/vlc-server/stats.go
+++ b/pkg/vlc-server/stats.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
 	"github.com/adanalife/tripbot/pkg/instrumentation"
 )
 
@@ -18,6 +19,8 @@ import (
 func (s *Server) pollStats(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+
+	playerStats := instrumentation.NewVLCPlayerStats(c.Conf.Platform)
 
 	var (
 		prevDisplayed float64
@@ -78,7 +81,7 @@ func (s *Server) pollStats(ctx context.Context, interval time.Duration) {
 			prevTime = now
 			havePrev = true
 
-			instrumentation.VLCPlayerStats.Update(instrumentation.VLCPlayerStatsSnapshot{
+			playerStats.Update(instrumentation.VLCPlayerStatsSnapshot{
 				InputBitRate:       stats.InputBitRate,
 				DemuxBitRate:       stats.DemuxBitRate,
 				DisplayedFPS:       fps,


### PR DESCRIPTION
## Summary
- `pkg/instrumentation`'s `platformAttr` was a mutable package global: `SetPlatform` reassigned it at startup while the stats pollers read it from their own goroutines.
- Since `SetPlatform` had exactly one caller and always ran before any poller started, the platform is now injected at construction — `NewVLCPlayerStats(platform)` / `NewOBSStats(platform)` capture the attribute once — and the global + setter are deleted (smaller API, no sync needed).
- `obs.PollStreamingActive` takes the platform as a parameter (`pkg/obs` stays free of binary-specific config imports); `pkg/vlc-server` reads it from its own config as it already does elsewhere.
- Metric output is unchanged: same `service.platform` attribute, same twitch default, same gauges.

## Test plan
- [x] `go vet` (all packages except CGO/libvlc ones, which don't compile bare on darwin)
- [x] `task test:macos` — full suite green
- [ ] After deploy: confirm twitch/youtube series still distinct on the Stream Health dashboard