### PR TITLE
fix(users): return an error from Find instead of a zero-ID sentinel

### DIFF
--- a/changelog.d/1104.fix.md
+++ b/changelog.d/1104.fix.md
@@ -1,0 +1,1 @@
+`users.Find` now returns a real error instead of a zero-ID sentinel, so a transient DB failure can no longer masquerade as "new user" — chat lookups report the outage instead of "I don't know them", and `FindOrCreate` won't create a duplicate row while the DB is flaking.

--- a/pkg/chatbot/commands.go
+++ b/pkg/chatbot/commands.go
@@ -179,11 +179,16 @@ func (a *App) milesCmd(ctx context.Context, user *users.User, params []string) {
 		monthlyMiles = a.Sessions.CurrentMonthlyMiles(ctx, *user)
 	} else {
 		username = helpers.StripAtSign(params[0])
-		u := a.Sessions.Find(ctx, username)
+		u, err := a.Sessions.Find(ctx, username)
 
 		// check to see if they are in our DB
-		if u.ID == 0 {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			a.Chat.Say("I don't know them, sorry!")
+			return
+		}
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding user", "err", err, "username", username)
+			a.Chat.Say("Couldn't look them up right now, try again in a bit")
 			return
 		}
 
@@ -235,11 +240,16 @@ func (a *App) kilometresCmd(ctx context.Context, user *users.User, params []stri
 		miles = a.Sessions.CurrentMiles(ctx, *user)
 	} else {
 		username = helpers.StripAtSign(params[0])
-		u := a.Sessions.Find(ctx, username)
+		u, err := a.Sessions.Find(ctx, username)
 
 		// check to see if they are in our DB
-		if u.ID == 0 {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			a.Chat.Say("I don't know them, sorry!")
+			return
+		}
+		if err != nil {
+			slog.ErrorContext(ctx, "error finding user", "err", err, "username", username)
+			a.Chat.Say("Couldn't look them up right now, try again in a bit")
 			return
 		}
 
@@ -623,8 +633,13 @@ func (a *App) giveMilesCmd(ctx context.Context, user *users.User, params []strin
 		a.Chat.Say("that amount isn't a number I understand")
 		return
 	}
-	if u := a.Sessions.Find(ctx, target); u.ID == 0 {
-		a.Chat.Say("I don't know them, sorry!")
+	if _, err := a.Sessions.Find(ctx, target); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			a.Chat.Say("I don't know them, sorry!")
+		} else {
+			slog.ErrorContext(ctx, "error finding user", "err", err, "username", target)
+			a.Chat.Say("Couldn't look them up right now, try again in a bit")
+		}
 		return
 	}
 	newTotal := a.Sessions.CorrectMiles(ctx, target, float32(delta))

--- a/pkg/chatbot/sessions.go
+++ b/pkg/chatbot/sessions.go
@@ -19,9 +19,10 @@ import (
 // through App.UserSessions directly. Keeping them off this interface keeps the
 // command-time fake surface (noopSessions / recordingSessions) minimal.
 type Sessions interface {
-	// Find looks up a user by username. Returns User{ID: 0} for an
-	// unknown user (mirrors pkg/users.Find's existing contract).
-	Find(ctx context.Context, username string) users.User
+	// Find looks up a user by username. Returns gorm.ErrRecordNotFound for
+	// an unknown user (mirrors pkg/users.Find's contract); any other error
+	// is a real DB failure.
+	Find(ctx context.Context, username string) (users.User, error)
 	// LifetimeLeaderboard returns the current snapshot of the
 	// lifetime-miles leaderboard, a slice of [username, miles] pairs
 	// hydrated at startup by InitLeaderboard. Read-only from the
@@ -57,7 +58,7 @@ type realSessions struct{ s *users.Sessions }
 // assigns the result onto App.Sessions once Sessions is constructed.
 func NewSessionsAdapter(s *users.Sessions) Sessions { return realSessions{s: s} }
 
-func (r realSessions) Find(ctx context.Context, username string) users.User {
+func (r realSessions) Find(ctx context.Context, username string) (users.User, error) {
 	return users.Find(ctx, username)
 }
 

--- a/pkg/chatbot/sessions_test.go
+++ b/pkg/chatbot/sessions_test.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 
 	"github.com/adanalife/tripbot/pkg/users"
+	"gorm.io/gorm"
 )
 
 // noopSessions satisfies Sessions for tests that don't care about user
-// lookups — Find returns the zero-value (unknown) user, the leaderboard
+// lookups — Find reports every user as unknown, the leaderboard
 // reads as empty, and Shutdown is a no-op.
 type noopSessions struct{}
 
-func (noopSessions) Find(_ context.Context, _ string) users.User                 { return users.User{} }
+func (noopSessions) Find(_ context.Context, _ string) (users.User, error) {
+	return users.User{}, gorm.ErrRecordNotFound
+}
 func (noopSessions) LifetimeLeaderboard() [][]string                             { return nil }
 func (noopSessions) Shutdown(_ context.Context)                                  {}
 func (noopSessions) SetBot(_ context.Context, _ string, _ bool) error            { return nil }
@@ -30,15 +33,25 @@ type recordingSessions struct {
 	Calls       []string
 	FindResult  users.User
 	Leaderboard [][]string
+	// FindErr is the error Find will return for every call. When unset and
+	// FindResult is the zero user, Find returns gorm.ErrRecordNotFound —
+	// mirroring pkg/users.Find's "not found" contract.
+	FindErr error
 	// SetBotErr is the error SetBot will return for every call.
 	SetBotErr error
 	// Miles / MonthlyMiles / Bonus stage what the miles methods return.
 	Miles, MonthlyMiles, Bonus float32
 }
 
-func (r *recordingSessions) Find(_ context.Context, username string) users.User {
+func (r *recordingSessions) Find(_ context.Context, username string) (users.User, error) {
 	r.Calls = append(r.Calls, fmt.Sprintf("Find(%q)", username))
-	return r.FindResult
+	if r.FindErr != nil {
+		return users.User{}, r.FindErr
+	}
+	if r.FindResult.ID == 0 {
+		return users.User{}, gorm.ErrRecordNotFound
+	}
+	return r.FindResult, nil
 }
 
 func (r *recordingSessions) LifetimeLeaderboard() [][]string {

--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/adanalife/tripbot/pkg/scoreboards"
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/gorilla/mux"
+	"gorm.io/gorm"
 )
 
 // findUser / sessionCount / monthlyMiles are the data seams the profile handler
@@ -70,15 +72,22 @@ func gatherUserProfile(ctx context.Context, username string) userProfile {
 	if username == "" {
 		return prof
 	}
-	if u := findUser(ctx, username); u.ID != 0 {
-		prof.Found = true
-		prof.IsBot = u.IsBot
-		prof.Miles = u.Miles
-		prof.MonthlyMiles = monthlyMiles(ctx, u)
-		prof.FirstSeen = bestEffortFirstSeen(u.FirstSeen, u.DateCreated, earliestEvent(ctx, u.Platform, username))
-		prof.LastSeen = u.LastSeen
-		prof.Sessions = sessionCount(ctx, username)
+	u, err := findUser(ctx, username)
+	if err != nil {
+		// not-found renders as Found=false; a real DB error does too, but
+		// gets logged so it's visible as a failure rather than a ghost user.
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			slog.ErrorContext(ctx, "error finding user", "err", err, "username", username)
+		}
+		return prof
 	}
+	prof.Found = true
+	prof.IsBot = u.IsBot
+	prof.Miles = u.Miles
+	prof.MonthlyMiles = monthlyMiles(ctx, u)
+	prof.FirstSeen = bestEffortFirstSeen(u.FirstSeen, u.DateCreated, earliestEvent(ctx, u.Platform, username))
+	prof.LastSeen = u.LastSeen
+	prof.Sessions = sessionCount(ctx, username)
 	return prof
 }
 

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/adanalife/tripbot/pkg/users"
 	"github.com/gorilla/mux"
+	"gorm.io/gorm"
 )
 
 // withProfileSeams stubs the DB-backed data reads so the handler renders without
@@ -21,7 +22,13 @@ func withProfileSeams(t *testing.T, u users.User, sessions int64, monthly float3
 	t.Cleanup(func() {
 		findUser, sessionCount, monthlyMiles, earliestEvent = savedFind, savedCount, savedMonthly, savedEarliest
 	})
-	findUser = func(context.Context, string) users.User { return u }
+	findUser = func(context.Context, string) (users.User, error) {
+		// mirror pkg/users.Find's contract: a staged zero-ID user means "no row"
+		if u.ID == 0 {
+			return users.User{}, gorm.ErrRecordNotFound
+		}
+		return u, nil
+	}
 	sessionCount = func(context.Context, string) int64 { return sessions }
 	monthlyMiles = func(context.Context, users.User) float32 { return monthly }
 	// default: no surviving event history. Tests exercising the first-seen

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -123,9 +123,9 @@ func (u User) save(ctx context.Context) {
 // SetBot flips users.is_bot for a username. Returns gorm.ErrRecordNotFound
 // if the user doesn't exist in the DB.
 func (s *Sessions) SetBot(ctx context.Context, username string, isBot bool) error {
-	user := Find(ctx, username)
-	if user.ID == 0 {
-		return gorm.ErrRecordNotFound
+	user, err := Find(ctx, username)
+	if err != nil {
+		return err
 	}
 	user.IsBot = isBot
 	user.save(ctx)
@@ -161,27 +161,29 @@ func FindOrCreate(ctx context.Context, username string) User {
 	if c.Conf.Verbose {
 		slog.InfoContext(ctx, "FindOrCreate", "username", username)
 	}
-	user := Find(ctx, username)
-	if user.ID != 0 {
+	user, err := Find(ctx, username)
+	if err == nil {
 		return user
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		// A real DB error must not look like a new user — creating here could
+		// duplicate an existing row. Callers treat a zero ID as "no DB row".
+		slog.ErrorContext(ctx, "error finding user", "err", err, "username", username)
+		return User{}
 	}
 	// create the user in the DB
 	return create(ctx, username)
 }
 
-// Find will look up the username in the DB, and return a User if possible
-func Find(ctx context.Context, username string) User {
+// Find looks up the username in the DB. A missing user surfaces as
+// gorm.ErrRecordNotFound; any other error is a real DB failure.
+func Find(ctx context.Context, username string) (User, error) {
 	var user User
 	result := database.GormDB().WithContext(ctx).Where("platform = ? AND username = ?", c.Conf.Platform, username).First(&user)
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		//TODO: is there a better way to do this?
-		return User{ID: 0}
-	}
 	if result.Error != nil {
-		slog.ErrorContext(ctx, "error finding user", "err", result.Error)
-		return User{ID: 0}
+		return User{}, result.Error
 	}
-	return user
+	return user, nil
 }
 
 // HasCommandAvailable lets users run a command once a day,
@@ -243,5 +245,9 @@ func create(ctx context.Context, username string) User {
 	if err := database.GormDB().WithContext(ctx).Create(&newUser).Error; err != nil {
 		slog.ErrorContext(ctx, "error creating user", "err", err)
 	}
-	return Find(ctx, username)
+	user, err := Find(ctx, username)
+	if err != nil {
+		slog.ErrorContext(ctx, "error finding user after create", "err", err, "username", username)
+	}
+	return user
 }

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -2,9 +2,45 @@ package users
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"gorm.io/gorm"
 )
+
+// Find's contract: a missing user is gorm.ErrRecordNotFound, while a real DB
+// failure propagates as itself — the two must never be conflated (a transient
+// DB error looking like "new user" is how duplicate rows get created).
+func TestFind_NotFoundVsDBError(t *testing.T) {
+	t.Run("missing user surfaces gorm.ErrRecordNotFound", func(t *testing.T) {
+		mock := installMockDB(t)
+		mock.ExpectQuery(`SELECT \* FROM "users"`).
+			WithArgs(c.Conf.Platform, "ghost", 1).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+		_, err := Find(context.Background(), "ghost")
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("want gorm.ErrRecordNotFound, got %v", err)
+		}
+	})
+
+	t.Run("DB failure propagates as itself, not as not-found", func(t *testing.T) {
+		mock := installMockDB(t)
+		dbErr := errors.New("connection refused")
+		mock.ExpectQuery(`SELECT \* FROM "users"`).WillReturnError(dbErr)
+
+		_, err := Find(context.Background(), "somebody")
+		if !errors.Is(err, dbErr) {
+			t.Fatalf("want underlying DB error, got %v", err)
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatal("DB failure must not look like not-found")
+		}
+	})
+}
 
 func TestGuessCooldownRemaining(t *testing.T) {
 	t.Run("zero lastLocation returns no cooldown", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `users.Find` now returns `(User, error)` instead of collapsing both "no such user" and real DB failures into the `User{ID: 0}` sentinel. A missing user surfaces as `gorm.ErrRecordNotFound`; real DB errors propagate as themselves.
- Callers discriminate with `errors.Is`: not-found paths keep their existing behavior ("I don't know them, sorry!", `Found=false` profiles, create-on-miss), while DB-error paths now log and fail visibly instead of masquerading as an unknown user.
- `FindOrCreate` no longer calls `create()` when Find failed for a reason other than not-found — a transient DB error can't mint a duplicate user row anymore.
- The `chatbot.Sessions.Find` seam and the `pkg/server` `findUser` seam carry the error through, so `!miles`/`!kilometres`/`!givemiles` and the profile endpoint distinguish the two cases too.

## Test plan
- [x] `task test:macos` — full suite green
- [x] New `TestFind_NotFoundVsDBError` in `pkg/users` (sqlmock) asserts not-found → `gorm.ErrRecordNotFound` and DB failure → the underlying error, never conflated
- [x] `go vet ./...` clean for the touched packages (one pre-existing `cmd/vlc-server` signal.Notify finding on develop, untouched here)
- [ ] Optional: sanity-check `!miles <unknown user>` on stage still replies "I don't know them, sorry!"