### PR TITLE
test: run DB tests against real postgres in CI

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,6 +1,8 @@
-# Placeholder env vars for `go test`. All values are fake — no real
-# services are touched. Several packages call log.Fatalf in init() if
-# these are missing; setting them lets the package load.
+# Env vars for `go test`. The DATABASE_* block points at the compose
+# stack's real postgres (used by pkg/database/testdb); everything else
+# is a fake placeholder — no other real services are touched. Several
+# packages call log.Fatalf in init() if these are missing; setting them
+# lets the package load.
 #
 # Used by:
 #   - infra/docker/docker-compose.testing.yml `test` service env_file
@@ -27,10 +29,12 @@ ONSCREENS_SERVER_HOST=http://localhost:8082
 VIDEO_DIR=/tmp
 RUN_DIR=/tmp
 
-# database
-DATABASE_USER=test
-DATABASE_DB=test
-DATABASE_HOST=localhost
+# database — must match the compose db service credentials (interpolated
+# from infra/docker/env.docker). Local-dev-only values, not secrets.
+DATABASE_USER=tripbot_docker
+DATABASE_PASS=hunter2
+DATABASE_DB=tripbot_docker
+DATABASE_HOST=db
 
 # twitch — stubs only; tests don't talk to real Twitch
 TWITCH_CLIENT_ID=test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,6 +12,7 @@ on:
       - 'configs/**'
       - 'assets/**'
       - 'infra/docker/**'
+      - '.env.testing'
       - 'Taskfile.yml'
       - '.github/workflows/testing.yml'
   push:

--- a/infra/docker/docker-compose.testing.yml
+++ b/infra/docker/docker-compose.testing.yml
@@ -9,6 +9,22 @@ services:
     environment:
       ENV: testing
 
+  # DB-backed tests (pkg/database/testdb) run against the real postgres
+  # from the base compose file; the healthcheck + depends_on chain below
+  # makes `docker compose run test` boot db, run migrations, and only
+  # then start `go test`.
+  db:
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  migrate:
+    depends_on:
+      db:
+        condition: service_healthy
+
   # `test` is a one-shot Go toolchain container for running `go test`
   # outside the running stack. Invoked via `ENV=testing bin/devenv
   # run --rm test ...` (see Taskfile.yml).
@@ -18,6 +34,14 @@ services:
       context: .
       dockerfile: infra/docker/test/Dockerfile
     working_dir: /src
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      # DB tests skip when postgres is unreachable (`task test:macos` has
+      # no docker); inside this stack the DB is always there, so a skip
+      # would mask a wiring bug — fail instead.
+      TESTDB_REQUIRED: "1"
     env_file:
       - ./.env.testing
     volumes:

--- a/pkg/database/testdb/testdb.go
+++ b/pkg/database/testdb/testdb.go
@@ -1,0 +1,90 @@
+// Package testdb hands tests a real postgres connection wired into the
+// database singleton, so repo-level tests exercise the actual schema and
+// dialect instead of sqlmock string-matching. New gives per-test isolation
+// via a transaction that rolls back in cleanup; Shared installs the
+// pool-backed connection for tests that need session-scoped features
+// (advisory locks) a transaction can't reach.
+//
+// The connection targets the compose stack's db service (see
+// infra/docker/docker-compose.testing.yml) using the same DATABASE_* env
+// vars as production code. When postgres is unreachable the calling test
+// skips — unless TESTDB_REQUIRED is set (the compose test service sets it),
+// where a skip would silently mask a wiring bug.
+package testdb
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/adanalife/tripbot/pkg/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+var (
+	once    sync.Once
+	pool    *gorm.DB
+	dialErr error
+)
+
+// New installs a transaction-scoped *gorm.DB as the database singleton and
+// returns it. The transaction rolls back in test cleanup, so writes never
+// leak between tests. Like SetGormDB itself, not safe for t.Parallel().
+func New(t *testing.T) *gorm.DB {
+	t.Helper()
+	tx := connect(t).Begin()
+	if tx.Error != nil {
+		t.Fatalf("testdb: begin: %v", tx.Error)
+	}
+	database.SetGormDB(tx)
+	t.Cleanup(func() {
+		database.SetGormDB(nil)
+		tx.Rollback()
+	})
+	return tx
+}
+
+// Shared installs the pool-backed *gorm.DB as the database singleton and
+// returns it. No transaction, no rollback — for tests exercising
+// session-scoped behavior like pg advisory locks, which need real pooled
+// connections (gorm's DB() errors on a transaction). Callers must clean up
+// any rows they write.
+func Shared(t *testing.T) *gorm.DB {
+	t.Helper()
+	gdb := connect(t)
+	database.SetGormDB(gdb)
+	t.Cleanup(func() { database.SetGormDB(nil) })
+	return gdb
+}
+
+func connect(t *testing.T) *gorm.DB {
+	t.Helper()
+	once.Do(func() {
+		// connect_timeout keeps the no-docker case (task test:macos) at a
+		// fast skip instead of a hanging dial.
+		dsn := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable&connect_timeout=3",
+			os.Getenv("DATABASE_USER"), os.Getenv("DATABASE_PASS"),
+			os.Getenv("DATABASE_HOST"), os.Getenv("DATABASE_DB"))
+		// database/sql, not otelsql — tests don't need spans. The postgres
+		// driver is registered by pkg/database's lib/pq import.
+		sqlDB, err := sql.Open("postgres", dsn)
+		if err == nil {
+			err = sqlDB.Ping()
+		}
+		if err != nil {
+			dialErr = err
+			return
+		}
+		pool, dialErr = gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{})
+	})
+	if dialErr != nil {
+		if os.Getenv("TESTDB_REQUIRED") != "" {
+			t.Fatalf("testdb: postgres unreachable with TESTDB_REQUIRED set: %v", dialErr)
+		}
+		t.Skipf("testdb: postgres unreachable, skipping: %v", dialErr)
+	}
+	return pool
+}

--- a/pkg/oauthtokens/oauthtokens_test.go
+++ b/pkg/oauthtokens/oauthtokens_test.go
@@ -6,33 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/adanalife/tripbot/pkg/database"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
+	"github.com/adanalife/tripbot/pkg/database/testdb"
 )
-
-// installMockDB mirrors pkg/users' helper: a sqlmock-backed *gorm.DB
-// installed as the process-wide singleton so package functions route to it.
-func installMockDB(t *testing.T) sqlmock.Sqlmock {
-	t.Helper()
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
-		SkipDefaultTransaction: true,
-	})
-	if err != nil {
-		t.Fatalf("gorm.Open: %v", err)
-	}
-	database.SetGormDB(gdb)
-	t.Cleanup(func() {
-		database.SetGormDB(nil)
-		_ = sqlDB.Close()
-	})
-	return mock
-}
 
 func sampleToken() Token {
 	return Token{
@@ -46,34 +21,69 @@ func sampleToken() Token {
 	}
 }
 
-func tokenColumns() []string {
-	return []string{
-		"id", "provider", "username", "twitch_user_id", "access_token", "refresh_token",
-		"expires_at", "scopes", "refresh_fail_count", "last_refresh_at",
-		"date_created", "date_updated",
+func TestUpsertThenGet(t *testing.T) {
+	testdb.New(t)
+	tok := sampleToken()
+	if err := Upsert(tok); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := Get("twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessToken != tok.AccessToken || got.RefreshToken != tok.RefreshToken || got.Scopes != tok.Scopes {
+		t.Errorf("unexpected token: %+v", got)
+	}
+	if !got.ExpiresAt.Equal(tok.ExpiresAt) {
+		t.Errorf("expires_at round-trip: want %v, got %v", tok.ExpiresAt, got.ExpiresAt)
+	}
+	if got.TwitchUserID.String != "12345" || !got.TwitchUserID.Valid {
+		t.Errorf("unexpected twitch_user_id: %+v", got.TwitchUserID)
+	}
+	if got.RefreshFailCount != 0 {
+		t.Errorf("expected RefreshFailCount=0, got %d", got.RefreshFailCount)
+	}
+	if !got.LastRefreshAt.Valid {
+		t.Error("expected last_refresh_at stamped on insert")
+	}
+	if got.DateCreated.IsZero() || got.DateUpdated.IsZero() {
+		t.Errorf("expected timestamps stamped: %+v", got)
 	}
 }
 
-func TestGetByProvider_Hit(t *testing.T) {
-	mock := installMockDB(t)
-	rows := sqlmock.NewRows(tokenColumns()).AddRow(
-		2, "youtube", "UC123", nil, "yt-access", "yt-refresh",
-		time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC),
-		"https://www.googleapis.com/auth/youtube.force-ssl",
-		0, nil,
-		time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
-		time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
-	)
-	mock.ExpectQuery(`SELECT \* FROM "oauth_tokens" WHERE provider = \$1 ORDER BY date_updated DESC`).
-		WithArgs("youtube", 1).
-		WillReturnRows(rows)
+func TestGet_MissReturnsErrNoToken(t *testing.T) {
+	testdb.New(t)
+	if _, err := Get("twitch", "ghost"); !errors.Is(err, ErrNoToken) {
+		t.Fatalf("expected ErrNoToken, got %v", err)
+	}
+}
+
+func TestGetByProvider_MostRecentlyUpdatedWins(t *testing.T) {
+	db := testdb.New(t)
+
+	older := sampleToken()
+	older.Provider, older.Username = "youtube", "UC-old"
+	older.TwitchUserID = sql.NullString{}
+	newer := older
+	newer.Username, newer.AccessToken = "UC-new", "yt-access"
+	for _, tok := range []Token{older, newer} {
+		if err := Upsert(tok); err != nil {
+			t.Fatalf("Upsert(%s): %v", tok.Username, err)
+		}
+	}
+	// Upsert stamps date_updated with NOW(), which is transaction-stable —
+	// both rows tie. Backdate one so the ORDER BY has something to order.
+	if err := db.Exec(`UPDATE oauth_tokens SET date_updated = date_updated - interval '1 hour' WHERE username = 'UC-old'`).Error; err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
 
 	got, err := GetByProvider("youtube")
 	if err != nil {
 		t.Fatalf("GetByProvider: %v", err)
 	}
-	if got.Username != "UC123" || got.AccessToken != "yt-access" {
-		t.Errorf("unexpected token: %+v", got)
+	if got.Username != "UC-new" || got.AccessToken != "yt-access" {
+		t.Errorf("expected most recently updated row, got %+v", got)
 	}
 	if got.TwitchUserID.Valid {
 		t.Errorf("twitch_user_id should scan as NULL for youtube rows: %+v", got.TwitchUserID)
@@ -81,169 +91,118 @@ func TestGetByProvider_Hit(t *testing.T) {
 }
 
 func TestGetByProvider_MissReturnsErrNoToken(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectQuery(`SELECT \* FROM "oauth_tokens" WHERE provider = \$1 ORDER BY date_updated DESC`).
-		WithArgs("youtube", 1).
-		WillReturnRows(sqlmock.NewRows(tokenColumns()))
-
+	testdb.New(t)
 	if _, err := GetByProvider("youtube"); !errors.Is(err, ErrNoToken) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
 	}
 }
 
-func TestGet_Hit(t *testing.T) {
-	mock := installMockDB(t)
-	rows := sqlmock.NewRows(tokenColumns()).AddRow(
-		1, "twitch", "tripbot4000", "12345", "access-abc", "refresh-xyz",
-		time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
-		"chat:read chat:edit",
-		0, nil,
-		time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
-		time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
-	)
-	mock.ExpectQuery(`SELECT \* FROM "oauth_tokens" WHERE provider = \$1 AND username = \$2`).
-		WithArgs("twitch", "tripbot4000", 1).
-		WillReturnRows(rows)
+func TestUpsert_OnConflictUpdatesInPlace(t *testing.T) {
+	testdb.New(t)
+	if err := Upsert(sampleToken()); err != nil {
+		t.Fatalf("first Upsert: %v", err)
+	}
+	first, err := Get("twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// Dirty the row so the conflict path's reset is observable.
+	if err := IncrementFailCount("twitch", "tripbot4000"); err != nil {
+		t.Fatalf("IncrementFailCount: %v", err)
+	}
 
+	rotated := sampleToken()
+	rotated.AccessToken = "access-2"
+	rotated.RefreshToken = "refresh-2"
+	rotated.ExpiresAt = rotated.ExpiresAt.Add(time.Hour)
+	rotated.Scopes = "chat:read"
+	if err := Upsert(rotated); err != nil {
+		t.Fatalf("conflicting Upsert: %v", err)
+	}
+
+	got, err := Get("twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("Get after upsert: %v", err)
+	}
+	if got.ID != first.ID {
+		t.Errorf("expected in-place update of row %d, got row %d", first.ID, got.ID)
+	}
+	if got.AccessToken != "access-2" || got.RefreshToken != "refresh-2" || got.Scopes != "chat:read" {
+		t.Errorf("row not updated: %+v", got)
+	}
+	if !got.ExpiresAt.Equal(rotated.ExpiresAt) {
+		t.Errorf("expires_at not updated: %v", got.ExpiresAt)
+	}
+	if got.RefreshFailCount != 0 {
+		t.Errorf("expected refresh_fail_count reset to 0, got %d", got.RefreshFailCount)
+	}
+	if !got.DateCreated.Equal(first.DateCreated) {
+		t.Errorf("date_created not preserved: %v vs %v", got.DateCreated, first.DateCreated)
+	}
+}
+
+func TestIncrementFailCount(t *testing.T) {
+	testdb.New(t)
+	if err := Upsert(sampleToken()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := IncrementFailCount("twitch", "tripbot4000"); err != nil {
+			t.Fatalf("IncrementFailCount: %v", err)
+		}
+	}
 	got, err := Get("twitch", "tripbot4000")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Username != "tripbot4000" || got.AccessToken != "access-abc" || got.RefreshToken != "refresh-xyz" {
-		t.Errorf("unexpected token: %+v", got)
+	if got.RefreshFailCount != 2 {
+		t.Errorf("expected RefreshFailCount=2, got %d", got.RefreshFailCount)
 	}
-	if got.RefreshFailCount != 0 {
-		t.Errorf("expected RefreshFailCount=0, got %d", got.RefreshFailCount)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestGet_Miss(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectQuery(`SELECT \* FROM "oauth_tokens" WHERE provider = \$1 AND username = \$2`).
-		WithArgs("twitch", "ghost", 1).
-		WillReturnRows(sqlmock.NewRows(tokenColumns()))
-
-	_, err := Get("twitch", "ghost")
-	if !errors.Is(err, ErrNoToken) {
-		t.Errorf("expected ErrNoToken, got %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestUpsert_RunsExpectedQuery(t *testing.T) {
-	mock := installMockDB(t)
-	tok := sampleToken()
-
-	mock.ExpectExec(`INSERT INTO oauth_tokens`).
-		WithArgs(
-			tok.Provider, tok.Username, tok.TwitchUserID,
-			tok.AccessToken, tok.RefreshToken, tok.ExpiresAt, tok.Scopes,
-		).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	if err := Upsert(tok); err != nil {
-		t.Fatalf("Upsert: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestUpsert_PropagatesExecError(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectExec(`INSERT INTO oauth_tokens`).
-		WillReturnError(errors.New("boom"))
-
-	if err := Upsert(sampleToken()); err == nil {
-		t.Fatal("expected error from Upsert, got nil")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestIncrementFailCount_UpdatesRow(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectExec(`UPDATE oauth_tokens`).
-		WithArgs("twitch", "tripbot4000").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	if err := IncrementFailCount("twitch", "tripbot4000"); err != nil {
-		t.Fatalf("IncrementFailCount: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	if !got.LastRefreshAt.Valid {
+		t.Error("expected last_refresh_at stamped")
 	}
 }
 
 func TestIncrementFailCount_NoRowReturnsErrNoToken(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectExec(`UPDATE oauth_tokens`).
-		WithArgs("twitch", "ghost").
-		WillReturnResult(sqlmock.NewResult(0, 0))
-
-	err := IncrementFailCount("twitch", "ghost")
-	if !errors.Is(err, ErrNoToken) {
+	testdb.New(t)
+	if err := IncrementFailCount("twitch", "ghost"); !errors.Is(err, ErrNoToken) {
 		t.Errorf("expected ErrNoToken, got %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
 }
 
-func TestTryRefreshLock_Acquired(t *testing.T) {
-	mock := installMockDB(t)
-	key := lockKey("twitch", "tripbot4000")
-
-	mock.ExpectQuery(`pg_try_advisory_lock`).
-		WithArgs(key).
-		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(true))
-	mock.ExpectExec(`pg_advisory_unlock`).
-		WithArgs(key).
-		WillReturnResult(sqlmock.NewResult(0, 0))
+func TestTryRefreshLock(t *testing.T) {
+	// Shared, not New: advisory locks are session-scoped, and TryRefreshLock
+	// pins pooled connections a transaction-backed gorm.DB can't hand out.
+	// No rows are written.
+	testdb.Shared(t)
 
 	acquired, release, err := TryRefreshLock("twitch", "tripbot4000")
 	if err != nil {
 		t.Fatalf("TryRefreshLock: %v", err)
 	}
-	if !acquired {
-		t.Fatal("expected acquired=true")
+	if !acquired || release == nil {
+		t.Fatalf("expected first acquire to succeed, got acquired=%v release-nil=%v", acquired, release == nil)
 	}
-	if release == nil {
-		t.Fatal("expected non-nil release fn")
+
+	// A second session must see contention while the first holds the lock.
+	contended, contendedRelease, err := TryRefreshLock("twitch", "tripbot4000")
+	if err != nil {
+		t.Fatalf("contended TryRefreshLock: %v", err)
 	}
+	if contended || contendedRelease != nil {
+		t.Fatal("expected contention while lock held")
+	}
+
 	release()
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
-}
 
-func TestTryRefreshLock_Contended(t *testing.T) {
-	mock := installMockDB(t)
-	key := lockKey("twitch", "tripbot4000")
-
-	mock.ExpectQuery(`pg_try_advisory_lock`).
-		WithArgs(key).
-		WillReturnRows(sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(false))
-
-	acquired, release, err := TryRefreshLock("twitch", "tripbot4000")
+	reacquired, release2, err := TryRefreshLock("twitch", "tripbot4000")
 	if err != nil {
-		t.Fatalf("TryRefreshLock: %v", err)
+		t.Fatalf("TryRefreshLock after release: %v", err)
 	}
-	if acquired {
-		t.Fatal("expected acquired=false")
+	if !reacquired {
+		t.Fatal("expected re-acquire after release")
 	}
-	if release != nil {
-		t.Fatal("expected nil release fn on contention")
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
-	}
+	release2()
 }
 
 func TestLockKey_StableAndDistinct(t *testing.T) {


### PR DESCRIPTION
Repo-level DB tests now run against the compose stack's actual postgres + migrations instead of sqlmock string-matching, so drifted GORM tags, broken `ON CONFLICT` clauses, and wrong column names fail in CI instead of prod.

## What's here

- **`infra/docker/docker-compose.testing.yml`**: the `test` service now depends on `migrate` (`service_completed_successfully`), which depends on a healthchecked `db` — `docker compose run test` boots postgres, applies all migrations, then runs `go test`. No Taskfile/workflow command changes needed.
- **`pkg/database/testdb`**: `testdb.New(t)` installs a transaction-scoped `*gorm.DB` as the database singleton and rolls it back in cleanup (per-test isolation); `testdb.Shared(t)` installs the pool-backed connection for session-scoped features (advisory locks) that GORM transactions can't reach.
- **Skip vs fail**: unreachable postgres → `t.Skip`, so `task test:macos` (no docker) stays green. The compose test service sets `TESTDB_REQUIRED=1` so in CI a skip fails loudly instead of silently masking a wiring bug.
- **`pkg/oauthtokens`** is the pilot migration: SQL-regex expectations become real write/read round-trips (the upsert test now actually proves the `ON CONFLICT` stamping/reset behavior; the advisory-lock test proves real cross-session contention).

## Follow-ups

Per-package migrations of the remaining sqlmock repo-level tests (`users`, `scoreboards`, `viewstats`, `rollups`, `video`, `feature`) as separate PRs. `pkg/chatbot` stays on sqlmock deliberately — it tests dispatch logic, not query correctness.

## Verification

- `ENV=testing bin/devenv run --rm test go test ./...` — full suite green, oauthtokens exercising real postgres
- Native no-docker run — DB tests skip, rest pass
