### PR TITLE
feat(chatbot): carry the sender's stable platform user ID on inbound messages

### DIFF
--- a/changelog.d/1109.chatbot.md
+++ b/changelog.d/1109.chatbot.md
@@ -1,0 +1,1 @@
+Inbound chat messages now carry the sender's stable platform user ID (`IncomingMessage.UserID`, from the gateway's new `author_id` field / Twitch IRC tags) so future viewer persistence can key on something rename-proof. Carried, not yet consumed.

--- a/pkg/chatbot/handlers.go
+++ b/pkg/chatbot/handlers.go
@@ -257,7 +257,12 @@ func (a *App) runCommand(ctx context.Context, user *users.User, message string) 
 // so the command path stays platform-agnostic.
 type IncomingMessage struct {
 	User string // sender's platform username (Twitch sends display-case)
-	Text string // the message body, original case
+	// UserID is the sender's platform-native stable user ID (Twitch user ID,
+	// YouTube channel ID, …). User can be a mutable display name on some
+	// platforms, so this is the identity key for any future viewer
+	// persistence or cross-platform linking. Carried, not yet consumed.
+	UserID string
+	Text   string // the message body, original case
 }
 
 // HandleMessage processes one inbound chat message: records it (Loki + the
@@ -314,7 +319,7 @@ func (a *App) HandleWhisper(msg IncomingMessage) {
 // command path never learns about platforms.
 
 func (a *App) onTwitchMessage(msg twitch.PrivateMessage) {
-	a.HandleMessage(context.Background(), IncomingMessage{User: msg.User.Name, Text: msg.Message})
+	a.HandleMessage(context.Background(), IncomingMessage{User: msg.User.Name, UserID: msg.User.ID, Text: msg.Message})
 }
 
 func (a *App) onTwitchJoin(joinMessage twitch.UserJoinMessage) {
@@ -326,5 +331,5 @@ func (a *App) onTwitchPart(partMessage twitch.UserPartMessage) {
 }
 
 func (a *App) onTwitchWhisper(message twitch.WhisperMessage) {
-	a.HandleWhisper(IncomingMessage{User: message.User.Name, Text: message.Message})
+	a.HandleWhisper(IncomingMessage{User: message.User.Name, UserID: message.User.ID, Text: message.Message})
 }

--- a/pkg/chatbot/youtube.go
+++ b/pkg/chatbot/youtube.go
@@ -109,7 +109,7 @@ func (p *gatewayYouTubeChatPoller) Run(ctx context.Context) {
 		}
 		cursor = page.Cursor
 		for _, m := range page.Messages {
-			p.handle(ctx, IncomingMessage{User: m.Author, Text: m.Text})
+			p.handle(ctx, IncomingMessage{User: m.Author, UserID: m.AuthorID, Text: m.Text})
 		}
 		wait := time.Duration(page.PollAfterMS) * time.Millisecond
 		if wait < p.pollFloor {

--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -193,10 +193,14 @@ func (c *Client) Followers(ctx context.Context) (int, error) {
 }
 
 // InboundChatMessage is one inbound live-chat line — viewer messages only (the
-// gateway filters the channel's own echoed sends).
+// gateway filters the channel's own echoed sends). Author is the human-facing
+// name (a mutable display name on some platforms); AuthorID is the
+// platform-native stable user ID — the key viewer persistence and identity
+// linking must use.
 type InboundChatMessage struct {
-	Author string `json:"author"`
-	Text   string `json:"text"`
+	Author   string `json:"author"`
+	AuthorID string `json:"author_id"`
+	Text     string `json:"text"`
 }
 
 // InboundChatPage is one page from GET /v1/chat/inbound. Cursor is opaque: pass


### PR DESCRIPTION
## What

`IncomingMessage` gains `UserID` — the sender's platform-native stable user ID — populated from the Twitch IRC tags on the IRC path and from the gateway wire's new `author_id` field ([platform-gateway#91](https://github.com/adanalife/platform-gateway/pull/91/changes)) on the gateway poller. Carried, not yet consumed.

## Why

`User` is a mutable display name on some platforms (YouTube today; Facebook once [#1088](https://github.com/adanalife/tripbot/pull/1088/changes) lands), so it can't key viewer persistence or cross-platform identity linking — a rename would split a viewer's history. Capturing the stable ID at the seam now means it's present from a viewer's first recorded message when persistence lands.

## Notes

- Zero behavior change; the field is plumbing only.
- The gateway poller hunk will conflict trivially with the platform PRs' rename of the youtube poller into `gateway_chat.go` ([#1087](https://github.com/adanalife/tripbot/pull/1087/changes)/[#1088](https://github.com/adanalife/tripbot/pull/1088/changes)/[#1089](https://github.com/adanalife/tripbot/pull/1089)) — whichever merges second, the resolution is the same one-line `UserID: m.AuthorID` in the moved file. Happy to rebase after they land.