### PR TITLE
ci: deploy only tripbot on release; vlc/onscreens via bump PRs

### DIFF
--- a/.github/workflows/bump-prs.yml
+++ b/.github/workflows/bump-prs.yml
@@ -1,0 +1,196 @@
+name: bump-prs
+
+# Dependabot-style prod version-bump PRs for the stream-sensitive components
+# (vlc, onscreens-server), one per component, so each deploy is its own merge
+# gesture. tripbot deploys with release-please's release PR (it only restarts
+# the chat bot); vlc/onscreens restarts interrupt the stream, so their pins
+# move here instead and the PRs sit until a quiet moment.
+#
+# Bump PRs are deploy gestures, not releases: the `chore(deploy):` title is
+# invisible to release-please's version computation when it squash-merges,
+# and the `skip-changelog` label exempts them from the fragment gate (a pin
+# edit needs no changelog entry).
+#
+# Fired by this repo's release workflow (workflow_dispatch with the released
+# version, once the images exist) or by hand. Each component leg:
+#
+#   - recreates the well-known branch bump/prod-<component> from main with the
+#     one-line cdk8s/versions.yaml pin edit + the re-synthed dist/, and
+#     force-pushes, so there is at most ONE open bump PR per component, always
+#     offering the latest release (update-in-place, like Dependabot);
+#   - opens the PR if missing, refreshes title/body if it exists;
+#   - if prod is already on the dispatched version, closes any stale PR.
+#
+# This repo's cdk8s gate is verify-only, so the bump job re-synths and commits
+# dist/ itself (hence the python/node toolchain below).
+#
+# Everything authenticates as the adanalife-automation GitHub App (token minted
+# per run; credentials fanned out by terraform/platform): GITHUB_TOKEN-created
+# commits/PRs never trigger workflow runs, so the cdk8s synth gate would not run.
+#
+# The awk edit is scoped to the prod-1 block; if another pinned env ever lands
+# in versions.yaml, the edit stays correct (it only touches keys inside prod-1).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'tripbot release version to offer (e.g. 3.16.0; leading v is stripped)'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [vlc, onscreens-server]
+    concurrency:
+      group: bump-prs-${{ matrix.component }}
+    env:
+      COMPONENT: ${{ matrix.component }}
+      BRANCH: bump/prod-${{ matrix.component }}
+    steps:
+      - name: Mint automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve and validate version
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::version '$VERSION' is not bare semver (expected e.g. 3.16.0)"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Read current prod pin
+        run: |
+          CURRENT=$(awk -v comp="$COMPONENT" '
+            /^[^ #]/ { in_prod = ($0 == "prod-1:") }
+            in_prod && $1 == comp":" { gsub(/"/, "", $2); print $2 }
+          ' cdk8s/versions.yaml)
+          if [ -z "$CURRENT" ]; then
+            echo "::error::no prod-1 pin found for $COMPONENT in cdk8s/versions.yaml"
+            exit 1
+          fi
+          echo "CURRENT=$CURRENT" >> "$GITHUB_ENV"
+
+      - name: Close stale PR if prod is already on this version
+        if: env.CURRENT == env.VERSION
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$PR" ]; then
+            gh pr close "$PR" --comment "prod is already on $VERSION — closing." --delete-branch
+          fi
+          echo "prod $COMPONENT already pinned at $VERSION; nothing to offer."
+
+      # --- everything below only runs when a bump is actually needed ---
+      - name: Recreate bump branch with the pin edit
+        if: env.CURRENT != env.VERSION
+        run: |
+          git checkout -B "$BRANCH"
+          awk -v comp="$COMPONENT" -v ver="$VERSION" '
+            /^[^ #]/ { in_prod = ($0 == "prod-1:") }
+            in_prod && $1 == comp":" { sub(/"[^"]*"/, "\"" ver "\"") }
+            { print }
+          ' cdk8s/versions.yaml > /tmp/versions.yaml
+          mv /tmp/versions.yaml cdk8s/versions.yaml
+          if git diff --quiet -- cdk8s/versions.yaml; then
+            echo "::error::pin edit produced no diff for $COMPONENT"
+            exit 1
+          fi
+
+      # Toolchain to re-synth dist/ in the same commit (this repo's cdk8s gate
+      # is verify-only, so the branch must carry the regenerated manifests).
+      - uses: jdx/mise-action@v4
+        if: env.CURRENT != env.VERSION
+        with:
+          working_directory: cdk8s
+
+      - uses: astral-sh/setup-uv@v7
+        if: env.CURRENT != env.VERSION
+
+      - name: Re-synth dist/ for the bumped pin
+        if: env.CURRENT != env.VERSION
+        working-directory: cdk8s
+        run: |
+          uv sync
+          mise exec -- uv run cdk8s import
+          mise exec -- uv run cdk8s synth
+          # cdk8s synth regenerated ALL prod-1 app manifests from main. This
+          # bump deploys ONE component, so freeze every OTHER prod component
+          # back to its own pinned release: without it, a chart/config change
+          # made to a component we're NOT bumping would leak into this PR.
+          # Only the bumped component's manifests change — carrying its image
+          # tag AND any config delta (new env var, mount, arg) since its last
+          # bump, so the deploy is visible as one diff. DISTNAME maps the pin
+          # key to the dist filename stem (onscreens-server -> onscreens;
+          # vlc unchanged).
+          DISTNAME="${COMPONENT%-server}"
+          git ls-files -- 'dist/prod-1-*-twitch.k8s.yaml' 'dist/prod-1-*-youtube.k8s.yaml' \
+            | { grep -v "prod-1-${DISTNAME}-" || true; } \
+            | xargs -r git checkout --
+
+      - name: Commit and push the bump branch
+        if: env.CURRENT != env.VERSION
+        run: |
+          if git diff --quiet -- cdk8s/dist/; then
+            echo "::error::pin edit produced no dist/ change for $COMPONENT (synth drift?)"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add cdk8s/versions.yaml cdk8s/dist/
+          git commit -m "chore(deploy): bump prod $COMPONENT to $VERSION"
+          git push -f origin "$BRANCH"
+
+      - name: Create or refresh the bump PR
+        if: env.CURRENT != env.VERSION
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # chore(deploy) in the title (not just the commit) because the PR
+          # title becomes the squash subject — it must stay conventional for
+          # the pr-title gate and invisible to release-please's next version.
+          TITLE="chore(deploy): bump prod $COMPONENT to $VERSION"
+          case "$COMPONENT" in
+            vlc)
+              IMPACT="⚠️ **Merging restarts vlc-server — the playing video drops briefly on stream.** Pick a quiet moment." ;;
+            *)
+              IMPACT="Restarts the overlay server; overlays blip, the stream itself stays up." ;;
+          esac
+          cat > /tmp/body.md <<EOF
+          Offers prod \`$COMPONENT\`: **$CURRENT → $VERSION**.
+
+          $IMPACT
+
+          - What changed: [v$CURRENT...v$VERSION](https://github.com/adanalife/tripbot/compare/v$CURRENT...v$VERSION) · [release notes](https://github.com/adanalife/tripbot/releases/tag/v$VERSION)
+          - Prod \`$COMPONENT\` autosyncs from \`main\`, so **merging deploys it** — no manual Argo step.
+          - Rollback: \`git revert\` the bump commit (same deploy path as above).
+          - The pin edit + the re-synthed \`dist/\` ride in the same commit on \`$BRANCH\`. The \`dist/\` diff shows the **full deploy** for this version — the image tag **and** any manifest/config change (env var, mount, arg) since the last bump, since prod is frozen to its pinned version between bumps.
+
+          This PR updates in place when newer releases ship (force-push to \`$BRANCH\`).
+          EOF
+          PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$PR" ]; then
+            gh pr edit "$PR" --title "$TITLE" --body-file /tmp/body.md --add-label skip-changelog
+          else
+            gh pr create --base main --head "$BRANCH" --title "$TITLE" --body-file /tmp/body.md --label skip-changelog
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,11 @@ name: release-please
 # the prod pins release-please just bumped) on the release PR branch, so the
 # built changelog + synced dist land atomically with the version bump when the
 # PR squash-merges. The re-synthed prod dist IS the deploy diff: prod-1
-# autosyncs from main, so merging the release PR deploys all three components.
+# autosyncs from main, so merging the release PR deploys tripbot. The
+# stream-sensitive components (vlc, onscreens-server) are NOT deployed here —
+# their pins move via per-component bump PRs (bump-prs.yml, fired by
+# release.yml once the images exist), so their restarts are separate,
+# deliberately-timed merges.
 #
 # Merging the release PR creates the vX.Y.Z tag + GitHub Release; release.yml is
 # then dispatched explicitly at that tag because GITHUB_TOKEN-created tags don't
@@ -86,16 +90,23 @@ jobs:
             uvx towncrier build --yes --config towncrier.toml --version "$VERSION"
           fi
 
-          # release-please bumped the prod pins in cdk8s/versions.yaml; a full
-          # (unfrozen) re-synth regenerates the pinned prod-1 app manifests at
-          # the new version, so the dist diff on this PR shows the complete
-          # deploy — the image tags AND any manifest/config change this release
-          # introduced. (The freeze in `task cdk8s:synth` is for BETWEEN
-          # releases; release time is exactly when prod dist regenerates.)
+          # release-please bumped tripbot's prod pin in cdk8s/versions.yaml; a
+          # full (unfrozen) re-synth regenerates the prod-1 app manifests, so
+          # the dist diff on this PR shows tripbot's complete deploy — the
+          # image tag AND any manifest/config change this release introduced.
+          # (The freeze in `task cdk8s:synth` is for BETWEEN releases; release
+          # time is exactly when tripbot's prod dist regenerates.)
           cd cdk8s
           uv sync
           mise exec -- uv run cdk8s import
           mise exec -- uv run cdk8s synth
+          # Only tripbot's pin moved — vlc/onscreens deploy via their own bump
+          # PRs (bump-prs.yml) — so restore every other prod component to its
+          # committed pinned manifests, which the unfrozen synth above
+          # regenerated from HEAD (same freeze as `task cdk8s:prod:bump`).
+          git ls-files -- 'dist/prod-1-*-twitch.k8s.yaml' 'dist/prod-1-*-youtube.k8s.yaml' \
+            | { grep -v 'prod-1-tripbot-' || true; } \
+            | xargs -r git checkout --
           cd ..
 
           if ! git diff --quiet || [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,21 @@ jobs:
       version: ${{ needs.version.outputs.version }}
       tags: ${{ needs.version.outputs.tags }}
 
+  # Offer the stream-sensitive components as per-component deploy PRs once
+  # their images exist. tripbot deploys with the release PR itself (see
+  # release-please.yml), so it needs no bump PR.
+  bump-prs:
+    needs: [version, vlc, onscreens-server]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch bump-prs with the released version
+        run: gh workflow run bump-prs.yml --repo "$GITHUB_REPOSITORY" --ref main -f version="${{ needs.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   notify:
     needs: [tripbot, vlc, onscreens-server]
     runs-on: ubuntu-latest

--- a/cdk8s/versions.yaml
+++ b/cdk8s/versions.yaml
@@ -8,24 +8,33 @@
 # A pinned env's app manifests are FROZEN to their release version: `task
 # cdk8s:synth` (and the CI gate) discard the HEAD re-synth of prod's app files,
 # so a chart/config change on main does NOT reach prod's committed dist until
-# the next release. The prod pins are bumped by release-please on its standing
-# release PR (the `x-release-please-version` markers anchor the replace), and
-# that PR re-synths cdk8s/dist to match — so the release PR's dist diff shows
-# the image tags AND every config change (env var, mount, arg) the release
-# introduced, as one deploy. (Identity Secrets + one-shot Jobs are not frozen —
-# they re-synth live.)
+# that component's pin moves. The bump is where the pinned manifests
+# regenerate, so a bump's dist diff shows the image tag AND every config
+# change (env var, mount, arg) since the last bump, as one deploy. (Identity
+# Secrets + one-shot Jobs are not frozen — they re-synth live.)
+#
+# How each pin moves:
+#   - tripbot: bumped by release-please on its standing release PR (the
+#     `x-release-please-version` marker anchors the replace) — merging the
+#     release PR deploys it. Chat bot only; safe to restart anytime.
+#   - vlc / onscreens-server: offered as per-component bump PRs by
+#     bump-prs.yml after each release — deploy gestures, merged when the
+#     stream can take the restart.
+#   - obs: built + deployed from the standalone adanalife/obs repo.
 #
 # Hand-edits (e.g. a rollback): change the pin, then `task cdk8s:prod:bump
 # COMPONENT=<name>` regenerates just that component's prod dist — plain
 # `task cdk8s:synth` won't, since it freezes prod.
+#
+# The comment line between pins is load-bearing: git can't auto-merge edits on
+# adjacent lines, so without a separator concurrent bump PRs conflict each
+# other.
 prod-1:
   # restarts the chat bot only; no stream impact
   tripbot: "3.16.0" # x-release-please-version
   # restarting drops the playing video briefly on stream
-  vlc: "3.16.0" # x-release-please-version
+  vlc: "3.16.0"
   # restarting takes the stream down until OBS reconnects — pick a quiet moment
-  # (OBS is built + deployed from the standalone adanalife/obs repo; this pin
-  # is not managed by release-please)
   obs: "3.4.1"
   # overlays blip; the stream itself stays up
-  onscreens-server: "3.16.0" # x-release-please-version
+  onscreens-server: "3.16.0"


### PR DESCRIPTION
Splits the prod deploy so merging the standing release PR only ships `tripbot` (safe to restart anytime); the stream-sensitive components get their own deliberately-timed deploy PRs, like the pre-#1110 bump-PR system.

**How it works now:**
- `cdk8s/versions.yaml`: only the `tripbot` pin keeps its `x-release-please-version` marker, so the release PR bumps (and deploys) tripbot alone. The release-PR re-synth freezes the other prod components back to their committed manifests (same pattern as `task cdk8s:prod:bump`).
- `bump-prs.yml` is back (resurrected from pre-#1110), scoped to `vlc` + `onscreens-server`: one update-in-place PR per component offering the latest release, dispatched by `release.yml` once the images exist. Merge when the stream can take the restart.
- Trunk-based adaptations: `chore(deploy):` titles (invisible to release-please's version computation — no `#none` tag-skip machinery needed) and the `skip-changelog` label instead of a fragment.

Version numbers stay repo-global — all three images are built at every release, so `vlc`/`onscreens-server` pins just lag until their bump PR merges, exactly like the standalone `obs` pin does today.

**First release after this merges:** the standing release PR ([#1111](https://github.com/adanalife/tripbot/pull/1111/changes)) will regenerate against the new marker set on the next push to main; merging it deploys tripbot only, then two bump PRs appear for vlc/onscreens.
