### PR TITLE
test(users): migrate from sqlmock to real-postgres harness

### DIFF
--- a/pkg/users/leaderboard_test.go
+++ b/pkg/users/leaderboard_test.go
@@ -2,66 +2,32 @@ package users
 
 import (
 	"context"
-	"database/sql/driver"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
-	"github.com/adanalife/tripbot/pkg/database"
-	"gorm.io/driver/postgres"
+	"github.com/adanalife/tripbot/pkg/database/testdb"
 	"gorm.io/gorm"
 )
 
-// installMockDB mirrors pkg/chatbot's helper: a sqlmock-backed *gorm.DB
-// installed as the process-wide singleton so fetchLeaderboard routes to it.
-func installMockDB(t *testing.T) sqlmock.Sqlmock {
+// seedUsers inserts users rows through GORM, so the model's column mapping is
+// the same one the code under test reads back through.
+func seedUsers(t *testing.T, db *gorm.DB, users ...User) {
 	t.Helper()
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	for i := range users {
+		if users[i].Platform == "" {
+			users[i].Platform = c.Conf.Platform
+		}
+		if err := db.Create(&users[i]).Error; err != nil {
+			t.Fatalf("seeding user %q: %v", users[i].Username, err)
+		}
 	}
-	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
-		SkipDefaultTransaction: true,
-	})
-	if err != nil {
-		t.Fatalf("gorm.Open: %v", err)
-	}
-	database.SetGormDB(gdb)
-	t.Cleanup(func() {
-		database.SetGormDB(nil)
-		_ = sqlDB.Close()
-	})
-	return mock
 }
 
-func leaderboardRows(rows ...[]driver.Value) *sqlmock.Rows {
-	r := sqlmock.NewRows([]string{"username", "miles", "platform", "is_bot"})
-	for _, row := range rows {
-		r.AddRow(row...)
-	}
-	return r
-}
-
-// TestUpdateLeaderboard_ReadsFromDB pins the platform-scoping contract with
-// strict args: the fetch must filter by this instance's platform and exclude
-// the channel owner (loose regexes have silently absorbed missing platform
-// filters before).
-func TestUpdateLeaderboard_ReadsFromDB(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectQuery(`SELECT \* FROM "users" WHERE platform = \$1 AND miles != 0 AND is_bot = false AND username != \$2 ORDER BY miles DESC LIMIT \$3`).
-		WithArgs(c.Conf.Platform, strings.ToLower(c.Conf.ChannelName), maxLeaderboardSize).
-		WillReturnRows(leaderboardRows(
-			[]driver.Value{"alice", float32(100), "twitch", false},
-			[]driver.Value{"bob", float32(50), "twitch", false},
-		))
-
-	s := New(noopChatterSource{})
-	s.UpdateLeaderboard(context.Background())
-
-	want := [][]string{{"alice", "100.0"}, {"bob", "50.0"}}
-	got := s.LifetimeLeaderboard()
+// assertBoard compares a leaderboard against the expected [username, miles] pairs.
+func assertBoard(t *testing.T, got [][]string, want [][]string) {
+	t.Helper()
 	if len(got) != len(want) {
 		t.Fatalf("expected %d entries, got %d: %v", len(want), len(got), got)
 	}
@@ -70,21 +36,57 @@ func TestUpdateLeaderboard_ReadsFromDB(t *testing.T) {
 			t.Fatalf("row %d: got %v, want %v", i, got[i], want[i])
 		}
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unmet sqlmock expectations: %v", err)
-	}
+}
+
+// The fetch must rank by stored miles, scoped to this instance's platform, and
+// exclude bots, the channel owner, and users with no miles.
+func TestUpdateLeaderboard_ReadsFromDB(t *testing.T) {
+	db := testdb.New(t)
+	seedUsers(t, db,
+		User{Username: "alice", Miles: 100},
+		User{Username: "bob", Miles: 50},
+		User{Username: "carol", Miles: 75},
+		User{Username: "botty", Miles: 200, IsBot: true},
+		User{Username: strings.ToLower(c.Conf.ChannelName), Miles: 300},
+		User{Username: "zed", Miles: 0},
+		User{Username: "elsewhere", Miles: 500, Platform: "youtube"},
+	)
+
+	s := New(noopChatterSource{})
+	s.UpdateLeaderboard(context.Background())
+
+	assertBoard(t, s.LifetimeLeaderboard(), [][]string{
+		{"alice", "100.0"},
+		{"carol", "75.0"},
+		{"bob", "50.0"},
+	})
+}
+
+// InitLeaderboard hydrates the same board at boot.
+func TestInitLeaderboard_ReadsFromDB(t *testing.T) {
+	db := testdb.New(t)
+	seedUsers(t, db,
+		User{Username: "alice", Miles: 10},
+		User{Username: "bob", Miles: 20},
+	)
+
+	s := New(noopChatterSource{})
+	s.InitLeaderboard(context.Background())
+
+	assertBoard(t, s.LifetimeLeaderboard(), [][]string{
+		{"bob", "20.0"},
+		{"alice", "10.0"},
+	})
 }
 
 // A logged-in user's in-progress session miles overlay their stored miles and
 // can reorder the board between logouts.
 func TestUpdateLeaderboard_OverlaysLiveSessionMiles(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectQuery(`SELECT \* FROM "users"`).
-		WithArgs(c.Conf.Platform, strings.ToLower(c.Conf.ChannelName), maxLeaderboardSize).
-		WillReturnRows(leaderboardRows(
-			[]driver.Value{"alice", float32(100), "twitch", false},
-			[]driver.Value{"bob", float32(99), "twitch", false},
-		))
+	db := testdb.New(t)
+	seedUsers(t, db,
+		User{Username: "alice", Miles: 100},
+		User{Username: "bob", Miles: 99},
+	)
 
 	s := New(noopChatterSource{})
 	// bob has been logged in for ~10 hours: 0.1mi/3min = ~20 miles in
@@ -96,23 +98,20 @@ func TestUpdateLeaderboard_OverlaysLiveSessionMiles(t *testing.T) {
 	if len(got) != 2 || got[0][0] != "bob" {
 		t.Fatalf("expected bob first after live-miles overlay, got %v", got)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unmet sqlmock expectations: %v", err)
-	}
 }
 
 // A failed fetch must leave the previous board in place rather than blanking
 // what the rotators display.
 func TestUpdateLeaderboard_KeepsCacheOnError(t *testing.T) {
-	mock := installMockDB(t)
-	mock.ExpectQuery(`SELECT \* FROM "users"`).
-		WillReturnError(context.DeadlineExceeded)
+	testdb.New(t)
 
 	s := New(noopChatterSource{})
 	s.lifetimeLeaderboard = [][]string{{"alice", "100.0"}}
-	s.UpdateLeaderboard(context.Background())
 
-	if len(s.LifetimeLeaderboard()) != 1 {
-		t.Fatalf("expected cache preserved on error, got %v", s.LifetimeLeaderboard())
-	}
+	// A cancelled context is the cheapest real query failure.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.UpdateLeaderboard(ctx)
+
+	assertBoard(t, s.LifetimeLeaderboard(), [][]string{{"alice", "100.0"}})
 }

--- a/pkg/users/session_test.go
+++ b/pkg/users/session_test.go
@@ -2,10 +2,12 @@ package users
 
 import (
 	"context"
-	"database/sql/driver"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/adanalife/tripbot/pkg/database/testdb"
+	"github.com/adanalife/tripbot/pkg/events"
 )
 
 // TestSessions_ConcurrentAccess hammers the session map and the leaderboard
@@ -16,11 +18,8 @@ import (
 func TestSessions_ConcurrentAccess(t *testing.T) {
 	const iterations = 50
 
-	mock := installMockDB(t)
-	for range iterations {
-		mock.ExpectQuery(`SELECT \* FROM "users"`).
-			WillReturnRows(leaderboardRows([]driver.Value{"alice", float32(100), "twitch", false}))
-	}
+	db := testdb.New(t)
+	seedUsers(t, db, User{Username: "alice", Miles: 100})
 
 	s := New(noopChatterSource{})
 	s.loggedIn["alice"] = &User{Username: "alice", Miles: 100, LoggedIn: time.Now()}
@@ -44,4 +43,159 @@ func TestSessions_ConcurrentAccess(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// A login creates the DB row, counts the visit, and records a login event
+// carrying the session ID that the eventual logout pairs with.
+func TestLoginIfNecessary_PersistsVisitAndEvent(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	s := New(noopChatterSource{})
+	user := s.LoginIfNecessary(ctx, "arrival")
+	if user.ID == 0 {
+		t.Fatal("expected a persisted user")
+	}
+
+	stored, err := Find(ctx, "arrival")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	// create() opens with one visit; login() counts this one on top.
+	if stored.NumVisits != 2 {
+		t.Errorf("expected NumVisits=2 after login, got %d", stored.NumVisits)
+	}
+
+	var loginEvents []events.Event
+	if err := db.Where("username = ? AND event = ?", "arrival", "login").Find(&loginEvents).Error; err != nil {
+		t.Fatalf("reading events: %v", err)
+	}
+	if len(loginEvents) != 1 {
+		t.Fatalf("expected 1 login event, got %d", len(loginEvents))
+	}
+	if loginEvents[0].SessionID != user.sessionID {
+		t.Errorf("login event session_id %v does not match the session's %v",
+			loginEvents[0].SessionID, user.sessionID)
+	}
+
+	// An already-logged-in user is not logged in twice.
+	if again := s.LoginIfNecessary(ctx, "arrival"); again.sessionID != user.sessionID {
+		t.Error("expected the existing session to be reused")
+	}
+	if s.LoggedInCount() != 1 {
+		t.Errorf("expected 1 logged-in user, got %d", s.LoggedInCount())
+	}
+}
+
+// Logging out banks the session's miles to the users row, drops the user from
+// the session, and closes the pairing with a logout event.
+func TestLogoutIfNecessary_BanksMilesAndClosesSession(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	s := New(noopChatterSource{})
+	user := s.LoginIfNecessary(ctx, "departure")
+	// Backdate the login so the session banks a non-zero mileage:
+	// 0.1mi/3min means ~20 miles for ten hours in chat.
+	s.mu.Lock()
+	s.loggedIn["departure"].LoggedIn = time.Now().Add(-10 * time.Hour)
+	s.mu.Unlock()
+
+	s.LogoutIfNecessary(ctx, "departure")
+
+	if s.LoggedInCount() != 0 {
+		t.Errorf("expected an empty session after logout, got %d", s.LoggedInCount())
+	}
+	stored, err := Find(ctx, "departure")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if stored.Miles < 15 || stored.Miles > 25 {
+		t.Errorf("expected ~20 session miles banked, got %v", stored.Miles)
+	}
+
+	var logoutEvents []events.Event
+	if err := db.Where("username = ? AND event = ?", "departure", "logout").Find(&logoutEvents).Error; err != nil {
+		t.Fatalf("reading events: %v", err)
+	}
+	if len(logoutEvents) != 1 {
+		t.Fatalf("expected 1 logout event, got %d", len(logoutEvents))
+	}
+	if logoutEvents[0].SessionID != user.sessionID {
+		t.Errorf("logout event does not pair with the login session ID")
+	}
+	// No sub-grants and not a subscriber, so the bonus column stays NULL.
+	if logoutEvents[0].ExtraMilesEarned != nil {
+		t.Errorf("expected extra_miles_earned NULL, got %v", *logoutEvents[0].ExtraMilesEarned)
+	}
+}
+
+// Community sub-grants are unreconstructable from the login/logout pairing, so
+// logout records them on the event as extra_miles_earned.
+func TestLogout_RecordsGiftedMilesAsExtra(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	s := New(noopChatterSource{})
+	s.LoginIfNecessary(ctx, "gifted")
+	s.GiveEveryoneMiles(5)
+	s.LogoutIfNecessary(ctx, "gifted")
+
+	var logoutEvents []events.Event
+	if err := db.Where("username = ? AND event = ?", "gifted", "logout").Find(&logoutEvents).Error; err != nil {
+		t.Fatalf("reading events: %v", err)
+	}
+	if len(logoutEvents) != 1 {
+		t.Fatalf("expected 1 logout event, got %d", len(logoutEvents))
+	}
+	if logoutEvents[0].ExtraMilesEarned == nil || *logoutEvents[0].ExtraMilesEarned != 5 {
+		t.Errorf("expected extra_miles_earned=5, got %v", logoutEvents[0].ExtraMilesEarned)
+	}
+}
+
+// CorrectMiles applies a manual delta and persists it, whether or not the user
+// is currently in chat.
+func TestCorrectMiles(t *testing.T) {
+	t.Run("logged-out user is corrected in the DB", func(t *testing.T) {
+		db := testdb.New(t)
+		ctx := context.Background()
+		seedUsers(t, db, User{Username: "offline", Miles: 10})
+
+		s := New(noopChatterSource{})
+		if got := s.CorrectMiles(ctx, "offline", -4); got != 6 {
+			t.Errorf("expected 6 miles returned, got %v", got)
+		}
+
+		stored, err := Find(ctx, "offline")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if stored.Miles != 6 {
+			t.Errorf("expected 6 miles persisted, got %v", stored.Miles)
+		}
+	})
+
+	t.Run("logged-in user's live copy is corrected too", func(t *testing.T) {
+		testdb.New(t)
+		ctx := context.Background()
+
+		s := New(noopChatterSource{})
+		s.LoginIfNecessary(ctx, "online")
+		s.CorrectMiles(ctx, "online", 12)
+
+		live, ok := s.get("online")
+		if !ok {
+			t.Fatal("expected the user to still be logged in")
+		}
+		if live.Miles != 12 {
+			t.Errorf("expected the live copy corrected, got %v", live.Miles)
+		}
+		stored, err := Find(ctx, "online")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if stored.Miles != 12 {
+			t.Errorf("expected 12 miles persisted, got %v", stored.Miles)
+		}
+	})
 }

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	c "github.com/adanalife/tripbot/pkg/config/tripbot"
+	"github.com/adanalife/tripbot/pkg/database/testdb"
 	"gorm.io/gorm"
 )
 
@@ -16,28 +16,169 @@ import (
 // DB error looking like "new user" is how duplicate rows get created).
 func TestFind_NotFoundVsDBError(t *testing.T) {
 	t.Run("missing user surfaces gorm.ErrRecordNotFound", func(t *testing.T) {
-		mock := installMockDB(t)
-		mock.ExpectQuery(`SELECT \* FROM "users"`).
-			WithArgs(c.Conf.Platform, "ghost", 1).
-			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		testdb.New(t)
 
-		_, err := Find(context.Background(), "ghost")
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
+		if _, err := Find(context.Background(), "ghost"); !errors.Is(err, gorm.ErrRecordNotFound) {
 			t.Fatalf("want gorm.ErrRecordNotFound, got %v", err)
 		}
 	})
 
 	t.Run("DB failure propagates as itself, not as not-found", func(t *testing.T) {
-		mock := installMockDB(t)
-		dbErr := errors.New("connection refused")
-		mock.ExpectQuery(`SELECT \* FROM "users"`).WillReturnError(dbErr)
+		db := testdb.New(t)
+		seedUsers(t, db, User{Username: "somebody", Miles: 1})
 
-		_, err := Find(context.Background(), "somebody")
-		if !errors.Is(err, dbErr) {
-			t.Fatalf("want underlying DB error, got %v", err)
+		// A cancelled context is the cheapest real query failure: the row is
+		// there, so a not-found return would mean the error got swallowed.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := Find(ctx, "somebody")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want the underlying DB error, got %v", err)
 		}
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			t.Fatal("DB failure must not look like not-found")
+		}
+	})
+}
+
+// Viewer identity is per-platform: a YouTube "ghost" is a different person from
+// a Twitch "ghost", so Find must not cross the platform boundary.
+func TestFind_IsPlatformScoped(t *testing.T) {
+	db := testdb.New(t)
+	seedUsers(t, db, User{Username: "ghost", Miles: 5, Platform: "youtube"})
+
+	if _, err := Find(context.Background(), "ghost"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("want gorm.ErrRecordNotFound for another platform's user, got %v", err)
+	}
+}
+
+// A brand-new user round-trips through the DB with a real ID, this instance's
+// platform, one visit, and stamped timestamps — the autoCreateTime tags are
+// what keep first_seen/date_created off the 0001-01-01 zero value (#499).
+func TestFindOrCreate_CreatesRow(t *testing.T) {
+	testdb.New(t)
+	ctx := context.Background()
+
+	user := FindOrCreate(ctx, "newbie")
+	if user.ID == 0 {
+		t.Fatal("expected a persisted user with a real ID")
+	}
+	if user.Username != "newbie" || user.Platform != c.Conf.Platform {
+		t.Errorf("unexpected identity: %+v", user)
+	}
+	if user.NumVisits != 1 {
+		t.Errorf("expected NumVisits=1 on create, got %d", user.NumVisits)
+	}
+	if user.Miles != 0 || user.IsBot || user.HasDonated {
+		t.Errorf("expected zeroed defaults, got %+v", user)
+	}
+	for name, ts := range map[string]time.Time{
+		"first_seen":   user.FirstSeen,
+		"last_seen":    user.LastSeen,
+		"date_created": user.DateCreated,
+	} {
+		if ts.Year() < 2000 {
+			t.Errorf("%s not stamped on insert: %v", name, ts)
+		}
+	}
+}
+
+// A second FindOrCreate returns the existing row rather than inserting a
+// duplicate.
+func TestFindOrCreate_FindsExistingRow(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	first := FindOrCreate(ctx, "repeat")
+	second := FindOrCreate(ctx, "repeat")
+	if second.ID != first.ID {
+		t.Fatalf("expected the same row, got %d then %d", first.ID, second.ID)
+	}
+
+	var count int64
+	if err := db.Model(&User{}).Where("username = ?", "repeat").Count(&count).Error; err != nil {
+		t.Fatalf("counting users: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 row for repeat, got %d", count)
+	}
+}
+
+// save() writes the mutable columns back — the update map names them by hand,
+// so a drifted column name only surfaces against a real schema.
+func TestSave_PersistsMutableColumns(t *testing.T) {
+	testdb.New(t)
+	ctx := context.Background()
+
+	user := FindOrCreate(ctx, "saver")
+	lastSeen := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	user.Miles = 42.5
+	user.NumVisits = 7
+	user.IsBot = true
+	user.LastSeen = lastSeen
+	user.save(ctx)
+
+	got, err := Find(ctx, "saver")
+	if err != nil {
+		t.Fatalf("Find after save: %v", err)
+	}
+	if got.Miles != 42.5 || got.NumVisits != 7 || !got.IsBot {
+		t.Errorf("columns not persisted: %+v", got)
+	}
+	if !got.LastSeen.Equal(lastSeen) {
+		t.Errorf("last_seen round-trip: want %v, got %v", lastSeen, got.LastSeen)
+	}
+}
+
+// A zero ID means no DB row was ever found or created; saving would emit an
+// UPDATE with no WHERE clause, so it must be refused outright.
+func TestSave_ZeroIDWritesNothing(t *testing.T) {
+	db := testdb.New(t)
+
+	User{Username: "phantom", Miles: 99}.save(context.Background())
+
+	var count int64
+	if err := db.Model(&User{}).Where("username = ?", "phantom").Count(&count).Error; err != nil {
+		t.Fatalf("counting users: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no row written for an ID-less user, got %d", count)
+	}
+}
+
+func TestSetBot(t *testing.T) {
+	t.Run("flips is_bot in the DB and in the live session", func(t *testing.T) {
+		testdb.New(t)
+		ctx := context.Background()
+
+		s := New(noopChatterSource{})
+		user := FindOrCreate(ctx, "maybebot")
+		s.loggedIn["maybebot"] = &user
+
+		if err := s.SetBot(ctx, "maybebot", true); err != nil {
+			t.Fatalf("SetBot: %v", err)
+		}
+
+		got, err := Find(ctx, "maybebot")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if !got.IsBot {
+			t.Error("expected is_bot persisted as true")
+		}
+		if live, ok := s.get("maybebot"); !ok || !live.IsBot {
+			t.Errorf("expected the live session copy flipped too, got %+v", live)
+		}
+	})
+
+	t.Run("unknown user returns not-found", func(t *testing.T) {
+		testdb.New(t)
+
+		s := New(noopChatterSource{})
+		err := s.SetBot(context.Background(), "ghost", true)
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("want gorm.ErrRecordNotFound, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Replace the shared sqlmock `installMockDB` helper and SQL-regex expectations across `pkg/users`' three test files (`leaderboard_test.go`, `users_test.go`, `session_test.go`) with the real-postgres `testdb` harness (landed in #1108).
- Whole-package migration because the helper is shared. Preserves the intent of the recently-merged tests (`Find` returning an error instead of a zero-ID sentinel, mutex-guarded `Sessions` state); the leaderboard ORDER BY now runs against real rows.

Follows #1108. `pkg/chatbot` stays on sqlmock, so `go-sqlmock` remains in `go.mod`.

## Test plan
- [x] `ENV=testing bin/devenv run --rm test go test -count=1 -race ./pkg/users/...` — green against real postgres
- [ ] CI green