### PR TITLE
test(video): migrate from sqlmock to real-postgres harness

### DIFF
--- a/pkg/video/db_test.go
+++ b/pkg/video/db_test.go
@@ -2,75 +2,192 @@ package video
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/adanalife/tripbot/pkg/database/testdb"
 )
 
-// expectVideoCount queues the playlist-length COUNT that bounds Next()'s walk.
-func expectVideoCount(mock sqlmock.Sqlmock, count int64) {
-	mock.ExpectQuery(`SELECT count\(\*\) FROM "videos"`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+// link writes from.next_vid = to.ID through the production helper, so the
+// chains these tests walk are built the same way the corpus importer builds
+// the real one.
+func link(t *testing.T, from, to Video) {
+	t.Helper()
+	if err := from.SetNextVid(context.Background(), to); err != nil {
+		t.Fatalf("SetNextVid(%d -> %d): %v", from.ID, to.ID, err)
+	}
 }
 
-// expectLoadByIdHit queues a successful loadById() returning the given
-// id/flagged/next_vid row.
-func expectLoadByIdHit(mock sqlmock.Sqlmock, id int64, flagged bool, nextVid int64) {
-	mock.ExpectQuery(`SELECT \* FROM "videos" WHERE "videos"\."id" = `).
-		WithArgs(id, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "flagged", "next_vid"}).
-			AddRow(id, flagged, nextVid))
+// reload re-reads a video by ID. SetNextVid updates the row, not the caller's
+// struct, so a walk must start from the persisted state.
+func reload(t *testing.T, id int) Video {
+	t.Helper()
+	vid, err := loadById(context.Background(), int64(id))
+	if err != nil {
+		t.Fatalf("loadById(%d): %v", id, err)
+	}
+	return vid
 }
 
 func TestVideoNext_ReturnsFirstUnflagged(t *testing.T) {
-	mock := installMockDB(t)
-	expectVideoCount(mock, 3)
-	expectLoadByIdHit(mock, 2, true, 3)  // flagged, keep walking
-	expectLoadByIdHit(mock, 3, false, 4) // unflagged, done
+	db := testdb.New(t)
 
-	v := Video{NextVid: sql.NullInt64{Int64: 2, Valid: true}}
-	got, err := v.Next(context.Background())
+	start := insertVideo(t, db, Video{Slug: "2018_0514_224801_001"})
+	flagged := insertVideo(t, db, Video{Slug: "2018_0514_224801_002", Flagged: true})
+	want := insertVideo(t, db, Video{Slug: "2018_0514_224801_003", State: "Oregon", Lat: 45.5, Lng: -122.6})
+
+	// start -> flagged (skipped) -> want (returned)
+	link(t, start, flagged)
+	link(t, flagged, want)
+
+	got, err := reload(t, start.ID).Next(context.Background())
 	if err != nil {
 		t.Fatalf("Next() error = %v, want nil", err)
 	}
-	if got.ID != 3 || got.Flagged {
-		t.Errorf("Next() = id %d flagged %v, want id 3 unflagged", got.ID, got.Flagged)
+	if got.ID != want.ID {
+		t.Errorf("Next() = id %d (slug %q), want id %d (slug %q)", got.ID, got.Slug, want.ID, want.Slug)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	if got.Flagged {
+		t.Error("Next() returned a flagged video")
+	}
+	// The whole row round-trips, so a drifted column tag fails here.
+	if got.Slug != want.Slug || got.State != "Oregon" || got.Lat != 45.5 || got.Lng != -122.6 {
+		t.Errorf("Next() row = %+v, want the persisted %+v", got, want)
 	}
 }
 
 func TestVideoNext_BrokenChainReturnsError(t *testing.T) {
-	mock := installMockDB(t)
-	expectVideoCount(mock, 3)
-	// loadById miss: next_vid points at a row that doesn't exist
-	mock.ExpectQuery(`SELECT \* FROM "videos" WHERE "videos"\."id" = `).
-		WithArgs(int64(42), 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	db := testdb.New(t)
 
-	v := Video{NextVid: sql.NullInt64{Int64: 42, Valid: true}}
-	if _, err := v.Next(context.Background()); err == nil {
-		t.Fatal("Next() with broken next_vid chain returned nil error, want error")
+	start := insertVideo(t, db, Video{Slug: "2018_0514_224801_010"})
+	// Dangle next_vid off the end of the table: videos.next_vid carries no FK,
+	// so a real corpus can (and does) hold links to rows that aren't there.
+	missingID := start.ID + 10_000
+	if err := db.Exec(`UPDATE videos SET next_vid = ? WHERE id = ?`, missingID, start.ID).Error; err != nil {
+		t.Fatalf("dangle next_vid: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+
+	if _, err := reload(t, start.ID).Next(context.Background()); err == nil {
+		t.Fatal("Next() over a dangling next_vid returned nil error, want error")
 	}
 }
 
 func TestVideoNext_AllFlaggedCycleReturnsError(t *testing.T) {
-	mock := installMockDB(t)
-	// two flagged videos pointing at each other; the walk stops at count=2
-	expectVideoCount(mock, 2)
-	expectLoadByIdHit(mock, 1, true, 2)
-	expectLoadByIdHit(mock, 2, true, 1)
+	db := testdb.New(t)
 
-	v := Video{NextVid: sql.NullInt64{Int64: 1, Valid: true}}
-	if _, err := v.Next(context.Background()); err == nil {
+	// Two flagged videos pointing at each other: a walk that isn't bounded by
+	// the playlist length spins here forever.
+	a := insertVideo(t, db, Video{Slug: "2018_0514_224801_020", Flagged: true})
+	b := insertVideo(t, db, Video{Slug: "2018_0514_224801_021", Flagged: true})
+	link(t, a, b)
+	link(t, b, a)
+
+	if _, err := reload(t, a.ID).Next(context.Background()); err == nil {
 		t.Fatal("Next() over an all-flagged cycle returned nil error, want error")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+}
+
+func TestLoadOrCreate_CreatesThenLoadsSameRow(t *testing.T) {
+	testdb.New(t)
+	ctx := context.Background()
+
+	created, err := LoadOrCreate(ctx, "/footage/2018_0514_224801_030.MP4")
+	if err != nil {
+		t.Fatalf("LoadOrCreate (create path): %v", err)
+	}
+	if created.ID == 0 {
+		t.Fatal("LoadOrCreate returned an unsaved video (ID 0)")
+	}
+	if created.Slug != "2018_0514_224801_030" {
+		t.Errorf("Slug = %q, want %q", created.Slug, "2018_0514_224801_030")
+	}
+	// A runtime-created clip has no GPS fix, so save() flags it and records the
+	// coords as missing (see db.go save()).
+	if !created.Flagged || created.CoordSource != CoordSourceMissing {
+		t.Errorf("created video = flagged %v coord_source %q, want flagged true / %q",
+			created.Flagged, created.CoordSource, CoordSourceMissing)
+	}
+	if created.DateCreated.IsZero() {
+		t.Error("expected date_created stamped on insert")
+	}
+	if !created.DateFilmed.Equal(created.toDate()) {
+		t.Errorf("date_filmed = %v, want the slug's timestamp %v", created.DateFilmed, created.toDate())
+	}
+
+	// Second call hits the load path — same row, no duplicate insert.
+	loaded, err := LoadOrCreate(ctx, "/footage/2018_0514_224801_030.MP4")
+	if err != nil {
+		t.Fatalf("LoadOrCreate (load path): %v", err)
+	}
+	if loaded.ID != created.ID {
+		t.Errorf("second LoadOrCreate made a new row %d, want the existing %d", loaded.ID, created.ID)
+	}
+}
+
+func TestFindRandomByState(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	want := insertVideo(t, db, Video{Slug: "2018_0514_224801_040", State: "Oregon", Lat: 45.5, Lng: -122.6})
+	insertVideo(t, db, Video{Slug: "2018_0514_224801_041", State: "Nevada"})
+
+	// Abbrev and long form both resolve to the stored title-cased state.
+	for _, state := range []string{"OR", "oregon"} {
+		got, err := FindRandomByState(ctx, state)
+		if err != nil {
+			t.Fatalf("FindRandomByState(%q): %v", state, err)
+		}
+		if got.ID != want.ID {
+			t.Errorf("FindRandomByState(%q) = id %d (state %q), want id %d", state, got.ID, got.State, want.ID)
+		}
+	}
+}
+
+func TestCorpusRoute_OrdersByFilmTimeAndExcludesFlaggedAndZeroes(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	// CorpusRoute reads the whole table, so give this test's rows coordinates
+	// nothing else would produce and assert only on those.
+	var (
+		earlyCoord = [2]float64{41.11, -71.11}
+		lateCoord  = [2]float64{42.22, -72.22}
+		flagCoord  = [2]float64{43.33, -73.33}
+	)
+	later := insertVideo(t, db, Video{Slug: "2018_0514_224801_051", Lat: lateCoord[0], Lng: lateCoord[1]})
+	earlier := insertVideo(t, db, Video{Slug: "2018_0514_224801_050", Lat: earlyCoord[0], Lng: earlyCoord[1]})
+	insertVideo(t, db, Video{Slug: "2018_0514_224801_052", Lat: flagCoord[0], Lng: flagCoord[1], Flagged: true})
+	insertVideo(t, db, Video{Slug: "2018_0514_224801_053"}) // 0/0: excluded
+
+	// date_filmed drives the ordering; insert order deliberately doesn't match.
+	backdate := func(v Video, iso string) {
+		if err := db.Exec(`UPDATE videos SET date_filmed = ?::timestamptz WHERE id = ?`, iso, v.ID).Error; err != nil {
+			t.Fatalf("backdate %d: %v", v.ID, err)
+		}
+	}
+	backdate(earlier, "2018-05-14T00:00:00Z")
+	backdate(later, "2018-05-15T00:00:00Z")
+
+	indexOf := func(route [][2]float64, want [2]float64) int {
+		for i, c := range route {
+			if c == want {
+				return i
+			}
+		}
+		return -1
+	}
+
+	route := CorpusRoute(ctx)
+	early, late := indexOf(route, earlyCoord), indexOf(route, lateCoord)
+	if early < 0 || late < 0 {
+		t.Fatalf("CorpusRoute() omitted an unflagged clip: early=%d late=%d in %v", early, late, route)
+	}
+	if early > late {
+		t.Errorf("CorpusRoute() not ordered by date_filmed: earlier clip at %d, later at %d", early, late)
+	}
+	if i := indexOf(route, flagCoord); i >= 0 {
+		t.Errorf("CorpusRoute() included a flagged clip at %d", i)
+	}
+	if i := indexOf(route, [2]float64{0, 0}); i >= 0 {
+		t.Errorf("CorpusRoute() included a 0/0 clip at %d", i)
 	}
 }

--- a/pkg/video/setup_test.go
+++ b/pkg/video/setup_test.go
@@ -8,40 +8,30 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/adanalife/tripbot/pkg/database"
 	vlcClient "github.com/adanalife/tripbot/pkg/vlc-client"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
-// installMockDB stands up a sqlmock-backed *gorm.DB and installs it as the
-// process-wide singleton via database.SetGormDB. db.go's load/create/save
-// helpers (which read from database.GormDB() directly) will route to the mock
-// instead of attempting a real postgres connection.
-//
-// SkipDefaultTransaction stops GORM from wrapping every write in BEGIN/COMMIT,
-// which would otherwise force every test to mock those bookends.
-//
-// Mirrors the pattern from pkg/chatbot/mockdb_test.go.
-func installMockDB(t *testing.T) sqlmock.Sqlmock {
+// insertVideo writes a videos row and returns it with the SERIAL-assigned ID
+// populated, so callers can link chains by real ID.
+func insertVideo(t *testing.T, db *gorm.DB, vid Video) Video {
 	t.Helper()
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	if err := db.Create(&vid).Error; err != nil {
+		t.Fatalf("insert video %q: %v", vid.Slug, err)
 	}
-	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
-		SkipDefaultTransaction: true,
-	})
-	if err != nil {
-		t.Fatalf("gorm.Open: %v", err)
+	return vid
+}
+
+// playCount returns how many video_plays rows point at the given video, so
+// tests can assert on the play the Player actually persisted rather than on a
+// scripted INSERT. Scoped by video_id — the table is shared.
+func playCount(t *testing.T, db *gorm.DB, videoID int) int64 {
+	t.Helper()
+	var n int64
+	if err := db.Raw(`SELECT count(*) FROM video_plays WHERE video_id = ?`, videoID).Scan(&n).Error; err != nil {
+		t.Fatalf("count video_plays for video %d: %v", videoID, err)
 	}
-	database.SetGormDB(gdb)
-	t.Cleanup(func() {
-		database.SetGormDB(nil)
-		_ = sqlDB.Close()
-	})
-	return mock
+	return n
 }
 
 // recordingOnscreens is an interface fake satisfying the Player's onscreens
@@ -79,23 +69,4 @@ func fakeVLCServer(t *testing.T, current *string) *vlcClient.Client {
 	// from the httptest URL before handing it over. nil publisher disables the
 	// NATS mirror — this rig exercises the HTTP path only.
 	return vlcClient.New(strings.TrimPrefix(srv.URL, "http://"), nil, "test")
-}
-
-// expectLoadHit queues a sqlmock expectation for a successful load() — i.e.
-// db.go's `SELECT ... WHERE slug = ?` returning one row with the given
-// id/slug/flagged. State and other columns are left zero.
-func expectLoadHit(mock sqlmock.Sqlmock, id int, slug string, flagged bool) {
-	mock.ExpectQuery(`SELECT \* FROM "videos" WHERE slug = `).
-		WithArgs(slug, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "slug", "flagged"}).
-			AddRow(id, slug, flagged))
-}
-
-// expectPlayInsert queues the video_plays INSERT a clip transition writes
-// (viewstats.RecordPlay). State/lat/lng are zero because expectLoadHit stages
-// only id/slug/flagged.
-func expectPlayInsert(mock sqlmock.Sqlmock, videoID int, flagged bool) {
-	mock.ExpectQuery(`INSERT INTO "video_plays"`).
-		WithArgs(sqlmock.AnyArg(), videoID, "", flagged, 0.0, 0.0, sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 }

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -5,13 +5,14 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/adanalife/tripbot/pkg/database/testdb"
 )
 
-// These tests cover the *Player state-machine introduced in #600. Before the
-// refactor, GetCurrentlyPlaying was a package-level function with package-level
-// state — no way to exercise the transition / GPS-overlay-toggle behaviour
-// without standing up real HTTP + DB. Now the Player is constructable, so we
-// can point it at httptest-backed clients and a sqlmock-backed gorm.DB.
+// These tests cover the *Player state-machine introduced in #600. The Player is
+// constructable, so it can be pointed at an httptest-backed vlc client, a
+// recording onscreens fake, and a real postgres transaction — each transition
+// loads the clip and records its play against the actual schema.
 //
 // Darwin path (figureOutCurrentVideo via lsof script) is not exercised here;
 // the Linux path is what runs in production and what CI tests against. The
@@ -43,69 +44,77 @@ func TestPlayer_Current_ZeroBeforeAnyCall(t *testing.T) {
 
 func TestPlayer_GetCurrentlyPlaying_FirstCall_FlaggedShowsGPS(t *testing.T) {
 	skipIfDarwin(t)
-	mock := installMockDB(t)
+	db := testdb.New(t)
 	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	// DB returns a flagged video for the slug derived from vlcCurrent.
-	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
-	expectPlayInsert(mock, 1, true)
+	// The clip vlc reports is already in the DB, flagged (no GPS fix).
+	vid := insertVideo(t, db, Video{Slug: "2018_0514_224801_013", Flagged: true, CoordSource: CoordSourceMissing})
 
 	p.GetCurrentlyPlaying(context.Background())
 
+	if p.Current().ID != vid.ID {
+		t.Errorf("CurrentlyPlaying.ID = %d, want the persisted %d", p.Current().ID, vid.ID)
+	}
 	if p.Current().Slug != "2018_0514_224801_013" {
 		t.Errorf("CurrentlyPlaying.Slug = %q, want %q", p.Current().Slug, "2018_0514_224801_013")
 	}
 	if !p.Current().Flagged {
-		t.Error("expected CurrentlyPlaying.Flagged = true (staged in mock rows)")
+		t.Error("expected CurrentlyPlaying.Flagged = true (the row is flagged)")
 	}
 	if len(rec.calls) != 1 || rec.calls[0] != "ShowGPSImage" {
 		t.Errorf("expected single ShowGPSImage call, got %v", rec.calls)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	// The transition is durable: a video_plays row lands with the clip's state.
+	if n := playCount(t, db, vid.ID); n != 1 {
+		t.Errorf("video_plays rows for video %d = %d, want 1", vid.ID, n)
+	}
+	var flagged bool
+	if err := db.Raw(`SELECT flagged FROM video_plays WHERE video_id = ?`, vid.ID).Scan(&flagged).Error; err != nil {
+		t.Fatalf("read video_plays.flagged: %v", err)
+	}
+	if !flagged {
+		t.Error("video_plays row recorded flagged = false for a flagged clip")
 	}
 }
 
 func TestPlayer_GetCurrentlyPlaying_FirstCall_NotFlaggedHidesGPS(t *testing.T) {
 	skipIfDarwin(t)
-	mock := installMockDB(t)
+	db := testdb.New(t)
 	rec := &recordingOnscreens{}
 	vlcCurrent := "2019_0615_183000_001.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	expectLoadHit(mock, 7, "2019_0615_183000_001", false)
-	expectPlayInsert(mock, 7, false)
+	vid := insertVideo(t, db, Video{Slug: "2019_0615_183000_001", State: "Oregon", Lat: 45.5, Lng: -122.6})
 
 	p.GetCurrentlyPlaying(context.Background())
 
 	if p.Current().Flagged {
-		t.Error("expected CurrentlyPlaying.Flagged = false (staged in mock rows)")
+		t.Error("expected CurrentlyPlaying.Flagged = false (the row is unflagged)")
+	}
+	if p.Current().State != "Oregon" {
+		t.Errorf("CurrentlyPlaying.State = %q, want %q", p.Current().State, "Oregon")
 	}
 	if len(rec.calls) != 1 || rec.calls[0] != "HideGPSImage" {
 		t.Errorf("expected single HideGPSImage call, got %v", rec.calls)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	if n := playCount(t, db, vid.ID); n != 1 {
+		t.Errorf("video_plays rows for video %d = %d, want 1", vid.ID, n)
 	}
 }
 
 func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 	skipIfDarwin(t)
-	mock := installMockDB(t)
+	db := testdb.New(t)
 	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	// Only one DB hit + play insert expected — the second GetCurrentlyPlaying
-	// call sees curVid == preVid and short-circuits before reaching
-	// LoadOrCreate.
-	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
-	expectPlayInsert(mock, 1, false)
+	vid := insertVideo(t, db, Video{Slug: "2018_0514_224801_013", State: "Nevada", Lat: 39.5, Lng: -119.8})
 
 	p.GetCurrentlyPlaying(context.Background())
 	timeStartedAfterFirst := p.timeStarted
@@ -113,6 +122,8 @@ func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 	// Tiny sleep so a stray timeStarted reset would be observable.
 	time.Sleep(2 * time.Millisecond)
 
+	// Second call sees curVid == preVid and short-circuits before LoadOrCreate,
+	// so no second play is recorded.
 	p.GetCurrentlyPlaying(context.Background())
 
 	if p.timeStarted != timeStartedAfterFirst {
@@ -121,26 +132,22 @@ func TestPlayer_GetCurrentlyPlaying_SameVidIsNoop(t *testing.T) {
 	if len(rec.calls) != 1 {
 		t.Errorf("expected exactly one onscreens call (from first transition), got %d: %v", len(rec.calls), rec.calls)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	if n := playCount(t, db, vid.ID); n != 1 {
+		t.Errorf("video_plays rows for video %d = %d, want 1 (the no-op call recorded a play)", vid.ID, n)
 	}
 }
 
 func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *testing.T) {
 	skipIfDarwin(t)
-	mock := installMockDB(t)
+	db := testdb.New(t)
 	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	// First vid: flagged → ShowGPSImage. Each transition loads the video then
-	// records its play, so the expectations interleave.
-	expectLoadHit(mock, 1, "2018_0514_224801_013", true)
-	expectPlayInsert(mock, 1, true)
-	// Second vid: not flagged → HideGPSImage.
-	expectLoadHit(mock, 2, "2019_0615_183000_001", false)
-	expectPlayInsert(mock, 2, false)
+	// First vid: flagged → ShowGPSImage. Second: unflagged → HideGPSImage.
+	first := insertVideo(t, db, Video{Slug: "2018_0514_224801_013", Flagged: true, CoordSource: CoordSourceMissing})
+	second := insertVideo(t, db, Video{Slug: "2019_0615_183000_001", State: "Oregon", Lat: 45.5, Lng: -122.6})
 
 	p.GetCurrentlyPlaying(context.Background())
 	firstStart := p.timeStarted
@@ -174,21 +181,24 @@ func TestPlayer_GetCurrentlyPlaying_TransitionTogglesGPSAndResetsTimeStarted(t *
 			t.Errorf("overlay call %d: want %q, got %q", i, want, rec.calls[i])
 		}
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Error(err)
+	// Each transition records its own play.
+	if n := playCount(t, db, first.ID); n != 1 {
+		t.Errorf("video_plays rows for the first clip = %d, want 1", n)
+	}
+	if n := playCount(t, db, second.ID); n != 1 {
+		t.Errorf("video_plays rows for the second clip = %d, want 1", n)
 	}
 }
 
 func TestPlayer_CurrentProgress_TracksTimeSinceStart(t *testing.T) {
 	skipIfDarwin(t)
-	mock := installMockDB(t)
+	db := testdb.New(t)
 	rec := &recordingOnscreens{}
 	vlcCurrent := "2018_0514_224801_013.MP4"
 	vlc := fakeVLCServer(t, &vlcCurrent)
 	p := NewPlayer(rec, vlc)
 
-	expectLoadHit(mock, 1, "2018_0514_224801_013", false)
-	expectPlayInsert(mock, 1, false)
+	insertVideo(t, db, Video{Slug: "2018_0514_224801_013", State: "Nevada", Lat: 39.5, Lng: -119.8})
 
 	p.GetCurrentlyPlaying(context.Background())
 	time.Sleep(10 * time.Millisecond)
@@ -204,10 +214,10 @@ func TestPlayer_CurrentProgress_TracksTimeSinceStart(t *testing.T) {
 
 func TestPlayer_GetCurrentlyPlaying_EmptyVlcResult_NoTransition(t *testing.T) {
 	skipIfDarwin(t)
-	// No mockDB needed — when vlc returns "" on the very first call,
-	// curVid stays "" and equals preVid (also ""), so LoadOrCreate is
-	// never invoked. installMockDB-less SetGormDB is left at nil; any
-	// DB hit would NPE and fail the test loudly.
+	// No testdb needed — when vlc returns "" on the very first call, curVid
+	// stays "" and equals preVid (also ""), so LoadOrCreate is never invoked.
+	// The database singleton is left nil; any DB hit would panic and fail the
+	// test loudly.
 	rec := &recordingOnscreens{}
 	vlcCurrent := ""
 	vlc := fakeVLCServer(t, &vlcCurrent)


### PR DESCRIPTION
## Summary
- Replace the shared sqlmock `installMockDB` helper and SQL-regex expectations across `pkg/video`' three test files (`setup_test.go`, `video_test.go`, `db_test.go`) with the real-postgres `testdb` harness (landed in #1108).
- Whole-package migration because the helper is shared. The recently-merged `Video.Next` walk tests now build a real chain of rows with actual `next_vid` links — including a deliberately broken link — instead of scripting driver responses, so a wrong walk-termination condition fails against the real schema.

Follows #1108. `pkg/chatbot` stays on sqlmock, so `go-sqlmock` remains in `go.mod`.

## Test plan
- [x] `ENV=testing bin/devenv run --rm test go test -count=1 ./pkg/video/...` — green against real postgres
- [ ] CI green