### PR TITLE
feat(vlc-server): measure clip-boundary dead-air as a histogram

### DIFF
--- a/changelog.d/1124.vlc.md
+++ b/changelog.d/1124.vlc.md
@@ -1,0 +1,1 @@
+Measure clip-boundary dead-air as a `vlc_player_media_swap_gap_seconds` histogram — armed when a clip ends (or a skip is requested), observed when the next clip reaches Playing, stamped per platform.

--- a/pkg/instrumentation/vlc_server.go
+++ b/pkg/instrumentation/vlc_server.go
@@ -34,6 +34,8 @@ var (
 
 	vlcTimeRemaining = mustFloat64Gauge("vlc_player_time_remaining_seconds", "Seconds remaining in the currently-playing clip (media length minus current playhead position)")
 	vlcProgress      = mustFloat64Gauge("vlc_player_progress_fraction", "Playback progress through the currently-playing clip as a 0..1 fraction")
+	vlcMediaSwapGap  = mustHistogram("vlc_player_media_swap_gap_seconds", "Dead-air at a clip boundary: seconds from the previous Media ending (or a clip change being requested) until the next Media reaches Playing",
+		0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10)
 
 	obsStreamingGauge         = mustGauge("obs_streaming_active", "1 if OBS is actively streaming, 0 otherwise")
 	obsActiveFPS              = mustFloat64Gauge("obs_active_fps", "Current FPS being rendered by OBS")
@@ -92,6 +94,23 @@ func (v VLCPlayerStats) Update(s VLCPlayerStatsSnapshot) {
 	vlcDemuxDiscontinuity.Record(ctx, s.DemuxDiscontinuity, v.platform)
 	vlcTimeRemaining.Record(ctx, s.TimeRemaining, v.platform)
 	vlcProgress.Record(ctx, s.Progress, v.platform)
+}
+
+// VLCSwapGap publishes clip-boundary dead-air observations, stamping every
+// sample with the streaming platform it was constructed with.
+type VLCSwapGap struct {
+	platform metric.MeasurementOption
+}
+
+// NewVLCSwapGap builds a publisher for the given streaming platform
+// (the instance's STREAM_PLATFORM value).
+func NewVLCSwapGap(platform string) VLCSwapGap {
+	return VLCSwapGap{platform: platformAttr(platform)}
+}
+
+// Record publishes one clip-boundary gap observation, in seconds.
+func (g VLCSwapGap) Record(seconds float64) {
+	vlcMediaSwapGap.Record(context.Background(), seconds, g.platform)
 }
 
 // OBSStatsSnapshot bundles OBS performance + stream-output stats so the

--- a/pkg/vlc-server/playback.go
+++ b/pkg/vlc-server/playback.go
@@ -14,10 +14,14 @@ import (
 // TODO: should we handle the case where index is outside range?
 // or just explicitly pass in what we get here?
 func (s *Server) playAtIndex(index int) error {
+	// A requested clip change is a boundary the EndReached event never sees,
+	// so arm the swap-gap tracker here; the next Playing event records it.
+	s.swapGap.arm(time.Now())
 	// start playing the media. The underlying media player is primed with a
 	// media at construction (see primePlayer) so this returns correctly even
 	// when it's the very first play against the freshly-created list player.
 	if err := s.Playlist.PlayAtIndex(uint(index)); err != nil {
+		s.swapGap.disarm()
 		return err
 	}
 	// Every playback path (random / file / skip / back) funnels through here,

--- a/pkg/vlc-server/server.go
+++ b/pkg/vlc-server/server.go
@@ -44,6 +44,8 @@ type Server struct {
 	MediaList  *libvlc.MediaList
 	VideoFiles []string
 
+	swapGap swapGapTracker
+
 	http *http.Server
 }
 

--- a/pkg/vlc-server/swapgap.go
+++ b/pkg/vlc-server/swapgap.go
@@ -1,0 +1,63 @@
+package vlcServer
+
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	c "github.com/adanalife/tripbot/pkg/config/vlc-server"
+	"github.com/adanalife/tripbot/pkg/instrumentation"
+	libvlc "github.com/adrg/libvlc-go/v3"
+)
+
+// swapGapTracker measures the dead-air at a clip boundary: armed when the
+// current Media ends (or a caller requests a different clip), observed when
+// the next Media reaches Playing. libvlc delivers events on its own threads,
+// so the timestamp is an atomic rather than a mutex-guarded field.
+type swapGapTracker struct {
+	armedAtNanos atomic.Int64 // 0 = disarmed
+}
+
+func (t *swapGapTracker) arm(now time.Time) { t.armedAtNanos.Store(now.UnixNano()) }
+
+func (t *swapGapTracker) disarm() { t.armedAtNanos.Store(0) }
+
+// observe returns the seconds since arm and disarms. ok is false when the
+// tracker wasn't armed — e.g. a Playing event with no preceding boundary.
+func (t *swapGapTracker) observe(now time.Time) (seconds float64, ok bool) {
+	armed := t.armedAtNanos.Swap(0)
+	if armed == 0 {
+		return 0, false
+	}
+	return time.Duration(now.UnixNano() - armed).Seconds(), true
+}
+
+// initSwapGapEvents wires the libvlc player events that bracket a clip
+// boundary: EndReached arms the tracker, the next Playing records the gap
+// as vlc_player_media_swap_gap_seconds. Manual clip changes arm in
+// playAtIndex instead, since they never pass through EndReached.
+//
+// Callbacks only touch atomics, OTel, and slog — calling back into libvlc
+// from an event callback can deadlock.
+func (s *Server) initSwapGapEvents() error {
+	em, err := s.Player.EventManager()
+	if err != nil {
+		return fmt.Errorf("fetching player event manager: %w", err)
+	}
+	if _, err := em.Attach(libvlc.MediaPlayerEndReached, func(libvlc.Event, interface{}) {
+		s.swapGap.arm(time.Now())
+	}, nil); err != nil {
+		return fmt.Errorf("attaching EndReached handler: %w", err)
+	}
+	gapMetric := instrumentation.NewVLCSwapGap(c.Conf.Platform)
+	if _, err := em.Attach(libvlc.MediaPlayerPlaying, func(libvlc.Event, interface{}) {
+		if gap, ok := s.swapGap.observe(time.Now()); ok {
+			gapMetric.Record(gap)
+			slog.Debug("media swap gap", "gap_seconds", gap)
+		}
+	}, nil); err != nil {
+		return fmt.Errorf("attaching Playing handler: %w", err)
+	}
+	return nil
+}

--- a/pkg/vlc-server/swapgap_test.go
+++ b/pkg/vlc-server/swapgap_test.go
@@ -1,0 +1,34 @@
+package vlcServer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSwapGapTracker(t *testing.T) {
+	var tr swapGapTracker
+	start := time.Now()
+
+	if _, ok := tr.observe(start); ok {
+		t.Fatal("observe on an unarmed tracker should report ok=false")
+	}
+
+	tr.arm(start)
+	gap, ok := tr.observe(start.Add(250 * time.Millisecond))
+	if !ok {
+		t.Fatal("observe after arm should report ok=true")
+	}
+	if gap < 0.249 || gap > 0.251 {
+		t.Fatalf("gap = %v, want ~0.25", gap)
+	}
+
+	if _, ok := tr.observe(start.Add(time.Second)); ok {
+		t.Fatal("observe should disarm the tracker")
+	}
+
+	tr.arm(start)
+	tr.disarm()
+	if _, ok := tr.observe(start.Add(time.Second)); ok {
+		t.Fatal("disarm should clear the armed state")
+	}
+}

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -105,6 +105,9 @@ func (s *Server) initPlayer() error {
 	if err := s.createPlayer(); err != nil {
 		return err
 	}
+	if err := s.initSwapGapEvents(); err != nil {
+		return err
+	}
 	if err := s.setToLoop(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds `vlc_player_media_swap_gap_seconds` — a per-platform histogram of the dead-air at each clip boundary, measured where it actually happens: inside vlc-server via libvlc player events.

**Mechanism** (`pkg/vlc-server/swapgap.go`): an atomic timestamp tracker is **armed** on `MediaPlayerEndReached` (natural playlist advance) or at the top of `playAtIndex` (skip/back/random/resume — those never pass through EndReached), and **observed + disarmed** on the next `MediaPlayerPlaying`. The gap is recorded through the existing OTel pipeline with the same `service.platform` stamping as the other `vlc_player_*` metrics. Callbacks touch only atomics/OTel/slog — never libvlc — to avoid the documented callback-deadlock trap.

**Why events, not polling:** OBS ingests one continuous RTSP stream (`sout-keep`), so OBS-side media events never fire at clip boundaries, and the 60s metric scrape can't resolve a sub-second seam. libvlc events give millisecond-accurate gaps; the histogram makes them queryable as p50/p99 per platform in Grafana (buckets 50ms–10s).

Notes:
- A boot-time resume records one large sample (process start → first Playing); at ~1 sample per restart vs hundreds of clip swaps a day it doesn't move the percentiles, and boot-to-first-frame is worth seeing anyway.
- Histogram-only measurement: this quantifies the VLC-side gap. The OBS-side decoder-reset flash (obs#15's software-decode flip) is a separate mechanism and isn't captured here — but this metric lets us say definitively how much of the seam is VLC's swap vs OBS's reaction.
- Grafana panels land in adanalife/infra#839.