### PR TITLE
fix(vlc-server): gather sout chain for a continuous stream across clips

### DIFF
--- a/changelog.d/1127.vlc.md
+++ b/changelog.d/1127.vlc.md
@@ -1,0 +1,1 @@
+Stream one continuous elementary stream across clip boundaries (`gather:` in the sout chain) — RTSP clients no longer get EOF + reconnect + mid-GOP garbage at every clip change, which was the visible inter-clip seam.

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -37,14 +37,22 @@ var vlcCmdFlags []string
 // mediaOptions returns the per-Media options driven by VLC_OUTPUT.
 // libvlc's --sout takes effect only when set on the media object itself —
 // passing --sout to libvlc.Init does NOT activate the stream-out chain.
-// `sout-keep` preserves the chain across playlist transitions so OBS
-// doesn't see EOF on every clip change.
+//
+// The chain is `gather:rtp{...}` + `sout-keep`, and both halves are
+// load-bearing for a seamless stream. `sout-keep` alone preserves the sout
+// *instance* across playlist transitions but still ends the RTP stream at
+// every media change, so each RTSP client (OBS) gets EOF every clip, eats
+// its reconnect delay, and rejoins mid-GOP — the visible inter-clip seam.
+// `gather` merges the successive Media into one continuous elementary
+// stream with monotonic timestamps, so clients never see a boundary at
+// all. gather requires the clips to share codec/dimensions/rate, which the
+// transcoded corpus guarantees.
 //
 //	rtsp   — RTSP listener only (container default).
 //	window — no sout; libvlc plays to its native window via --vout.
 //	both   — duplicate to a local display target and the RTSP listener.
 func mediaOptions() []string {
-	const rtspChain = "rtp{sdp=rtsp://:8554/dashcam}"
+	const rtspChain = "gather:rtp{sdp=rtsp://:8554/dashcam}"
 	switch c.Conf.VlcOutput {
 	case "window":
 		return nil


### PR DESCRIPTION
One-line root-cause fix for the visible inter-clip seam: prepend `gather:` to the RTSP sout chain, so successive playlist Media merge into one continuous elementary stream with monotonic timestamps.

**The diagnosis chain** (packet-level probe of the prod RTSP feed, 2026-07-12):
1. The new `vlc_player_media_swap_gap_seconds` histogram ([#1124](https://github.com/adanalife/tripbot/pull/1124)) showed libvlc's player-side swap costs only ~10ms — the seam had to be downstream.
2. OBS logs show an H.264 decode-error burst (`concealing … errors`, `co located POCs unavailable`) timestamp-matched to **every** clip boundary.
3. An in-pod `ffprobe` client on `rtsp://:8554/dashcam` received EOF at exactly the clip boundary — `sout-keep` preserves the sout *instance*, but the RTP stream still terminates per Media. Every client (OBS included) reconnects each clip: ~1s reconnect delay + RTSP handshake + mid-GOP rejoin (2s GOP) ≈ the 1.5–3.5s visible seam. This corrects the 2026-05-20 "sout-keep holds the session" conclusion.

**Verification** (local VLC.app CLI, same sout core, three identical-param 20s test clips):
- Baseline `#rtp{…}`: client EOF at every boundary, exactly one clip per connection (1119 packets/19s, reproduced 3×).
- `#gather:rtp{…}`: 64.5s continuous capture across 3+ boundaries — zero EOF, zero arrival gaps >200ms, zero PTS jumps, zero decode errors.
- `#duplicate{dst=display,dst=gather:rtp{…}}` (the `both` variant): same result, syntax parses.

**Caveat:** `gather` requires successive Media to share codec/dimensions/rate — guaranteed for the transcoded `_opt` corpus. Manual jumps (`!timewarp`) also stop producing EOF; whether the decoder still hiccups on the timestamp-continuous-but-content-discontinuous splice is worth watching on stage.

After deploy, the swap-gap + stutter panels on the [VLC service-health dashboard](https://adanalife.grafana.net/d/vlc-server-service-health) and the boundary-matched decode-error bursts in OBS logs are the before/after evidence.