### PR TITLE
fix(vlc-server): revert gather sout chain that corrupted clip boundaries

### DIFF
--- a/changelog.d/1129.vlc.md
+++ b/changelog.d/1129.vlc.md
@@ -1,0 +1,1 @@
+Revert the `gather` sout chain: it removed the inter-clip seam but traded it for whole-frame block corruption at clip boundaries. Playback returns to the 3.17 baseline (subtle seam) pending a corruption-free fix.

--- a/pkg/vlc-server/vlc.go
+++ b/pkg/vlc-server/vlc.go
@@ -37,22 +37,14 @@ var vlcCmdFlags []string
 // mediaOptions returns the per-Media options driven by VLC_OUTPUT.
 // libvlc's --sout takes effect only when set on the media object itself —
 // passing --sout to libvlc.Init does NOT activate the stream-out chain.
-//
-// The chain is `gather:rtp{...}` + `sout-keep`, and both halves are
-// load-bearing for a seamless stream. `sout-keep` alone preserves the sout
-// *instance* across playlist transitions but still ends the RTP stream at
-// every media change, so each RTSP client (OBS) gets EOF every clip, eats
-// its reconnect delay, and rejoins mid-GOP — the visible inter-clip seam.
-// `gather` merges the successive Media into one continuous elementary
-// stream with monotonic timestamps, so clients never see a boundary at
-// all. gather requires the clips to share codec/dimensions/rate, which the
-// transcoded corpus guarantees.
+// `sout-keep` preserves the chain across playlist transitions so OBS
+// doesn't see EOF on every clip change.
 //
 //	rtsp   — RTSP listener only (container default).
 //	window — no sout; libvlc plays to its native window via --vout.
 //	both   — duplicate to a local display target and the RTSP listener.
 func mediaOptions() []string {
-	const rtspChain = "gather:rtp{sdp=rtsp://:8554/dashcam}"
+	const rtspChain = "rtp{sdp=rtsp://:8554/dashcam}"
 	switch c.Conf.VlcOutput {
 	case "window":
 		return nil


### PR DESCRIPTION
Reverts [#1127](https://github.com/adanalife/tripbot/pull/1127/changes).

The `gather:` sout chain removed the per-clip RTP EOF (and with it the 1.5–3.5s inter-clip reconnect seam), but in prod it traded that subtle seam for **whole-frame block corruption** at clip boundaries.

**Root cause:** `gather` keeps every RTSP client (OBS) on one continuous decoder session with no per-clip reconnect. The corpus is not at fault — the airing `_opt` clips are closed-GOP, keyint=120, IDR-leading (verified with `ffprobe`). But on a continuous decoder the B-frames straddling each splice lose the reference pictures they point at (`co located POCs unavailable`), so OBS reconstructs whole frames against stale references. Confirmed on the live feed: the `co located POCs unavailable` decode-error rate jumped ~10–20× under gather and dropped back to baseline on revert.

Playback returns to the 3.17 baseline (subtle seam, next-frame cover active). A corruption-free path — re-transcode with B-frames disabled, then retry gather on stage — is the follow-up.

New Grafana panels that track this decode-corruption signal: [adanalife/infra#840](https://github.com/adanalife/infra/pull/840/changes).