### PR TITLE
fix(vlc): scope playback command subjects per platform

### DIFF
--- a/changelog.d/1133.vlc.md
+++ b/changelog.d/1133.vlc.md
@@ -1,0 +1,1 @@
+`!find` and the other playback commands are now scoped per streaming platform — a Twitch command no longer seeks the YouTube stream (and vice versa). The NATS command subjects gained a trailing platform leaf (`tripbot.<env>.vlc.<verb>.<platform>`).

--- a/cmd/tripbot/tripbot.go
+++ b/cmd/tripbot/tripbot.go
@@ -168,7 +168,7 @@ func NewTripbot(version string) *Tripbot {
 		srv:     server.New(),
 		player: video.NewPlayer(
 			onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment, c.Conf.Platform),
-			vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment),
+			vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment, c.Conf.Platform),
 		),
 		flagClient: feature.NewInMemoryClient(nil),
 		gateway:    newGatewayClient(),

--- a/pkg/chatbot/chatbot.go
+++ b/pkg/chatbot/chatbot.go
@@ -157,7 +157,7 @@ func New() *App {
 		botless:  c.Conf.Platform == platformYouTube && !c.Conf.YouTubeInboundEnabled,
 		// DB stays nil; commands use a.db() which falls back to database.GormDB().
 		Onscreens:  realOnscreens{c: onscreensClient.New(natsclient.DefaultPublisher(), c.Conf.Environment, c.Conf.Platform)},
-		VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment)},
+		VLC:        realVLC{c: vlcClient.New(c.Conf.VlcServerHost, natsclient.DefaultPublisher(), c.Conf.Environment, c.Conf.Platform)},
 		Video:      realVideo{},
 		Chat:       disconnectedChat{},
 		Sessions:   realSessions{},

--- a/pkg/config/vlc-server/type.go
+++ b/pkg/config/vlc-server/type.go
@@ -7,10 +7,12 @@ type VlcServerConfig struct {
 	// Platform names which streaming platform's stack this instance feeds
 	// ("twitch" / "youtube"). Reads the same STREAM_PLATFORM env key the other
 	// per-platform images use (contract.EnvKeyStreamPlatform), so the cdk8s
-	// factory stamps one platform per instance. It scopes the lastplayed
-	// subject leaf (tripbot.<env>.vlc.lastplayed.<platform>) — every platform
-	// instance shares the env's NATS, so without it the instances would
-	// clobber each other's resume state.
+	// factory stamps one platform per instance. It's the trailing leaf on both
+	// the command subjects (tripbot.<env>.vlc.<verb>.<platform>) and the
+	// lastplayed state leaf (tripbot.<env>.vlc.lastplayed.<platform>) — every
+	// platform instance shares the env's NATS, so without it a Twitch !find
+	// would seek the YouTube stream and the instances would clobber each
+	// other's resume state.
 	Platform string `default:"twitch" envconfig:"STREAM_PLATFORM"`
 
 	// Verbose determines output verbosity

--- a/pkg/video/setup_test.go
+++ b/pkg/video/setup_test.go
@@ -68,5 +68,5 @@ func fakeVLCServer(t *testing.T, current *string) *vlcClient.Client {
 	// vlcClient.New builds the URL as "http://" + host, so strip the scheme
 	// from the httptest URL before handing it over. nil publisher disables the
 	// NATS mirror — this rig exercises the HTTP path only.
-	return vlcClient.New(strings.TrimPrefix(srv.URL, "http://"), nil, "test")
+	return vlcClient.New(strings.TrimPrefix(srv.URL, "http://"), nil, "test", "twitch")
 }

--- a/pkg/vlc-client/nats_test.go
+++ b/pkg/vlc-client/nats_test.go
@@ -50,7 +50,7 @@ func okServer(t *testing.T) string {
 
 func TestPlayRandom_PublishesToNATS(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(commandHost, rec, "stage")
+	c := New(commandHost, rec, "stage", "twitch")
 
 	if err := c.PlayRandom(context.Background()); err != nil {
 		t.Fatalf("PlayRandom: %v", err)
@@ -59,8 +59,8 @@ func TestPlayRandom_PublishesToNATS(t *testing.T) {
 	if len(rec.Publishes) != 1 {
 		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
 	}
-	if rec.Publishes[0].Subject != "tripbot.stage.vlc.play.random" {
-		t.Errorf("subject = %q, want tripbot.stage.vlc.play.random", rec.Publishes[0].Subject)
+	if rec.Publishes[0].Subject != "tripbot.stage.vlc.play.random.twitch" {
+		t.Errorf("subject = %q, want tripbot.stage.vlc.play.random.twitch", rec.Publishes[0].Subject)
 	}
 	var ev ve.Command
 	if err := json.Unmarshal(rec.Publishes[0].Payload, &ev); err != nil {
@@ -73,7 +73,7 @@ func TestPlayRandom_PublishesToNATS(t *testing.T) {
 
 func TestPlayFileInPlaylist_PublishesFile(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(commandHost, rec, "prod")
+	c := New(commandHost, rec, "prod", "twitch")
 
 	if err := c.PlayFileInPlaylist(context.Background(), "clip.mp4"); err != nil {
 		t.Fatalf("PlayFileInPlaylist: %v", err)
@@ -83,8 +83,8 @@ func TestPlayFileInPlaylist_PublishesFile(t *testing.T) {
 		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
 	}
 	pub := rec.Publishes[0]
-	if pub.Subject != "tripbot.prod.vlc.play.file" {
-		t.Errorf("subject = %q, want tripbot.prod.vlc.play.file", pub.Subject)
+	if pub.Subject != "tripbot.prod.vlc.play.file.twitch" {
+		t.Errorf("subject = %q, want tripbot.prod.vlc.play.file.twitch", pub.Subject)
 	}
 	var ev ve.PlayFile
 	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
@@ -97,7 +97,7 @@ func TestPlayFileInPlaylist_PublishesFile(t *testing.T) {
 
 func TestPlayFileAtTimestamp_PublishesFileAndPosition(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(commandHost, rec, "prod")
+	c := New(commandHost, rec, "prod", "twitch")
 
 	if err := c.PlayFileAtTimestamp(context.Background(), "clip.mp4", 163.5); err != nil {
 		t.Fatalf("PlayFileAtTimestamp: %v", err)
@@ -107,8 +107,8 @@ func TestPlayFileAtTimestamp_PublishesFileAndPosition(t *testing.T) {
 		t.Fatalf("expected 1 publish, got %d", len(rec.Publishes))
 	}
 	pub := rec.Publishes[0]
-	if pub.Subject != "tripbot.prod.vlc.play.at" {
-		t.Errorf("subject = %q, want tripbot.prod.vlc.play.at", pub.Subject)
+	if pub.Subject != "tripbot.prod.vlc.play.at.twitch" {
+		t.Errorf("subject = %q, want tripbot.prod.vlc.play.at.twitch", pub.Subject)
 	}
 	var ev ve.PlayFileAt
 	if err := json.Unmarshal(pub.Payload, &ev); err != nil {
@@ -124,7 +124,7 @@ func TestPlayFileAtTimestamp_PublishesFileAndPosition(t *testing.T) {
 
 func TestPlayFileAtTimestamp_NegativeClampsToZero(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(commandHost, rec, "stage")
+	c := New(commandHost, rec, "stage", "twitch")
 
 	if err := c.PlayFileAtTimestamp(context.Background(), "clip.mp4", -5); err != nil {
 		t.Fatalf("PlayFileAtTimestamp: %v", err)
@@ -144,13 +144,13 @@ func TestSkipAndBack_PublishN(t *testing.T) {
 		call    func(c *Client) error
 		subject string
 	}{
-		{"skip", func(c *Client) error { return c.Skip(context.Background(), 3) }, "tripbot.stage.vlc.skip"},
-		{"back", func(c *Client) error { return c.Back(context.Background(), 2) }, "tripbot.stage.vlc.back"},
+		{"skip", func(c *Client) error { return c.Skip(context.Background(), 3) }, "tripbot.stage.vlc.skip.twitch"},
+		{"back", func(c *Client) error { return c.Back(context.Background(), 2) }, "tripbot.stage.vlc.back.twitch"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := &recordingPublisher{}
-			c := New(commandHost, rec, "stage")
+			c := New(commandHost, rec, "stage", "twitch")
 			if err := tc.call(c); err != nil {
 				t.Fatalf("call: %v", err)
 			}
@@ -180,7 +180,7 @@ func TestSkipAndBack_PublishN(t *testing.T) {
 // not a fire-and-forget command and must not hit NATS.
 func TestCurrentlyPlaying_DoesNotPublish(t *testing.T) {
 	rec := &recordingPublisher{}
-	c := New(okServer(t), rec, "stage")
+	c := New(okServer(t), rec, "stage", "twitch")
 	_ = c.CurrentlyPlaying(context.Background())
 	if len(rec.Publishes) != 0 {
 		t.Errorf("expected 0 publishes for CurrentlyPlaying, got %d", len(rec.Publishes))
@@ -192,11 +192,11 @@ func TestTopicReflectsEnv(t *testing.T) {
 	for _, env := range []string{"prod", "development", "test"} {
 		t.Run(env, func(t *testing.T) {
 			rec := &recordingPublisher{}
-			c := New(commandHost, rec, env)
+			c := New(commandHost, rec, env, "twitch")
 			if err := c.Skip(context.Background(), 1); err != nil {
 				t.Fatalf("Skip: %v", err)
 			}
-			want := "tripbot." + env + ".vlc.skip"
+			want := "tripbot." + env + ".vlc.skip.twitch"
 			if rec.Publishes[0].Subject != want {
 				t.Errorf("subject = %q, want %q", rec.Publishes[0].Subject, want)
 			}
@@ -207,7 +207,7 @@ func TestTopicReflectsEnv(t *testing.T) {
 // TestNilPublisher_NoPublishNoPanic asserts a nil publisher disables
 // publishing without panicking.
 func TestNilPublisher_NoPublishNoPanic(t *testing.T) {
-	c := New(commandHost, nil, "test")
+	c := New(commandHost, nil, "test", "twitch")
 	if err := c.Skip(context.Background(), 1); err != nil {
 		t.Fatalf("Skip: %v", err)
 	}

--- a/pkg/vlc-client/vlc-client.go
+++ b/pkg/vlc-client/vlc-client.go
@@ -13,18 +13,24 @@ import (
 )
 
 // Client issues vlc-server playback commands over NATS and reads the
-// currently-playing file over HTTP. Construct via New(host, nats, env).
+// currently-playing file over HTTP. Construct via New(host, nats, env, platform).
 //
 // The four fire-and-forget commands (PlayRandom, PlayFileInPlaylist, Skip,
-// Back) publish to tripbot.<env>.vlc.<verb>; vlc-server's subscriber acts on
-// them. The HTTP command path (the mirror that preceded the peel) is gone.
-// nats may be nil (tests that don't exercise pubsub) — publishes no-op then.
-// CurrentlyPlaying is a read and stays on HTTP, so host is still required.
+// Back) publish to tripbot.<env>.vlc.<verb>.<platform>; vlc-server's subscriber
+// acts on them. The HTTP command path (the mirror that preceded the peel) is
+// gone. nats may be nil (tests that don't exercise pubsub) — publishes no-op
+// then. CurrentlyPlaying is a read and stays on HTTP, so host is still required.
+//
+// platform is the streaming platform this tripbot instance serves ("twitch" /
+// "youtube"); it's the trailing leaf on every command subject so only the
+// matching vlc-<platform> server acts on it — a Twitch-triggered !find never
+// seeks the YouTube stream.
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
 	nats       natsclient.Publisher
 	env        string
+	platform   string
 }
 
 // New returns a Client pointed at the given vlc-server host. The HTTP
@@ -35,12 +41,13 @@ type Client struct {
 // caller's trace. nats + env drive command publishing; pass
 // natsclient.DefaultPublisher() in production, or a nil publisher to disable
 // publishing (tests).
-func New(host string, nats natsclient.Publisher, env string) *Client {
+func New(host string, nats natsclient.Publisher, env, platform string) *Client {
 	return &Client{
 		serverURL:  "http://" + host,
 		httpClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 		nats:       nats,
 		env:        env,
+		platform:   platform,
 	}
 }
 
@@ -70,13 +77,13 @@ func (c *Client) CurrentlyPlaying(ctx context.Context) string {
 
 // PlayRandom plays a random file from the playlist
 func (c *Client) PlayRandom(ctx context.Context) error {
-	c.publish(ctx, ve.PlayRandomSubject(c.env), ve.Command{Envelope: ve.NewEnvelope()})
+	c.publish(ctx, ve.PlayRandomSubject(c.env, c.platform), ve.Command{Envelope: ve.NewEnvelope()})
 	return nil
 }
 
 // PlayFileInPlaylist plays a given file
 func (c *Client) PlayFileInPlaylist(ctx context.Context, filename string) error {
-	c.publish(ctx, ve.PlayFileSubject(c.env), ve.PlayFile{Envelope: ve.NewEnvelope(), File: filename})
+	c.publish(ctx, ve.PlayFileSubject(c.env, c.platform), ve.PlayFile{Envelope: ve.NewEnvelope(), File: filename})
 	return nil
 }
 
@@ -89,17 +96,17 @@ func (c *Client) PlayFileAtTimestamp(ctx context.Context, filename string, tsSec
 	if posMs < 0 {
 		posMs = 0
 	}
-	c.publish(ctx, ve.PlayFileAtSubject(c.env), ve.PlayFileAt{Envelope: ve.NewEnvelope(), File: filename, PositionMs: posMs})
+	c.publish(ctx, ve.PlayFileAtSubject(c.env, c.platform), ve.PlayFileAt{Envelope: ve.NewEnvelope(), File: filename, PositionMs: posMs})
 	return nil
 }
 
 func (c *Client) Skip(ctx context.Context, n int) error {
-	c.publish(ctx, ve.SkipSubject(c.env), ve.Skip{Envelope: ve.NewEnvelope(), N: n})
+	c.publish(ctx, ve.SkipSubject(c.env, c.platform), ve.Skip{Envelope: ve.NewEnvelope(), N: n})
 	return nil
 }
 
 func (c *Client) Back(ctx context.Context, n int) error {
-	c.publish(ctx, ve.BackSubject(c.env), ve.Back{Envelope: ve.NewEnvelope(), N: n})
+	c.publish(ctx, ve.BackSubject(c.env, c.platform), ve.Back{Envelope: ve.NewEnvelope(), N: n})
 	return nil
 }
 

--- a/pkg/vlc-events/events_test.go
+++ b/pkg/vlc-events/events_test.go
@@ -11,11 +11,11 @@ func TestSubjects(t *testing.T) {
 		got  string
 		want string
 	}{
-		{"play.random", PlayRandomSubject("staging"), "tripbot.staging.vlc.play.random"},
-		{"play.file", PlayFileSubject("prod"), "tripbot.prod.vlc.play.file"},
-		{"play.at", PlayFileAtSubject("prod"), "tripbot.prod.vlc.play.at"},
-		{"skip", SkipSubject("development"), "tripbot.development.vlc.skip"},
-		{"back", BackSubject("staging"), "tripbot.staging.vlc.back"},
+		{"play.random", PlayRandomSubject("staging", "twitch"), "tripbot.staging.vlc.play.random.twitch"},
+		{"play.file", PlayFileSubject("prod", "youtube"), "tripbot.prod.vlc.play.file.youtube"},
+		{"play.at", PlayFileAtSubject("prod", "twitch"), "tripbot.prod.vlc.play.at.twitch"},
+		{"skip", SkipSubject("development", "youtube"), "tripbot.development.vlc.skip.youtube"},
+		{"back", BackSubject("staging", "twitch"), "tripbot.staging.vlc.back.twitch"},
 		{"lastplayed", LastPlayedSubject("prod", "twitch"), "tripbot.prod.vlc.lastplayed.twitch"},
 		{"lastplayed wildcard", LastPlayedWildcard("prod"), "tripbot.prod.vlc.lastplayed.*"},
 	}

--- a/pkg/vlc-events/subjects.go
+++ b/pkg/vlc-events/subjects.go
@@ -6,7 +6,7 @@ import (
 )
 
 // domain is the fixed segment between <env> and the verb in every vlc
-// subject: tripbot.<env>.vlc.<verb>.
+// subject: tripbot.<env>.vlc.<verb>.<platform>.
 const domain = "vlc"
 
 // subject builds tripbot.<env>.vlc.<verb...>. Unexported so callers go
@@ -18,11 +18,15 @@ func subject(env string, verb ...string) string {
 	return fmt.Sprintf("tripbot.%s.%s.%s", env, domain, strings.Join(verb, "."))
 }
 
-func PlayRandomSubject(env string) string { return subject(env, "play", "random") }
-func PlayFileSubject(env string) string   { return subject(env, "play", "file") }
-func PlayFileAtSubject(env string) string { return subject(env, "play", "at") }
-func SkipSubject(env string) string       { return subject(env, "skip") }
-func BackSubject(env string) string       { return subject(env, "back") }
+// The command subjects carry a trailing platform leaf so each streaming
+// platform's playback stays isolated: vlc-twitch and vlc-youtube share the
+// env's NATS and each subscribes only to its own leaf, so a Twitch-triggered
+// !find never seeks the YouTube stream — same shape as the lastplayed leaf below.
+func PlayRandomSubject(env, platform string) string { return subject(env, "play", "random", platform) }
+func PlayFileSubject(env, platform string) string   { return subject(env, "play", "file", platform) }
+func PlayFileAtSubject(env, platform string) string { return subject(env, "play", "at", platform) }
+func SkipSubject(env, platform string) string       { return subject(env, "skip", platform) }
+func BackSubject(env, platform string) string       { return subject(env, "back", platform) }
 
 // LastPlayedSubject is the per-platform leaf vlc-server publishes its
 // now-playing state to (tripbot.<env>.vlc.lastplayed.<platform>). Unlike the

--- a/pkg/vlc-server/nats.go
+++ b/pkg/vlc-server/nats.go
@@ -27,16 +27,16 @@ func (s *Server) StartNATSSubscribers(ctx context.Context) {
 		slog.InfoContext(ctx, "nats subscriber skipped (NATS_URL unset)")
 		return
 	}
-	env := c.Conf.Environment
+	env, platform := c.Conf.Environment, c.Conf.Platform
 	subs := []struct {
 		subject string
 		handler nats.MsgHandler
 	}{
-		{ve.PlayRandomSubject(env), s.handlePlayRandom},
-		{ve.PlayFileSubject(env), s.handlePlayFile},
-		{ve.PlayFileAtSubject(env), s.handlePlayFileAt},
-		{ve.SkipSubject(env), s.handleSkip},
-		{ve.BackSubject(env), s.handleBack},
+		{ve.PlayRandomSubject(env, platform), s.handlePlayRandom},
+		{ve.PlayFileSubject(env, platform), s.handlePlayFile},
+		{ve.PlayFileAtSubject(env, platform), s.handlePlayFileAt},
+		{ve.SkipSubject(env, platform), s.handleSkip},
+		{ve.BackSubject(env, platform), s.handleBack},
 	}
 	for _, sb := range subs {
 		// Best-effort: one bad subject shouldn't stop the rest from binding.

--- a/pkg/vlc-server/nats_test.go
+++ b/pkg/vlc-server/nats_test.go
@@ -20,10 +20,10 @@ func TestNATSHandlersTolerateMalformedPayloads(t *testing.T) {
 
 	// Malformed bodies are logged and dropped, not panicked on, and never
 	// reach s.skip / s.back / s.PlayVideoFile.
-	s.handleSkip(&nats.Msg{Subject: ve.SkipSubject("test"), Data: bad})
-	s.handleBack(&nats.Msg{Subject: ve.BackSubject("test"), Data: bad})
-	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test"), Data: bad})
-	s.handlePlayFileAt(&nats.Msg{Subject: ve.PlayFileAtSubject("test"), Data: bad})
+	s.handleSkip(&nats.Msg{Subject: ve.SkipSubject("test", "twitch"), Data: bad})
+	s.handleBack(&nats.Msg{Subject: ve.BackSubject("test", "twitch"), Data: bad})
+	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test", "twitch"), Data: bad})
+	s.handlePlayFileAt(&nats.Msg{Subject: ve.PlayFileAtSubject("test", "twitch"), Data: bad})
 }
 
 // handlePlayFile / handlePlayFileAt with an empty filename is a publisher bug —
@@ -31,6 +31,6 @@ func TestNATSHandlersTolerateMalformedPayloads(t *testing.T) {
 func TestPlayFileEmptyFilenameDropped(t *testing.T) {
 	s := &Server{}
 	empty := []byte(`{"emitted_at":"2026-01-01T00:00:00Z","file":""}`)
-	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test"), Data: empty})
-	s.handlePlayFileAt(&nats.Msg{Subject: ve.PlayFileAtSubject("test"), Data: empty})
+	s.handlePlayFile(&nats.Msg{Subject: ve.PlayFileSubject("test", "twitch"), Data: empty})
+	s.handlePlayFileAt(&nats.Msg{Subject: ve.PlayFileAtSubject("test", "twitch"), Data: empty})
 }


### PR DESCRIPTION
`!find` and the other playback commands (`!jump`, `!timewarp`, skip, back) were published to `tripbot.<env>.vlc.<verb>`, which **every** platform's vlc-server subscribed to. With YouTube live on stage, a Twitch-triggered `!find` also seeked the YouTube stream (and vice versa) — the two audiences fought over each other's playback.

Add the platform as a trailing subject leaf: `tripbot.<env>.vlc.<verb>.<platform>`. Each `vlc-<platform>` instance now acts only on its own commands.

Both sides already read `STREAM_PLATFORM` (the client via `c.Conf.Platform`, the server via `VlcServerConfig.Platform`), so this is a subject-shape change only — no new config, no infra change (these are core NATS pub/sub, not JetStream, so no stream/consumer filter to update).

The trailing-leaf placement matches every other platform-scoped subject in the tree — onscreens commands + state, vlc `lastplayed`, `auth.status`, `chat.send`, `obs.refresh` — keeping the shared `tripbot.<env>.<domain>.…` prefix that stream wildcards key off.