### PR TITLE
ci: allowlist 'unparseable' in codespell

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,4 +1,5 @@
 [codespell]
 # abitrate/commads/quess/loacation/lcoation: quoted in CHANGELOG.md's historical #466 entry.
 # locaiton/stae/comands: used by the fuzzy-router tests.
-ignore-words-list = caf,nd,abitrate,commads,quess,loacation,lcoation,locaiton,stae,comands
+# unparseable: a legitimate spelling (playback_test.go); codespell wants "unparsable".
+ignore-words-list = caf,nd,abitrate,commads,quess,loacation,lcoation,locaiton,stae,comands,unparseable


### PR DESCRIPTION
The weekly `super-linter` sweep on tripbot is **failing** (verified via `workflow_dispatch` on `main`) on codespell false positives introduced by a recent test:

```
pkg/chatbot/playback_test.go:167: Unparseable ==> Unparsable
pkg/chatbot/playback_test.go:169: unparseable ==> unparsable
```

`unparseable` is a legitimate spelling; add it to the existing `.github/linters/.codespellrc` allowlist (case-insensitive, so it covers `Unparseable` too).

CI-only change — no changelog fragment (skip-changelog label applied).

Verified green via `workflow_dispatch` on this branch.