### PR TITLE
chore(deploy): pin prod tripbot to good 4.0.0 image digest

### DIFF
--- a/cdk8s/dist/prod-1-job-seed.k8s.yaml
+++ b/cdk8s/dist/prod-1-job-seed.k8s.yaml
@@ -15,7 +15,7 @@ spec:
                 name: tripbot-twitch-config
             - secretRef:
                 name: tripbot-database-creds
-          image: adanalife/tripbot:4.0.0
+          image: adanalife/tripbot:4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0
           imagePullPolicy: IfNotPresent
           name: seed
           resources:
@@ -46,7 +46,7 @@ spec:
                 name: tripbot-twitch-config
             - secretRef:
                 name: tripbot-database-creds
-          image: adanalife/tripbot:4.0.0
+          image: adanalife/tripbot:4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0
           imagePullPolicy: IfNotPresent
           name: migrate
           resources:

--- a/cdk8s/dist/prod-1-tripbot-twitch.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-twitch.k8s.yaml
@@ -74,7 +74,7 @@ spec:
             - secretRef:
                 name: tripbot-discord-bot-token
                 optional: true
-          image: adanalife/tripbot:4.0.0
+          image: adanalife/tripbot:4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -118,7 +118,7 @@ spec:
                 name: tripbot-twitch-config
             - secretRef:
                 name: tripbot-database-creds
-          image: adanalife/tripbot:4.0.0
+          image: adanalife/tripbot:4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0
           imagePullPolicy: IfNotPresent
           name: migrate
           resources:

--- a/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
+++ b/cdk8s/dist/prod-1-tripbot-youtube.k8s.yaml
@@ -98,7 +98,7 @@ spec:
                 optional: true
             - secretRef:
                 name: tripbot-youtube-creds
-          image: adanalife/tripbot:4.0.0
+          image: adanalife/tripbot:4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -142,7 +142,7 @@ spec:
                 name: tripbot-youtube-config
             - secretRef:
                 name: tripbot-database-creds
-          image: adanalife/tripbot:4.0.0
+          image: adanalife/tripbot:4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0
           imagePullPolicy: IfNotPresent
           name: migrate
           resources:

--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -71,7 +71,9 @@ def test_prod_pinned_stage_floats(env, platform):
         for c in dep["spec"]["template"]["spec"]["containers"]
         if c["name"].startswith("tripbot")
     )
-    image, tag = container["image"].rsplit(":", 1)
+    # Split on the first colon: the repo has no registry-host:port prefix, and
+    # the tag itself may carry a @sha256 digest suffix (a digest-pinned deploy).
+    image, tag = container["image"].split(":", 1)
     assert image == "adanalife/tripbot"  # public Docker Hub image, no v-prefix tag
     if env == "prod-1":
         assert tag == pins["prod-1"]["tripbot"]

--- a/cdk8s/versions.yaml
+++ b/cdk8s/versions.yaml
@@ -29,7 +29,12 @@
 # other.
 prod-1:
   # restarts the chat bot only; no stream impact
-  tripbot: "4.0.0" # x-release-please-version
+  # Digest-pinned to the correctly-built 4.0.0 multi-arch image: the minipc had
+  # a stale image locally tagged 4.0.0 (missing migrations 032/033), and
+  # IfNotPresent kept using it instead of the published tag. Pinning the digest
+  # forces the node to pull the exact good image. Restore to a plain "4.0.x" tag
+  # at the next release.
+  tripbot: "4.0.0@sha256:121491f29555440c039a46a569a7fa1f2e3dc6d2c5d2ce915bc4228ebade71f0" # x-release-please-version
   # restarting takes the stream down until OBS reconnects — pick a quiet moment
   obs: "3.4.1"
   # overlays blip; the stream itself stays up


### PR DESCRIPTION
## What

Pin the prod `tripbot` image to the published 4.0.0 multi-arch manifest digest (`@sha256:121491f2…`) so the minipc pulls the exact correctly-built image.

## Why

Prod's `4.0.0` rollout was wedged: both new `tripbot-{twitch,youtube}` pods crash-looped in the `migrate` init container with:

```
error: no migration found for version 33: read down for version 33 .: file does not exist
```

Root cause: the minipc had a **stale image locally tagged `adanalife/tripbot:4.0.0`** (built 2026-07-06, *before* migrations `032`/`033` landed — its `/migrations` only goes to `031`). With `imagePullPolicy: IfNotPresent`, the kubelet kept that stale local image and never pulled the correctly-built published `4.0.0` (which has all migrations through `033`). Since the DB is at v33, `migrate up` couldn't find version 33 in the stale image → crash loop.

The stream stayed up throughout on the old `3.20.0` pods. The `4.0.0` source/Dockerfile are fine — nothing was deleted (`#1135` only removed vlc-server).

## What changed

- `cdk8s/versions.yaml`: `tripbot` pin → `4.0.0@sha256:121491f2…` (the multi-arch manifest-list digest).
- Re-synthed prod tripbot dist (both deploys) + the seed Job to the digest ref.
- `tests/test_cdk8s.py`: parse the deploy image ref on the first colon so a `tag@digest` value validates.

## Follow-ups

- **release-please caveat:** the `x-release-please-version` marker still anchors this line, so the next release would produce `4.0.x@sha256:<stale digest>`. Restore a plain `4.0.x` tag when cutting the next release.
- Consider making prod pins digest-based by default (or setting the migrate init to `Always`) so a mis-tagged local image can't shadow a published release again.