### PR TITLE
ci: keep release green when the Discord notification fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Discord notification
+        # A rotated or deleted webhook returns 404 and must not fail a release
+        # whose image already shipped; the notification is best-effort.
+        continue-on-error: true
         uses: Ilshidur/action-discord@0.4.0
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
Hardening so the `notify` job's Discord step (best-effort) can never fail an already-shipped release.

The Discord notification runs after the image has already been built and pushed. If the webhook is dead or rotated, the step returns `404 Unknown Webhook` and fails the whole release run — turning a release red even though the artifact shipped fine. A sibling issue where exactly this happened turned other repos' releases red.

Marking the step `continue-on-error: true` keeps the notification best-effort: a broken webhook logs the failure but no longer fails the release. tripbot's webhook currently works; this is fleet-wide hardening.