### PR TITLE
test(cdk8s): stop pinning prod's replica count in the park test

### DIFF
--- a/cdk8s/tests/test_cdk8s.py
+++ b/cdk8s/tests/test_cdk8s.py
@@ -112,11 +112,13 @@ def test_youtube_tripbot_emits_youtube_creds():
     assert "tripbot-youtube-creds" in es_names
 
 
-def test_stage_parks_everything_prod_keeps_one():
-    """Every stage platform Deployment renders replicas:0 — the resting
-    state is everything-off, and a platform comes online via the console's
-    scale-up button (stage selfHeal off, so the hand scale sticks). Prod
-    keeps replicas:1 so Argo holds it."""
+def test_stage_parks_every_platform():
+    """Every stage platform Deployment renders replicas:0 — the resting state is
+    everything-off; a platform comes online via the console's mode switch. Prod's
+    replica count isn't pinned here: replicas are runtime-owned (Argo ignores
+    .spec.replicas per infra#877), so prod births at 0 too and a live scale
+    sticks — the committed prod value is just whatever the last release synthed
+    (0), not a policy this test guards."""
 
     def _deploy(stem):
         return _by_kind(_objects(stem), "Deployment")[0]
@@ -124,7 +126,9 @@ def test_stage_parks_everything_prod_keeps_one():
     for platform in ("twitch", "youtube", "tiktok", "facebook", "instagram"):
         stem = f"stage-1-tripbot-{platform}"
         assert _deploy(stem)["spec"]["replicas"] == 0, f"{stem} should be parked"
-    assert _deploy("prod-1-tripbot-twitch")["spec"]["replicas"] == 1
+    # prod still renders its Deployment (existence is the invariant; the replica
+    # count is Argo-ignored, so it isn't asserted).
+    assert _deploy("prod-1-tripbot-twitch")
 
 
 def test_stage_twitch_routes_through_gateway():


### PR DESCRIPTION
## Why

The release PR ([tripbot#1187](https://github.com/adanalife/tripbot/pull/1187), `chore(main): release 4.7.0`) fails its `synth` check on `test_stage_parks_everything_prod_keeps_one`:

```
assert _deploy("prod-1-tripbot-twitch")["spec"]["replicas"] == 1
E       assert 0 == 1
```

That test still encodes the pre-runtime-replicas model. Since [#1185](https://github.com/adanalife/tripbot/pull/1185/changes) renders `replicas: 0` unconditionally and [infra#877](https://github.com/adanalife/infra/pull/877) makes Argo ignore `.spec.replicas`, prod births at 0 like everything else. The test reads **committed dist**, and the committed prod value legitimately differs by branch — `1` on `main` (pin-protection reverts the prod dist re-synth) vs `0` on the release branch (full re-synth) — so no fixed count can pass on both.

## Fix

Assert the stable invariant — every stage platform Deployment parks at `replicas: 0` — and that prod renders its Deployment, but drop the Argo-ignored prod replica-count assertion. Renamed `test_stage_parks_every_platform` and refreshed the stale docstring.

Once merged, release-please regenerates #1187 and its `synth` check passes (prod dist re-synths to 0 there, which is correct).

## Test

`mise exec -- uv run pytest -q` in `cdk8s/`: 25 passed (was 1 failed / 24 passed). Passes on `main` (prod dist still 1, not asserted) and on the release branch (prod dist 0).

`skip-changelog`: test-only, no user-facing change.