### PR TITLE
chore(comments): make change-narration comments timeless

### DIFF
--- a/cmd/tripbot/chatsend.go
+++ b/cmd/tripbot/chatsend.go
@@ -15,10 +15,9 @@ import (
 
 // startChatSendSubscriber wires the "send a chat message" command. A publisher
 // emits chatEvents.Send on tripbot.<env>.chat.send.<platform>; tripbot owns the
-// Twitch identities, so it's the thing that actually sends. The in-tripbot admin
-// panel that used to publish this was retired with the tripbot-console split;
-// this subscriber stays as the receive side, ready for the standalone console to
-// publish to over the same wire format when its chat-send feature lands.
+// Twitch identities, so it's the thing that actually sends. This subscriber is
+// the receive side; the standalone tripbot-console publishes to it over the
+// same wire format once its chat-send feature lands.
 //
 // No-op when NATS is unconfigured (the singleton conn is nil) — the same
 // fire-and-forget posture as the rest of the NATS surface. Must run after

--- a/pkg/chat-events/events.go
+++ b/pkg/chat-events/events.go
@@ -6,12 +6,10 @@
 //
 // It is imported by the subscriber (cmd/tripbot, which owns the Twitch
 // identities and does the actual sending) and by whatever publishes the command
-// — the standalone tripbot-console, once its chat-send feature lands (the
-// in-tripbot panel that used to publish this was retired with the console
-// split). Like pkg/onscreens-events and pkg/playout-events it is
-// stdlib-only and side-effect-free: no init(), no pkg/config import, env is
-// always a parameter rather than read from config here — so it links safely
-// into any binary.
+// — the standalone tripbot-console, once its chat-send feature lands. Like
+// pkg/onscreens-events and pkg/playout-events it is stdlib-only and
+// side-effect-free: no init(), no pkg/config import, env is always a parameter
+// rather than read from config here — so it links safely into any binary.
 package chatEvents
 
 import "time"

--- a/pkg/natsclient/natsclient.go
+++ b/pkg/natsclient/natsclient.go
@@ -38,7 +38,7 @@ const reconnectWait = 2 * time.Second
 //
 // The connection retries forever: RetryOnFailedConnect covers the boot race
 // where this process starts before NATS is reachable (a node reboot brings
-// apps and NATS up together), so a failed first dial no longer leaves the
+// apps and NATS up together), so a failed first dial doesn't leave the
 // process permanently deaf. The returned conn is usable immediately —
 // subscriptions made while disconnected are queued client-side and replayed
 // on connect; publishes buffer up to the client's reconnect buffer and are

--- a/pkg/onscreens-server/left-rotator.go
+++ b/pkg/onscreens-server/left-rotator.go
@@ -9,8 +9,8 @@ var leftRotatorUpdateFrequency = time.Duration(45 * time.Second)
 
 // !miles and !guess are Twitch-only (not in the YouTube command allowlist), so
 // those lines are scoped to Twitch — a YouTube overlay would otherwise advertise
-// commands that silently no-op there. Weight 2 reproduces the old duplicated
-// entries (!discord, !commands each appeared twice).
+// commands that silently no-op there. Weight 2 makes !discord and !commands
+// twice as likely as the unweighted lines.
 var possibleLeftMessages = []rotatorMessage{
 	{Text: "Crave something new? Try `!timewarp`"},
 	{Text: "Earn miles for every minute you watch (`!miles`)", Platforms: []string{platformTwitch}},

--- a/pkg/onscreens-server/right-rotator.go
+++ b/pkg/onscreens-server/right-rotator.go
@@ -11,12 +11,12 @@ import (
 // shared-texture handoff occasionally gets a stale/blank frame stuck — and CEF
 // only pushes a fresh frame when the rendered pixels actually change. A content
 // rotation is what forces that repaint, so a shorter interval bounds how long a
-// stuck-blank overlay stays blank. This was 90s, which left the right rotator
-// visibly blank ~2x longer than the left (the asymmetry that surfaced the bug).
+// stuck-blank overlay stays blank.
 var rightRotatorUpdateFrequency = time.Duration(45 * time.Second)
 
 // All right-rotator lines are platform-neutral (!location and !timewarp are both
-// in the YouTube allowlist). Weight 2 reproduces the old duplicated entries.
+// in the YouTube allowlist). Weight 2 makes the follow and !location hints
+// twice as likely as the unweighted lines.
 var possibleRightMessages = []rotatorMessage{
 	{Text: "Don't forget to follow :)", Weight: 2},
 	{Text: "Try running `!location`", Weight: 2},

--- a/pkg/twitch/client.go
+++ b/pkg/twitch/client.go
@@ -7,10 +7,10 @@ import (
 	"github.com/nicklaw5/helix/v2"
 )
 
-// API owns the mutable Twitch state that used to live in package-level
-// globals: the two helix clients, the App Access Token, the per-identity
-// user-access-tokens, and the cached channel/viewer/audience data. It is the
-// in-process implementation of "talk to Twitch"; construct one with New().
+// API owns the mutable Twitch state: the two helix clients, the App Access
+// Token, the per-identity user-access-tokens, and the cached
+// channel/viewer/audience data. It is the in-process implementation of
+// "talk to Twitch"; construct one with New().
 //
 // (Named API rather than Client because the package already exposes a
 // Client() helix-getter that callers depend on — the type can be renamed once


### PR DESCRIPTION
A `/comment-audit` pass over tripbot: rewrites comments that narrated the change that produced them into present-tense statements of the standing behavior. Comment-only diff — no executable line changed (verified: `gofmt` clean, no non-comment additions/removals).

Findings (7 comments, 5 files):

- `cmd/tripbot/chatsend.go` — dropped "the in-tripbot admin panel that used to publish this was retired with the tripbot-console split"; keep the standing fact (this is the receive side; console publishes once its chat-send feature lands).
- `pkg/chat-events/events.go` — same removal-history parenthetical dropped.
- `pkg/twitch/client.go` — "state that used to live in package-level globals" → "state: the two helix clients, ...".
- `pkg/natsclient/natsclient.go` — "a failed first dial no longer leaves the process permanently deaf" → "doesn't leave".
- `pkg/onscreens-server/right-rotator.go` — deleted "This was 90s, which left the right rotator visibly blank ~2x longer than the left" (the timeless reason for a short interval is already stated); reworded the weight comment off "reproduces the old duplicated entries".
- `pkg/onscreens-server/left-rotator.go` — same weight-comment reword.

The rest of the first-pass grep hits were legit constraint-comments (runtime "previously-active series", "old pod" during rolling deploys, hardware/timing reasons) and left as-is.