### PR TITLE
ci(cdk8s): exempt jsii@5.9.48 from mise's trust-downgrade check

### DIFF
--- a/cdk8s/.mise.toml
+++ b/cdk8s/.mise.toml
@@ -9,4 +9,12 @@ python = "3.12"
 node = "24"
 # Kept in lockstep with infra/cdk8s/.mise.toml so both repos synth against the
 # same cdk8s-cli (the synthed dist/ is byte-compared during the cutover).
-"npm:cdk8s-cli" = "2.207.12"
+#
+# jsii@5.9.48 trips mise's no-downgrade trust policy: 5.9.18 was published to
+# npm through GitHub's OIDC trusted publisher, 5.9.48 through a classic token,
+# which reads as weaker publish evidence. The build provenance is intact — the
+# SLSA attestation on 5.9.48 resolves to aws/jsii-compiler, .github/workflows/
+# release.yml, tag v5.9.48 — so this is a publish-path change at the maintainer,
+# not a tampered release. Drop the exclude once a jsii the pinned cdk8s-cli
+# resolves to is published via the trusted publisher again.
+"npm:cdk8s-cli" = { version = "2.207.12", trust_policy_excludes = ["jsii@5.9.48"] }


### PR DESCRIPTION
`gates` fails on every PR: mise 2026.7.15 added a supply-chain trust policy and refuses to install `npm:cdk8s-cli@2.207.12`.

```
Failed to install npm:cdk8s-cli@2.207.12: aube install failed: failed to resolve dependencies
  caused by: trust downgrade for jsii@5.9.48 (trustPolicy=no-downgrade): earlier
  published version 5.9.18 had trusted publisher but this version has provenance attestation
```

## Why this is safe

jsii 5.9.18 was published to npm through GitHub's OIDC trusted publisher; 5.9.48 was published by `aws-cdk-team` with a classic token. mise ranks trusted-publisher above plain provenance, so the newer release reads as a downgrade.

The build provenance is still intact. 5.9.48's SLSA attestation resolves to:

| field | value |
|---|---|
| repository | `https://github.com/aws/jsii-compiler` |
| workflow | `.github/workflows/release.yml` |
| ref | `refs/tags/v5.9.48` |
| run | [aws/jsii-compiler#29720822771](https://github.com/aws/jsii-compiler/actions/runs/29720822771) |

So this is a publish-path change at the maintainer, not a tampered release — one of the cases mise's own error message calls out.

## The fix

Narrowest possible exemption: the single `jsii@5.9.48`, scoped to this one tool. Not a bare package name (which would exempt every version), and not `npm.shell_out=true` (which would disable the check entirely). `cdk8s-cli` is pinned, so the resolution is deterministic — nothing else can slip through the hole.

Drop the exclude once a jsii that the pinned cdk8s-cli resolves to ships via the trusted publisher again.

Unblocks [#1237](https://github.com/adanalife/tripbot/pull/1237/changes) (release 4.13.0). `infra/cdk8s/.mise.toml` carries the same pin and will need the same change.
