### PR TITLE
fix(chatbot): only treat album subdirectories as track sources

### DIFF
--- a/changelog.d/+album-subdirectories.fix.md
+++ b/changelog.d/+album-subdirectories.fix.md
@@ -1,0 +1,1 @@
+The album background-audio bed now only plays tracks from album subdirectories of the music share. Loose audio files at the share root — it also holds a 556MB `carsounds.m4a` — were being shuffled into the rotation as tracks.

--- a/pkg/obs/beds/beds.go
+++ b/pkg/obs/beds/beds.go
@@ -235,17 +235,29 @@ func (s *Store) apply(ctx context.Context, bed Bed, track string) error {
 	return s.obs.SetLocalFile(ctx, InputName, track, bed != Album)
 }
 
-// scanTracks lists every audio file under dir, sorted so the pre-shuffle order
+// scanTracks lists the album tracks under dir, sorted so the pre-shuffle order
 // is deterministic (the shuffle is what makes playback vary, not readdir order).
+//
+// Albums are SUBDIRECTORIES of the share; loose files at its root are not
+// tracks. The share holds other audio beside the albums — carsounds.m4a, a
+// 556MB archive — and a flat scan would shuffle that in as one enormous track.
+//
+// ponytail: every album subdirectory is one pool, which with a single album is
+// that album. Add a picker when a second one shows up and they shouldn't
+// interleave.
 func scanTracks(dir string) ([]string, error) {
 	var out []string
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !d.IsDir() && audioExts[strings.ToLower(filepath.Ext(path))] {
-			out = append(out, path)
+		if d.IsDir() || !audioExts[strings.ToLower(filepath.Ext(path))] {
+			return nil
 		}
+		if filepath.Dir(path) == filepath.Clean(dir) {
+			return nil // loose file at the share root, not an album track
+		}
+		out = append(out, path)
 		return nil
 	})
 	if err != nil {

--- a/pkg/obs/beds/beds_test.go
+++ b/pkg/obs/beds/beds_test.go
@@ -40,19 +40,28 @@ func (f *fakeOBS) Settings(context.Context, string) (map[string]any, error) {
 	return f.settings, nil
 }
 
-// albumDir writes n dummy tracks (plus a non-audio file that must be ignored)
-// and returns the directory.
+// albumDir builds a share holding one album of n tracks. It mirrors the real
+// layout: the album is a SUBDIRECTORY, and the share root also holds a loose
+// audio file (the 556MB carsounds.m4a lives there) plus a non-audio file —
+// neither of which is a track. Returns the share root, which is what gets
+// mounted.
 func albumDir(t *testing.T, n int) string {
 	t.Helper()
 	dir := t.TempDir()
+	album := filepath.Join(dir, "fifty-horizons")
+	if err := os.MkdirAll(album, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < n; i++ {
-		name := filepath.Join(dir, string(rune('a'+i))+" track.mp3")
+		name := filepath.Join(album, string(rune('a'+i))+" track.mp3")
 		if err := os.WriteFile(name, nil, 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), nil, 0o600); err != nil {
-		t.Fatal(err)
+	for _, loose := range []string{"carsounds.m4a", "readme.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, loose), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return dir
 }
@@ -93,8 +102,8 @@ func TestSet_AlbumPlaysATrackUnlooped(t *testing.T) {
 	if err := s.Set(context.Background(), Album); err != nil {
 		t.Fatal(err)
 	}
-	if filepath.Dir(o.file) != dir {
-		t.Fatalf("album track %q not from %q", o.file, dir)
+	if filepath.Dir(o.file) != filepath.Join(dir, "fifty-horizons") {
+		t.Fatalf("album track %q not from the album directory under %q", o.file, dir)
 	}
 	// Looping an album track means OBS never reports media-ended, so the
 	// advance never fires and the stream sticks on one song forever.
@@ -107,7 +116,7 @@ func TestSet_AlbumPlaysATrackUnlooped(t *testing.T) {
 }
 
 func TestSet_AlbumSkipsNonAudioFiles(t *testing.T) {
-	dir := albumDir(t, 1) // one .mp3 + one readme.txt
+	dir := albumDir(t, 1)
 	o := &fakeOBS{}
 	s := NewStore(o, CarHum, dir)
 	if err := s.Set(context.Background(), Album); err != nil {
@@ -115,6 +124,42 @@ func TestSet_AlbumSkipsNonAudioFiles(t *testing.T) {
 	}
 	if filepath.Ext(o.file) != ".mp3" {
 		t.Fatalf("picked a non-audio file: %s", o.file)
+	}
+}
+
+func TestSet_AlbumIgnoresLooseFilesAtTheShareRoot(t *testing.T) {
+	// The real share keeps carsounds.m4a — 556MB, nine hours — beside the album
+	// directories. Treating it as a track would put it on the stream and stall
+	// the rotation until it ended.
+	dir := albumDir(t, 3)
+	o := &fakeOBS{}
+	s := NewStore(o, CarHum, dir)
+	for i := 0; i < 6; i++ {
+		if err := s.Set(context.Background(), Album); err != nil {
+			t.Fatal(err)
+		}
+		if filepath.Base(o.file) == "carsounds.m4a" {
+			t.Fatal("picked the loose carsounds.m4a from the share root")
+		}
+		if err := s.Advance(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if filepath.Base(o.file) == "carsounds.m4a" {
+			t.Fatal("advanced onto the loose carsounds.m4a from the share root")
+		}
+	}
+}
+
+func TestSet_AlbumWithOnlyLooseRootFilesFails(t *testing.T) {
+	// A share with audio but no album directory has nothing playable — better a
+	// refused switch than a 556MB archive on the stream.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "carsounds.m4a"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(&fakeOBS{}, CarHum, dir)
+	if err := s.Set(context.Background(), Album); err == nil {
+		t.Fatal("a share with no album directory should refuse the album bed")
 	}
 }
 
@@ -201,7 +246,7 @@ func TestDetect_ReadsTheLiveBedFromOBS(t *testing.T) {
 	}{
 		{"network stream", map[string]any{"is_local_file": false}, SomaFM},
 		{"carhum flac", map[string]any{"is_local_file": true, "local_file": CarHumFile}, CarHum},
-		{"album track", map[string]any{"is_local_file": true, "local_file": filepath.Join(dir, "a track.mp3")}, Album},
+		{"album track", map[string]any{"is_local_file": true, "local_file": filepath.Join(dir, "fifty-horizons", "a track.mp3")}, Album},
 		// A sibling directory whose name merely prefixes the share must not
 		// read as the album.
 		{"lookalike dir", map[string]any{"is_local_file": true, "local_file": dir + "-old/x.mp3"}, CarHum},


### PR DESCRIPTION
Follow-up to #1246, from putting the real album on the NAS.

The share is `/volume1/ADanaLife/audio/`, and it already held a **556MB `carsounds.m4a`** next to the new `fifty-horizons/` directory. The track scan walked the whole tree, so the album bed could pick that archive as a "track" — a nine-hour file, unlooped, that would stall the rotation until it ended.

Albums are subdirectories of the share; loose files at its root are not tracks. That's the upgrade path the original `ponytail:` comment named ("group by subdirectory when a second one shows up") — a sibling showed up, just not a second album.

The alternative was pointing the PV at `audio/fifty-horizons` directly, which needs no code — but a bound PV's `nfs.path` is immutable, so adding a second album later would mean recreating the PV and PVC. `MUSIC_NFS_PATH="/volume1/ADanaLife/audio"` plus this rule keeps that a drag-and-drop.

adanalife/obs#71 applies the identical rule (`-mindepth 2`) to the entrypoint's starting-track pick.

## Tests

`albumDir` now mirrors the real layout — album in a subdirectory, with `carsounds.m4a` and a `readme.txt` loose at the root — so every existing bed test exercises the new shape. Two new ones:

- switching to the album and advancing, six rounds, never lands on the root-level file
- a share holding audio but **no** album directory refuses the album bed rather than playing the archive

Confirmed the tests fail without the fix, rather than only that they pass with it: dropping the guard makes both `TestSet_AlbumPlaysATrackUnlooped` and `TestSet_AlbumSkipsNonAudioFiles` pick `carsounds.m4a`.