### PR TITLE
docs(cdk8s): describe TWITCH_API_URL as the twitch chat transport

### DIFF
--- a/cdk8s/adanalife_k8s/constructs/tripbot.py
+++ b/cdk8s/adanalife_k8s/constructs/tripbot.py
@@ -170,9 +170,11 @@ def config_data(env: EnvConfig, platform: str) -> dict[str, str]:
     data.update(_ENV_CONFIG[env.name])
     if env.nats_url:
         data["NATS_URL"] = env.nats_url
-    # Route the twitch instance's command-time Helix calls through the
-    # platform-gateway gateway-twitch where the env wires it. Only the
-    # twitch platform talks Helix, so the youtube instance never carries it.
+    # Route the twitch instance's chat (both directions) and its command-time
+    # Helix calls through the platform-gateway gateway-twitch where the env
+    # wires it — required for chat to come up at all (the binary boots
+    # chat-less without it). Only the twitch platform talks Helix, so the
+    # youtube instance never carries it.
     if platform == "twitch" and env.twitch_api_url:
         data["TWITCH_API_URL"] = env.twitch_api_url
     # Route the youtube instance's outbound chat sends through gateway-youtube

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -28,7 +28,7 @@ var (
 	scoreboardWrites          = mustCounter("tripbot_scoreboard_writes_total", "Total successful scoreboard score writes, labeled by scoreboard")
 	twitchSubscribers         = mustGauge("twitch_subscribers_total", "Current number of Twitch channel subscribers")
 	twitchFollowers           = mustGauge("twitch_followers_total", "Current number of Twitch channel followers")
-	twitchConnected           = mustGauge("tripbot_twitch_connected", "1 when the bot is connected to Twitch chat (IRC), 0 otherwise")
+	twitchConnected           = mustGauge("tripbot_twitch_connected", "1 when the bot is receiving Twitch chat, 0 otherwise")
 	twitchTokenExpiry         = mustGauge("tripbot_twitch_token_expires_at_seconds", "Unix timestamp of the in-memory Twitch user-access-token's ExpiresAt, labeled by account (bot|broadcaster). 0 when the account has no loaded token.")
 	twitchHelixErrors         = mustCounter("twitch_helix_errors_total", "Total non-2xx responses from the Twitch Helix API, labeled by endpoint and status_code")
 	twitchChannelLive         = mustGauge("tripbot_twitch_channel_live", "1 when Helix GetStreams reports the configured channel as live, 0 when offline. Driven by the OBS silent-disconnect watchdog's Helix poll.")


### PR DESCRIPTION
The comment above the `TWITCH_API_URL` emit described the key as carrying only the twitch instance's command-time Helix calls. Since [#1266](https://github.com/adanalife/tripbot/pull/1266) retired the in-process IRC client, it also carries the chat transport in both directions — and an instance without it boots chat-less rather than merely losing Helix features.

Rewritten to say both, matching the phrasing of the sibling gateway-transport comment a few lines below.

Comment-only; no rendered manifest change.