### PR TITLE
ci: one release notification wording, and alert on a red release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Discord notification
         # A rotated or deleted webhook returns 404 and must not fail a release
-        # whose image already shipped; the notification is best-effort.
+        # that already shipped; the notification is best-effort.
         continue-on-error: true
         uses: Ilshidur/action-discord@0.4.0
         env:
@@ -75,4 +75,4 @@ jobs:
         with:
           # Link the tagged CHANGELOG.md, not a payload `compare` URL: releases
           # dispatch via workflow_dispatch, whose event payload has no `compare`.
-          args: 'New Docker images released for [{{ EVENT_PAYLOAD.repository.full_name }}]({{ EVENT_PAYLOAD.repository.html_url }}): [{{ VERSION_TAG }}]({{ EVENT_PAYLOAD.repository.html_url }}/blob/{{ VERSION_TAG }}/CHANGELOG.md)'
+          args: 'New release for [{{ EVENT_PAYLOAD.repository.full_name }}]({{ EVENT_PAYLOAD.repository.html_url }}): [{{ VERSION_TAG }}]({{ EVENT_PAYLOAD.repository.html_url }}/blob/{{ VERSION_TAG }}/CHANGELOG.md)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,32 @@ jobs:
           # Link the tagged CHANGELOG.md, not a payload `compare` URL: releases
           # dispatch via workflow_dispatch, whose event payload has no `compare`.
           args: 'New release for [{{ EVENT_PAYLOAD.repository.full_name }}]({{ EVENT_PAYLOAD.repository.html_url }}): [{{ VERSION_TAG }}]({{ EVENT_PAYLOAD.repository.html_url }}/blob/{{ VERSION_TAG }}/CHANGELOG.md)'
+
+  # Nothing else says a release went red. The release PR merged green long
+  # before the tag ran, so the only record is this run's own entry in a run
+  # list nobody is watching.
+  #
+  # `if: failure()` is what makes this the catch-all: it runs when any job
+  # above failed, including when a later one was skipped as a result. `notify`
+  # cannot trip it, since continue-on-error keeps a dead webhook out of that
+  # job's status.
+  #
+  # Best-effort like the announcement -- a failure to report a failure should
+  # not become a second failure.
+  alert:
+    needs: [version, tripbot, onscreens-server, notify]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Alert Discord on failure
+        continue-on-error: true
+        uses: Ilshidur/action-discord@0.4.0
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_ALERTS }}
+          VERSION_TAG: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          # Points at the log rather than naming what failed: any job above can
+          # be the one, and naming it would go stale as the jobs change.
+          args: 'Release failed for [{{ EVENT_PAYLOAD.repository.full_name }}]({{ EVENT_PAYLOAD.repository.html_url }}) at {{ VERSION_TAG }}: [run log]({{ RUN_URL }})'


### PR DESCRIPTION
Two commits, one theme: a release should say the same thing in every repo, whether it went green or red.

## One announcement wording

Every repo posted its release to Discord in its own words: five said `New Docker image released for …`, tripbot said `images`, website said `New release for …` linking the GitHub Release, and guessr said `Guessr v1.0.1 is live — https://guessr.dana.lol`. Four shapes for one event.

All eight now post the identical line, linking the tagged `CHANGELOG.md` (what six of the eight already did):

> New release for [adanalife/&lt;repo&gt;](…): [vX.Y.Z](…/blob/vX.Y.Z/CHANGELOG.md)

The step is named `Discord notification` everywhere, and `continue-on-error: true` is on all eight — a rotated webhook must not fail a release that already shipped. (playout was missing it.)

## An alert when a release goes red

guessr was the only repo that said anything when a release failed ([guessr#54](https://github.com/adanalife/guessr/pull/54/changes)). Everywhere else the sole record was the run's own entry in a list nobody watches — a release that builds a bad image was exactly as invisible as guessr's was before that PR.

Now all eight alert on `DISCORD_WEBHOOK_ALERTS`, with one wording:

> Release failed for [adanalife/&lt;repo&gt;](…) at vX.Y.Z: [run log](…)

The mechanism follows each workflow's shape. guessr and website are a single job, so it's a last step with `if: failure()`. The six image repos have a separate `notify` job, which GitHub **skips** when the build it needs fails — so a step there would never fire. They get an `alert` job with `if: failure()`, which runs when any job above it failed, including when a later one was skipped as a result. `notify` can't trip it, since `continue-on-error` keeps a dead webhook out of that job's status.

Best-effort like the announcement: a failure to report a failure shouldn't become a second failure.

### Secret

`DISCORD_WEBHOOK_ALERTS` is an org secret, so the five **public** repos (guessr, website, tripbot, obs, playout) inherit it. On the free tier org secrets aren't shared with private repos, so **tripbot-console, platform-gateway and video-pipeline need it set per-repo**. Until then their alert step no-ops behind `continue-on-error` — it cannot turn a release red.

## One change across eight repos

- [guessr#79](https://github.com/adanalife/guessr/pull/79/changes)
- [website#263](https://github.com/adanalife/website/pull/263/changes)
- [tripbot#1326](https://github.com/adanalife/tripbot/pull/1326/changes)
- [tripbot-console#254](https://github.com/adanalife/tripbot-console/pull/254/changes)
- [obs#85](https://github.com/adanalife/obs/pull/85/changes)
- [playout#107](https://github.com/adanalife/playout/pull/107/changes)
- [platform-gateway#182](https://github.com/adanalife/platform-gateway/pull/182/changes)
- [video-pipeline#100](https://github.com/adanalife/video-pipeline/pull/100/changes)
