### PR TITLE
ci(dependabot): batch minor and patch bumps into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,22 @@ updates:
   # without a workflow edit). Note: setting `labels` replaces Dependabot's
   # defaults, so the otherwise-automatic dependencies/ecosystem labels are
   # restated here.
+  #
+  # Every ecosystem here batches its minor and patch bumps into one PR per run.
+  # A major is deliberately left out of every group so it arrives on its own,
+  # where a breaking change is attributable to a single dependency instead of
+  # hiding among a dozen safe ones.
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: daily
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
       - go
@@ -22,6 +34,13 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
       - github_actions
@@ -42,6 +61,13 @@ updates:
     directory: cdk8s
     schedule:
       interval: daily
+    groups:
+      cdk8s:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
       - javascript


### PR DESCRIPTION
Fifteen open bump PRs sit on this repo right now, each on its own branch with its own CI run, reviewed one at a time. Dependabot batches natively, so grouping collapses a run's safe bumps into a single PR per ecosystem: `go-deps`, `actions`, `cdk8s`.

**Majors stay out of every group** — `update-types` is `[minor, patch]` — so a breaking bump (setup-python 6→7, checkout 6→7, setup-uv 8→9) arrives on its own, attributable to one dependency instead of buried among a dozen safe ones.

Two things this deliberately does not group:

- **`docker`** — one image, so a group would hold exactly one dependency.
- **Security updates** — Dependabot fires those regardless of the `updates:` config and `groups` does not apply to them, so they keep arriving alone. That's the desired behaviour.

Part of a fleet-wide pass; the sibling PRs land the same shape per repo, and infra's leaves the terraform providers ungrouped on purpose.