### PR TITLE
ci(changelog): skip fragment numbering on dependabot PRs

### DIFF
--- a/.github/workflows/changelog-number.yml
+++ b/.github/workflows/changelog-number.yml
@@ -40,9 +40,16 @@ jobs:
     timeout-minutes: 15
     # Skip forks (their GITHUB_TOKEN/app token can't push to the head branch)
     # and release-please's own branch (it carries no fragments to number).
+    #
+    # Dependabot for the same reason, plus one that would fail loudly rather
+    # than idle: a Dependabot pull_request event receives no Actions secrets,
+    # so `secrets.AUTOMATION_APP_PRIVATE_KEY` arrives empty and the mint step
+    # below dies on it -- leaving every bump PR with a red required check for
+    # work it never had to do.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.head_ref != 'release-please--branches--main'
+      github.head_ref != 'release-please--branches--main' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Mint automation app token
         id: app-token


### PR DESCRIPTION
Every dependabot PR in this repo carries a red `number` check. #1333 (the new 13-update go group) is the current example.

**Cause:** a Dependabot `pull_request` event receives no Actions secrets — Dependabot has a separate secret store — so `vars.AUTOMATION_APP_ID` resolves while `secrets.AUTOMATION_APP_PRIVATE_KEY` arrives empty, and `create-github-app-token` dies on it:

```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
  app-id: 4029932
Error: The 'private-key' input must be set to a non-empty string. If using a
secret or variable, ensure it is available in this workflow context.
```

**Fix:** exclude Dependabot from the job, the same way release-please's own branch already is and for the same underlying reason — there is nothing here to number. Dependabot writes no changelog fragments, so the job was pure waste on those PRs even before it started failing.

Fleet-wide: the identical `number` job fails on dependabot PRs in all six towncrier repos, so this lands in each. Sibling PRs: [tripbot-console](https://github.com/adanalife/tripbot-console/pull/269), [platform-gateway](https://github.com/adanalife/platform-gateway/pull/188), [obs](https://github.com/adanalife/obs/pull/87), [guessr](https://github.com/adanalife/guessr/pull/88), [playout](https://github.com/adanalife/playout/pull/112).

**Not covered here:** this repo's `gates` job mints the same token for the `platforms.json` drift assert, so it fails on dependabot PRs too. That one is being fixed the other way — by seeding the key into the Dependabot secret store — since the assert is a real check rather than waste, and the terraform for it is a separate PR.