### PR TITLE
ci(gates): skip the platforms.json assert on dependabot PRs

### DIFF
--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -91,7 +91,17 @@ jobs:
       #
       # The gateway repo is private, so read it with an org-scoped automation
       # app token (least privilege: platform-gateway only), not GITHUB_TOKEN.
+      #
+      # Skipped on Dependabot PRs, which cannot answer the question this asks. A
+      # Dependabot `pull_request` event is granted Actions variables but not
+      # Actions secrets, so the private key arrives empty and the mint fails with
+      # "The 'private-key' input must be set to a non-empty string" — a red
+      # required check on every bump. Nothing is lost by not asking: platforms.json
+      # only ever moves by `task platforms:sync`, which no dependency bump runs,
+      # and gateway-side drift is caught daily by platforms-contract.yml regardless
+      # of what any PR does.
       - name: Mint automation app token
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -101,6 +111,7 @@ jobs:
           repositories: platform-gateway
 
       - name: Assert platforms.json matches platform-gateway/main
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
The last piece of the dependabot-PR unblocking. #1334 fixed the `number` job; this fixes `gates`, which fails on the same root cause.

**Cause:** a Dependabot `pull_request` event is granted Actions *variables* but not Actions *secrets*, so `vars.AUTOMATION_APP_ID` resolves while `secrets.AUTOMATION_APP_PRIVATE_KEY` arrives empty:

```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
  app-id: 4029932
Error: The 'private-key' input must be set to a non-empty string.
```

Every bump PR carries a red required `gates` as a result — #1333 (the 13-update go group) is the live example.

**Why skipping is right rather than a workaround.** The assert asks whether `platforms.json` still matches platform-gateway/main. That answer cannot differ on a bump: the file moves only by `task platforms:sync`, which no dependency bump runs. And gateway-side drift — the case the comment says this is unguarded-by-paths to catch — is swept daily by `platforms-contract.yml` independently of any PR. So nothing goes unchecked; one PR-time sample of a daily check is skipped where it has nothing to sample.

**The alternative, and why not.** Mirroring the App key into Dependabot's own secret store would make the mint work. But the automation App's installation carries `actions, actions_variables, contents, metadata, pull_requests, secrets` and **not `dependabot_secrets`** — `secrets` is the Actions store only. Granting it needs an App permission change plus an org-level approval, to enable a check that detects nothing here, and it would put the App private key in scope for Dependabot-triggered runs. Reverted in [infra#949](https://github.com/adanalife/infra/pull/949/changes).

After this, a dependabot PR in this repo should be green on both required checks. Verification is post-merge — this PR is mine, so its own `gates` mints the token normally; #1333 is the real test.