### PR TITLE
ci(dependabot): watch cdk8s Python, widen cooldown, stop auto-rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,21 @@ updates:
       - dependencies
       - javascript
       - skip-changelog
+  # The cdk8s Python layer: the libraries the authoring code imports. The npm
+  # entry above covers the CLI half of the same toolchain; without this one the
+  # Python half takes no updates at all, security included.
+  - package-ecosystem: uv
+    directory: cdk8s
+    schedule:
+      interval: daily
+    groups:
+      python:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - python
+      - skip-changelog

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,26 @@
 
 version: 2
 updates:
+  # Three settings are repeated on every entry below, since Dependabot has no
+  # place to state a default once:
+  #
+  #   cooldown        holds a new release for 7 days before it becomes a PR, so
+  #                   a release that gets yanked or immediately patched never
+  #                   costs a review. A major waits 14 -- but only where the
+  #                   ecosystem has a SemVer model: Dependabot rejects the
+  #                   semver-* keys for github-actions and docker, so those
+  #                   carry the flat 7. The asymmetry is required, not an
+  #                   oversight.
+  #                   Dependabot already applies 3 days by default; this widens
+  #                   it. Security updates ignore cooldown entirely, so nothing
+  #                   urgent waits.
+  #   rebase-strategy is disabled. The default rebases every open bump PR
+  #                   whenever main moves and re-runs all of their checks, which
+  #                   costs far more CI than it saves; no ruleset here needs
+  #                   a branch to be up to date before merging.
+  #   schedule        is weekly on Monday 13:00 UTC, so a week's bumps arrive as
+  #                   one batch to review rather than trickling in daily.
+  #
   # Bumps carry no user-facing change, so they never need a towncrier
   # changelog fragment. Self-apply skip-changelog so the changelog
   # workflow's existing label escape hatch exempts them — this keeps the
@@ -18,7 +38,9 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+      time: "13:00"
     groups:
       go-deps:
         patterns:
@@ -34,10 +56,16 @@ updates:
   # normally a runner or Node version bump rather than an API break, so the
   # attributability that keeps majors solo elsewhere buys little here — and
   # holding them out produced a standing queue of one-line PRs nobody merged.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    rebase-strategy: disabled
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+      time: "13:00"
     groups:
       actions:
         patterns:
@@ -46,10 +74,15 @@ updates:
       - dependencies
       - github_actions
       - skip-changelog
+    cooldown:
+      default-days: 7
+    rebase-strategy: disabled
   - package-ecosystem: docker
     directory: infra/docker/tripbot
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+      time: "13:00"
     labels:
       - dependencies
       - docker
@@ -58,10 +91,18 @@ updates:
   # this is only reachable because the CLI is pinned in package-lock.json
   # rather than cdk8s/.mise.toml. The cdk8s gate re-synths on the bump PR, so a
   # codegen change that would move dist/ fails the PR instead of main.
+    cooldown:
+      default-days: 7
+    rebase-strategy: disabled
+  # Direct dependencies only: the point of the lockfile is that cdk8s-cli's
+  # transitive tree moves when the CLI moves, so a lone transitive bump is
+  # churn against a pin that is deliberate.
   - package-ecosystem: npm
     directory: cdk8s
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+      time: "13:00"
     groups:
       cdk8s:
         patterns:
@@ -76,10 +117,18 @@ updates:
   # The cdk8s Python layer: the libraries the authoring code imports. The npm
   # entry above covers the CLI half of the same toolchain; without this one the
   # Python half takes no updates at all, security included.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    rebase-strategy: disabled
+    allow:
+      - dependency-type: direct
   - package-ecosystem: uv
     directory: cdk8s
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+      time: "13:00"
     groups:
       python:
         patterns:
@@ -91,3 +140,7 @@ updates:
       - dependencies
       - python
       - skip-changelog
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    rebase-strategy: disabled


### PR DESCRIPTION
`pyproject.toml` + `uv.lock` declare the cdk8s authoring layer's Python libraries (cdk8s, constructs, pyyaml), and no `package-ecosystem` entry covered them — so they have been taking **no updates at all, security patches included**.

Confirmed reachable rather than assumed: tripbot-console declares its deps in the identical shape (`[dependency-groups] cdk8s = [...]`, not `[project.dependencies]`) and [tripbot-console#264](https://github.com/adanalife/tripbot-console/pull/264/changes) bumped `cdk8s 2.70.77→2.70.88` and `constructs 10.6.0→10.8.0` through its `uv` entry.

Grouped `minor`+`patch` to match every other non-Actions ecosystem; majors still arrive alone.

---

**Extended beyond the original scope** with three fleet-wide settings, one PR per repo:

- **`cooldown`** — 7 days, 14 for a major. Dependabot already applies 3 by default; this widens it so a yanked or immediately-patched release never costs a review. Security updates ignore cooldown, so nothing urgent is delayed.
- **`rebase-strategy: disabled`** — the default rebases every open bump PR whenever `main` moves and re-runs all their checks, which is most of the CI these PRs spend. Verified safe: no repo's `protect-main` sets `strict_required_status_checks_policy`, so a branch does not need to be up to date to merge.
- **`schedule`** — weekly, Monday 13:00 UTC, replacing the daily/weekly split across the fleet, so a week of bumps arrives as one batch.