### PR TITLE
ci(gates): run PR gates on every pull request, not just main-targeted

### DIFF
--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -19,7 +19,11 @@ name: pr-gates
 
 on:
   pull_request:
-    branches: [main]
+    # Every PR, whatever it targets. Filtering to `branches: [main]` would leave a
+    # PR stacked on another feature branch running no tests at all — the review
+    # that most wants them, since its diff is against a branch nobody has looked
+    # at rather than against main.
+    #
     # Union of the triggers the individual gates needed: `edited` for the title
     # check, `labeled`/`unlabeled` for the skip-changelog escape hatch.
     types: [opened, edited, reopened, synchronize, labeled, unlabeled]


### PR DESCRIPTION
## Summary
- `pr-gates.yml` triggered on `pull_request` with `branches: [main]`, so a PR stacked on another feature branch matched nothing and ran no gates at all — only `pre-commit`, which has no branch filter. That is the review that most wants them, since its diff is against a branch nobody has looked at.
- Dropping the `branches:` key is the whole change; the `types:` list is unchanged.
- Ordering note: GitHub picks which workflows run from the *base* branch's copy, so this only takes effect for PRs opened after it lands on `main`.

Part of a fleet-wide sweep — sibling PRs:

- https://github.com/adanalife/tripbot-console/pull/304
- https://github.com/adanalife/platform-gateway/pull/195
- https://github.com/adanalife/obs/pull/103
- https://github.com/adanalife/playout/pull/120
- https://github.com/adanalife/video-pipeline/pull/133
- https://github.com/adanalife/website/pull/282
- https://github.com/adanalife/infra/pull/982

## Test plan
- [x] YAML still parses; the resulting trigger is `pull_request` with the same `types:` and no branch filter.
- [x] This PR itself targets `main`, so `pr-gates` still fires on it.
- [ ] After merge: open a PR stacked on a feature branch and confirm `pr-gates` runs on it.
