### PR TITLE
docs(audio): rewrap the audiowatchdog package doc

### DIFF
--- a/pkg/obs/audiowatchdog/audiowatchdog.go
+++ b/pkg/obs/audiowatchdog/audiowatchdog.go
@@ -10,10 +10,11 @@
 // the stream isn't silent: the album on the mounted share, or the Car Hum FLAC
 // baked into the OBS image when the share has no tracks. An outage lasts hours,
 // and a music stream degraded to music beats one degraded to a drone. It probes
-// SomaFM in the background and swaps back once an edge is serving bytes again. All of it is the OBS-side analogue of the silent-
-// disconnect stream watchdog in pkg/obs/watchdog — same injectable-deps shape
-// so the decision loop unit-tests without a real OBS WebSocket. cmd/tripbot
-// (Twitch only) is the sole consumer.
+// SomaFM in the background and swaps back once an edge is serving bytes again.
+// All of it is the OBS-side analogue of the silent-disconnect stream watchdog
+// in pkg/obs/watchdog — same injectable-deps shape so the decision loop
+// unit-tests without a real OBS WebSocket. cmd/tripbot (Twitch only) is the
+// sole consumer.
 package audiowatchdog
 
 import (


### PR DESCRIPTION
Follow-up to [#1360](https://github.com/adanalife/tripbot/pull/1360). Editing the package doc there left one line running well past the comment width, and split the compound "silent-disconnect" across two lines mid-word. This reflows the paragraph.

Comment text only — no behaviour change, and nothing else in the file is touched. `gofmt` doesn't reflow comment prose, so it took a human read to catch.

No changelog fragment: comment formatting isn't a user-visible change. Pushed with `SKIP_CHANGELOG=1` and labelled `skip-changelog` accordingly.

---

**CI note:** the first `test` run here failed on `TestSchedule_ReportsThePendingTuneWithoutClaimingIt`, which this PR cannot affect — it changes comment text only. It's a pre-existing flake, reproduced on a clean `origin/main` worktree at `dfdbaa9c` before any of this work, and also flagged on [#1360](https://github.com/adanalife/tripbot/pull/1360). Re-run once.

The cause looks benign but the assertion is on the wrong signal: `applyPending` sets the bed (inside `setNow`) and only *then* clears `pending`, so there's a window where the bed reads as landed while `Pending()` is still true. The store's ordering is the safe one — `pending == false` always implies the bed is live — so it's the test that should wait on `Pending()` clearing rather than on the bed. Worth a small test-only fix, since this will keep reddening unrelated PRs.
