### PR TITLE
test(audio): wait on Pending clearing, not the bed value

### DIFF
--- a/pkg/obs/beds/beds_test.go
+++ b/pkg/obs/beds/beds_test.go
@@ -1039,19 +1039,15 @@ func TestSchedule_ReportsThePendingTuneWithoutClaimingIt(t *testing.T) {
 		t.Error("the pending station is being reported as the live one")
 	}
 
-	// Wait on the bed, not on the pending flag. applyPending clears pending and
-	// records the station under one lock, then releases it before switching the
-	// bed — so between those two the tune reads as landed while Current() still
-	// reports the old bed, and asserting in that window fails a store that is
-	// working correctly. The bed is the last thing to move, so waiting on it
-	// covers the station and the pending flag too.
+	// Wait on the pending flag, not the bed. applyPending records the station,
+	// switches the bed, and only then clears pending — so the cleared flag is the
+	// one signal that the whole tune has landed. Waiting on the bed instead
+	// asserts inside the window between the bed moving and the flag clearing,
+	// which fails a store that is working correctly.
 	waitFor(t, "the tune to land", func() bool {
-		bed, _ := s.Current()
-		return bed == SomaFM
+		_, pending := s.Pending()
+		return !pending
 	})
-	if _, pending := s.Pending(); pending {
-		t.Error("still reporting a pending tune after it landed")
-	}
 	if got := s.Station(); got != "dronezone" {
 		t.Errorf("station = %q after the tune landed, want dronezone", got)
 	}


### PR DESCRIPTION
`TestSchedule_ReportsThePendingTuneWithoutClaimingIt` fails intermittently on unrelated PRs (it reddened [#1362](https://github.com/adanalife/tripbot/pull/1362), a comment-only change).

The store is fine; the test watches the wrong signal. `applyPending` records the station, calls `setNow` (which sets the bed), and *only then* clears `pending`. The test waited on the bed reaching `somafm` and then asserted `Pending()` was clear — an assertion landing in the window between those last two steps, which also spans `record()`, a counter increment and a log line. So a correct store fails the assertion.

Waiting on `Pending()` clearing instead matches the store's ordering: a cleared flag implies the station, album and bed have all moved. The stale comment above the wait (it described an older `applyPending` that cleared the flag first) is rewritten to the actual ordering, and the now-redundant `Pending()` assertion after the wait is dropped.

Test-only; no production code touched.

Reproduced locally on a clean `origin/main` worktree: `go test -run 'TestSchedule_ReportsThePendingTuneWithoutClaimingIt' -count=200 ./pkg/obs/beds/...` failed with `still reporting a pending tune after it landed`. After the fix the same 200-run passes, as does `-race -run 'TestSchedule_' -count=50` and the full `go test ./...`.